### PR TITLE
add multiarch travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: bash
+sudo: required
+services: docker
+env:
+  global:
+  - REPO=gwelican/bazarr
+  - QEMU_VERSION=v2.11.0
+  - COMMIT=${TRAVIS_COMMIT::8}
+  - secure: p29iUgrD8tRnoWu1ZG9OpunG4/tydnnvyodDFNEMrqpY+4iO05p3LJBQfhi5OrkNMiJNLgeMB9nrLH0hJVKbiqRsaS0qMeeZwnFtU7AyoNmCbUhCKwz2xZB4djy2mt0tehTFNMzDwSX/w4YwaM60b3Dl2s2J96x7ovz/Mg6VWb195JD3WC6ags1+vmcAqOyzo+++GASJ8p/EO7MYiwkvUyXWW+RStaM+v8Pf7HN5xk+lKEaGvuL4PaxA74pRrg8roEcbOmhUcFE56PHstej3IieUUInumIbUm7ct577luPhnAfelm/xQwSFCArZCt0c7wJB284cY3FxeaRZHy7PnjyMatV/gtoea02ov0Wc3fq3KbpsGQbnr+SbkszMAfFOFSI2OVzqm51d3uNX5+KQu8hmyA2AUB+Nq09GObdMngXEIa3EsW2WtOWhYs0WKSvhmicglR10CtMP30v5T9kppcysl1cw8mc8OwJnxaeoSqreIMNMaIMc3EBG6XQMZVXkHZSELAJsf35o6Ny06rH0JtpAgDGgFZB2eUkOeu18NNIjiIV3bAF3SPKl+3o6P6OT9AQmgLTq6IsIA3UUGC6cBQMWnArjy+ZVeLZzhvDA/50x+QmOqay0XGG12xJIzYAGalJ/HpBYRcSuSQymqvzrv99CyGfDjQ4pXi5hNtzKxHZ8=
+  - secure: n4xpzgWGDdr8SSGh7R6ffoAcxywK2juhKrxftCxpaBTNIVV2lRIsaUW2fMUkbi4ohEpA8QRg6OHBYfWH/LiWG2o7jjixQFV3aPdbIqS8mI6hxBz7abxYSYmg4qbdCX7+4o/73G8HdA5W1lFLp6qvFOasjb181qvyQwpCBxvxjg5BAeOPP0+Fr4swso/JnrkqVtaacNmstMTnNhNe34nbs3yh+nOhXxQyrdKQeq+9SCTsMglDK9JL/G9in7QYsAwfGxjzwy1k93Y1eVGiLb10ik2MJStzKUvC3OBzE+7p5sScdieJuXC1/zRxgU8eSecN8ryDVVOWdIF9SjZupZOe6QdMrrSf4noQbJeqKcdTHzkKXtd3C3VV8a9evTzp2lEqxrqJ6nLMNKtry3JtB6O6kIXeXBk/c6rmG8/7ZtGzYwS97g4EV4owfcINA5LmAPyqTGeNxo5ZxhlM6fonRw8kZtPH+JY3/cxzoM3Y5jcWUlLOPf/TvHCvyFCcNW0QtIfBc+LIl9ZMk2oXANM99t6AUNSYUABSV9ZQj1xp/8FhLF9qWumt4m0ty5hm976GonngLyzh3Tfr3lTb2bODSvcaNkkzL9mk8+lEkWnIfIO6OLrh+varsUUYDWY6PLgjICetQEoN+RiaCFITms4NuwURqYMY8vDTe5JkbBL+MvQT+sM=
+  matrix:
+  - ARCH=amd64
+  - QEMU_ARCH=arm ARCH=armhf
+  - QEMU_ARCH=aarch64 ARCH=arm64
+script:
+- docker run --rm --privileged multiarch/qemu-user-static:register
+- docker build -t $REPO:$COMMIT -f Dockerfile.$ARCH .
+after_success:
+- docker login -u $DOCKER_USER -p $DOCKER_PASS
+- if [ "$ARCH" == "amd64" ]; then docker tag $REPO:$COMMIT $REPO:latest; fi
+- docker tag $REPO:$COMMIT $REPO:$ARCH-latest
+- docker push $REPO

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,8 @@ env:
   - QEMU_ARCH=aarch64 ARCH=arm64
 script:
 - docker run --rm --privileged multiarch/qemu-user-static:register
-- docker build -t $REPO:$COMMIT -f Dockerfile.$ARCH .
+- docker build -t $REPO:$ARCH-latest -f Dockerfile.$ARCH .
 after_success:
 - docker login -u $DOCKER_USER -p $DOCKER_PASS
 - if [ "$ARCH" == "amd64" ]; then docker tag $REPO:$COMMIT $REPO:latest; fi
-- docker tag $REPO:$COMMIT $REPO:$ARCH-latest
 - docker push $REPO

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,21 @@
+FROM lsiobase/alpine.python:3.7
+
+# set python to use utf-8 rather than ascii.
+ENV PYTHONIOENCODING="UTF-8"
+ENV QEMU_VERSION v2.11.0
+
+ADD https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_VERSION}/qemu-arm-static /usr/bin
+
+VOLUME /tv
+
+RUN apk add --update git py-pip jpeg-dev && \
+    apk add --update --virtual build-dependencies build-base python-dev libffi-dev zlib-dev  && \
+    git clone https://github.com/morpheus65535/bazarr.git /bazarr && \
+    pip install -r /bazarr/requirements.txt && \
+    apk del --purge build-dependencies
+
+VOLUME /bazarr/data
+
+EXPOSE 6767
+
+CMD ["python", "/bazarr/bazarr.py"]

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,0 +1,21 @@
+FROM lsiobase/alpine.python:3.7
+
+# set python to use utf-8 rather than ascii.
+ENV PYTHONIOENCODING="UTF-8"
+ENV QEMU_VERSION v2.11.0
+
+ADD https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_VERSION}/qemu-arm-static /usr/bin
+
+VOLUME /tv
+
+RUN apk add --update git py-pip jpeg-dev && \
+    apk add --update --virtual build-dependencies build-base python-dev libffi-dev zlib-dev  && \
+    git clone https://github.com/morpheus65535/bazarr.git /bazarr && \
+    pip install -r /bazarr/requirements.txt && \
+    apk del --purge build-dependencies
+
+VOLUME /bazarr/data
+
+EXPOSE 6767
+
+CMD ["python", "/bazarr/bazarr.py"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # bazarr
 Bazarr is a companion application to Sonarr. It manage and download subtitles based on your requirements. You defined your preferences by TV show and Bazarr take care of everything for you.
 
+# Build status
+![Build status](https://travis-ci.org/morpheus65535/bazarr.svg?branch=master)
+
 # Support
 For installation and configuration instructions, see [wiki](https://github.com/morpheus65535/bazarr/wiki).
 


### PR DESCRIPTION
Adds multiarch support by building multiple images with travis.

How to set it up:
Register an account on https://travis-ci.org/ (you can use your github login to do so)
Sync your github projects

Once the repository is registered with travis, download travis commandline: `gem install travis`
Then run the two following commands(the current directory should be the one, which has .travis.yml): 
(Replace username and password with your own credentials)
`travis encrypt DOCKER_PASS=<password>`
`travis encrypt DOCKER_USER=<username>`

This will setup secrets in travis project and store the encrypted version in .travis.yml. More at https://docs.travis-ci.com/user/encryption-keys/ 

Once this is setup, every commit you push will be built and pushed to dockerhub. You can check how it looks like on my mine: https://hub.docker.com/r/gwelican/bazarr/

Altho I believe the tags speak for themselves, but basically the layout is the following:

:latest is pointing to amd64-latest
:arm64-latest is pointing to the image with arm64
:armhf-latest is pointing to the image with armhf
:amd64-latest is pointing to the image with amd64

Travis will also build pull request, currently the .travis.yml is not set to ignore the docker push on pull request, you can disable it in travis UI, if you want.

For the future:
As I mentioned there is a way to annotate images with arch, so docker pull bazarr would pull the right image(based on the docker host arch) 
More at https://lobradov.github.io/Building-docker-multiarch-images/


