### PR TITLE
Fix for issue #139 (ISO 639-2/B language code detection)

### DIFF
--- a/bazarr.py
+++ b/bazarr.py
@@ -771,7 +771,7 @@ def settings():
     authorize()
     db = sqlite3.connect(os.path.join(config_dir, 'db/bazarr.db'), timeout=30)
     c = db.cursor()
-    c.execute("SELECT * FROM table_settings_languages ORDER BY name")
+    c.execute("SELECT code3, code2, name, enabled FROM table_settings_languages ORDER BY name")
     settings_languages = c.fetchall()
     c.execute("SELECT * FROM table_settings_providers ORDER BY name")
     settings_providers = c.fetchall()

--- a/create_db.sql
+++ b/create_db.sql
@@ -22,6 +22,7 @@ CREATE TABLE "table_settings_providers" (
 );
 CREATE TABLE "table_settings_languages" (
 	`code3`	TEXT NOT NULL UNIQUE,
+	`code3b`	TEXT,
 	`code2`	TEXT,
 	`name`	TEXT NOT NULL,
 	`enabled`	INTEGER,

--- a/get_languages.py
+++ b/get_languages.py
@@ -18,6 +18,13 @@ def load_language_in_db():
     c.executemany('''INSERT OR IGNORE INTO table_settings_languages(code3, code2, name) VALUES(?, ?, ?)''', langs)
     c.execute('''INSERT OR IGNORE INTO table_settings_languages(code3, code2, name) VALUES(?, ?, ?)''', ('pob','pb','Brazilian Portuguese'))
 
+    langs = [[lang.bibliographic,lang.alpha_3]
+        for lang in pycountry.languages
+        if hasattr(lang, 'alpha_2') and hasattr(lang, 'bibliographic')]
+
+    # Update languages in database table
+    c.executemany('''UPDATE table_settings_languages SET code3b = ? WHERE code3 = ?''', langs)
+
     # Commit changes to database table
     db.commit()
 
@@ -40,7 +47,7 @@ def language_from_alpha3(lang):
     db = sqlite3.connect(os.path.join(config_dir, 'db/bazarr.db'), timeout=30)
     c = db.cursor()
     try:
-        result = c.execute('''SELECT name FROM table_settings_languages WHERE code3 = ?''', (lang,)).fetchone()[0]
+        result = c.execute('''SELECT name FROM table_settings_languages WHERE code3 = ? OR code3b = ?''', (lang,lang)).fetchone()[0]
     except:
         result = None
     db.close()
@@ -52,7 +59,7 @@ def alpha2_from_alpha3(lang):
     db = sqlite3.connect(os.path.join(config_dir, 'db/bazarr.db'), timeout=30)
     c = db.cursor()
     try:
-        result = c.execute('''SELECT code2 FROM table_settings_languages WHERE code3 = ?''', (lang,)).fetchone()[0]
+        result = c.execute('''SELECT code2 FROM table_settings_languages WHERE code3 = ? OR code3b = ?''', (lang,lang)).fetchone()[0]
     except:
         result = None
     db.close()

--- a/update_db.py
+++ b/update_db.py
@@ -75,6 +75,11 @@ if os.path.exists(os.path.join(config_dir, 'db/bazarr.db')) == True:
     except:
         pass
 
+    try:
+        c.execute('alter table table_settings_languages add column "code3b" "text"')
+    except:
+        pass
+
 
     # Commit change to db
     db.commit()


### PR DESCRIPTION
Also use the ISO 639-2/B language codes present in pycountry/databases/iso639-3.json when detecting languages.
This fixes issue #139.