### PR TITLE
Add the ability to import based on tag

### DIFF
--- a/bazarr/config.py
+++ b/bazarr/config.py
@@ -57,6 +57,8 @@ defaults = {
         'apikey': '',
         'full_update': 'Daily',
         'only_monitored': 'False',
+		'tag_enabled': 'False',
+		'tag': '',
 },
     'radarr': {
         'ip': '127.0.0.1',
@@ -66,6 +68,8 @@ defaults = {
         'apikey': '',
         'full_update': 'Daily',
         'only_monitored': 'False',
+		'tag_enabled': 'False',
+		'tag': '',
 },
     'proxy': {
         'type': 'None',

--- a/bazarr/config.py
+++ b/bazarr/config.py
@@ -58,6 +58,7 @@ defaults = {
         'full_update': 'Daily',
         'only_monitored': 'False',
 		'tag_enabled': 'False',
+		'tag_autoremove': 'False',
 		'tag': '',
 },
     'radarr': {
@@ -69,6 +70,7 @@ defaults = {
         'full_update': 'Daily',
         'only_monitored': 'False',
 		'tag_enabled': 'False',
+		'tag_autoremove': 'False',
 		'tag': '',
 },
     'proxy': {

--- a/bazarr/get_movies.py
+++ b/bazarr/get_movies.py
@@ -20,6 +20,7 @@ def update_movies():
     movie_default_language = settings.general.movie_default_language
     movie_default_hi = settings.general.movie_default_hi
     radarr_tag_enabled = settings.radarr.getboolean('tag_enabled')
+    radarr_tag_autoremove = settings.radarr.getboolean('tag_autoremove')
     radarr_tag = settings.radarr.tag.lower()
     radarr_tag_id = 0
 	
@@ -49,7 +50,7 @@ def update_movies():
                         radarr_tag_id = radarrtags['id']
 
             if str(radarr_tag_id) == "0":
-			    logging.exception("Could not find matching tag in Radarr")
+			    logging.exception("Could not find matching tag to " + radarr_tag + " in Radarr")
         
         # Get movies data from radarr
         url_radarr_api_movies = url_radarr + "/api/movie?apikey=" + apikey_radarr
@@ -137,7 +138,7 @@ def update_movies():
                                 tags = str([item for item in movie['tags']])
 
                             # Add movies in radarr to current movies list
-                            if radarr_tag_enabled is False:
+                            if radarr_tag_enabled is False or radarr_tag_autoremove is False:
                                 current_movies_radarr.append(unicode(movie['tmdbId']))
                             
                             # Detect file separator

--- a/bazarr/get_movies.py
+++ b/bazarr/get_movies.py
@@ -137,7 +137,8 @@ def update_movies():
                                 tags = str([item for item in movie['tags']])
 
                             # Add movies in radarr to current movies list
-                            current_movies_radarr.append(unicode(movie['tmdbId']))
+                            if radarr_tag_enabled is False:
+                                current_movies_radarr.append(unicode(movie['tmdbId']))
                             
                             # Detect file separator
                             if movie['path'][0] == "/":
@@ -153,6 +154,8 @@ def update_movies():
                                                          unicode(bool(movie['monitored'])), movie['sortTitle'],
                                                          movie['year'], alternativeTitles, format, resolution,
                                                          videoCodec, audioCodec, imdbId, movie["tmdbId"]))
+                                if str(radarr_tag_id) in tags:
+					                current_movies_db_list.append(show['tmdbId'])
                             elif radarr_tag_enabled is False:
                                 if movie_default_enabled is True:
                                     movies_to_add.append((movie["title"],

--- a/bazarr/get_movies.py
+++ b/bazarr/get_movies.py
@@ -19,11 +19,37 @@ def update_movies():
     movie_default_enabled = settings.general.getboolean('movie_default_enabled')
     movie_default_language = settings.general.movie_default_language
     movie_default_hi = settings.general.movie_default_hi
-    
+    radarr_tag_enabled = settings.radarr.getboolean('tag_enabled')
+    radarr_tag = settings.radarr.tag.lower()
+    radarr_tag_id = 0
+	
     if apikey_radarr is None:
         pass
     else:
         get_profile_list()
+        
+        # Get tags data from Radarr
+        if radarr_tag_enabled is True:
+            url_radarr_api_tag = url_radarr + "/api/tag?apikey=" + apikey_radarr
+            try:
+                tag = requests.get(url_radarr_api_tag, timeout=15, verify=False)
+                tag.raise_for_status()
+            except requests.exceptions.HTTPError as errh:
+                logging.exception("BAZARR Error trying to get tags from Radarr. HTTP error.")
+            except requests.exceptions.ConnectionError as errc:
+                logging.exception("BAZARR Error trying to get tags from Radarr. Connection Error.")
+            except requests.exceptions.Timeout as errt:
+                logging.exception("BAZARR Error trying to get tags from Radarr. Timeout Error.")
+            except requests.exceptions.RequestException as err:
+                logging.exception("BAZARR Error trying to get tags from Radarr.")
+            else:
+        
+                for radarrtags in tag.json():
+                    if radarrtags['label'] == radarr_tag:
+                        radarr_tag_id = radarrtags['id']
+
+            if str(radarr_tag_id) == "0":
+			    logging.exception("Could not find matching tag in Radarr")
         
         # Get movies data from radarr
         url_radarr_api_movies = url_radarr + "/api/movie?apikey=" + apikey_radarr
@@ -107,6 +133,9 @@ def update_movies():
                                 videoCodec = None
                                 audioCodec = None
 
+                            if movie['tags'] != None:
+                                tags = str([item for item in movie['tags']])
+
                             # Add movies in radarr to current movies list
                             current_movies_radarr.append(unicode(movie['tmdbId']))
                             
@@ -124,7 +153,7 @@ def update_movies():
                                                          unicode(bool(movie['monitored'])), movie['sortTitle'],
                                                          movie['year'], alternativeTitles, format, resolution,
                                                          videoCodec, audioCodec, imdbId, movie["tmdbId"]))
-                            else:
+                            elif radarr_tag_enabled is False:
                                 if movie_default_enabled is True:
                                     movies_to_add.append((movie["title"],
                                                           movie["path"] + separator + movie['movieFile']['relativePath'],
@@ -143,11 +172,32 @@ def update_movies():
                                                           unicode(bool(movie['monitored'])), movie['sortTitle'],
                                                           movie['year'], alternativeTitles, format, resolution,
                                                           videoCodec, audioCodec, imdbId))
+                            elif radarr_tag_enabled is True:
+                                if str(radarr_tag_id) in tags:
+                                    logging.info("Detected Radarr tag \"" + radarr_tag + "\" on " + movie["title"])
+                                    if movie_default_enabled is True:
+                                        movies_to_add.append((movie["title"],
+                                                              movie["path"] + separator + movie['movieFile']['relativePath'],
+                                                              movie["tmdbId"], movie_default_language, '[]', movie_default_hi,
+                                                              movie["id"], overview, poster, fanart,
+                                                              profile_id_to_language(movie['qualityProfileId']), sceneName,
+                                                              unicode(bool(movie['monitored'])), movie['sortTitle'],
+                                                              movie['year'], alternativeTitles, format, resolution,
+                                                              videoCodec, audioCodec, imdbId))
+                                    else:
+                                        movies_to_add.append((movie["title"],
+                                                              movie["path"] + separator + movie['movieFile'][
+                                                                  'relativePath'], movie["tmdbId"], movie["tmdbId"],
+                                                              movie["tmdbId"], movie["id"], overview, poster, fanart,
+                                                              profile_id_to_language(movie['qualityProfileId']), sceneName,
+                                                              unicode(bool(movie['monitored'])), movie['sortTitle'],
+                                                              movie['year'], alternativeTitles, format, resolution,
+                                                              videoCodec, audioCodec, imdbId))
                         else:
                             logging.error(
                                 'BAZARR Radarr returned a movie without a file path: ' + movie["path"] + separator +
                                 movie['movieFile']['relativePath'])
-            
+                
             # Update or insert movies in DB
             db = sqlite3.connect(os.path.join(args.config_dir, 'db', 'bazarr.db'), timeout=30)
             c = db.cursor()

--- a/bazarr/get_series.py
+++ b/bazarr/get_series.py
@@ -19,6 +19,7 @@ def update_series():
     serie_default_language = settings.general.serie_default_language
     serie_default_hi = settings.general.serie_default_hi
     sonarr_tag_enabled = settings.sonarr.getboolean('tag_enabled')
+    sonarr_tag_autoremove = settings.sonarr.getboolean('tag_autoremove')
     sonarr_tag = settings.sonarr.tag.lower()
     sonarr_tag_id = 0
     
@@ -48,7 +49,7 @@ def update_series():
                         sonarr_tag_id = sonarrtags['id']
 						
             if str(sonarr_tag_id) == "0":
-			    logging.exception("Could not find matching tag in Sonarr")
+			    logging.exception("Could not find matching tag to" + sonarr_tag + " in Sonarr")
 		
 		
         # Get shows data from Sonarr
@@ -103,7 +104,7 @@ def update_series():
                     tags = str([item for item in show['tags']])
 					
                 # Add shows in Sonarr to current shows list
-                if sonarr_tag_enabled is False:
+                if sonarr_tag_enabled is False or sonarr_tag_autoremove is False:
                     current_shows_sonarr.append(show['tvdbId'])
                 
                 if show['tvdbId'] in current_shows_db_list:

--- a/bazarr/get_series.py
+++ b/bazarr/get_series.py
@@ -103,13 +103,16 @@ def update_series():
                     tags = str([item for item in show['tags']])
 					
                 # Add shows in Sonarr to current shows list
-                current_shows_sonarr.append(show['tvdbId'])
+                if sonarr_tag_enabled is False:
+                    current_shows_sonarr.append(show['tvdbId'])
                 
                 if show['tvdbId'] in current_shows_db_list:
                     series_to_update.append((show["title"], show["path"], show["tvdbId"], show["id"], overview, poster,
                                              fanart, profile_id_to_language(
                         (show['qualityProfileId'] if sonarr_version == 2 else show['languageProfileId'])),
                                              show['sortTitle'], show['year'], alternateTitles, show["tvdbId"]))
+                    if str(sonarr_tag_id) in tags:
+					    current_shows_sonarr.append(show['tvdbId'])
                 elif sonarr_tag_enabled is False:
                     if serie_default_enabled is True:
                         series_to_add.append((show["title"], show["path"], show["tvdbId"], serie_default_language,

--- a/bazarr/get_series.py
+++ b/bazarr/get_series.py
@@ -18,12 +18,39 @@ def update_series():
     serie_default_enabled = settings.general.getboolean('serie_default_enabled')
     serie_default_language = settings.general.serie_default_language
     serie_default_hi = settings.general.serie_default_hi
+    sonarr_tag_enabled = settings.sonarr.getboolean('tag_enabled')
+    sonarr_tag = settings.sonarr.tag.lower()
+    sonarr_tag_id = 0
     
     if apikey_sonarr is None:
         pass
     else:
         get_profile_list()
-        
+
+        # Get tags data from Sonarr
+        if sonarr_tag_enabled is True:
+            url_sonarr_api_tag = url_sonarr + "/api/tag?apikey=" + apikey_sonarr
+            try:
+                tag = requests.get(url_sonarr_api_tag, timeout=15, verify=False)
+                tag.raise_for_status()
+            except requests.exceptions.HTTPError as errh:
+                logging.exception("BAZARR Error trying to get tags from Sonarr. HTTP error.")
+            except requests.exceptions.ConnectionError as errc:
+                logging.exception("BAZARR Error trying to get tags from Sonarr. Connection Error.")
+            except requests.exceptions.Timeout as errt:
+                logging.exception("BAZARR Error trying to get tags from Sonarr. Timeout Error.")
+            except requests.exceptions.RequestException as err:
+                logging.exception("BAZARR Error trying to get tags from Sonarr.")
+            else:
+		
+                for sonarrtags in tag.json():
+                    if sonarrtags['label'] == sonarr_tag:
+                        sonarr_tag_id = sonarrtags['id']
+						
+            if str(sonarr_tag_id) == "0":
+			    logging.exception("Could not find matching tag in Sonarr")
+		
+		
         # Get shows data from Sonarr
         url_sonarr_api_series = url_sonarr + "/api/series?apikey=" + apikey_sonarr
         try:
@@ -71,7 +98,10 @@ def update_series():
 
                 if show['alternateTitles'] != None:
                     alternateTitles = str([item['title'] for item in show['alternateTitles']])
-
+					
+                if show['tags'] != None:
+                    tags = str([item for item in show['tags']])
+					
                 # Add shows in Sonarr to current shows list
                 current_shows_sonarr.append(show['tvdbId'])
                 
@@ -80,7 +110,7 @@ def update_series():
                                              fanart, profile_id_to_language(
                         (show['qualityProfileId'] if sonarr_version == 2 else show['languageProfileId'])),
                                              show['sortTitle'], show['year'], alternateTitles, show["tvdbId"]))
-                else:
+                elif sonarr_tag_enabled is False:
                     if serie_default_enabled is True:
                         series_to_add.append((show["title"], show["path"], show["tvdbId"], serie_default_language,
                                               serie_default_hi, show["id"], overview, poster, fanart,
@@ -91,6 +121,19 @@ def update_series():
                                               show["tvdbId"], show["id"], overview, poster, fanart,
                                               profile_id_to_language(show['qualityProfileId']), show['sortTitle'],
                                               show['year'], alternateTitles))
+                elif sonarr_tag_enabled is True:
+                    if str(sonarr_tag_id) in tags:
+                        logging.info("Detected Sonarr tag \"" + sonarr_tag + "\" on " + show["title"])
+                        if serie_default_enabled is True:
+                            series_to_add.append((show["title"], show["path"], show["tvdbId"], serie_default_language,
+                                                  serie_default_hi, show["id"], overview, poster, fanart,
+                                                  profile_id_to_language(show['qualityProfileId']), show['sortTitle'],
+                                                  show['year'], alternateTitles))
+                        else:
+                            series_to_add.append((show["title"], show["path"], show["tvdbId"], show["tvdbId"],
+                                                  show["tvdbId"], show["id"], overview, poster, fanart,
+                                                  profile_id_to_language(show['qualityProfileId']), show['sortTitle'],
+                                                  show['year'], alternateTitles))
             
             # Update or insert series in DB
             db = sqlite3.connect(os.path.join(args.config_dir, 'db', 'bazarr.db'), timeout=30)

--- a/bazarr/main.py
+++ b/bazarr/main.py
@@ -310,6 +310,7 @@ def save_wizard():
     settings_sonarr_port = request.forms.get('settings_sonarr_port')
     settings_sonarr_baseurl = request.forms.get('settings_sonarr_baseurl')
     settings_sonarr_ssl = request.forms.get('settings_sonarr_ssl')
+    settings_sonarr_tag = request.forms.get('settings_sonarr_tag')
     if settings_sonarr_ssl is None:
         settings_sonarr_ssl = 'False'
     else:
@@ -321,17 +322,26 @@ def save_wizard():
     else:
         settings_sonarr_only_monitored = 'True'
     
+    settings_sonarr_tag_enabled = request.forms.get('settings_sonarr_tag_enabled')
+    if settings_sonarr_tag_enabled is None:
+        settings_sonarr_tag_enabled = 'False'
+    else:
+        settings_sonarr_tag_enabled = 'True'
+		
     settings.sonarr.ip = text_type(settings_sonarr_ip)
     settings.sonarr.port = text_type(settings_sonarr_port)
     settings.sonarr.base_url = text_type(settings_sonarr_baseurl)
     settings.sonarr.ssl = text_type(settings_sonarr_ssl)
     settings.sonarr.apikey = text_type(settings_sonarr_apikey)
     settings.sonarr.only_monitored = text_type(settings_sonarr_only_monitored)
+    settings.sonarr.tag_enabled = text_type(settings_sonarr_tag_enabled)
+    settings.sonarr.tag = text_type(settings_sonarr_tag)
     
     settings_radarr_ip = request.forms.get('settings_radarr_ip')
     settings_radarr_port = request.forms.get('settings_radarr_port')
     settings_radarr_baseurl = request.forms.get('settings_radarr_baseurl')
     settings_radarr_ssl = request.forms.get('settings_radarr_ssl')
+    settings_radarr_tag = request.forms.get('settings_radarr_tag')
     if settings_radarr_ssl is None:
         settings_radarr_ssl = 'False'
     else:
@@ -342,6 +352,12 @@ def save_wizard():
         settings_radarr_only_monitored = 'False'
     else:
         settings_radarr_only_monitored = 'True'
+		
+    settings_radarr_tag_enabled = request.forms.get('settings_radarr_tag_enabled')
+    if settings_radarr_tag_enabled is None:
+        settings_radarr_tag_enabled = 'False'
+    else:
+        settings_radarr_tag_enabled = 'True'
     
     settings.radarr.ip = text_type(settings_radarr_ip)
     settings.radarr.port = text_type(settings_radarr_port)
@@ -349,6 +365,8 @@ def save_wizard():
     settings.radarr.ssl = text_type(settings_radarr_ssl)
     settings.radarr.apikey = text_type(settings_radarr_apikey)
     settings.radarr.only_monitored = text_type(settings_radarr_only_monitored)
+    settings.radarr.tag_enabled = text_type(settings_radarr_tag_enabled)
+    settings.radarr.tag = text_type(settings_radarr_tag)
     
     settings_subliminal_providers = request.forms.getall('settings_subliminal_providers')
     settings.general.enabled_providers = u'' if not settings_subliminal_providers else ','.join(
@@ -1400,6 +1418,7 @@ def save_settings():
     settings_sonarr_port = request.forms.get('settings_sonarr_port')
     settings_sonarr_baseurl = request.forms.get('settings_sonarr_baseurl')
     settings_sonarr_ssl = request.forms.get('settings_sonarr_ssl')
+    settings_sonarr_tag = request.forms.get('settings_sonarr_tag')
     if settings_sonarr_ssl is None:
         settings_sonarr_ssl = 'False'
     else:
@@ -1410,11 +1429,20 @@ def save_settings():
         settings_sonarr_only_monitored = 'False'
     else:
         settings_sonarr_only_monitored = 'True'
+		
+    settings_sonarr_tag_enabled = request.forms.get('settings_sonarr_tag_enabled')
+    if settings_sonarr_tag_enabled is None:
+        settings_sonarr_tag_enabled = 'False'
+    else:
+        settings_sonarr_tag_enabled = 'True'
+		
     settings_sonarr_sync = request.forms.get('settings_sonarr_sync')
 
     settings.sonarr.ip = text_type(settings_sonarr_ip)
     settings.sonarr.port = text_type(settings_sonarr_port)
     settings.sonarr.base_url = text_type(settings_sonarr_baseurl)
+    settings.sonarr.tag_enabled = text_type(settings_sonarr_tag_enabled)
+    settings.sonarr.tag = text_type(settings_sonarr_tag)
     settings.sonarr.ssl = text_type(settings_sonarr_ssl)
     settings.sonarr.apikey = text_type(settings_sonarr_apikey)
     settings.sonarr.only_monitored = text_type(settings_sonarr_only_monitored)
@@ -1424,6 +1452,7 @@ def save_settings():
     settings_radarr_port = request.forms.get('settings_radarr_port')
     settings_radarr_baseurl = request.forms.get('settings_radarr_baseurl')
     settings_radarr_ssl = request.forms.get('settings_radarr_ssl')
+    settings_radarr_tag = request.forms.get('settings_radarr_tag')
     if settings_radarr_ssl is None:
         settings_radarr_ssl = 'False'
     else:
@@ -1436,6 +1465,12 @@ def save_settings():
         settings_radarr_only_monitored = 'True'
     settings_radarr_sync = request.forms.get('settings_radarr_sync')
 
+    settings_radarr_tag_enabled = request.forms.get('settings_radarr_tag_enabled')
+    if settings_radarr_tag_enabled is None:
+        settings_radarr_tag_enabled = 'False'
+    else:
+        settings_radarr_tag_enabled = 'True'
+	
     settings.radarr.ip = text_type(settings_radarr_ip)
     settings.radarr.port = text_type(settings_radarr_port)
     settings.radarr.base_url = text_type(settings_radarr_baseurl)
@@ -1443,6 +1478,8 @@ def save_settings():
     settings.radarr.apikey = text_type(settings_radarr_apikey)
     settings.radarr.only_monitored = text_type(settings_radarr_only_monitored)
     settings.radarr.full_update = text_type(settings_radarr_sync)
+    settings.radarr.tag_enabled = text_type(settings_radarr_tag_enabled)
+    settings.radarr.tag = text_type(settings_radarr_tag)
 
     settings_subliminal_providers = request.forms.getall('settings_subliminal_providers')
     settings.general.enabled_providers = u'' if not settings_subliminal_providers else ','.join(

--- a/bazarr/main.py
+++ b/bazarr/main.py
@@ -328,6 +328,12 @@ def save_wizard():
     else:
         settings_sonarr_tag_enabled = 'True'
 		
+    settings_sonarr_tag_autoremove = request.forms.get('settings_sonarr_tag_autoremove')
+    if settings_sonarr_tag_autoremove is None:
+        settings_sonarr_tag_autoremove = 'False'
+    else:
+        settings_sonarr_tag_autoremove = 'True'
+		
     settings.sonarr.ip = text_type(settings_sonarr_ip)
     settings.sonarr.port = text_type(settings_sonarr_port)
     settings.sonarr.base_url = text_type(settings_sonarr_baseurl)
@@ -335,6 +341,7 @@ def save_wizard():
     settings.sonarr.apikey = text_type(settings_sonarr_apikey)
     settings.sonarr.only_monitored = text_type(settings_sonarr_only_monitored)
     settings.sonarr.tag_enabled = text_type(settings_sonarr_tag_enabled)
+    settings.sonarr.tag_autoremove = text_type(settings_sonarr_tag_autoremove)
     settings.sonarr.tag = text_type(settings_sonarr_tag)
     
     settings_radarr_ip = request.forms.get('settings_radarr_ip')
@@ -358,6 +365,12 @@ def save_wizard():
         settings_radarr_tag_enabled = 'False'
     else:
         settings_radarr_tag_enabled = 'True'
+		
+    settings_radarr_tag_autoremove = request.forms.get('settings_radarr_tag_autoremove')
+    if settings_radarr_tag_autoremove is None:
+        settings_radarr_tag_autoremove = 'False'
+    else:
+        settings_radarr_tag_autoremove = 'True'
     
     settings.radarr.ip = text_type(settings_radarr_ip)
     settings.radarr.port = text_type(settings_radarr_port)
@@ -366,6 +379,7 @@ def save_wizard():
     settings.radarr.apikey = text_type(settings_radarr_apikey)
     settings.radarr.only_monitored = text_type(settings_radarr_only_monitored)
     settings.radarr.tag_enabled = text_type(settings_radarr_tag_enabled)
+    settings.radarr.tag_autoremove = text_type(settings_radarr_tag_autoremove)
     settings.radarr.tag = text_type(settings_radarr_tag)
     
     settings_subliminal_providers = request.forms.getall('settings_subliminal_providers')
@@ -1436,12 +1450,19 @@ def save_settings():
     else:
         settings_sonarr_tag_enabled = 'True'
 		
+    settings_sonarr_tag_autoremove = request.forms.get('settings_sonarr_tag_autoremove')
+    if settings_sonarr_tag_autoremove is None:
+        settings_sonarr_tag_autoremove = 'False'
+    else:
+        settings_sonarr_tag_autoremove = 'True'
+		
     settings_sonarr_sync = request.forms.get('settings_sonarr_sync')
 
     settings.sonarr.ip = text_type(settings_sonarr_ip)
     settings.sonarr.port = text_type(settings_sonarr_port)
     settings.sonarr.base_url = text_type(settings_sonarr_baseurl)
     settings.sonarr.tag_enabled = text_type(settings_sonarr_tag_enabled)
+    settings.sonarr.tag_autoremove = text_type(settings_sonarr_tag_autoremove)
     settings.sonarr.tag = text_type(settings_sonarr_tag)
     settings.sonarr.ssl = text_type(settings_sonarr_ssl)
     settings.sonarr.apikey = text_type(settings_sonarr_apikey)
@@ -1470,6 +1491,12 @@ def save_settings():
         settings_radarr_tag_enabled = 'False'
     else:
         settings_radarr_tag_enabled = 'True'
+		
+    settings_radarr_tag_autoremove = request.forms.get('settings_radarr_tag_autoremove')
+    if settings_radarr_tag_autoremove is None:
+        settings_radarr_tag_autoremove = 'False'
+    else:
+        settings_radarr_tag_autoremove = 'True'
 	
     settings.radarr.ip = text_type(settings_radarr_ip)
     settings.radarr.port = text_type(settings_radarr_port)
@@ -1479,6 +1506,7 @@ def save_settings():
     settings.radarr.only_monitored = text_type(settings_radarr_only_monitored)
     settings.radarr.full_update = text_type(settings_radarr_sync)
     settings.radarr.tag_enabled = text_type(settings_radarr_tag_enabled)
+    settings.radarr.tag_autoremove = text_type(settings_radarr_tag_autoremove)
     settings.radarr.tag = text_type(settings_radarr_tag)
 
     settings_subliminal_providers = request.forms.getall('settings_subliminal_providers')

--- a/views/settings.tpl
+++ b/views/settings.tpl
@@ -829,10 +829,43 @@
                         </div>
                     </div>
                 </div>
-
+				
+                <div class="middle aligned row">
+                    <div class="right aligned four wide column">
+                        <label>Enable Sonarr Tag</label>
+                    </div>
+                    <div class="one wide column">
+                        <div id="settings_sonarr_tag_enabled" class="ui toggle checkbox" data-monitored={{settings.sonarr.getboolean('tag_enabled')}}>
+                            <input name="settings_sonarr_tag_enabled" type="checkbox">
+                            <label></label>
+                        </div>
+                    </div>
+                    <div class="collapsed column">
+                        <div class="collapsed center aligned column">
+                            <div class="ui basic icon" data-tooltip="Only import TV Shows with the specified Sonarr Tag" data-inverted="">
+                                <i class="help circle large icon"></i>
+                            </div>
+                        </div>
                     </div>
                 </div>
-
+						
+                <div class="middle aligned row">
+                    <div class="right aligned four wide column">
+                        <label>Sonarr Tag</label>
+                    </div>
+                    <div class="three wide column">
+                        <div class="ui fluid input">
+                            <input id="settings_sonarr_tag" name="settings_sonarr_tag" type="text" class="sonarr_config" value="{{settings.sonarr.tag}}">
+                        </div>
+                    </div>
+                    <div class="collapsed center aligned column">
+                        <div class="ui basic icon" data-tooltip="Enter the name of the tag you have created within Sonarr." data-inverted="">
+                            <i class="help circle large icon"></i>
+                        </div>
+                    </div>
+                </div>
+                    </div>
+                </div>
                 <div class="ui dividing header">Synchronization</div>
                 <div class="twelve wide column">
                     <div class="ui grid">
@@ -975,10 +1008,43 @@
                         </div>
                     </div>
                 </div>
-
+				
+                <div class="middle aligned row">
+                    <div class="right aligned four wide column">
+                        <label>Enable Radarr Tag</label>
+                    </div>
+                    <div class="one wide column">
+                        <div id="settings_radarr_tag_enabled" class="ui toggle checkbox" data-monitored={{settings.radarr.getboolean('tag_enabled')}}>
+                            <input name="settings_radarr_tag_enabled" type="checkbox">
+                            <label></label>
+                        </div>
+                    </div>
+                    <div class="collapsed column">
+                        <div class="collapsed center aligned column">
+                            <div class="ui basic icon" data-tooltip="Only import Movies with the specified Radarr Tag" data-inverted="">
+                                <i class="help circle large icon"></i>
+                            </div>
+                        </div>
                     </div>
                 </div>
-
+						
+                <div class="middle aligned row">
+                    <div class="right aligned four wide column">
+                        <label>Radarr Tag</label>
+                    </div>
+                    <div class="three wide column">
+                        <div class="ui fluid input">
+                            <input id="settings_radarr_tag" name="settings_radarr_tag" type="text" class="radarr_config" value="{{settings.radarr.tag}}">
+                        </div>
+                    </div>
+                    <div class="collapsed center aligned column">
+                        <div class="ui basic icon" data-tooltip="Enter the name of the tag you have created within Radarr." data-inverted="">
+                            <i class="help circle large icon"></i>
+                        </div>
+                    </div>
+                </div>
+                    </div>
+                </div>
                 <div class="ui dividing header">Synchronization</div>
                 <div class="twelve wide column">
                     <div class="ui grid">
@@ -2237,13 +2303,25 @@
             } else {
                 $("#settings_only_monitored_sonarr").checkbox('uncheck');
             }
-
+			
     if ($('#settings_only_monitored_radarr').data("monitored") === "True") {
                 $("#settings_only_monitored_radarr").checkbox('check');
             } else {
                 $("#settings_only_monitored_radarr").checkbox('uncheck');
             }
 
+    if ($('#settings_sonarr_tag_enabled').data("monitored") === "True") {
+                $("#settings_sonarr_tag_enabled").checkbox('check');
+            } else {
+                $("#settings_sonarr_tag_enabled").checkbox('uncheck');
+            }
+			
+    if ($('#settings_radarr_tag_enabled').data("monitored") === "True") {
+                $("#settings_radarr_tag_enabled").checkbox('check');
+            } else {
+                $("#settings_radarr_tag_enabled").checkbox('uncheck');
+            }
+			
     if ($('#settings_adaptive_searching').data("adaptive") === "True") {
                 $("#settings_adaptive_searching").checkbox('check');
             } else {

--- a/views/settings.tpl
+++ b/views/settings.tpl
@@ -829,41 +829,6 @@
                         </div>
                     </div>
                 </div>
-				
-                <div class="middle aligned row">
-                    <div class="right aligned four wide column">
-                        <label>Enable Sonarr Tag</label>
-                    </div>
-                    <div class="one wide column">
-                        <div id="settings_sonarr_tag_enabled" class="ui toggle checkbox" data-monitored={{settings.sonarr.getboolean('tag_enabled')}}>
-                            <input name="settings_sonarr_tag_enabled" type="checkbox">
-                            <label></label>
-                        </div>
-                    </div>
-                    <div class="collapsed column">
-                        <div class="collapsed center aligned column">
-                            <div class="ui basic icon" data-tooltip="Only import TV Shows with the specified Sonarr Tag" data-inverted="">
-                                <i class="help circle large icon"></i>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-						
-                <div class="middle aligned row">
-                    <div class="right aligned four wide column">
-                        <label>Sonarr Tag</label>
-                    </div>
-                    <div class="three wide column">
-                        <div class="ui fluid input">
-                            <input id="settings_sonarr_tag" name="settings_sonarr_tag" type="text" class="sonarr_config" value="{{settings.sonarr.tag}}">
-                        </div>
-                    </div>
-                    <div class="collapsed center aligned column">
-                        <div class="ui basic icon" data-tooltip="Enter the name of the tag you have created within Sonarr." data-inverted="">
-                            <i class="help circle large icon"></i>
-                        </div>
-                    </div>
-                </div>
                     </div>
                 </div>
                 <div class="ui dividing header">Synchronization</div>
@@ -880,6 +845,67 @@
                                         <option value="Daily">Daily (at 4am)</option>
                                         <option value="Weekly">Weekly (sunday at 4am)</option>
                                     </select>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="ui dividing header">Import Settings</div>
+                <div class="twelve wide column">
+                    <div class="ui grid">
+                        <div class="middle aligned row">
+                            <div class="right aligned four wide column">
+                                <label>Enable Sonarr Tag</label>
+                                    </div>
+                            <div class="one wide column">
+                                <div id="settings_sonarr_tag_enabled" class="ui toggle checkbox provider" data-monitored={{settings.sonarr.getboolean('tag_enabled')}}>
+                                    <input name="settings_sonarr_tag_enabled" type="checkbox">
+                                    <label></label>
+                                </div>
+                            </div>
+                            <div class="collapsed column">
+                                <div class="collapsed center aligned column">
+                                    <div class="ui basic icon" data-tooltip="Only import TV Shows with the specified Sonarr Tag" data-inverted="">
+                                        <i class="help circle large icon"></i>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div id="settings_sonarr_tag_enabled_option" class="ui grid container">
+                            <div class="middle aligned row">
+                                <div class="right aligned four wide column">
+                                    <label>Sonarr Tag</label>
+                                </div>
+                                <div class="three wide column">
+                                    <div class="ui fluid input">
+                                        <input id="settings_sonarr_tag" name="settings_sonarr_tag" type="text" class="sonarr_config" value="{{settings.sonarr.tag}}">
+                                    </div>
+                                </div>
+                                <div class="collapsed center aligned column">
+                                    <div class="ui basic icon" data-tooltip="Enter the name of the tag you have created within Sonarr." data-inverted="">
+                                        <i class="help circle large icon"></i>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="middle aligned row">
+                                <div class="right aligned four wide column">
+                                    <label>Autoremove</label>
+                                </div>
+                                <div class="one wide column">
+                                    <div id="settings_sonarr_tag_autoremove" class="ui toggle checkbox" data-monitored={{settings.sonarr.getboolean('tag_autoremove')}}>
+                                        <input name="settings_sonarr_tag_autoremove" type="checkbox">
+                                        <label></label>
+                                    </div>
+                                </div>
+                                <div class="collapsed center aligned column">
+                                    <div class="ui basic icon" data-tooltip="Enabling this option will remove any TV Shows from Bazarr which do not contain the specified tag." data-inverted="">
+                                         <i class="yellow warning sign icon"></i>
+                                    </div>
+                                </div>
+                                <div class="collapsed center aligned column">
+                                    <div class="ui basic icon" data-tooltip="When enabled, removing the specified tag from the TV Show in Sonarr will result in it being deleted within Bazarr." data-inverted="">
+                                        <i class="help circle large icon"></i>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -1008,41 +1034,6 @@
                         </div>
                     </div>
                 </div>
-				
-                <div class="middle aligned row">
-                    <div class="right aligned four wide column">
-                        <label>Enable Radarr Tag</label>
-                    </div>
-                    <div class="one wide column">
-                        <div id="settings_radarr_tag_enabled" class="ui toggle checkbox" data-monitored={{settings.radarr.getboolean('tag_enabled')}}>
-                            <input name="settings_radarr_tag_enabled" type="checkbox">
-                            <label></label>
-                        </div>
-                    </div>
-                    <div class="collapsed column">
-                        <div class="collapsed center aligned column">
-                            <div class="ui basic icon" data-tooltip="Only import Movies with the specified Radarr Tag" data-inverted="">
-                                <i class="help circle large icon"></i>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-						
-                <div class="middle aligned row">
-                    <div class="right aligned four wide column">
-                        <label>Radarr Tag</label>
-                    </div>
-                    <div class="three wide column">
-                        <div class="ui fluid input">
-                            <input id="settings_radarr_tag" name="settings_radarr_tag" type="text" class="radarr_config" value="{{settings.radarr.tag}}">
-                        </div>
-                    </div>
-                    <div class="collapsed center aligned column">
-                        <div class="ui basic icon" data-tooltip="Enter the name of the tag you have created within Radarr." data-inverted="">
-                            <i class="help circle large icon"></i>
-                        </div>
-                    </div>
-                </div>
                     </div>
                 </div>
                 <div class="ui dividing header">Synchronization</div>
@@ -1063,6 +1054,67 @@
                             </div>
                         </div>
                     </div>
+                </div>
+                <div class="ui dividing header">Import Settings</div>
+                <div class="twelve wide column">
+                    <div class="ui grid">
+                        <div class="middle aligned row">
+                            <div class="right aligned four wide column">
+                                <label>Enable Radarr Tag</label>
+                                    </div>
+                            <div class="one wide column">
+                                <div id="settings_radarr_tag_enabled" class="ui toggle checkbox provider" data-monitored={{settings.radarr.getboolean('tag_enabled')}}>
+                                    <input name="settings_radarr_tag_enabled" type="checkbox">
+                                    <label></label>
+                                </div>
+                            </div>
+                            <div class="collapsed column">
+                                <div class="collapsed center aligned column">
+                                    <div class="ui basic icon" data-tooltip="Only import Movies with the specified Radarr Tag" data-inverted="">
+                                        <i class="help circle large icon"></i>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div id="settings_radarr_tag_enabled_option" class="ui grid container">
+                            <div class="middle aligned row">
+                                <div class="right aligned four wide column">
+                                    <label>Radarr Tag</label>
+                                </div>
+                                <div class="three wide column">
+                                    <div class="ui fluid input">
+                                        <input id="settings_radarr_tag" name="settings_radarr_tag" type="text" class="radarr_config" value="{{settings.radarr.tag}}">
+                                    </div>
+                                </div>
+                                <div class="collapsed center aligned column">
+                                    <div class="ui basic icon" data-tooltip="Enter the name of the tag you have created within Radarr." data-inverted="">
+                                        <i class="help circle large icon"></i>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="middle aligned row">
+                                <div class="right aligned four wide column">
+                                    <label>Autoremove</label>
+                                </div>
+                                <div class="one wide column">
+                                    <div id="settings_radarr_tag_autoremove" class="ui toggle checkbox" data-monitored={{settings.radarr.getboolean('tag_autoremove')}}>
+                                        <input name="settings_radarr_tag_autoremove" type="checkbox">
+                                        <label></label>
+                                    </div>
+                                </div>
+                                <div class="collapsed center aligned column">
+                                    <div class="ui basic icon" data-tooltip="Enabling this option will remove any Movies from Bazarr which do not contain the specified tag." data-inverted="">
+                                        <i class="yellow warning sign icon"></i>
+                                    </div>
+                                </div>
+                                <div class="collapsed center aligned column">
+                                    <div class="ui basic icon" data-tooltip="When enabled, removing the specified tag from the Movie in Radarr will result in it being deleted within Bazarr." data-inverted="">
+                                        <i class="help circle large icon"></i>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                      </div>
                 </div>
             </div>
             <div class="ui bottom attached tab segment" data-tab="subliminal">
@@ -2320,6 +2372,18 @@
                 $("#settings_radarr_tag_enabled").checkbox('check');
             } else {
                 $("#settings_radarr_tag_enabled").checkbox('uncheck');
+            }
+			
+    if ($('#settings_sonarr_tag_autoremove').data("monitored") === "True") {
+                $("#settings_sonarr_tag_autoremove").checkbox('check');
+            } else {
+                $("#settings_sonarr_tag_autoremove").checkbox('uncheck');
+            }
+			
+    if ($('#settings_radarr_tag_autoremove').data("monitored") === "True") {
+                $("#settings_radarr_tag_autoremove").checkbox('check');
+            } else {
+                $("#settings_radarr_tag_autoremove").checkbox('uncheck');
             }
 			
     if ($('#settings_adaptive_searching').data("adaptive") === "True") {

--- a/views/wizard.tpl
+++ b/views/wizard.tpl
@@ -1320,6 +1320,22 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="middle aligned row">
+                                <div class="right aligned four wide column">
+                                    <label>Autoremove</label>
+                                </div>
+                                <div class="one wide column">
+                                    <div id="settings_sonarr_tag_autoremove" class="ui toggle checkbox" data-monitored={{settings.sonarr.getboolean('tag_autoremove')}}>
+                                        <input name="settings_sonarr_tag_autoremove" type="checkbox">
+                                        <label></label>
+                                    </div>
+                                </div>
+                                <div class="collapsed center aligned column">
+                                    <div class="ui basic icon" data-tooltip="When enabled, removing the specified tag from the TV Show in Sonarr will result in it being deleted within Bazarr." data-inverted="">
+                                        <i class="help circle large icon"></i>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -1508,6 +1524,22 @@
                                 </div>
                                 <div class="collapsed center aligned column">
                                     <div class="ui basic icon" data-tooltip="Enter the name of the tag you have created within Radarr." data-inverted="">
+                                        <i class="help circle large icon"></i>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="middle aligned row">
+                                <div class="right aligned four wide column">
+                                    <label>Autoremove</label>
+                                </div>
+                                <div class="one wide column">
+                                    <div id="settings_radarr_tag_autoremove" class="ui toggle checkbox" data-monitored={{settings.radarr.getboolean('tag_autoremove')}}>
+                                        <input name="settings_radarr_tag_autoremove" type="checkbox">
+                                        <label></label>
+                                    </div>
+                                </div>
+                                <div class="collapsed center aligned column">
+                                    <div class="ui basic icon" data-tooltip="When enabled, removing the specified tag from the Movie in Radarr will result in it being deleted within Bazarr." data-inverted="">
                                         <i class="help circle large icon"></i>
                                     </div>
                                 </div>

--- a/views/wizard.tpl
+++ b/views/wizard.tpl
@@ -1280,26 +1280,32 @@
                             </div>
                         </div>
                     </div>
-                    <div class="sonarr_hide middle aligned row">
-                        <div class="right aligned four wide column">
-                            <label>Enable Sonarr Tag</label>
-                        </div>
-                        <div class="one wide column">
-                            <div id="settings_sonarr_tag_enabled" class="ui toggle checkbox" data-monitored={{settings.sonarr.getboolean('tag_enabled')}}>
-                                <input name="settings_sonarr_tag_enabled" type="checkbox">
-                                <label></label>
+                    </div>
+                </div>
+
+                <div class="sonarr_hide ui dividing header">Import Settings</div>
+                <div class="sonarr_hide twelve wide column">
+                    <div class="ui grid">
+                        <div class="middle aligned row">
+                            <div class="right aligned four wide column">
+                                <label>Enable Sonarr Tag</label>
+                                    </div>
+                            <div class="one wide column">
+                                <div id="settings_sonarr_tag_enabled" class="ui toggle checkbox provider" data-monitored={{settings.sonarr.getboolean('tag_enabled')}}>
+                                    <input name="settings_sonarr_tag_enabled" type="checkbox">
+                                    <label></label>
+                                </div>
                             </div>
-                        </div>
-                        <div class="collapsed column">
-                            <div class="collapsed center aligned column">
-                                <div class="ui basic icon" data-tooltip="Only import TV Shows with the specified Sonarr Tag" data-inverted="">
-                                    <i class="help circle large icon"></i>
+                            <div class="collapsed column">
+                                <div class="collapsed center aligned column">
+                                    <div class="ui basic icon" data-tooltip="Only import TV Shows with the specified Sonarr Tag" data-inverted="">
+                                        <i class="help circle large icon"></i>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
-						
-                            <div class="sonarr_hide middle aligned row">
+                        <div id="settings_sonarr_tag_enabled_option" class="ui grid container">
+                            <div class="middle aligned row">
                                 <div class="right aligned four wide column">
                                     <label>Sonarr Tag</label>
                                 </div>
@@ -1314,8 +1320,10 @@
                                     </div>
                                 </div>
                             </div>
+                        </div>
                     </div>
                 </div>
+				
 
             </div>
             <div class="ui bottom attached tab segment" data-tab="radarr" id="radarr">
@@ -1465,26 +1473,31 @@
                             </div>
                         </div>
                     </div>
-                    <div class="radarr_hide middle aligned row">
-                        <div class="right aligned four wide column">
-                            <label>Enable Radarr Tag</label>
-                        </div>
-                        <div class="one wide column">
-                            <div id="settings_radarr_tag_enabled" class="ui toggle checkbox" data-monitored={{settings.radarr.getboolean('tag_enabled')}}>
-                                <input name="settings_radarr_tag_enabled" type="checkbox">
-                                <label></label>
+                    </div>
+                </div>
+                <div class="radarr_hide ui dividing header">Import Settings</div>
+                <div class="radarr_hide twelve wide column">
+                    <div class="ui grid">
+                        <div class="middle aligned row">
+                            <div class="right aligned four wide column">
+                                <label>Enable Radarr Tag</label>
+                                    </div>
+                            <div class="one wide column">
+                                <div id="settings_radarr_tag_enabled" class="ui toggle checkbox provider" data-monitored={{settings.radarr.getboolean('tag_enabled')}}>
+                                    <input name="settings_radarr_tag_enabled" type="checkbox">
+                                    <label></label>
+                                </div>
                             </div>
-                        </div>
-                        <div class="collapsed column">
-                            <div class="collapsed center aligned column">
-                                <div class="ui basic icon" data-tooltip="Only import TV Shows with the specified Radarr Tag" data-inverted="">
-                                    <i class="help circle large icon"></i>
+                            <div class="collapsed column">
+                                <div class="collapsed center aligned column">
+                                    <div class="ui basic icon" data-tooltip="Only import Movies with the specified Radarr Tag" data-inverted="">
+                                        <i class="help circle large icon"></i>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
-						
-                            <div class="radarr_hide middle aligned row">
+                        <div id="settings_radarr_tag_enabled_option" class="ui grid container">
+                            <div class="middle aligned row">
                                 <div class="right aligned four wide column">
                                     <label>Radarr Tag</label>
                                 </div>
@@ -1499,6 +1512,7 @@
                                     </div>
                                 </div>
                             </div>
+                        </div>
                     </div>
                 </div>
 

--- a/views/wizard.tpl
+++ b/views/wizard.tpl
@@ -1262,7 +1262,7 @@
                             </div>
                         </div>
 
-                        <div class="sonarr_hide middle aligned row">
+                    <div class="sonarr_hide middle aligned row">
                         <div class="right aligned four wide column">
                             <label>Download only monitored</label>
                         </div>
@@ -1280,6 +1280,40 @@
                             </div>
                         </div>
                     </div>
+                    <div class="sonarr_hide middle aligned row">
+                        <div class="right aligned four wide column">
+                            <label>Enable Sonarr Tag</label>
+                        </div>
+                        <div class="one wide column">
+                            <div id="settings_sonarr_tag_enabled" class="ui toggle checkbox" data-monitored={{settings.sonarr.getboolean('tag_enabled')}}>
+                                <input name="settings_sonarr_tag_enabled" type="checkbox">
+                                <label></label>
+                            </div>
+                        </div>
+                        <div class="collapsed column">
+                            <div class="collapsed center aligned column">
+                                <div class="ui basic icon" data-tooltip="Only import TV Shows with the specified Sonarr Tag" data-inverted="">
+                                    <i class="help circle large icon"></i>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+						
+                            <div class="sonarr_hide middle aligned row">
+                                <div class="right aligned four wide column">
+                                    <label>Sonarr Tag</label>
+                                </div>
+                                <div class="three wide column">
+                                    <div class="ui fluid input">
+                                        <input id="settings_sonarr_tag" name="settings_sonarr_tag" type="text" class="sonarr_config" value="{{settings.sonarr.tag}}">
+                                    </div>
+                                </div>
+                                <div class="collapsed center aligned column">
+                                    <div class="ui basic icon" data-tooltip="Enter the name of the tag you have created within Sonarr." data-inverted="">
+                                        <i class="help circle large icon"></i>
+                                    </div>
+                                </div>
+                            </div>
                     </div>
                 </div>
 
@@ -1431,6 +1465,40 @@
                             </div>
                         </div>
                     </div>
+                    <div class="radarr_hide middle aligned row">
+                        <div class="right aligned four wide column">
+                            <label>Enable Radarr Tag</label>
+                        </div>
+                        <div class="one wide column">
+                            <div id="settings_radarr_tag_enabled" class="ui toggle checkbox" data-monitored={{settings.radarr.getboolean('tag_enabled')}}>
+                                <input name="settings_radarr_tag_enabled" type="checkbox">
+                                <label></label>
+                            </div>
+                        </div>
+                        <div class="collapsed column">
+                            <div class="collapsed center aligned column">
+                                <div class="ui basic icon" data-tooltip="Only import TV Shows with the specified Radarr Tag" data-inverted="">
+                                    <i class="help circle large icon"></i>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+						
+                            <div class="radarr_hide middle aligned row">
+                                <div class="right aligned four wide column">
+                                    <label>Radarr Tag</label>
+                                </div>
+                                <div class="three wide column">
+                                    <div class="ui fluid input">
+                                        <input id="settings_radarr_tag" name="settings_radarr_tag" type="text" class="radarr_config" value="{{settings.radarr.tag}}">
+                                    </div>
+                                </div>
+                                <div class="collapsed center aligned column">
+                                    <div class="ui basic icon" data-tooltip="Enter the name of the tag you have created within Radarr." data-inverted="">
+                                        <i class="help circle large icon"></i>
+                                    </div>
+                                </div>
+                            </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
These changes enables a new option for Sonarr & Radarr to allow only importing items with a specific Sonarr/Radarr tag.

This gives more granularity for those who do not want to import everything, and the tags are configurable on Sonarr, Radarr & Bazarr.