### PR TITLE
Fixed grammar in tooltips on the history page.

### DIFF
--- a/views/historymovies.tpl
+++ b/views/historymovies.tpl
@@ -59,19 +59,19 @@
 					<tr class="selectable">
 						<td class="collapsing">
 						%if row[0] == 0:
-							<div class="ui inverted basic compact icon" data-tooltip="Subtitles file have been erased." data-inverted="" data-position="top left">
+							<div class="ui inverted basic compact icon" data-tooltip="Subtitles file has been erased." data-inverted="" data-position="top left">
 								<i class="ui trash icon"></i>
 							</div>
 						%elif row[0] == 1:
-							<div class="ui inverted basic compact icon" data-tooltip="Subtitles file have been downloaded." data-inverted="" data-position="top left">
+							<div class="ui inverted basic compact icon" data-tooltip="Subtitles file has been downloaded." data-inverted="" data-position="top left">
 								<i class="ui download icon"></i>
 							</div>
 						%elif row[0] == 2:
-							<div class="ui inverted basic compact icon" data-tooltip="Subtitles file have been manually downloaded." data-inverted="" data-position="top left">
+							<div class="ui inverted basic compact icon" data-tooltip="Subtitles file has been manually downloaded." data-inverted="" data-position="top left">
 								<i class="ui user icon"></i>
 							</div>
 						%elif row[0] == 3:
-							<div class="ui inverted basic compact icon" data-tooltip="Subtitles file have been upgraded." data-inverted="" data-position="top left">
+							<div class="ui inverted basic compact icon" data-tooltip="Subtitles file has been upgraded." data-inverted="" data-position="top left">
 								<i class="ui recycle icon"></i>
 							</div>
 						%end


### PR DESCRIPTION
Fixed the grammar in the tooltips on the history page:

<img width="313" alt="image" src="https://user-images.githubusercontent.com/6069593/57198351-f42ba780-6f71-11e9-878f-a7b9e42d05e6.png">
