### PR TITLE
 Fix video hash not being computed when using Napisy24 provider 

### DIFF
--- a/libs/subliminal_patch/core.py
+++ b/libs/subliminal_patch/core.py
@@ -560,6 +560,10 @@ def scan_video(path, dont_use_actual_file=False, hints=None, providers=None, ski
                 except MemoryError:
                     logger.warning(u"Couldn't compute napiprojekt hash for %s", path)
 
+            if "napisy24" in providers:
+                # Napisy24 uses the same hash as opensubtitles
+                video.hashes['napisy24'] = hash_opensubtitles(path)
+
             logger.debug('Computed hashes %r', video.hashes)
         else:
             logger.warning('Size is lower than 10MB: hashes not computed')

--- a/libs/subliminal_patch/providers/napisy24.py
+++ b/libs/subliminal_patch/providers/napisy24.py
@@ -33,7 +33,7 @@ class Napisy24Subtitle(Subtitle):
         matches = set()
 
         # hash
-        if 'opensubtitles' in video.hashes and video.hashes['opensubtitles'] == self.hash:
+        if 'napisy24' in video.hashes and video.hashes['napisy24'] == self.hash:
             matches.add('hash')
 
         # imdb_id
@@ -46,7 +46,7 @@ class Napisy24Subtitle(Subtitle):
 class Napisy24Provider(Provider):
     '''Napisy24 Provider.'''
     languages = {Language(l) for l in ['pol']}
-    required_hash = 'opensubtitles'
+    required_hash = 'napisy24'
     api_url = 'http://napisy24.pl/run/CheckSubAgent.php'
 
     def __init__(self, username=None, password=None):
@@ -116,7 +116,7 @@ class Napisy24Provider(Provider):
         return subtitle
 
     def list_subtitles(self, video, languages):
-        subtitles = [self.query(l, video.size, video.name, video.hashes['opensubtitles']) for l in languages]
+        subtitles = [self.query(l, video.size, video.name, video.hashes['napisy24']) for l in languages]
         return [s for s in subtitles if s is not None]
 
     def download_subtitle(self, subtitle):


### PR DESCRIPTION
If a user had `opensubtitles` provider disabled the hash would never be computed.