### PR TITLE
Fix Subdivx provider, new webpage

### DIFF
--- a/libs/subliminal_patch/providers/subdivx.py
+++ b/libs/subliminal_patch/providers/subdivx.py
@@ -22,16 +22,15 @@ class SubdivxSubtitle(Subtitle):
     provider_name = 'subdivx'
     hash_verifiable = False
 
-    def __init__(self, language, page_link, download_link, description, title):
+    def __init__(self, language, page_link, description, title):
         super(SubdivxSubtitle, self).__init__(language, hearing_impaired=False,
                                               page_link=page_link)
-        self.download_link = download_link
         self.description = description.lower()
         self.title = title
 
     @property
     def id(self):
-        return self.download_link
+        return self.page_link
 
     def get_matches(self, video):
         matches = set()
@@ -142,10 +141,8 @@ class SubdivxSubtitlesProvider(Provider):
 
                 # body
                 description = body_soup.find("div", {'id': 'buscador_detalle_sub'}).text
-                download_link = body_soup.find("div", {'id': 'buscador_detalle_sub_datos'}
-                    ).find("a", {'target': 'new'})["href"].replace('http://', 'https://')
 
-                subtitle = self.subtitle_class(language, page_link, download_link, description, title)
+                subtitle = self.subtitle_class(language, page_link, description, title)
 
                 logger.debug('Found subtitle %r', subtitle)
                 subtitles.append(subtitle)
@@ -178,12 +175,28 @@ class SubdivxSubtitlesProvider(Provider):
 
         return subtitles
 
+    def get_download_link(self, subtitle):
+        r = self.session.get(subtitle.page_link, timeout=10)
+        r.raise_for_status()
+
+        if r.content:
+            page_soup = ParserBeautifulSoup(r.content.decode('iso-8859-1', 'ignore'), ['lxml', 'html.parser'])
+            links_soup = page_soup.find_all("a", {'class': 'detalle_link'})
+            for link_soup in links_soup:
+                if link_soup['href'].startswith('bajar'):
+                    return self.server_url + link_soup['href']
+
+        logger.debug('No data returned from provider')
+        return None
+
     def download_subtitle(self, subtitle):
         if isinstance(subtitle, SubdivxSubtitle):
             # download the subtitle
             logger.info('Downloading subtitle %r', subtitle)
-            r = self.session.get(subtitle.download_link, headers={'Referer': subtitle.page_link},
-                                 timeout=30)
+
+            # get download link
+            download_link = self.get_download_link(subtitle)
+            r = self.session.get(download_link, headers={'Referer': subtitle.page_link}, timeout=30)
             r.raise_for_status()
 
             if not r.content:


### PR DESCRIPTION
Subdivx changed the webpage. This PR fix the provider. Related #582
```
21/09/2019 13:06:45|INFO    |subliminal_patch.core           |Listing subtitles with provider 'subdivx' and languages set([<Language [es]>])|
21/09/2019 13:06:45|INFO    |subliminal_patch.core           |Initializing provider subdivx|
21/09/2019 13:06:45|DEBUG   |subliminal_patch.providers.subdivx|Searching subtitles u'Big Little Lies S02E05'|
21/09/2019 13:06:45|DEBUG   |urllib3.connectionpool          |Starting new HTTPS connection (1): www.subdivx.com:443|
21/09/2019 13:06:45|DEBUG   |subliminal_patch.http           |DNS: Falling back to default DNS or IP on www.subdivx.com|
21/09/2019 13:06:46|DEBUG   |urllib3.connectionpool          |https://www.subdivx.com:443 "GET /index.php?pg=1&accion=5&buscar=Big+Little+Lies+S02E05&oxdown=1 HTTP/1.1" 200 None|
21/09/2019 13:06:46|ERROR   |subliminal_patch.core           |Unexpected error in provider 'subdivx': Traceback (most recent call last):  File "/root/scripts/bazarr/bazarr/../libs/subliminal_patch/core.py", line 162, in list_subtitles_provider    results = self[provider].list_subtitles(video, provider_languages)  File "/root/scripts/bazarr/bazarr/../libs/subliminal_patch/providers/subdivx.py", line 173, in list_subtitles    episode=video.episode, year=video.year)  File "/root/scripts/bazarr/bazarr/../libs/subliminal_patch/providers/subdivx.py", line 146, in query    ).find("a", {'target': 'new'})["href"].replace('http://', 'https://')TypeError: 'NoneType' object has no attribute '__getitem__'|Traceback (most recent call last):  File "/root/scripts/bazarr/bazarr/../libs/subliminal_patch/core.py", line 162, in list_subtitles_provider    results = self[provider].list_subtitles(video, provider_languages)  File "/root/scripts/bazarr/bazarr/../libs/subliminal_patch/providers/subdivx.py", line 173, in list_subtitles    episode=video.episode, year=video.year)  File "/root/scripts/bazarr/bazarr/../libs/subliminal_patch/providers/subdivx.py", line 146, in query    ).find("a", {'target': 'new'})["href"].replace('http://', 'https://')TypeError: 'NoneType' object has no attribute '__getitem__'|
21/09/2019 13:06:46|INFO    |subliminal_patch.core           |Discarding provider subdivx|
```