### PR TITLE
Improve provider throttle / status to handle all exceptions

### DIFF
--- a/bazarr/get_providers.py
+++ b/bazarr/get_providers.py
@@ -141,10 +141,11 @@ def provider_throttle(name, exception):
     throttle_data = PROVIDER_THROTTLE_MAP.get(name, PROVIDER_THROTTLE_MAP["default"]).get(cls, None) or \
                     PROVIDER_THROTTLE_MAP["default"].get(cls, None)
     
-    if not throttle_data:
-        return
+    if throttle_data:
+        throttle_delta, throttle_description = throttle_data
+    else:
+        throttle_delta, throttle_description = datetime.timedelta(minutes=10), "10 minutes"
     
-    throttle_delta, throttle_description = throttle_data
     throttle_until = datetime.datetime.now() + throttle_delta
     
     if cls_name not in VALID_COUNT_EXCEPTIONS or throttled_count(name):

--- a/libs/subliminal_patch/core.py
+++ b/libs/subliminal_patch/core.py
@@ -186,12 +186,9 @@ class SZProviderPool(ProviderPool):
         except (requests.Timeout, socket.timeout):
             logger.error('Provider %r timed out', provider)
 
-        except (TooManyRequests, DownloadLimitExceeded, ServiceUnavailable, APIThrottled), e:
-            self.throttle_callback(provider, e)
-            return
-
-        except:
+        except Exception as e:
             logger.exception('Unexpected error in provider %r: %s', provider, traceback.format_exc())
+            self.throttle_callback(provider, e)
 
     def list_subtitles(self, video, languages):
         """List subtitles.


### PR DESCRIPTION
I did this for my fork. Please, discuss before merging, maybe it's too aggressive.

If any provider raises an exception that is not in => https://github.com/morpheus65535/bazarr/blob/master/bazarr/get_providers.py#L17
it will be throttled for 10 minutes.
This include, connection errors, authorization, bad response... The objective of this is, if the user see a yellow icon he will report the bug.

![image](https://user-images.githubusercontent.com/10577978/65390473-9f8d9b00-dd5f-11e9-8952-ffe08ad8b8fe.png)

Fix #582