### PR TITLE
Allow assrt to fetch subtitles through only ISO 639-2

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,6 @@
+sympy
+vcrpy>=1.6.1
+pytest
+pytest-pep8
+pytest-flakes
+pytest-cov

--- a/libs/subliminal_patch/converters/assrt.py
+++ b/libs/subliminal_patch/converters/assrt.py
@@ -10,8 +10,8 @@ class AssrtConverter(LanguageReverseConverter):
                             u'英文': ('eng',),
                             u'chs': ('zho', None, 'Hans'), u'cht': ('zho', None, 'Hant'),
                             u'chn': ('zho', None, 'Hans'), u'twn': ('zho', None, 'Hant')}
-        self.to_assrt = { ('zho', None, 'Hans'): u'chs', ('zho', None, 'Hant'): u'cht', ('eng',) : u'eng',
-                          ('zho',): u'chs'}
+        self.to_assrt = { ('zho', None, 'Hans'): u'chs', ('zho', None, 'Hant'): u'cht',
+                         ('eng', None, None) : u'eng', ('zho', None, None): u'chs'}
         self.codes = set(self.from_assrt.keys())
 
     def convert(self, alpha3, country=None, script=None):

--- a/tests/cassettes/assrt/test_download_episode_subtitle.yaml
+++ b/tests/cassettes/assrt/test_download_episode_subtitle.yaml
@@ -1,0 +1,605 @@
+interactions:
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - Sub-Zero/2
+    method: GET
+    uri: https://api.assrt.net/v1/sub/search?q=%5B%27The+Big+Bang+Theory+S07E05%27%5D&token=SECRET&is_file=%5B%271%27%5D
+  response:
+    body:
+      string: "{\"status\":0,\"sub\":{\"keyword\":\"The Big Bang Theory S07E05\",\"\
+        result\":\"succeed\",\"subs\":[{\"subtype\":\"Subrip(srt)\",\"id\":618200,\"\
+        lang\":{\"desc\":\"\u7B80\",\"langlist\":{\"langchs\":true}},\"vote_score\"\
+        :0,\"upload_time\":\"2018-01-26 19:23:52\",\"native_name\":\"\u5929\u624D\u7406\
+        \u8BBA\u4F20\u7B2C7\u5B63\u516824\u96C6The.Big.Bang.Theory.S07.1080p.WEB-DL.DD5.1.H.264\"\
+        ,\"videoname\":\"The.Big.Bang.Theory.S07.1080p.WEB-DL.DD5.1.H.264\",\"release_site\"\
+        :\"\u4F0A\u7538\u56ED\",\"revision\":0},{\"upload_time\":\"2014-12-06 04:13:43\"\
+        ,\"subtype\":\"Subrip(srt)\",\"id\":316965,\"native_name\":\"\u751F\u6D3B\u5927\
+        \u7206\u70B8 \u7B2C\u4E03\u5B63 \u7B2C 5 \u96C6\",\"videoname\":\"The Big\
+        \ Bang Theory S07E05 720p HDTV X264-DIMENSION\",\"revision\":0,\"vote_score\"\
+        :0},{\"upload_time\":\"2014-12-06 04:13:43\",\"subtype\":\"Subrip(srt)\",\"\
+        id\":316966,\"native_name\":\"\u751F\u6D3B\u5927\u7206\u70B8 \u7B2C\u4E03\u5B63\
+        \ \u7B2C 5 \u96C6\",\"videoname\":\"The Big Bang Theory S07E05 720p HDTV X264-DIMENSION\"\
+        ,\"revision\":0,\"vote_score\":0},{\"upload_time\":\"2014-11-02 10:41:05\"\
+        ,\"subtype\":\"SSA\",\"revision\":0,\"id\":264973,\"lang\":{\"desc\":\"\u53CC\
+        \u8BED\",\"langlist\":{\"langdou\":true}},\"videoname\":\"The.Big.Bang.Theory.S07E05.720p.BluRay.x264-DEMAND\"\
+        ,\"native_name\":\"The Big Bang Theory S07\\/\u751F\u6D3B\u5927\u7206\u70B8\
+        \ \u7B2C\u4E03\u5B63\\/The Big Bang Theory Season 07\",\"vote_score\":80},{\"\
+        upload_time\":\"2014-08-30 05:11:21\",\"subtype\":\"Subrip(srt)\",\"revision\"\
+        :0,\"id\":261680,\"lang\":{\"desc\":\"\u7B80\",\"langlist\":{\"langchs\":true}},\"\
+        videoname\":\"The.Big.Bang.Theory.S07.720p.BluRay.x264-DEMAND\",\"native_name\"\
+        :\"\u751F\u6D3B\u5927\u7206\u70B8 \u7B2C\u4E03\u5B63\\/\u5929\u624D\u7406\u8BBA\
+        \u4F20\",\"vote_score\":0},{\"upload_time\":\"2013-10-19 03:34:04\",\"subtype\"\
+        :\"Subrip(srt)\",\"revision\":0,\"id\":244659,\"lang\":{\"desc\":\"\u82F1\
+        \ \u7B80 \u7E41\",\"langlist\":{\"langeng\":true,\"langchs\":true,\"langcht\"\
+        :true}},\"videoname\":\"The Big Bang Theory S07E05 the.big.bang.theory.705.hdtv-lol\"\
+        ,\"native_name\":\"\u5929\u624D\u7406\u8BBA\u4F20\\/\u751F\u6D3B\u5927\u7206\
+        \u70B8 \u7B2C\u4E03\u5B63\u7B2C\u4E94\u96C6\",\"vote_score\":0},{\"upload_time\"\
+        :\"2013-10-18 23:33:24\",\"subtype\":\"Subrip(srt)\",\"revision\":0,\"id\"\
+        :244640,\"lang\":{\"desc\":\"\u82F1 \u7B80 \u7E41 \u53CC\u8BED\",\"langlist\"\
+        :{\"langcht\":true,\"langeng\":true,\"langdou\":true,\"langchs\":true}},\"\
+        videoname\":\"\u751F\u6D3B\u5927\u7206\u70B8\\/The Big Bang Theory S07E05\\\
+        /\u7B2C\u4E03\u5B63\u7B2C5\u96C6\\/\u5723\u57CE\u5BB6\u56ED\u53CC\u8BED\u5B57\
+        \u5E55 the.big.bang.theory.705.hdtv-lol\",\"native_name\":\"\",\"vote_score\"\
+        :0},{\"upload_time\":\"2013-10-18 22:15:16\",\"subtype\":\"SSA\",\"revision\"\
+        :0,\"id\":244632,\"lang\":{\"desc\":\"\u82F1 \u7B80\",\"langlist\":{\"langchs\"\
+        :true,\"langeng\":true}},\"videoname\":\"The.Big.Bang.Theory.S07E05.720p.HDTV.X264-DIMENSION\"\
+        ,\"native_name\":\"\u5929\u624D\u7406\u8BBA\u4F20\\/The Big Bang Theory S07E05\u751F\
+        \u6D3B\u5927\u7206\u70B8 \u7B2C\u4E03\u5B63\u7B2C\u4E94\u96C6\u3010\u8C22\u8033\
+        \u6735\u5B57\u5E55\u7EC4\u3011\",\"vote_score\":0},{\"upload_time\":\"2013-10-18\
+        \ 21:31:21\",\"subtype\":\"\u5176\u4ED6\",\"revision\":0,\"id\":244630,\"\
+        lang\":{\"desc\":\"\",\"langlist\":{}},\"videoname\":\"\u751F\u6D3B\u5927\u7206\
+        \u70B8 \u7B2C7\u96C6\u7B2C5\u96C6 720P\",\"native_name\":\"\",\"vote_score\"\
+        :0},{\"upload_time\":\"2013-10-18 20:46:57\",\"subtype\":\"\u5176\u4ED6\"\
+        ,\"revision\":0,\"id\":244624,\"lang\":{\"desc\":\"\u82F1 \u7B80 \u7E41\"\
+        ,\"langlist\":{\"langeng\":true,\"langchs\":true,\"langcht\":true}},\"videoname\"\
+        :\"\u751F\u6D3B\u5927\u7206\u70B8\u7B2C\u4E03\u5B63\u7B2C5\u96C6\",\"native_name\"\
+        :\"The Big Bang Theory S07E05\",\"vote_score\":0},{\"subtype\":\"Subrip(srt)\"\
+        ,\"id\":585062,\"lang\":{\"desc\":\"\u82F1 \u7B80 \u7E41 \u53CC\u8BED\",\"\
+        langlist\":{\"langcht\":true,\"langeng\":true,\"langdou\":true,\"langchs\"\
+        :true}},\"vote_score\":0,\"upload_time\":\"2013-10-17 17:31:00\",\"native_name\"\
+        :\"\u751F\u6D3B\u5927\u7206\u70B8   \u7B2C7\u96C6\u7B2C5\u96C6\",\"videoname\"\
+        :\"The Big Bang Theory   S07E05\",\"release_site\":\"\u4EBA\u4EBA\u5F71\u89C6\
+        YYeTs\",\"revision\":0}],\"action\":\"search\"}}\n"
+    headers:
+      access-control-allow-origin:
+      - '*'
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Sat, 30 Nov 2019 07:14:41 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - Sub-Zero/2
+    method: GET
+    uri: https://api.assrt.net/v1/sub/detail?token=SECRET&id=%5B%27618200%27%5D
+  response:
+    body:
+      string: "{\"status\":0,\"sub\":{\"result\":\"succeed\",\"subs\":[{\"id\":618200,\"\
+        filelist\":[{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\/-\\\
+        /1\\/The.Big.Bang.Theory.S07E01.The.Hofstadter.Insufficiency.720p.WEB-DL.DD5.1.H.264.srt?_=1575098081&-=dc994ecdf3a6a02a2651950fb52956d5&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E01.The.Hofstadter.Insufficiency.720p.WEB-DL.DD5.1.H.264.srt\"\
+        ,\"s\":\"20KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\\
+        /-\\/2\\/The.Big.Bang.Theory.S07E02.The.Deception.Verification.720p.WEB-DL.DD5.1.H.264.srt?_=1575098081&-=3d7591f8ce42e96aae82d6565f45847f&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E02.The.Deception.Verification.720p.WEB-DL.DD5.1.H.264.srt\"\
+        ,\"s\":\"25KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\\
+        /-\\/3\\/The.Big.Bang.Theory.S07E03.The.Scavenger.Vortex.720p.WEB-DL.DD5.1.H.264.srt?_=1575098081&-=b243d9b5ea70772b40af9e1399c3dce2&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E03.The.Scavenger.Vortex.720p.WEB-DL.DD5.1.H.264.srt\"\
+        ,\"s\":\"25KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\\
+        /-\\/4\\/The.Big.Bang.Theory.S07E04.The.Raiders.Minimization.720p.WEB-DL.DD5.1.H.264.srt?_=1575098081&-=0b6f5092475eeb0e24442658271cc8a7&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E04.The.Raiders.Minimization.720p.WEB-DL.DD5.1.H.264.srt\"\
+        ,\"s\":\"24KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\\
+        /-\\/5\\/The.Big.Bang.Theory.S07E05.The.Workplace.Proximity.720p.WEB-DL.DD5.1.H.264.srt?_=1575098081&-=f2aed4f15f4806f96780aafe2b2aed71&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E05.The.Workplace.Proximity.720p.WEB-DL.DD5.1.H.264.srt\"\
+        ,\"s\":\"19KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\\
+        /-\\/6\\/The.Big.Bang.Theory.S07E06.The.Romance.Resonance.720p.WEB-DL.DD5.1.H.264.srt?_=1575098081&-=8f6888f21277235187af784756188bd7&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E06.The.Romance.Resonance.720p.WEB-DL.DD5.1.H.264.srt\"\
+        ,\"s\":\"24KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\\
+        /-\\/7\\/The.Big.Bang.Theory.S07E07.The.Proton.Displacement.720p.WEB-DL.DD5.1.H.264.srt?_=1575098081&-=90d234aed204bdef9a3e2d699e1a3f11&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E07.The.Proton.Displacement.720p.WEB-DL.DD5.1.H.264.srt\"\
+        ,\"s\":\"20KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\\
+        /-\\/8\\/The.Big.Bang.Theory.S07E08.The.Itchy.Brain.Simulation.720p.WEB-DL.DD5.1.H.264.srt?_=1575098081&-=e65fd7846fcdf3fb1c12c4d81bae4600&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E08.The.Itchy.Brain.Simulation.720p.WEB-DL.DD5.1.H.264.srt\"\
+        ,\"s\":\"20KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\\
+        /-\\/9\\/The.Big.Bang.Theory.S07E09.The.Thanksgiving.Decoupling.720p.WEB-DL.DD5.1.H.264.srt?_=1575098081&-=56aa3deed2441fc3ba57501e44240739&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E09.The.Thanksgiving.Decoupling.720p.WEB-DL.DD5.1.H.264.srt\"\
+        ,\"s\":\"21KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\\
+        /-\\/10\\/The.Big.Bang.Theory.S07E10.The.Discovery.Dissipation.720p.WEB-DL.DD5.1.H.264.srt?_=1575098081&-=02740b8e5500328af67531babfba02ff&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E10.The.Discovery.Dissipation.720p.WEB-DL.DD5.1.H.264.srt\"\
+        ,\"s\":\"24KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\\
+        /-\\/11\\/The.Big.Bang.Theory.S07E11.The.Cooper.Extraction.720p.WEB-DL.DD5.1.H.264.srt?_=1575098081&-=4402626f09db033a2f1fd7cd9ac374d4&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E11.The.Cooper.Extraction.720p.WEB-DL.DD5.1.H.264.srt\"\
+        ,\"s\":\"21KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\\
+        /-\\/12\\/The.Big.Bang.Theory.S07E12.The.Hesitation.Ramification.720p.WEB-DL.DD5.1.H.264.srt?_=1575098081&-=24ebaf0165ab4b525419afb41aded7b6&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E12.The.Hesitation.Ramification.720p.WEB-DL.DD5.1.H.264.srt\"\
+        ,\"s\":\"20KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\\
+        /-\\/13\\/The.Big.Bang.Theory.S07E13.The.Occupation.Recalibration.720p.WEB-DL.DD5.1.H.264.srt?_=1575098081&-=44a96783c63e37c23504e203f3a963ee&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E13.The.Occupation.Recalibration.720p.WEB-DL.DD5.1.H.264.srt\"\
+        ,\"s\":\"23KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\\
+        /-\\/14\\/The.Big.Bang.Theory.S07E14.The.Convention.Conundrum.720p.WEB-DL.DD5.1.H.264.srt?_=1575098081&-=a581f9a7a58cd18fda8d29cbad3000b3&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E14.The.Convention.Conundrum.720p.WEB-DL.DD5.1.H.264.srt\"\
+        ,\"s\":\"23KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\\
+        /-\\/15\\/The.Big.Bang.Theory.S07E15.The.Locomotive.Manipulation.720p.WEB-DL.DD5.1.H.264.srt?_=1575098081&-=217c6ae8f48eba667d258b6448fe1022&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E15.The.Locomotive.Manipulation.720p.WEB-DL.DD5.1.H.264.srt\"\
+        ,\"s\":\"22KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\\
+        /-\\/16\\/The.Big.Bang.Theory.S07E16.The.Table.Polarization.720p.WEB-DL.DD5.1.H.264.srt?_=1575098081&-=ef0f11100e90ed343fe510418effaaf9&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E16.The.Table.Polarization.720p.WEB-DL.DD5.1.H.264.srt\"\
+        ,\"s\":\"22KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\\
+        /-\\/17\\/The.Big.Bang.Theory.S07E17.The.Friendship.Turbulence.720p.WEB-DL.DD5.1.H.264.srt?_=1575098081&-=63a6b5c214c15b380674315bc9a7a1ad&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E17.The.Friendship.Turbulence.720p.WEB-DL.DD5.1.H.264.srt\"\
+        ,\"s\":\"21KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\\
+        /-\\/18\\/The.Big.Bang.Theory.S07E18.The.Mommy.Observation.720p.WEB-DL.DD5.1.AAC2.0.H.264-YFN.srt?_=1575098081&-=21b5bfa881f07f4a9dcb04189b7f2666&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E18.The.Mommy.Observation.720p.WEB-DL.DD5.1.AAC2.0.H.264-YFN.srt\"\
+        ,\"s\":\"22KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\\
+        /-\\/19\\/The.Big.Bang.Theory.S07E19.The.Indecision.Amalgamation.720p.WEB-DL.DD5.1.AAC2.0.H.264-YFN.srt?_=1575098081&-=0d3cf082feb58e0c92ffe27bdc396fca&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E19.The.Indecision.Amalgamation.720p.WEB-DL.DD5.1.AAC2.0.H.264-YFN.srt\"\
+        ,\"s\":\"21KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\\
+        /-\\/20\\/The.Big.Bang.Theory.S07E20.The.Relationship.Diremption.720p.WEB-DL.DD5.1.H.264.srt?_=1575098081&-=79e8f4c5123eac1a33860e333a4056e8&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E20.The.Relationship.Diremption.720p.WEB-DL.DD5.1.H.264.srt\"\
+        ,\"s\":\"22KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\\
+        /-\\/21\\/The.Big.Bang.Theory.S07E21.The.Anything.Can.Happen.Recurrence.720p.WEB-DL.DD5.1.H.264.srt?_=1575098081&-=c8cf7d8354f11fe4ed919ed2428b9cb3&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E21.The.Anything.Can.Happen.Recurrence.720p.WEB-DL.DD5.1.H.264.srt\"\
+        ,\"s\":\"19KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\\
+        /-\\/22\\/The.Big.Bang.Theory.S07E22.The.Protron.Transmogrification.720p.WEB-DL.DD5.1.H.264.gb.srt?_=1575098081&-=874f8e01f5c910b365e1fa2dcb2633d3&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E22.The.Protron.Transmogrification.720p.WEB-DL.DD5.1.H.264.gb.srt\"\
+        ,\"s\":\"22KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\\
+        /-\\/23\\/The.Big.Bang.Theory.S07E23.The.Gorilla.Dissolution.720p.WEB-DL.DD5.1.H.264.gb.srt?_=1575098081&-=58925fc05efb7b49bf8caa65ec7e79a2&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E23.The.Gorilla.Dissolution.720p.WEB-DL.DD5.1.H.264.gb.srt\"\
+        ,\"s\":\"23KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618200\\\
+        /-\\/24\\/The.Big.Bang.Theory.S07E24.The.Status.Quo.Combustion.720p.WEB-DL.DD5.1.AAC2.0.H.264-YFN.gb.srt?_=1575098081&-=796e260c7590e4a5eb6e2a866de47111&api=1\"\
+        ,\"f\":\"The.Big.Bang.Theory.S07E24.The.Status.Quo.Combustion.720p.WEB-DL.DD5.1.AAC2.0.H.264-YFN.gb.srt\"\
+        ,\"s\":\"26KB\"}],\"url\":\"http:\\/\\/file0.assrt.net\\/download\\/618200\\\
+        /The.Big.Bang.Theory.S07.1080p.WEB-DL.DD5.1.H.264.zip?_=1575098081&-=b56a01003b604bdd203ef305f3b49287&api=1\"\
+        ,\"release_site\":\"\u4F0A\u7538\u56ED\",\"revision\":0,\"filename\":\"The.Big.Bang.Theory.S07.1080p.WEB-DL.DD5.1.H.264.zip\"\
+        ,\"subtype\":\"Subrip(srt)\",\"lang\":{\"desc\":\"\u7B80\",\"langlist\":{\"\
+        langchs\":true}},\"videoname\":\"The.Big.Bang.Theory.S07.1080p.WEB-DL.DD5.1.H.264\"\
+        ,\"vote_score\":0,\"upload_time\":\"2018-01-26 19:23:52\",\"title\":\"\u5929\
+        \u624D\u7406\u8BBA\u4F20\u7B2C7\u5B63\u516824\u96C6The.Big.Bang.Theory.S07.1080p.WEB-DL.DD5.1.H.264\"\
+        ,\"view_count\":1020,\"native_name\":\"\u5929\u624D\u7406\u8BBA\u4F20\u7B2C\
+        7\u5B63\u516824\u96C6The.Big.Bang.Theory.S07.1080p.WEB-DL.DD5.1.H.264\",\"\
+        producer\":{\"source\":\"\u539F\u521B\u7FFB\u8BD1\",\"verifier\":\"\",\"producer\"\
+        :\"\",\"uploader\":\"\"},\"size\":247871,\"down_count\":309}],\"action\":\"\
+        detail\"}}\n"
+    headers:
+      access-control-allow-origin:
+      - '*'
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Sat, 30 Nov 2019 07:14:41 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - Sub-Zero/2
+    method: GET
+    uri: http://file0.assrt.net/onthefly/618200/-/1/The.Big.Bang.Theory.S07E01.The.Hofstadter.Insufficiency.720p.WEB-DL.DD5.1.H.264.srt?api=%5B%271%27%5D&-=%5B%27dc994ecdf3a6a02a2651950fb52956d5%27%5D&_=%5B%271575098081%27%5D
+  response:
+    body:
+      string: !!binary |
+        MQ0KMDA6MDA6MTAsMDAwIC0tPiAwMDowMDoxMiw2MDANClNoZWxkb24gz9bU2rK7ysfBxMzstcS6
+        w8qxuvIhDQoNCjINCjAwOjAwOjEyLDYwMCAtLT4gMDA6MDA6MTQsMDcwDQrE48/ruMnC8D8NCg0K
+        Mw0KMDA6MDA6MTQsMDcwIC0tPiAwMDowMDoyMCwwNzANCsTjusPRvSCxp8e4ILWr1eLKwrrc1tjS
+        qg0KDQo0DQowMDowMDoyMCwwNzAgLS0+IDAwOjAwOjIxLDcxMA0KybbKwj8NCg0KNQ0KMDA6MDA6
+        MjEsNzEwIC0tPiAwMDowMDoyNiwxODANCiK72LW9zrTAtCK12rb+sr+1xLX6xqwNCtewtb212sj9
+        sr+1xLrQ19PA78HLDQoNCjYNCjAwOjAwOjI2LDE4MCAtLT4gMDA6MDA6MzEsODIwDQq2+CK72LW9
+        zrTAtCK12sj9sr+1xLX6xqwNCsXcvfjBy7Xatv6yv7XEutDX08DvDQoNCjcNCjAwOjAwOjMyLDI2
+        MCAtLT4gMDA6MDA6MzMsNzkwDQrL+dLUxNg/DQoNCjgNCjAwOjAwOjMzLDgwMCAtLT4gMDA6MDA6
+        MzgsOTMwDQrL+dLUINXiysfE47jJtcQNCru5ysfLtbzSwO/T0LHwyMu9+MC0wcs/DQoNCjkNCjAw
+        OjAwOjM5LDkwMCAtLT4gMDA6MDA6NDIsMDIwDQpTaGVsZG9uIM7StcO9+LLVwcsNCg0KMTANCjAw
+        OjAwOjQyLDAyMCAtLT4gMDA6MDA6NDQsODUwDQrN4sPmt+fAy9S9wLTUvbTzwcsNCg0KMTENCjAw
+        OjAwOjQ2LDAyMCAtLT4gMDA6MDA6NDgsOTQwDQrE49Tau9ix3M7KzOINCs7Svs3WqrXAysfE47jJ
+        tcQNCg0KMTINCjAwOjAwOjUyLDUzMCAtLT4gMDA6MDA6NTMsODgwDQrKssO0yfnS9D8NCg0KMTMN
+        CjAwOjAwOjUzLDg4MCAtLT4gMDA6MDA6NTUsNDAwDQrKssO0yrLDtMn50vQ/DQoNCjE0DQowMDow
+        MDo1NSw0MDAgLS0+IDAwOjAwOjU2LDgyMA0K0MW6xcrHsrvMq7rDDQoNCjE1DQowMDowMDo1Niw4
+        MjAgLS0+IDAwOjAwOjU5LDk1MA0KtavM/cbwwLTP8crHDQrT0MjLsNG6o7nWuPi3xbP2wLTByw0K
+        DQoxNg0KMDA6MDA6NTYsODIwIC0tPiAwMDowMDo1OSw5NTENCntcYTd9KLP219Qi1u7J8dau1b0i
+        KQ0KDQoxNw0KMDA6MDE6MDAsNzQwIC0tPiAwMDowMTowNCw5NjANCrrDwcsgztK50rXnu7DByw0K
+        DQoxOA0KMDA6MDE6MDQsOTYwIC0tPiAwMDowMTowNiw2NjANCsTj1qq1wMTHtqvO97j5sb6yuy4u
+        Lg0KDQoxOQ0KMDA6MDE6MDksNDEwIC0tPiAwMDowMToxMiwyMjANCrK7IQ0KDQoyMA0KMDA6MDE6
+        MTIsMjIwIC0tPiAwMDowMToxNiw3NTANClBlbm55IFBlbm55IFBlbm55IQ0KDQoyMQ0KMDA6MDE6
+        MTYsNzUwIC0tPiAwMDowMToxOSwxNzANCtT1w7TByz8NCg0KMjINCjAwOjAxOjE5LDE3MCAtLT4g
+        MDA6MDE6MjQsNzEwDQq27i4uLsTHuPYuLi7O0rWj0MQNCsTju+HS8s6qz+vE7kxlb25hcmQNCg0K
+        MjMNCjAwOjAxOjI1LDc2MCAtLT4gMDA6MDE6MjgsNDgwDQq2+Nf22KzDzg0KDQoyNA0KMDA6MDE6
+        MjgsNDgwIC0tPiAwMDowMTozMyw5OTANCrHIyOfKx8Tjyc+0ssewv7S1xA0KItbuyfHWrtW9IsDv
+        tcTH6b3aDQoNCjI1DQowMDowMTozNCw3NDAgLS0+IDAwOjAxOjM3LDY2MA0Kx9ewrrXEIMTj1/bY
+        rMPOwcs/DQoNCjI2DQowMDowMTozOCw1MzAgLS0+IDAwOjAxOjQwLDExMA0Ky7XKtbuwIMO7tO0N
+        Cg0KMjcNCjAwOjAxOjQxLDA2MCAtLT4gMDA6MDE6NDUsNDEwDQoiu9i1vc60wLQitdq2/rK/tcS1
+        +sasDQqxu7fFvfi12sj9sr+1xLrQ19PA78HLDQoNCjI4DQowMDowMTo0NSw0MjAgLS0+IDAwOjAx
+        OjQ3LDUzMA0KysdMZW9uYXJkuMm1xA0KDQoyOQ0KMDA6MDE6NDcsNTQwIC0tPiAwMDowMTo0OCw1
+        MDANCs3tsLINCg0KMzANCjAwOjAxOjQ4LDUwMCAtLT4gMDA6MDE6NDksOTkwDQqx8CC1yLXIDQoN
+        CjMxDQowMDowMTo0OSw5OTAgLS0+IDAwOjAxOjU1LDYxMA0K0rLQ7c7S06a4w8uvxOPV4rb5DQrV
+        4tH5xOO+zbK7u+HMq8/rxO5MZW9uYXJkwcsNCg0KMzINCjAwOjAxOjU1LDYxMCAtLT4gMDA6MDE6
+        NTgsODQwDQrE49aqtcDE49Ta1eK3vcPmzabQocWuyfq1xA0KDQozMw0KMDA6MDI6MDMsMzAwIC0t
+        PiAwMDowMjowNSw4MDANCtXi0fnIt8q1xNzIw87SusPK3NCpDQoNCjM0DQowMDowMjowNSw4MDAg
+        LS0+IDAwOjAyOjA3LDY5MA0KLSDQu9C7DQotILK7v83G+A0KDQozNQ0KMDA6MDI6MTEsNjYwIC0t
+        PiAwMDowMjoxMyw4MTANCs3tsLINCg0KMzYNCjAwOjAyOjE1LDQ0MCAtLT4gMDA6MDI6MjEsMDMw
+        DQo8Zm9udCBjb2xvcj0iI2ZmZmYwMCI+LT3SwbXp1LDDwL7nICBodHRwOi8vYmJzLnNmaWxlMjAx
+        Mi5jb209LQ0KLT3SwbXp1LDX1sS71b4gIGh0dHA6Ly95dGV0Lm9yZy89LQ0KyNnT/rP2xrcNCrG+
+        19bEu732uanRp8+wvbvB96Os0c+9+9PD09rJzNK1zb6+tjwvZm9udD4NCg0KMzcNCjAwOjAyOjIx
+        LDEzMCAtLT4gMDA6MDI6MzEsNjYwDQo8Zm9udCBjb2xvcj0iI2ZmZmYwMCI+LT1ZVEVULdLBtenU
+        sNfWxLvX6T0tDQq3rdLrOiBELlm7xtChzcMgSG9sbGllIKH01tKpptiRqaafrSBlbGVxdWVudA0K
+        0KO21DogsKK5qw0KyrG85NbhOiCw7rXC1u0gPC9mb250Pg0KDQozOA0KMDA6MDI6MzMsMTYwIC0t
+        PiAwMDowMjozNSw1NTANCjxmb250IGNvbG9yPSIjZmZmZjAwIj7M7LLFwO3C27SrILXaxt+8viC1
+        2tK7vK8NCjcyMFAgaVR1bmVzIC0g19TAtPfcYWs8L2ZvbnQ+DQoNCjM5DQowMDowMjo0MSwyODAg
+        LS0+IDAwOjAyOjQ0LDU4MA0KztK+9bXDxOPM/bW91eK49rvhuN/Qy7XEDQq98dTn1NrNo7O1s6EN
+        Cg0KNDANCjAwOjAyOjQ0LDU4MCAtLT4gMDA6MDI6NDksNjAwDQrO0r+018W12MnPtcTTzdfVDQrQ
+        zte0vs3P8c7StcTHsMWu09FMdWN5DQoNCjQxDQowMDowMjo0OSw2MDAgLS0+IDAwOjAyOjUxLDY5
+        MA0KtvjO0s3qyKvDu9PQsa/Jy9O/yc/QxM23tcS40L71DQoNCjQyDQowMDowMjo1MSw2OTAgLS0+
+        IDAwOjAyOjUzLDM0MA0KztLOqsTjuNC1vb2+sMENCg0KNDMNCjAwOjAyOjUzLDM0MCAtLT4gMDA6
+        MDI6NTcsMTMwDQq1sci7wLIg0vLOqsv9vs3Su8PAyMvF39fTDQoNCjQ0DQowMDowMjo1NywxMzAg
+        LS0+IDAwOjAzOjAwLDQ2MA0KzOzExSEgxOPKx7j2zOzOxNGnvNINCg0KNDUNCjAwOjAzOjAwLDQ3
+        MCAtLT4gMDA6MDM6MDQsNjcwDQrSstDtxOO74dPQ0KmzvsrAtcTHo7DtDQq1q8Tj06a4w7DR0MTL
+        vLfFtb3M7Mzl0dC+v8nPyKUNCg0KNDYNCjAwOjAzOjA0LDY3MCAtLT4gMDA6MDM6MDksMjkwDQrJ
+        8bChIL7NwayxsM6itcTKur/HwMkNCra8u+HA+9PDzOzM5bnmwsnAtNbGtqjQ0L34wrfP3w0KDQo0
+        Nw0KMDA6MDM6MDksMjkwIC0tPiAwMDowMzoxMCw0NjANCtXmtcQ/DQoNCjQ4DQowMDowMzoxMCw0
+        NjAgLS0+IDAwOjAzOjEzLDI2MA0KztLL+dHUvLTKx9XmwO0NCg0KNDkNCjAwOjAzOjEzLDI2MCAt
+        LT4gMDA6MDM6MTcsNjEwDQq1sci7wLIgyrq/x8DJ0rLPsru2s9S34LHjDQrXodTat+Cx48DvDQoN
+        CjUwDQowMDowMzoxNyw2MjAgLS0+IDAwOjAzOjE5LDkzMA0KsNG34LHjufazydChx/LH8g0KDQo1
+        MQ0KMDA6MDM6MTksOTMwIC0tPiAwMDowMzoyNSw2MjANCsv50tTV4sG91tbJ+rvut73KvQ0KxOPX
+        1Ly60aHSu9bWsMkNCg0KNTINCjAwOjAzOjI2LDQ0MCAtLT4gMDA6MDM6MjgsMTIwDQqw3c3QIMTj
+        z9bU2sTcuPrFrsn6vbvMuMHLDQoNCjUzDQowMDowMzoyOCwxMzAgLS0+IDAwOjAzOjMwLDI4MA0K
+        srvE0dTZ1dK49tDCxa7T0bXEDQoNCjU0DQowMDowMzozMCwyODAgLS0+IDAwOjAzOjM0LDE4MA0K
+        ztLP1tTav7TJtra8s6TBy9XFTHVjecGzDQrV4tH5ztLU9cO01dLQwsWu09GwoT8NCg0KNTUNCjAw
+        OjAzOjM0LDE4MCAtLT4gMDA6MDM6MzksMjkwDQrE0bXAxOPDu9Ta1eLFzLymyOLFycnPDQq/tLW9
+        y/21xM6i0KbC8D8NCg0KNTYNCjAwOjAzOjM5LDI5MCAtLT4gMDA6MDM6NDEsMTQwDQrE48TcsrvE
+        3M/7zaO147ChIQ0KDQo1Nw0KMDA6MDM6NDUsNDYwIC0tPiAwMDowMzo0Niw3MTANCs/W1NogzP3O
+        0su1DQoNCjU4DQowMDowMzo0Niw3MTAgLS0+IDAwOjAzOjQ5LDA1MA0KvfHN7dPQuPbQwr36sqnK
+        v7rzu7bTrcXJttQNCg0KNTkNCjAwOjAzOjQ5LDA1MCAtLT4gMDA6MDM6NTMsOTAwDQrIpbLOvNMg
+        yLu689XSuPbIy8Dg1/bFrtPRDQoNCjYwDQowMDowMzo1Myw5MDAgLS0+IDAwOjAzOjU3LDI0MA0K
+        xOPAz8bFyse49sjLwODBy7K7xvCwoT8NCg0KNjENCjAwOjAzOjU5LDY0MCAtLT4gMDA6MDQ6MDMs
+        MzEwDQrM/dfFIEJlcm5pZbj6QW15DQrIpbLOvNPJ8b6tv8bRp7vh0unByw0KDQo2Mg0KMDA6MDQ6
+        MDMsMzEwIC0tPiAwMDowNDowNCw2OTANCs7SuPrE49K7xvDIpcXJttQNCg0KNjMNCjAwOjA0OjA0
+        LDcwMCAtLT4gMDA6MDQ6MDUsODUwDQotIMTj1LjS4sXjztI/DQotILWxyLsNCg0KNjQNCjAwOjA0
+        OjA1LDg1MCAtLT4gMDA6MDQ6MDcsMDgwDQrE48rHztLF89PRDQoNCjY1DQowMDowNDowNywwODAg
+        LS0+IDAwOjA0OjA4LDQ1MA0KztLPo837xOO/qtDEDQoNCjY2DQowMDowNDowOCw0NTAgLS0+IDAw
+        OjA0OjEwLDMzMA0K0LvQuyDEx8O0IFNoZWxkb24NCg0KNjcNCjAwOjA0OjEwLDM0MCAtLT4gMDA6
+        MDQ6MTEsODcwDQq8yMi7QW150rLIpb+qu+HByw0KxOPUuNLi0rvG8MC0wvA/DQoNCjY4DQowMDow
+        NDoxMSw4NzAgLS0+IDAwOjA0OjE3LDg3MA0KztLSss+jzfvE47+q0MQNCrWr1eKyu9fj0tS02cq5
+        ztLOqrTL1/bIzrrOysINCg0KNjkNCjAwOjA0OjIwLDU4MCAtLT4gMDA6MDQ6MjYsMTMwDQpIb3dp
+        ZSCx8NXi0fkg1eLDtMjiwum1xLuwDQrO0r2ysruz9r/aIEFtedTaxdSx38TYDQoNCjcwDQowMDow
+        NDoyNiwxMzAgLS0+IDAwOjA0OjMxLDUyMA0KU2hlbGRvbiCx8NXi0fkgztLU2cu11+6689K7sekN
+        Cs7Ssru74bDRtLLKrbT4u9jIpbXEDQoNCjcxDQowMDowNDozMSw1MjAgLS0+IDAwOjA0OjMyLDY3
+        MA0K1eLCw7ndutyw9A0KDQo3Mg0KMDA6MDQ6MzIsNjcwIC0tPiAwMDowNDozNCwzOTANCtPQ076z
+        2CDT0L2hye23vw0KDQo3Mw0KMDA6MDQ6MzQsMzkwIC0tPiAwMDowNDozNiwwMTANCr7GsMnSsrrc
+        sru07Q0KDQo3NA0KMDA6MDQ6MzYsMDEwIC0tPiAwMDowNDozOSw5MDANCtLyzqrO0r+0wcu0ssbM
+        DQrEx8nPw+bDu9PQtLLKrQ0KDQo3NQ0KMDA6MDQ6MzksOTAwIC0tPiAwMDowNDo0MSwyMDANCs7S
+        0rKwrsTjDQoNCjc2DQowMDowNDo0MSwyMDAgLS0+IDAwOjA0OjQ1LDQ4MA0KyOe5+8Tjy6/Xxcew
+        IMO709DM/bW9ztK1xMn50vQNCsTHztK74dPrxOPU2sPOwO/P4LvhtcQNCg0KNzcNCjAwOjA0OjQ1
+        LDQ5MCAtLT4gMDA6MDQ6NDYsNzQwDQrN7bCyDQoNCjc4DQowMDowNDo0Niw3NDAgLS0+IDAwOjA0
+        OjUwLDA0MA0KsrsgztKyu7vhv7zCx8uv1NrCw9DQtPzA77XEDQoNCjc5DQowMDowNDo1MywzOTAg
+        LS0+IDAwOjA0OjU3LDE2MA0KUGVubnkgxOPT0MO709DP67n9DQrQx7zKvaK207bTs6TKx8jnus4u
+        Li4NCg0KODANCjAwOjA0OjU3LDE3MCAtLT4gMDA6MDQ6NTksMzUwDQrDu9PQDQoNCjgxDQowMDow
+        NTowMSwxNzAgLS0+IDAwOjA1OjAzLDM5MA0KxMfP1tTaztK8pMbwxOO1xNDLyKTByw0KDQo4Mg0K
+        MDA6MDU6MDMsMzkwIC0tPiAwMDowNTowNiwzNDANCru2063AtLW9M0S5+rzKz/PG5bXEyfHG5srA
+        vecNCg0KODMNCjAwOjA1OjA2LDM0MCAtLT4gMDA6MDU6MDksNDgwDQrE47jJwvCyu7jJtOC147PQ
+        yM/Byw0KxOPP683m1eLTzs+31rvKx9LyzqouLi4NCg0KODQNCjAwOjA1OjA5LDQ4MCAtLT4gMDA6
+        MDU6MTIsMDEwDQrE49fcuPpMZW9uYXJk0rvG8M3mDQq2+MTjz9bU2rrcz+vL+z8NCg0KODUNCjAw
+        OjA1OjEyLDAxMCAtLT4gMDA6MDU6MTUsNTYwDQrE48yruN+5wMv71NrO0sn6w/zW0LXE1tjSqtDU
+        wcsNCg0KODYNCjAwOjA1OjE2LDgyMCAtLT4gMDA6MDU6MjEsMjIwDQrO0rvhz+vE7sv7ysfI57rO
+        DQrU2s7StcS7qrfysf3Jz9PDufu9tLut0KbBs7XEwvA/DQoNCjg3DQowMDowNToyMSwyMjAgLS0+
+        IDAwOjA1OjIyLDgxMA0KssWyu7vhxNgNCg0KODgNCjAwOjA1OjIyLDgxMCAtLT4gMDA6MDU6Mjgs
+        MDMwDQrO0rvhz+vE7sv7ysfI57rO0N66ww0KztKxu7+o16G1xLzQv8vArcG0tcTC8D8NCg0KODkN
+        CjAwOjA1OjI4LDAzMCAtLT4gMDA6MDU6MzAsMTEwDQrO0r/JsrvV4sO0vvW1ww0KDQo5MA0KMDA6
+        MDU6MzAsMTEwIC0tPiAwMDowNTozNSw5OTANCs7Su+HP68TuztLDx8rHyOe6zg0K08PEpsu5tefC
+        69TaztTK0se9yc/Hw7P2Is3tsLIitcTC8D8NCg0KOTENCjAwOjA1OjQwLDg0MCAtLT4gMDA6MDU6
+        NDIsMjYwDQrO0rauwcsgztK2rsHLDQoNCjkyDQowMDowNTo0MiwyNjAgLS0+IDAwOjA1OjQ0LDEz
+        MA0KxOO+zcrHuPbDu7jQx+m1xLv6xvfIyw0KDQo5Mw0KMDA6MDU6NDQsMTMwIC0tPiAwMDowNTo0
+        Niw1MzANCs7SvqHBpsHLDQoNCjk0DQowMDowNTo0Niw1MzAgLS0+IDAwOjA1OjQ5LDE3MA0Kv+y/
+        qsq81eLJtdPOz7ewyQ0KDQo5NQ0KMDA6MDU6NDksMTcwIC0tPiAwMDowNTo1MCw0MDANCsyrusPB
+        yyDO0s/IwLQNCg0KOTYNCjAwOjA1OjUwLDQwMCAtLT4gMDA6MDU6NTIsNTUwDQq21MHLIMTju+HQ
+        3sCtwbTC8D8NCg0KOTcNCjAwOjA1OjUyLDU1MCAtLT4gMDA6MDU6NTMsMjQwDQrU9cO0Pw0KDQo5
+        OA0KMDA6MDU6NTMsMjcwIC0tPiAwMDowNTo1Nyw2MTANCs7SsdjQ68il0rvMy8+0yta85A0K1eLA
+        rcG0v8nE0cCtwcsNCg0KOTkNCjAwOjA2OjAwLDIzMCAtLT4gMDA6MDY6MDQsNjMwDQrE47bUy67E
+        uMnxvq3N+MLntcTR0L6/zabT0MiktcQNCg0KMTAwDQowMDowNjowNCw2MzAgLS0+IDAwOjA2OjA1
+        LDgyMA0Kw7u07Q0KDQoxMDENCjAwOjA2OjA1LDgyMCAtLT4gMDA6MDY6MDgsNjIwDQrE47/J0tTI
+        pdGn0KPN+NW+z8LU2M7StcTC287EDQoNCjEwMg0KMDA6MDY6MDgsNjIwIC0tPiAwMDowNjoxMyw2
+        NjANCrrDtcQgxOPSsr/J0tTIpc/C1NgNCs7SudjT2re2sKzC17f4yeS0+NHQvr+1xMLbzsQNCg0K
+        MTAzDQowMDowNjoxMyw2NjAgLS0+IDAwOjA2OjE1LDQxMA0KusO1xA0KDQoxMDQNCjAwOjA2OjE2
+        LDQxMCAtLT4gMDA6MDY6MTgsNTgwDQq6w7DJDQoNCjEwNQ0KMDA6MDY6MzIsNzQwIC0tPiAwMDow
+        NjozNCwzMTANCtT1w7TR+T8NCg0KMTA2DQowMDowNjozNCwzMTAgLS0+IDAwOjA2OjQwLDQ4MA0K
+        yOe5+8Tjz7K7tt7P3s7H0s20v+C12LjJwcQNCsTHvs3L47Osy7PA+w0KDQoxMDcNCjAwOjA2OjQx
+        LDMwMCAtLT4gMDA6MDY6NDIsNzUwDQq/7L+0DQoNCjEwOA0KMDA6MDY6NDIsNzUwIC0tPiAwMDow
+        Njo0NCw4MjANCsjLysKyv7XERGF2aXPQob3jDQoNCjEwOQ0KMDA6MDY6NDQsODIwIC0tPiAwMDow
+        Njo0Nyw0NzANCsv9usPP8dTavOC2vdDUyafIxQ0KDQoxMTANCjAwOjA2OjQ3LDQ4MCAtLT4gMDA6
+        MDY6NDgsNzIwDQrMq7rDwcsNCg0KMTExDQowMDowNjo0OCw3MzAgLS0+IDAwOjA2OjUxLDY0MA0K
+        ztLU4tP20NTJp8jFtcS7+rvhw7vByw0KDQoxMTINCjAwOjA2OjUxLDY1MCAtLT4gMDA6MDY6NTYs
+        NDIwDQrM/cu1y/3Az7mrxdfG+sv9DQrV0sHLuPbE6sfhxq/BwbXEtPPRp8n6DQoNCjExMw0KMDA6
+        MDY6NTYsNDIwIC0tPiAwMDowNjo1OSwyMDANCtfcscjV0rj209bAz9PWs/O1xNKqusOwyQ0KDQox
+        MTQNCjAwOjA3OjAzLDk0MCAtLT4gMDA6MDc6MDYsNDMwDQpXb2xvd2l0es/IyfogS29vdGhyYXBw
+        YWxpsqnKvw0KDQoxMTUNCjAwOjA3OjA2LDQzMCAtLT4gMDA6MDc6MDcsODQwDQpEYXZpc8Wuyr8g
+        xOO6ww0KDQoxMTYNCjAwOjA3OjA3LDg1MCAtLT4gMDA6MDc6MTQsMjAwDQrO0tfuvfy/tMHLxqrT
+        0LnYxvO27LK71tK1xM7E1cINCg0KMTE3DQowMDowNzoxNCwyMDAgLS0+IDAwOjA3OjE2LDgwMA0K
+        usO1xA0KDQoxMTgNCjAwOjA3OjE2LDgwMCAtLT4gMDA6MDc6MjEsMzQwDQrI57n7xOPS8s6q1cm3
+        8rXExdfG+rb4xNG5/Q0KxOPWu9KqvMfXoS4uLg0KDQoxMTkNCjAwOjA3OjIxLDM0MCAtLT4gMDA6
+        MDc6MjQsMzgwDQrG87bs0rK74bP2uewgsru5/cv7w8e63L/JsK7E2A0KDQoxMjANCjAwOjA3OjM3
+        LDI0MCAtLT4gMDA6MDc6MzksOTYwDQqxyMTjsrvE3Lj6xa7Iy72yu7C1xMqxuvK6w7bgwcsNCg0K
+        MTIxDQowMDowNzo0MiwxMzAgLS0+IDAwOjA3OjQ4LDQ3MA0KztK7ude8sbjIpcz9uvO/27T4u9jG
+        pLLjy/DJyw0K0v3G8NfUtKvM5bzH0uS1xNHdvbINCg0KMTIyDQowMDowNzo0OCw0NzAgLS0+IDAw
+        OjA3OjUwLDQyMA0KxNTL8MnLyse63M780v3Iy7XEDQoNCjEyMw0KMDA6MDc6NTAsNDIwIC0tPiAw
+        MDowNzo1Myw1MTANCsjnufvKx8Tj19S8usvwycsNCsTHvs2yu8780v3Iy8HLDQoNCjEyNA0KMDA6
+        MDc6NTMsNTEwIC0tPiAwMDowNzo1NiwwNDANCr60v8bRp7XEvfiyvQ0KDQoxMjUNCjAwOjA3OjU2
+        LDA0MCAtLT4gMDA6MDc6NTksMTQwDQq+tMq5v8bRp734sr21xLyysqG6zcvAzfYNCg0KMTI2DQow
+        MDowODowMSwyNjAgLS0+IDAwOjA4OjA0LDQzMA0K09DS4su8tcTKxw0KztLDx7u5tNPDu7rNUGVu
+        bnnM1sLbuf3V4tCpDQoNCjEyNw0KMDA6MDg6MDQsNDQwIC0tPiAwMDowODowNiwxOTANCtK7sOO2
+        vMrHwcTXxcHE18W+zcHEtb3E0MjLwcsNCg0KMTI4DQowMDowODowNiwxOTAgLS0+IDAwOjA4OjEw
+        LDM5MA0Ksru5/crKtbG808jr0afK9bbUu7DNprrDtcQNCg0KMTI5DQowMDowODoxMCwzOTAgLS0+
+        IDAwOjA4OjEzLDAxMA0KsMnMqMG9zrvE0Mq/x+u1xA0KDQoxMzANCjAwOjA4OjEzLDAxMCAtLT4g
+        MDA6MDg6MTQsNjEwDQrM7MTEINPQxNDIy8frztLDx7/NIQ0KDQoxMzENCjAwOjA4OjE0LDYxMCAt
+        LT4gMDA6MDg6MTcsMjgwDQrT0MTQyMvH67/NIQ0KDQoxMzINCjAwOjA4OjE3LDI4MCAtLT4gMDA6
+        MDg6MTksMTUwDQrQu9C7INC70LsgzKu40NC7wcsNCg0KMTMzDQowMDowODoyMCw1MzAgLS0+IDAw
+        OjA4OjIyLDI1MA0KLSC1rbaoteMNCi0g1PXDtLWttqi1w8bwwLQhDQoNCjEzNA0KMDA6MDg6MjIs
+        MjUwIC0tPiAwMDowODoyNSwzNDANCtPQxNDIy73TvfzO0sPHILu5srvKx9LyzqpQZW5ueQ0KDQox
+        MzUNCjAwOjA4OjI2LDMyMCAtLT4gMDA6MDg6MjgsMDkwDQrKx7ChDQoNCjEzNg0KMDA6MDg6Mjgs
+        MDkwIC0tPiAwMDowODoyOSw1NDANCtC70LvAsg0KDQoxMzcNCjAwOjA4OjM0LDEzMCAtLT4gMDA6
+        MDg6MzYsMzMwDQrg3iEgs/TG5dK7sr0NCg0KMTM4DQowMDowODozNiwzMzAgLS0+IDAwOjA4OjM4
+        LDUwMA0KsKE/IM6qyrLDtD8NCg0KMTM5DQowMDowODozOCw1MDAgLS0+IDAwOjA4OjQxLDcyMA0K
+        ztK1xLvKuvPP1tTaxNy008/Cw+YNCrPUtfTE47XEs7XByw0KDQoxNDANCjAwOjA4OjQxLDcyMCAt
+        LT4gMDA6MDg6NDMsODEwDQrS4su8ysfO0srkwcs/DQoNCjE0MQ0KMDA6MDg6NDMsODEwIC0tPiAw
+        MDowODo0NSw0NDANCr3hyvjByyENCg0KMTQyDQowMDowODo0NSw0NDAgLS0+IDAwOjA4OjQ4LDg0
+        MA0KyOe5+87S19/V4tK7sr0uLi4NCg0KMTQzDQowMDowODo0OCw4NTAgLS0+IDAwOjA4OjUyLDM2
+        MA0KxMe+zbK7u+HV4sO0usPN5sHLDQrL+dLUztKyu7vh19+1xA0KDQoxNDQNCjAwOjA4OjUzLDE3
+        MCAtLT4gMDA6MDg6NTYsMDQwDQrQ3c+i0rvPwrDJDQoNCjE0NQ0KMDA6MDg6NTYsMDQwIC0tPiAw
+        MDowODo1OCw5NTANCs7Sw8fDu77GwcsNCg0KMTQ2DQowMDowODo1OCw5NjAgLS0+IDAwOjA5OjAw
+        LDU5MA0KztLT1rK7ysfSqsilusi+xg0KDQoxNDcNCjAwOjA5OjA3LDA4MCAtLT4gMDA6MDk6MDgs
+        ODMwDQq6w8/r1qq1wExlb25hcmTU2rjJwvANCg0KMTQ4DQowMDowOTowOCw4MzAgLS0+IDAwOjA5
+        OjExLDEzMA0KusPP68v7DQoNCjE0OQ0KMDA6MDk6MTEsMTQwIC0tPiAwMDowOToxNCwxNzANCs7S
+        w8e08rXnu7C4+Mv7sMkNCg0KMTUwDQowMDowOToxNCwxNzAgLS0+IDAwOjA5OjE2LDM3MA0KztIg
+        ztLKx8u1IMTjtPK157uwuPjL+7DJDQoNCjE1MQ0KMDA6MDk6MTYsMzcwIC0tPiAwMDowOToxOSw4
+        MTANCs7S1q7HsMu1uf0NCsXz09Gyu9TasqKyu8TcyrnO0snL0MQNCg0KMTUyDQowMDowOToxOSw4
+        MTAgLS0+IDAwOjA5OjI1LDQwMA0K0qG59snZxOpQYXVsIFNpbW9u1PjLtQ0KIs7S1rvKx7/pyq/N
+        tyDSu8astbottbottbrT7CINCg0KMTUzDQowMDowOToyNiw1NzAgLS0+IDAwOjA5OjI4LDM3MA0K
+        ztLAtLTyDQoNCjE1NA0KMDA6MDk6MjgsMzcwIC0tPiAwMDowOTozMCwyNDANCrrDsKEhIL+qw+LM
+        4SENCg0KMTU1DQowMDowOTozOCw2NjAgLS0+IDAwOjA5OjQxLDYxMA0Ksru6w9Liy7wgztK1xL/j
+        19PV8LavwLINCg0KMTU2DQowMDowOTo0NCwwMDAgLS0+IDAwOjA5OjQ2LDQ5MA0KsbG6oyDT0Mnx
+        wu0iyqoiwvA/DQoNCjE1Nw0KMDA6MDk6NDgsNTcwIC0tPiAwMDowOTo0OSw1NDANCkxlb25hcmQ/
+        DQoNCjE1OA0KMDA6MDk6NDksNTQwIC0tPiAwMDowOTo1MCw2NzANClBlbm55Pw0KDQoxNTkNCjAw
+        OjA5OjUwLDY4MCAtLT4gMDA6MDk6NTEsNzkwDQq62SDKx1Blbm55DQoNCjE2MA0KMDA6MDk6NTEs
+        NzkwIC0tPiAwMDowOTo1Miw5OTANCrTzvNLSu8bwwLS4+lBlbm55tPLV0Lr0DQoNCjE2MQ0KMDA6
+        MDk6NTIsOTkwIC0tPiAwMDowOTo1NCw2ODANCuDLIFBlbm55IQ0KDQoxNjINCjAwOjA5OjU0LDY4
+        MCAtLT4gMDA6MDk6NTgsNDAwDQrN2yC/tMC0xOPN5rXDzaa/qtDEtcTC7w0KDQoxNjMNCjAwOjA5
+        OjU4LDQwMCAtLT4gMDA6MTA6MDEsMjgwDQrIy8n61+6/qtDEtcTKsbniIQ0KDQoxNjQNCjAwOjEw
+        OjAyLDg5MCAtLT4gMDA6MTA6MDYsMDQwDQrEx8DvsrvKx7LF1OfJzzU6MzDC8D8NCg0KMTY1DQow
+        MDoxMDowNiwwNDAgLS0+IDAwOjEwOjA3LDE3MA0KysfC8D8NCg0KMTY2DQowMDoxMDowNywxNzAg
+        LS0+IDAwOjEwOjA5LDg5MA0KutkgtPO77yDP1tTaysfU58nPNTozMCENCg0KMTY3DQowMDoxMDox
+        Myw0NTAgLS0+IDAwOjEwOjE2LDg1MA0KusOwySDO0sPHtPK157uwysfS8s6qz+vE48HLDQoNCjE2
+        OA0KMDA6MTA6MTYsODUwIC0tPiAwMDoxMDoxOCwwNzANCrH5yb0hDQoNCjE2OQ0KMDA6MTA6MTgs
+        MDcwIC0tPiAwMDoxMDoxOSwxNTANCrXIu+G2+Q0KDQoxNzANCjAwOjEwOjE5LDE1MCAtLT4gMDA6
+        MTA6MjAsNzkwDQrE49PQzqPP1cHLwvA/DQoNCjE3MQ0KMDA6MTA6MjAsNzkwIC0tPiAwMDoxMDoy
+        MiwzMjANCrK7yscg1eLKx7j2s6nS+9POz7cNCg0KMTcyDQowMDoxMDoyMiwzMjAgLS0+IDAwOjEw
+        OjI0LDM2MA0K1rvSqsz9tb0isfnJvSLBvbj219YNCr7NvtmxrbOp0vshDQoNCjE3Mw0KMDA6MTA6
+        MjQsMzYwIC0tPiAwMDoxMDoyNiw0MTANCrH5yb0hILH5yb0hDQoNCjE3NA0KMDA6MTA6MjYsNDEw
+        IC0tPiAwMDoxMDoyOCw4MzANCrH5yb0hILH5yb0hILH5yb0hILH5yb0hDQoNCjE3NQ0KMDA6MTA6
+        MjksNTUwIC0tPiAwMDoxMDozMCw4MzANCkxlb25hcmQgTGVvbmFyZD8NCg0KMTc2DQowMDoxMDoz
+        Myw5NzAgLS0+IDAwOjEwOjM2LDY3MA0KztLDx765yLu74c/rxMe49rvstbANCg0KMTc3DQowMDox
+        MDozNiw2NzAgLS0+IDAwOjEwOjM5LDQ5MA0KysfE48/rDQoNCjE3OA0KMDA6MTA6NDMsODUwIC0t
+        PiAwMDoxMDo0NSw3MzANCtT1w7TR+cHLPw0KDQoxNzkNCjAwOjEwOjQ1LDczMCAtLT4gMDA6MTA6
+        NDksMDcwDQrDu8rCIM7S09bQu7n9y/vDxw0KuObL38v7w8cgztLDx8P7u6jT0Nb3wcsNCg0KMTgw
+        DQowMDoxMDo0OSwwNzAgLS0+IDAwOjEwOjUzLDE2MA0K1eLDtMu1IM7SsrvTw7PUv/e+zb/J0tS6
+        yL7GwLINCg0KMTgxDQowMDoxMDo1MywxNjAgLS0+IDAwOjEwOjU0LDI3MA0Kyse1xCDMq7/hwcsN
+        Cg0KMTgyDQowMDoxMDo1NCwyODAgLS0+IDAwOjEwOjU4LDQ5MA0K0qrKx8Tjz+u6zcv7w8fG5NbQ
+        0ru49sy4zLgNCsO7yMu74bnWxOO1xA0KDQoxODMNCjAwOjEwOjU4LDUwMCAtLT4gMDA6MTE6MDEs
+        MjgwDQrOqsm2w7vIy7vhudbO0g0KDQoxODQNCjAwOjExOjAyLDEyMCAtLT4gMDA6MTE6MDUsNTcw
+        DQrO0tTauvrR1MLS0+/E2A0KDQoxODUNCjAwOjExOjA1LDU3MCAtLT4gMDA6MTE6MDksODQwDQrM
+        /cbwwLTE49Liy7zKxw0KztLE3NXStb2xyFNoZWxkb264/LrDtcQNCg0KMTg2DQowMDoxMTowOSw4
+        NDAgLS0+IDAwOjExOjEyLDIxMA0K1eK+xr/J1ebB0rChDQoNCjE4Nw0KMDA6MTE6MTMsNjMwIC0t
+        PiAwMDoxMToxNyw4NjANCszsxMUgztK98c3tv8+2qNKqzcLLwMHLDQoNCjE4OA0KMDA6MTE6MTks
+        MTgwIC0tPiAwMDoxMToyMiw2NDANCrjmy9/O0iDE48u1xMe7sMqyw7TS4su8DQoNCjE4OQ0KMDA6
+        MTE6MjQsODEwIC0tPiAwMDoxMToyOSwwNjANCsTjw7u94bvpIMTjxNDF89PR09bKxy4uLg0KDQox
+        OTANCjAwOjExOjI5LDA2MCAtLT4gMDA6MTE6MzEsMDMwDQpTaGVsZG9uxMfA4NDNtcQNCg0KMTkx
+        DQowMDoxMTozMSwwMzAgLS0+IDAwOjExOjM0LDA2MA0KxOPVybfyu7nKx0hvd2FyZMTH0M21xMTY
+        DQoNCjE5Mg0KMDA6MTE6MzQsMDcwIC0tPiAwMDoxMTozNiw1MzANCsTjz+ux7bTvyrLDtA0KDQox
+        OTMNCjAwOjExOjM3LDYyMCAtLT4gMDA6MTE6MzksNDUwDQqxp8e4IM7Syba2vLK7z+ux7bTvDQoN
+        CjE5NA0KMDA6MTE6MzksNDUwIC0tPiAwMDoxMTo0MCw5NDANCsu11eLKwsyrzt7BxMHLDQoNCjE5
+        NQ0KMDA6MTE6NDAsOTQwIC0tPiAwMDoxMTo0MywzMjANCtTbxNzN/MHL1eKy5yC8zND44MvG8MC0
+        sMkNCg0KMTk2DQowMDoxMTo0MywzMjAgLS0+IDAwOjExOjQ2LDYzMA0Kv8nS1LXEILWrsrvQ0rXE
+        yscNCs7StPPE1L/Jw7vT0MvwycsNCg0KMTk3DQowMDoxMTo0Niw2MzAgLS0+IDAwOjExOjUwLDc1
+        MA0KztK7ubzHtcPE48u1ztK80rGmsbS1xLu1u7DE2A0KDQoxOTgNCjAwOjExOjUwLDc1MCAtLT4g
+        MDA6MTE6NTEsOTEwDQq6w8CyIM7StcDHuA0KDQoxOTkNCjAwOjExOjUxLDkyMCAtLT4gMDA6MTE6
+        NTMsODgwDQrE3M38vMe41bLFtcTKwsLwDQoNCjIwMA0KMDA6MTE6NTQsODQwIC0tPiAwMDoxMTo1
+        NywwOTANCi0gtbHIuw0KLSDQu8CyDQoNCjIwMQ0KMDA6MTE6NTgsODkwIC0tPiAwMDoxMjowMSw3
+        OTANCsTj1cm38rXEudbS7LrNtKnXxcyru6y7/MHLDQoNCjIwMg0KMDA6MTI6MDQsMjMwIC0tPiAw
+        MDoxMjowNSwyODANCtXmsru40s/g0MUNCg0KMjAzDQowMDoxMjowNSwyODAgLS0+IDAwOjEyOjA4
+        LDI4MA0K1eK2zsqxvOQgztK+zdK71rHX+NfFz+vE7sTHvNK77w0KDQoyMDQNCjAwOjEyOjA4LDI4
+        MCAtLT4gMDA6MTI6MDksOTMwDQrWqrXA1+7U47XEysfKssO0wvANCg0KMjA1DQowMDoxMjowOSw5
+        MzAgLS0+IDAwOjEyOjEzLDU3MA0KxOPP1tTa1eLDtMnL0MQgu7nDu7eovei+xs/7s+4/DQoNCjIw
+        Ng0KMDA6MTI6MTgsNDkwIC0tPiAwMDoxMjoyMCw0OTANCrK7yscNCg0KMjA3DQowMDoxMjoyMCw1
+        MDAgLS0+IDAwOjEyOjIyLDU4MA0Kw7u07Q0KDQoyMDgNCjAwOjEyOjI0LDQ4MCAtLT4gMDA6MTI6
+        MjYsNDgwDQrWqrXAu7nT0Mqyw7TSsrrc1OPC8A0KDQoyMDkNCjAwOjEyOjI2LDQ4MCAtLT4gMDA6
+        MTI6MjgsMDMwDQrL+7j5sb6+zbK7z+vO0g0KDQoyMTANCjAwOjEyOjI4LDA0MCAtLT4gMDA6MTI6
+        MzAsOTQwDQrIw87SwLSwss6/z8LE47DJDQoNCjIxMQ0KMDA6MTI6MzAsOTQwIC0tPiAwMDoxMjoz
+        NCwxMTANCsbwwuvE49Xi0fnX9s2mvaG/tbXEDQoNCjIxMg0KMDA6MTI6MzYsMTEwIC0tPiAwMDox
+        MjozOCw3MzANCtXmtc65/iDN6srCwcsg1eLSssvjsLLOvw0KDQoyMTMNCjAwOjEyOjM4LDczMCAt
+        LT4gMDA6MTI6NDUsNzkwDQrSu7DZxOq68yDE48Gptryyu9TawcsNCsTHvs3Du7nYz7XByw0KDQoy
+        MTQNCjAwOjEyOjQ1LDc5MCAtLT4gMDA6MTI6NDcsOTQwDQq448qyw7SwoQ0KDQoyMTUNCjAwOjEy
+        OjQ3LDk0MCAtLT4gMDA6MTI6NTAsNzIwDQrE49OmuMPLtSAiy/u1sci7z+vE4yINCg0KMjE2DQow
+        MDoxMjo1MCw3MzAgLS0+IDAwOjEyOjUzLDY4MA0Ky/vWrsv50tTN5sTHw7S36A0KysfP6838tfTL
+        +7XEsa/Jyw0KDQoyMTcNCjAwOjEyOjUzLDY4MCAtLT4gMDA6MTI6NTYsMzMwDQrO0r/JsrvEx8O0
+        yM/Oqg0KDQoyMTgNCjAwOjEyOjU4LDg1MCAtLT4gMDA6MTM6MDAsMjMwDQrMq7vEw/3Byw0KDQoy
+        MTkNCjAwOjEzOjAwLDI0MCAtLT4gMDA6MTM6MDIsNzQwDQq+zdLyzqrL+83mtcO63ODLIM7Svs3S
+        qsTRuf3C8A0KDQoyMjANCjAwOjEzOjAyLDc0MCAtLT4gMDA6MTM6MDYsOTYwDQrV4rj2wu8uLi7S
+        stDtxOPU2s/rDQoNCjIyMQ0KMDA6MTM6MDYsOTYwIC0tPiAwMDoxMzoxMSwyOTANCsv7us3ExLj2
+        xO/Dx77GuvPC0tDUxNgNCg0KMjIyDQowMDoxMzoxMyw2ODAgLS0+IDAwOjEzOjE3LDMyMA0KysfC
+        8CDO0su1ttTBy8LwDQoNCjIyMw0KMDA6MTM6MTgsODQwIC0tPiAwMDoxMzoxOSw5MjANCsyrsPTA
+        sg0KDQoyMjQNCjAwOjEzOjE5LDkyMCAtLT4gMDA6MTM6MjIsMjEwDQrE47K708PK1NfFsLLOv87S
+        wcsNCg0KMjI1DQowMDoxMzoyMiwyMTAgLS0+IDAwOjEzOjI3LDQ2MA0KsrvQ0CBMZW9uYXJk19/W
+        rsewDQrL+8jDztKxo9akIM7Su+HV1bnLusPE47XEDQoNCjIyNg0KMDA6MTM6MjcsNDYwIC0tPiAw
+        MDoxMzoyOSw4NTANCi0g1ea1xMLwDQotIMrHtcQNCg0KMjI3DQowMDoxMzoyOSw4NTAgLS0+IDAw
+        OjEzOjMyLDYzMA0KzKvM+dDEwcsNCg0KMjI4DQowMDoxMzozMiw2MzAgLS0+IDAwOjEzOjM3LDE3
+        MA0Ku7nT0CDI57n7ztLX9rXDs/bJqw0Ky/vLtbvhuPjO0rT4u9jAtNK7tqXLrsrWw7ENCg0KMjI5
+        DQowMDoxMzozOSwwNzAgLS0+IDAwOjEzOjQwLDk5MA0Kz9bU2s7SuPzP68Tuy/vByw0KDQoyMzAN
+        CjAwOjEzOjQwLDk5MCAtLT4gMDA6MTM6NDUsNTgwDQrI57n7udzTw7XEu7AgztLIt9DFDQoNCjIz
+        MQ0KMDA6MTM6NDUsNTgwIC0tPiAwMDoxMzo1MSwwMzANCkxlb25hcmTUtsDrxOO7s7Gnus3T8bS9
+        DQq1xMO/0ru/zLa8sbjK3LzlsL4NCg0KMjMyDQowMDoxMzo1Miw1MDAgLS0+IDAwOjEzOjUzLDQ3
+        MA0K0LvQuw0KDQoyMzMNCjAwOjEzOjUzLDQ3MCAtLT4gMDA6MTM6NTUsMzQwDQrE47u5tbHV5sCy
+        DQoNCjIzNA0KMDA6MTM6NTcsOTQwIC0tPiAwMDoxNDowMCwzODANCrTyyMXByyBEYXZpc7fyyMsN
+        Cg0KMjM1DQowMDoxNDowMCwzODAgLS0+IDAwOjE0OjAxLDY4MA0K1PXDtMHLDQoNCjIzNg0KMDA6
+        MTQ6MDEsNjgwIC0tPiAwMDoxNDowNCw3MTANCrGnx7jO0sTHw7TCs8OnDQoNCjIzNw0KMDA6MTQ6
+        MDQsNzIwIC0tPiAwMDoxNDoxMSw5NDANCru5zqrO28PvxvO27LXAx7gNCtLyzqo5OSW1xMbztuy2
+        vLu5zabT0NLiy7y1xA0KDQoyMzgNCjAwOjE0OjExLDk0MCAtLT4gMDA6MTQ6MTMsOTcwDQrL48HL
+        sMkNCg0KMjM5DQowMDoxNDoxNSwzNjAgLS0+IDAwOjE0OjE4LDQ5MA0K1qq1wMLwINTbwanT0NDt
+        tuDP4MvG1q60pg0KDQoyNDANCjAwOjE0OjE4LDUwMCAtLT4gMDA6MTQ6MjEsNjEwDQotIMrHwvAN
+        Ci0gtbHIuyDO0tKyLi4uDQoNCjI0MQ0KMDA6MTQ6MjEsNjIwIC0tPiAwMDoxNDoyNCwyMzANCrGl
+        ytzQxMvp1q7NtA0KDQoyNDINCjAwOjE0OjI0LDI0MCAtLT4gMDA6MTQ6MjYsMDQwDQq6w7DJIMz9
+        ztLPuM+4tcDAtA0KDQoyNDMNCjAwOjE0OjI4LDY2MCAtLT4gMDA6MTQ6MzMsMTMwDQq4+MTjsa3I
+        yNL7ILCyzr/PwsTjDQoNCjI0NA0KMDA6MTQ6MzMsMTMwIC0tPiAwMDoxNDozNSwwMzANCtPDtcTS
+        u7TO0NSxrdfTDQoNCjI0NQ0KMDA6MTQ6MzUsMDMwIC0tPiAwMDoxNDozNiw4ODANCsvmsePIzsTj
+        tKbWww0KDQoyNDYNCjAwOjE0OjM4LDYyMCAtLT4gMDA6MTQ6NDEsNTAwDQqx8MLvILu51OfE2A0K
+        DQoyNDcNCjAwOjE0OjQxLDUwMCAtLT4gMDA6MTQ6NDIsODkwDQrV0rXjysLX9rDJDQoNCjI0OA0K
+        MDA6MTQ6NDIsODkwIC0tPiAwMDoxNDo0OCw0NzANCs7S0rvWsdTaubnLvDREufq8ys/zxuUNCg0K
+        MjQ5DQowMDoxNDo0OCw0ODAgLS0+IDAwOjE0OjUwLDE5MA0K0qqyu77NueLBxMzssMkNCg0KMjUw
+        DQowMDoxNDo1MCwxOTAgLS0+IDAwOjE0OjUxLDI0MA0KusOwyQ0KDQoyNTENCjAwOjE0OjUxLDI1
+        MCAtLT4gMDA6MTQ6NTMsNTEwDQotINTaNES5+rzKz/PG5dbQDQotIM2jDQoNCjI1Mg0KMDA6MTQ6
+        NTQsNjgwIC0tPiAwMDoxNDo1NywyMjANCsC0wcTBxMn6u+6wyQ0KDQoyNTMNCjAwOjE0OjU3LDIy
+        MCAtLT4gMDA6MTQ6NTksMTAwDQq45svfztLQqcTjsrvOqsjL1qq1xMrCDQoNCjI1NA0KMDA6MTU6
+        MDIsMTcwIC0tPiAwMDoxNTowNSw5ODANCs7S09C+xcz1v+PX0w0KDQoyNTUNCjAwOjE1OjA3LDgx
+        MCAtLT4gMDA6MTU6MTIsMjEwDQq/qs23sru07SDO0s/rzP3Qqbj8y73Iy7XEysINCg0KMjU2DQow
+        MDoxNToxMiwyMjAgLS0+IDAwOjE1OjE0LDU4MA0KztK2rsHLDQoNCjI1Nw0KMDA6MTU6MTQsNTkw
+        IC0tPiAwMDoxNToxOCw5OTANCs7S09C+xcz1xNq/4w0KDQoyNTgNCjAwOjE1OjIxLDI5MCAtLT4g
+        MDA6MTU6MjMsMDYwDQrSqrK7ztLPyMC0sMkNCg0KMjU5DQowMDoxNToyMywwNjAgLS0+IDAwOjE1
+        OjI2LDIxMA0KtavO0rK7z+vWqrXAxOPT0Ly4zPXE2r/jDQoNCjI2MA0KMDA6MTU6MjYsMjEwIC0t
+        PiAwMDoxNTozMCwwNTANCrK7uf24+b7dxOPO1MrStdiw5cC0v7QNCsTj06a4w9PQ0rvHp8z1sMkN
+        Cg0KMjYxDQowMDoxNTozMCwwNTAgLS0+IDAwOjE1OjM0LDU1MA0KzP3XxSC45svfxOPQqc7SsrvO
+        qsjL1qq1xMrCDQoNCjI2Mg0KMDA6MTU6MzQsNTYwIC0tPiAwMDoxNTozNiwzOTANCs7SuNWw4bW9
+        wuXJvO22yrENCg0KMjYzDQowMDoxNTozNiwzOTAgLS0+IDAwOjE1OjQwLDQ0MA0KztLC49DYs/bR
+        3cHL0ruyv7nY09oNCrTz0MnQycmxyta1xLXNs8mxvr/WssDGrA0KDQoyNjQNCjAwOjE1OjQwLDQ1
+        MCAtLT4gMDA6MTU6NDEsODQ2DQrWrrrzIM7SuNC1vbrc0N/Aog0KDQoyNjUNCjAwOjE1OjQyLDAx
+        MCAtLT4gMDA6MTU6NDYsMTgwDQq40NC7yc+12yDEx8as19PDu7eisrwNCg0KMjY2DQowMDoxNTo0
+        NiwxODAgLS0+IDAwOjE1OjQ4LDM1MA0KztK/tLn9xMfGrMTYDQoNCjI2Nw0KMDA6MTU6NDksMzAw
+        IC0tPiAwMDoxNTo1MSw0MDANCsrHsKEgway7t7HkzKzQydDJDQoNCjI2OA0KMDA6MTU6NTQsMDQw
+        IC0tPiAwMDoxNTo1Niw5NjANCrz7xOO12tK7zOwgSG93YXJkvs3L0bW9wcsNCg0KMjY5DQowMDox
+        NTo1Niw5NjAgLS0+IDAwOjE1OjU4LDQ2MA0KxbYgzOzExC4uLg0KDQoyNzANCjAwOjE1OjU4LDQ2
+        MCAtLT4gMDA6MTY6MDEsMjYwDQq+zdTaxOOz9sPFxMfSu7/MDQoNCjI3MQ0KMDA6MTY6MDMsMjAw
+        IC0tPiAwMDoxNjowNyw4MDANCs7Sz9bU2taqtcDE49KqwcTKssO0xNrI3cHLDQoNCjI3Mg0KMDA6
+        MTY6MDcsODEwIC0tPiAwMDoxNjoxMSw1MTANCrrDsMkg1eK49sPYw9wNCs7Ssb7AtNKqtPi9+LnX
+        ssS1xA0KDQoyNzMNCjAwOjE2OjExLDUxMCAtLT4gMDA6MTY6MTIsNzkwDQq6ww0KDQoyNzQNCjAw
+        OjE2OjE1LDEwMCAtLT4gMDA6MTY6MTksNjgwDQrWrsewIFlvdXR1YmWw0dPDu6e958PmDQoNCjI3
+        NQ0KMDA6MTY6MTksNjgwIC0tPiAwMDoxNjoyNCwzNzANCtPJIsbA0Mciu7uzySKwtNTeIg0KDQoy
+        NzYNCjAwOjE2OjI0LDM3MCAtLT4gMDA6MTY6MjksMzkwDQrO0rHtw+bJz9TezawgxuTKtdK7teO2
+        vLK7DQoNCjI3Nw0KMDA6MTY6MzQsMjYwIC0tPiAwMDoxNjozNSw5MjANCtXivs3Kx8TjtcTD2MPc
+        Pw0KDQoyNzgNCjAwOjE2OjM1LDkyMCAtLT4gMDA6MTY6MzcsMDA4DQrKx7XEDQoNCjI3OQ0KMDA6
+        MTY6MzcsNjUwIC0tPiAwMDoxNjo0MSwyNDANCs3bISDSu8/Cx+HBy8quve8NCg0KMjgwDQowMDox
+        Njo0MSwyNDAgLS0+IDAwOjE2OjQ1LDk5MA0KusPByyDO0rK7zebByyDLr771yKUNCg0KMjgxDQow
+        MDoxNjo0Niw2ODAgLS0+IDAwOjE2OjQ5LDIxMA0K1Nm4+sTjy7W8/s7SsrvOqsjL1qq1xMrCDQoN
+        CjI4Mg0KMDA6MTY6NDksMjEwIC0tPiAwMDoxNjo1MCw2NjANCsTjuNXJy7qmwcvO0g0KDQoyODMN
+        CjAwOjE2OjUwLDY3MCAtLT4gMDA6MTY6NTIsNTcwDQrO0tf2tO3JtsHLPw0KDQoyODQNCjAwOjE2
+        OjUyLDU3MCAtLT4gMDA6MTY6NTgsMDIwDQrO0rOov6rQxLuzILjmy9/E47z+yMPO0sTRyty1xMrC
+        DQrE48i0sru1sbvYysINCg0KMjg1DQowMDoxNjo1OCwwMjAgLS0+IDAwOjE3OjAwLDg5MA0KztIu
+        Li4gztKyu771tcPEx9PQyrLDtA0KDQoyODYNCjAwOjE3OjAwLDg5MCAtLT4gMDA6MTc6MDMsNzMw
+        DQq1q7bUztLAtMu1yLTKx7TzysINCg0KMjg3DQowMDoxNzowNiw1ODAgLS0+IDAwOjE3OjA4LDI2
+        MA0KU2hlbGRvbiDE48u1tcO21A0KDQoyODgNCjAwOjE3OjA4LDI3MCAtLT4gMDA6MTc6MTEsMDIw
+        DQrV5rXEttSyu8bwDQrO0tOmuMO4/MHLveLE4w0KDQoyODkNCjAwOjE3OjExLDAyMCAtLT4gMDA6
+        MTc6MTIsODUwDQq908rcxOO1xLXAx7gNCg0KMjkwDQowMDoxNzoxMiw4NTAgLS0+IDAwOjE3OjE0
+        LDk0MA0K0LvQuw0KDQoyOTENCjAwOjE3OjE0LDk0MCAtLT4gMDA6MTc6MTYsMjQwDQrAtCCxp7Gn
+        Pw0KDQoyOTINCjAwOjE3OjE2LDI0MCAtLT4gMDA6MTc6MTksNjMwDQotILu5ysfO1crWsMk/DQot
+        IMC0sMkNCg0KMjkzDQowMDoxNzoyMiw2MTAgLS0+IDAwOjE3OjI3LDgzMA0Kz9bU2s7Swcu94sTj
+        sbux5Mys0MnQyc+uu/e1xLjQvvXByw0KDQoyOTQNCjAwOjE3OjQzLDMyMCAtLT4gMDA6MTc6NDQs
+        MzUwDQrN7bCyDQoNCjI5NQ0KMDA6MTc6NTIsMzMwIC0tPiAwMDoxNzo1NSw1OTANCr7TyLvT0MSw
+        yfrIy8Lyvsa4+M7Sw8cNCsrcs+jI9L6qsKENCg0KMjk2DQowMDoxNzo1NSw2MDAgLS0+IDAwOjE3
+        OjU4LDEwMA0KysewoSC40L71sru07Q0KDQoyOTcNCjAwOjE3OjU5LDYzMCAtLT4gMDA6MTg6MDIs
+        NzAwDQrD99TnztLDx7XDtKnM9dDUuNC/47/jDQoNCjI5OA0KMDA6MTg6MDIsNzAwIC0tPiAwMDox
+        ODowNSw5MTANCr+0v7TT0MO709DD4rfRusmw/LWwDQoNCjI5OQ0KMDA6MTg6MDcsMzcwIC0tPiAw
+        MDoxODoxMyw5MTANCrzZyOfLtSDV5tKq0aEgxOPRocTE0ru49j8NCg0KMzAwDQowMDoxODoxNiwx
+        ODAgLS0+IDAwOjE4OjIwLDI3MA0KztLRocTHuPa3otDNudbS7LXEsKu49tfTDQoNCjMwMQ0KMDA6
+        MTg6MjAsMjcwIC0tPiAwMDoxODoyMiwzNDANCsyrusPByyDO0s+yu7bEx7j2yt2437j2tvkNCg0K
+        MzAyDQowMDoxODoyMiwzNDAgLS0+IDAwOjE4OjI3LDAxMA0Ky/u/tMbwwLS63LTPw/cg0rK63LnC
+        xqcNCtKy0O3Du8qyw7TQ1L6t0ekNCg0KMzAzDQowMDoxODoyNywwMTAgLS0+IDAwOjE4OjI5LDkw
+        MA0Ku7m1w87SvczL+w0KDQozMDQNCjAwOjE4OjMxLDc3MCAtLT4gMDA6MTg6MzMsNjIwDQrO0tGh
+        tcS/ybK71eLR+Q0KDQozMDUNCjAwOjE4OjMzLDYyMCAtLT4gMDA6MTg6MzUsNTcwDQrO0r+0tb3L
+        +7ai18XO0tDYv7TE2A0KDQozMDYNCjAwOjE4OjM2LDQ3MCAtLT4gMDA6MTg6NDEsMjkwDQrO0s+y
+        u7bEx9bWDQrP68y9y/fO0sOr0sLA78PmtcTE0MjLDQoNCjMwNw0KMDA6MTg6NDEsMjkwIC0tPiAw
+        MDoxODo0NCwyOTANCsuzsePLtc/CIMDvw+a7ucrHvP7Dq9LCDQoNCjMwOA0KMDA6MTg6NDYsNDMw
+        IC0tPiAwMDoxODo0OSw3NzANCsTHuPa8or/KtcSwq7j219PT0LXjz/FIb3dhcmQNCg0KMzA5DQow
+        MDoxODo0OSw3NzAgLS0+IDAwOjE4OjUzLDA0MA0KxOPEx7j2tM/D97XEtKbE0M/xU2hlbGRvbg0K
+        DQozMTANCjAwOjE4OjUzLDEwMCAtLT4gMDA6MTg6NTUsNjQwDQotIM3tsLINCi0gze2wsg0KDQoz
+        MTENCjAwOjE4OjU4LDM0MCAtLT4gMDA6MTk6MDEsMzEwDQq6w8HLIEtvb3RocmFwcGFsabKpyr8N
+        Crj6xOPMuLuwuty439DLDQoNCjMxMg0KMDA6MTk6MDEsMzEwIC0tPiAwMDoxOTowMyw4MTANCrWr
+        ztLSqrvYvNINCr3it8XO0rXEsaPEt8HLDQoNCjMxMw0KMDA6MTk6MDMsODEwIC0tPiAwMDoxOTow
+        NiwwNzANCsrHsKEgztLBy73itaXJ7bi4xLi1xLjQytwNCg0KMzE0DQowMDoxOTowNiwwNzAgLS0+
+        IDAwOjE5OjA4LDAyMA0KztLT0NK71rvQobm3DQoNCjMxNQ0KMDA6MTk6MDgsMDIwIC0tPiAwMDox
+        OToxMCw4NTANCsrHsKEgzerIq9K70fkNCg0KMzE2DQowMDoxOToxMCw4NjAgLS0+IDAwOjE5OjEy
+        LDE1MA0Kze2wsg0KDQozMTcNCjAwOjE5OjEyLDE2MCAtLT4gMDA6MTk6MTMsODIwDQpEYXZpc8Wu
+        yr8uLi4NCg0KMzE4DQowMDoxOToxMyw4MjAgLS0+IDAwOjE5OjE2LDY2MA0KztIuLi4gtu4gxuTK
+        tS4uLg0KDQozMTkNCjAwOjE5OjE2LDY2MCAtLT4gMDA6MTk6MjAsODEwDQq98c3tztLKx7Gn18XD
+        7MOjz6PN+w0Kuf3AtL+0v7TE3LK7xNzF3bW9ucK2wLXEsqnKv7rzDQoNCjMyMA0KMDA6MTk6MjAs
+        ODIwIC0tPiAwMDoxOToyNSwwNTANCrWryLS6zcTj1ebQxMHEyc/Byw0KDQozMjENCjAwOjE5OjI1
+        LDA1MCAtLT4gMDA6MTk6MjcsODIwDQq4/LzTw8DD7rXE0rvN7Q0KDQozMjINCjAwOjE5OjI4LDU2
+        MCAtLT4gMDA6MTk6MzAsNjIwDQrE48jLuty6ww0KDQozMjMNCjAwOjE5OjMwLDYzMCAtLT4gMDA6
+        MTk6MzIsMzcwDQrE47K7u+G21M7S09DS4su8sMk/DQoNCjMyNA0KMDA6MTk6MzIsMzgwIC0tPiAw
+        MDoxOTozNCwxMzANCrK7ILK7ILK7IMTHvs236MHLIQ0KDQozMjUNCjAwOjE5OjM0LDEzMCAtLT4g
+        MDA6MTk6MzgsNDAwDQq82cjnztK21MTj09DS4su8IMTj1Oe3or71wcsNCtTauNC+9bK7y6zWrtPg
+        IMTju7m74dPQtePNrMfpztINCg0KMzI2DQowMDoxOTo0Miw2NzAgLS0+IDAwOjE5OjQ0LDU1MA0K
+        xOPV5r/JsK4NCg0KMzI3DQowMDoxOTo0NCw1OTAgLS0+IDAwOjE5OjQ2LDk5OQ0Kze2wsiBLb290
+        aHJhcHBhbGmyqcq/DQoNCjMyOA0KMDA6MTk6NDcsMDEwIC0tPiAwMDoxOTo0OSw2MTANCs3tsLIN
+        Cg0KMzI5DQowMDoxOTo1MSwxMTAgLS0+IDAwOjE5OjUzLDMzMA0Kw7LLxsTjtcDHuLPJuabByw0K
+        DQozMzANCjAwOjE5OjUzLDMzMCAtLT4gMDA6MTk6NTUsMDMwDQq2+MfSLi4uDQoNCjMzMQ0KMDA6
+        MTk6NTUsMDMwIC0tPiAwMDoxOTo1NywxMjANCs7SvvW1w87Sw8e7uc2mwLS157XEDQoNCjMzMg0K
+        MDA6MTk6NTcsMTIwIC0tPiAwMDoxOTo1OSw3OTANCsvjwcuwySDAtLXnxOO49s23DQoNCjMzMw0K
+        MDA6MTk6NTksNzkwIC0tPiAwMDoyMDowMSw5OTANCsTjyrLDtMqxuvKzycHLIsC0tefWrs31IsHL
+        Pw0KDQozMzQNCjAwOjIwOjA0LDMyMCAtLT4gMDA6MjA6MDYsMDk4DQq6w7DJIL7Ny+PE48PH09DA
+        tLXnDQoNCjMzNQ0KMDA6MjA6MDYsMTEwIC0tPiAwMDoyMDowOCw3ODANCi0gsb7AtL7N09ANCi0g
+        w7vT0A0KDQozMzYNCjAwOjIwOjA4LDc4MCAtLT4gMDA6MjA6MTIsODgwDQq1qy4uLiC1q7y0yrnT
+        0CDE49Kq1PXDtNf2Pw0KDQozMzcNCjAwOjIwOjEyLDg4MCAtLT4gMDA6MjA6MTgsODAwDQrO0rvh
+        wv3C/bm00v3L/Q0K1rG1vcv9zt7W+rXYtbnU2s7StLLJzw0KDQozMzgNCjAwOjIwOjE4LDgxMCAt
+        LT4gMDA6MjA6MjAsODEwDQq/ys3718XWu9PQztLE3Lj4y/21xL/swNYNCg0KMzM5DQowMDoyMDoy
+        MCw4MTAgLS0+IDAwOjIwOjIyLDY4MA0KLSDL+dLUy7UgyrLDtLa8srvX9g0KLSDKssO0tryyu9f2
+        DQoNCjM0MA0KMDA6MjA6MjgsNjAwIC0tPiAwMDoyMDozNCw3MzANCtXmuN/Qy76vsuzW1dPa16W1
+        vcHLxMe49g0K0MTA7bHkzKy1xLv50vK4xNTs0MnQyQ0KDQozNDENCjAwOjIwOjM5LDk5MCAtLT4g
+        MDA6MjA6NDIsMjEwDQrO0reiysQg1eLKx87Sxa7F89PRIQ0KDQozNDINCjAwOjIwOjQzLDc1MCAt
+        LT4gMDA6MjA6NDcsMjgwDQpMZW9uYXJkISBMZW9uYXJkIQ0KTGVvbmFyZCEgTGVvbmFyZCENCg0K
+        MzQzDQowMDoyMDo0OCwyNDAgLS0+IDAwOjIwOjUwLDE0MA0KPGZvbnQgY29sb3I9IzIzOEU2OD4t
+        LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQ0Ksb7C28yz19bEu732t63S6727
+        wffRp8+w1q7Tww0KvfvWucjOus7JzNK108PNvrfx1PK687n719S4ug0KLS0tLS0tLS0tLS0tLS0t
+        LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS08L2ZvbnQ+DQoNCjM0NA0KMDA6MjA6NTAsMjgwIC0tPiAw
+        MDoyMDo1MiwyNjANCjxmb250IGNvbG9yPSMyMzhFNjg+zOyyxcDtwtu0qyC12sbfvL4gtdrSu7yv
+        IM3qDQo3MjBQIGlUdW5lcyAtINfUwLT33GFrPC9mb250Pg0K
+    headers:
+      cache-control:
+      - max-age=2678400
+      connection:
+      - keep-alive
+      content-disposition:
+      - subtitle; filename="The.Big.Bang.Theory.S07E01.The.Hofstadter.Insufficiency.720p.WEB-DL.DD5.1.H.264.srt"
+      content-length:
+      - '21411'
+      content-type:
+      - application/octet-stream
+      date:
+      - Sat, 30 Nov 2019 07:14:46 GMT
+      expires:
+      - Tue, 31 Dec 2019 07:14:46 GMT
+      master:
+      - Windu
+      server:
+      - nginx
+      x-cache:
+      - HIT
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/assrt/test_download_subtitle.yaml
+++ b/tests/cassettes/assrt/test_download_subtitle.yaml
@@ -1,0 +1,3932 @@
+interactions:
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - Sub-Zero/2
+    method: GET
+    uri: https://api.assrt.net/v1/sub/search?q=%5B%27Man+of+Steel+2013%27%5D&token=SECRET&is_file=%5B%271%27%5D
+  response:
+    body:
+      string: "{\"status\":0,\"sub\":{\"keyword\":\"Man of Steel 2013\",\"result\"\
+        :\"succeed\",\"subs\":[{\"subtype\":\"SSA\",\"id\":618185,\"lang\":{\"desc\"\
+        :\"\u82F1 \u7B80 \u7E41 \u53CC\u8BED\",\"langlist\":{\"langcht\":true,\"langeng\"\
+        :true,\"langdou\":true,\"langchs\":true}},\"vote_score\":0,\"upload_time\"\
+        :\"2018-01-26 12:19:27\",\"native_name\":\"\u8D85\u4EBA\uFF1A\u94A2\u94C1\u4E4B\
+        \u8EAF.Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7B80\u7E41\u82F1\
+        \u53CC\u8BED\u5B57\u5E55\",\"videoname\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT\"\
+        ,\"release_site\":\"CMCT\",\"revision\":0},{\"upload_time\":\"2014-12-06 04:13:44\"\
+        ,\"subtype\":\"SSA\",\"id\":316973,\"native_name\":\"\u8D85\u4EBA\uFF1A\u94A2\
+        \u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA\uFF1A\u94A2\u94C1\u82F1\u96C4\",\"videoname\"\
+        :\"Man of Steel 2013 720p BluRay x264 DTS-WiKi\",\"revision\":0,\"vote_score\"\
+        :0},{\"upload_time\":\"2014-03-17 15:30:19\",\"subtype\":\"Subrip(srt)\",\"\
+        revision\":0,\"id\":253629,\"lang\":{\"desc\":\"\u7E41\",\"langlist\":{\"\
+        langcht\":true}},\"videoname\":\"[\u8D85\u4EBA \u92FC\u9435\u82F1\u96C4]Man.of.Steel.(2013).BDRip.720p.DTS.X264-Felony\"\
+        ,\"native_name\":\"\",\"vote_score\":0},{\"upload_time\":\"2014-03-05 18:10:39\"\
+        ,\"subtype\":\"SSA\",\"revision\":0,\"id\":252930,\"lang\":{\"desc\":\"\u82F1\
+        \ \u7E41 \u53CC\u8BED\",\"langlist\":{\"langeng\":true,\"langcht\":true,\"\
+        langdou\":true}},\"videoname\":\"Man of Steel\",\"native_name\":\"\u8D85\u4EBA\
+        \uFF1A\u92FC\u9435\u82F1\u96C4\",\"vote_score\":45},{\"upload_time\":\"2013-11-09\
+        \ 10:43:13\",\"subtype\":\"Subrip(srt)\",\"revision\":0,\"id\":246016,\"lang\"\
+        :{\"desc\":\"\u82F1 \u7B80 \u7E41\",\"langlist\":{\"langeng\":true,\"langchs\"\
+        :true,\"langcht\":true}},\"videoname\":\"Man.of.Steel.2013.720p.BluRay.x264.YIFY\"\
+        ,\"native_name\":\"\u8D85\u4EBA\uFF1A\u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA\
+        \uFF1A\u94A2\u94C1\u82F1\u96C4\\/\u3010TLF\u5B57\u5E55\u7EC4\u3011Man of Steel\"\
+        ,\"vote_score\":0},{\"upload_time\":\"2013-11-02 05:56:40\",\"subtype\":\"\
+        SSA\",\"revision\":0,\"id\":245602,\"lang\":{\"desc\":\"\u7B80 \u7E41 \u53CC\
+        \u8BED\",\"langlist\":{\"langcht\":true,\"langchs\":true,\"langdou\":true}},\"\
+        videoname\":\"Man of Steel 1080p.bluray.x264-sector7\",\"native_name\":\"\u8D85\
+        \u4EBA\uFF1A\u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA\uFF1A\u94A2\u94C1\u82F1\
+        \u96C4\\/\u7279\u6548\u53CC\u8BED\\/\u84DD\u5149\u5B57\u5E55\",\"vote_score\"\
+        :0},{\"upload_time\":\"2013-10-31 23:41:07\",\"subtype\":\"\u5176\u4ED6\"\
+        ,\"revision\":0,\"id\":245568,\"lang\":{\"desc\":\"\u7B80\",\"langlist\":{\"\
+        langchs\":true}},\"videoname\":\"Man.of.Steel.2013\",\"native_name\":\"\u8D85\
+        \u4EBA: \u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA: \u94A2\u94C1\u82F1\u96C4\"\
+        ,\"vote_score\":0},{\"upload_time\":\"2013-10-27 07:04:18\",\"subtype\":\"\
+        VobSub\",\"id\":245259,\"native_name\":\"\",\"videoname\":\"Man.Of.Steel.3D.2013.1080p.BluRay.Half-SBS.DTS.x264-PublicHD\"\
+        ,\"revision\":0,\"vote_score\":100},{\"upload_time\":\"2013-10-25 04:50:37\"\
+        ,\"subtype\":\"Subrip(srt)\",\"revision\":0,\"id\":245131,\"lang\":{\"desc\"\
+        :\"\u7B80\",\"langlist\":{\"langchs\":true}},\"videoname\":\"Man.Of.Steel\"\
+        ,\"native_name\":\"\u8D85\u4EBA-\u94A2\u94C1\u4E4B\u8EAF\",\"vote_score\"\
+        :80},{\"upload_time\":\"2013-10-24 07:52:31\",\"subtype\":\"SSA\",\"revision\"\
+        :0,\"id\":245056,\"lang\":{\"desc\":\"\u7E41\",\"langlist\":{\"langcht\":true}},\"\
+        videoname\":\"\u8D85\u4EBA \u92FC\u9435\u82F1\u96C4 Man of Steel (2013) 1080p.cht\"\
+        ,\"native_name\":\"\",\"vote_score\":0},{\"upload_time\":\"2013-10-23 00:46:40\"\
+        ,\"subtype\":\"Subrip(srt)\",\"revision\":0,\"id\":244971,\"lang\":{\"desc\"\
+        :\"\u7B80 \u7E41\",\"langlist\":{\"langcht\":true,\"langchs\":true}},\"videoname\"\
+        :\"\u8D85\u4EBA: \u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA: \u94A2\u94C1\u82F1\
+        \u96C4(\u6E2F\\/\u53F0).Man.of.Steel.2013.BluRay CEE\u7248\u84DD\u5149\u539F\
+        \u76D8\",\"native_name\":\"\u84DD\u5149\u539F\u76D8\u5B57\u5E55\",\"vote_score\"\
+        :10},{\"upload_time\":\"2013-10-22 23:39:00\",\"subtype\":\"Subrip(srt)\"\
+        ,\"revision\":0,\"id\":244969,\"lang\":{\"desc\":\"\",\"langlist\":{}},\"\
+        videoname\":\"Man.Of.Steel.3D.2013.1080p.BluRay.Half-SBS.DTS.x264-PublicHD\"\
+        ,\"native_name\":\"\u8D85\u4EBA\uFF1A\u94A2\u94C1\u4E4B\u8EAF 3D\\/\u8D85\u4EBA\
+        \uFF1A\u94A2\u94C1\u82F1\u96C4\\/Man of Steel 3D\",\"vote_score\":0},{\"upload_time\"\
+        :\"2013-10-22 22:06:42\",\"subtype\":\"SSA\",\"revision\":0,\"id\":244960,\"\
+        lang\":{\"desc\":\"\u82F1 \u7B80\",\"langlist\":{\"langchs\":true,\"langeng\"\
+        :true}},\"videoname\":\"Superman: Man of Steel BD\",\"native_name\":\"\u8D85\
+        \u4EBA:\u94A2\u94C1\u4E4B\u8EAF\",\"vote_score\":0},{\"upload_time\":\"2013-10-22\
+        \ 17:42:45\",\"subtype\":\"\u5176\u4ED6\",\"revision\":0,\"id\":244939,\"\
+        lang\":{\"desc\":\"\",\"langlist\":{}},\"videoname\":\"\u8D85\u4EBA\uFF1A\u94A2\
+        \u94C1\u4E4B\u8EAF.Man.of.Steel.2013.1080p-PublicHD 2D.1080p\u62163D.1080p.HSBS-PublicHD\"\
+        ,\"native_name\":\"\",\"vote_score\":0},{\"upload_time\":\"2013-10-21 16:52:23\"\
+        ,\"subtype\":\"Subrip(srt)\",\"revision\":0,\"id\":244863,\"lang\":{\"desc\"\
+        :\"\u82F1 \u7B80 \u7E41\",\"langlist\":{\"langeng\":true,\"langchs\":true,\"\
+        langcht\":true}},\"videoname\":\"man.of.steel.2013.720p.bluray.x264-felony.mkv\"\
+        ,\"native_name\":\"\\/Man of Steel \\/\u8D85\u4EBA:\u94A2\u94C1\u4E4B\u8EAF\
+        \\/\u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA:\u94A2\u94C1\u82F1\u96C4\",\"vote_score\"\
+        :0}],\"action\":\"search\"}}\n"
+    headers:
+      access-control-allow-origin:
+      - '*'
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Sat, 30 Nov 2019 07:14:40 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - Sub-Zero/2
+    method: GET
+    uri: https://api.assrt.net/v1/sub/detail?token=SECRET&id=%5B%27618185%27%5D
+  response:
+    body:
+      string: "{\"status\":0,\"sub\":{\"result\":\"succeed\",\"subs\":[{\"id\":618185,\"\
+        filelist\":[{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618185\\/-\\\
+        /1\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E7%AE%80%E4%BD%93%26%E8%8B%B1%E6%96%87.ass?_=1575098080&-=89464d94d08c606674b645a8625f3dae&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7B80\u4F53\
+        &\u82F1\u6587.ass\",\"s\":\"233KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\\
+        /onthefly\\/618185\\/-\\/2\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E7%AE%80%E4%BD%93%26%E8%8B%B1%E6%96%87.srt?_=1575098080&-=50d60b7ab566442b141746abb7446eed&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7B80\u4F53\
+        &\u82F1\u6587.srt\",\"s\":\"200KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\\
+        /onthefly\\/618185\\/-\\/3\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E7%AE%80%E4%BD%93.ass?_=1575098080&-=c22e2c72cf726d705f9f5cfcc69bed3e&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7B80\u4F53\
+        .ass\",\"s\":\"133KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\\
+        /618185\\/-\\/4\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E7%AE%80%E4%BD%93.srt?_=1575098080&-=872afa545589f9edab516c4de1b4da66&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7B80\u4F53\
+        .srt\",\"s\":\"80KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\\
+        /618185\\/-\\/5\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E7%B9%81%E4%BD%93%26%E8%8B%B1%E6%96%87.ass?_=1575098080&-=ba69a8766469b168fa0024bee07644ff&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7E41\u4F53\
+        &\u82F1\u6587.ass\",\"s\":\"233KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\\
+        /onthefly\\/618185\\/-\\/6\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E7%B9%81%E4%BD%93%26%E8%8B%B1%E6%96%87.srt?_=1575098080&-=f3c74b15bc3f3275d57f78d97dae639a&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7E41\u4F53\
+        &\u82F1\u6587.srt\",\"s\":\"200KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\\
+        /onthefly\\/618185\\/-\\/7\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E7%B9%81%E4%BD%93.ass?_=1575098080&-=2fd32d1e9258bd0d723d35996abb6528&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7E41\u4F53\
+        .ass\",\"s\":\"133KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\\
+        /618185\\/-\\/8\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E7%B9%81%E4%BD%93.srt?_=1575098080&-=fe26844b485b60d3e799f1dfaa3d4173&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7E41\u4F53\
+        .srt\",\"s\":\"119KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\\
+        /618185\\/-\\/9\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E8%8B%B1%E6%96%87%26%E7%AE%80%E4%BD%93.ass?_=1575098080&-=c027d5b713399dca2f0911399ae547bd&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u82F1\u6587\
+        &\u7B80\u4F53.ass\",\"s\":\"233KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\\
+        /onthefly\\/618185\\/-\\/10\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E8%8B%B1%E6%96%87%26%E7%AE%80%E4%BD%93.srt?_=1575098080&-=f38451f13a3c0e9aa847436bc6bd4f6a&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u82F1\u6587\
+        &\u7B80\u4F53.srt\",\"s\":\"200KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\\
+        /onthefly\\/618185\\/-\\/11\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E8%8B%B1%E6%96%87%26%E7%B9%81%E4%BD%93.ass?_=1575098080&-=0aeb81283ff1fc32b011e67b95cf3c29&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u82F1\u6587\
+        &\u7E41\u4F53.ass\",\"s\":\"233KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\\
+        /onthefly\\/618185\\/-\\/12\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E8%8B%B1%E6%96%87%26%E7%B9%81%E4%BD%93.srt?_=1575098080&-=bb97c6954807ffe4004084562f3a3f5a&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u82F1\u6587\
+        &\u7E41\u4F53.srt\",\"s\":\"200KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\\
+        /onthefly\\/618185\\/-\\/13\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E8%8B%B1%E6%96%87.srt?_=1575098080&-=73a24cabafbb7a59383e204de657a971&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u82F1\u6587\
+        .srt\",\"s\":\"85KB\"}],\"url\":\"http:\\/\\/file0.assrt.net\\/download\\\
+        /618185\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.zip?_=1575098080&-=272e8e5858cae6889592e4ec48dab6b5&api=1\"\
+        ,\"release_site\":\"CMCT\",\"revision\":0,\"filename\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.zip\"\
+        ,\"subtype\":\"SSA\",\"lang\":{\"desc\":\"\u82F1 \u7B80 \u7E41 \u53CC\u8BED\
+        \",\"langlist\":{\"langchs\":true,\"langeng\":true,\"langdou\":true,\"langcht\"\
+        :true}},\"videoname\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT\"\
+        ,\"vote_score\":0,\"upload_time\":\"2018-01-26 12:19:27\",\"title\":\"\u8D85\
+        \u4EBA\uFF1A\u94A2\u94C1\u4E4B\u8EAF.Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7B80\
+        \u7E41\u82F1\u53CC\u8BED\u5B57\u5E55\",\"view_count\":2541,\"native_name\"\
+        :\"\u8D85\u4EBA\uFF1A\u94A2\u94C1\u4E4B\u8EAF.Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7B80\
+        \u7E41\u82F1\u53CC\u8BED\u5B57\u5E55\",\"producer\":{\"source\":\"\u539F\u521B\
+        \u7FFB\u8BD1\",\"verifier\":\"\",\"producer\":\"\",\"uploader\":\"\"},\"size\"\
+        :627625,\"down_count\":1290}],\"action\":\"detail\"}}\n"
+    headers:
+      access-control-allow-origin:
+      - '*'
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Sat, 30 Nov 2019 07:14:40 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - Sub-Zero/2
+    method: GET
+    uri: http://file0.assrt.net/onthefly/618185/-/5/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E7%B9%81%E4%BD%93%26%E8%8B%B1%E6%96%87.ass?api=%5B%271%27%5D&-=%5B%27ba69a8766469b168fa0024bee07644ff%27%5D&_=%5B%271575098080%27%5D
+  response:
+    body:
+      string: "\uFEFF[Script Info]\r\n;SrtEdit 6.3.2012.1001\r\n;Copyright(C) 2005-2012\
+        \ Yuan Weiguo\r\n\r\nTitle: \r\nOriginal Script: \r\nOriginal Translation:\
+        \ \r\nOriginal Timing: \r\nOriginal Editing: \r\nScript Updated By: \r\nUpdate\
+        \ Details: \r\nScriptType: v4.00+\r\nCollisions: Normal\r\nPlayResX: 384\r\
+        \nPlayResY: 288\r\nTimer: 100.0000\r\nSynch Point: \r\nWrapStyle: 0\r\nScaledBorderAndShadow:\
+        \ no\r\n\r\n[V4+ Styles]\r\nFormat: Name, Fontname, Fontsize, PrimaryColour,\
+        \ SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut,\
+        \ ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment,\
+        \ MarginL, MarginR, MarginV, Encoding\r\nStyle: chs,Arial,20,&H00E0E0E0,&H00000000,&H00000000,&H80000000,0,0,0,0,100,100,0,0,0,2,1,2,1,1,1,1\r\
+        \nStyle: Default,Arial,18,&H00FFFFFF,&H0000FFFF,&H00000000,&H00000000,-1,0,0,0,100,100,0,0,1,2,3,2,20,20,20,1\r\
+        \n\r\n[Events]\r\nFormat: Layer, Start, End, Style, Name, MarginL, MarginR,\
+        \ MarginV, Effect, Text\r\nDialogue: 0,0:00:01.00,0:00:05.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\fs18\\1c&H00FFFF&}--==\u672C\u5F71\u7247\u7531\
+        \ {\\1c&HFF8000&\\b1}CMCT \u5718\u968A{\\r\\fn\u534E\u6587\u6977\u4F53\\fs18\\\
+        1c&H00FFFF&} \u69AE\u8B7D\u51FA\u54C1==--\\N\u66F4\u591A\u7CBE\u5F69\u5F71\
+        \u8996 \u8ACB\u8A2A\u554F {\\fnCronos Pro Light Subhead\\1c&HFF00FF&\\b1}http://cmct.cc{\\\
+        r\\fn\u534E\u6587\u6977\u4F53\\fs18\\1c&H00FFFF&}{\\r}\r\nDialogue: 0,0:00:06.00,0:00:10.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\fs16\\1c&H00FFFF&}\u5F71\u7247\u58D3\u5236: \u66AE\
+        \u96E8\u701F\u701F   \u5B57\u5E55\u8ABF\u6821\uFF1A\u4E5D\u5929     \u62DB\
+        \u52DFQ\u865F: 76846146{\\r}\r\nDialogue: 0,0:00:58.52,0:01:00.02,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5FEB\u9EDE{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Hurry!{\\r}\r\nDialogue: 0,0:02:11.03,0:02:14.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5011\u9084\u4E0D\u660E\u767D\u55CE\
+        \uFF1F\u6C2A\u661F\u7684\u6838\u5FC3\u6B63\u5728\u574D\u584C{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Do you not understand? Krypton's core\
+        \ is collapsing.{\\r}\r\nDialogue: 0,0:02:15.20,0:02:18.54,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u4E5F\u8A31\u53EA\u5269\u5E7E\
+        \u500B\u661F\u671F\u4E86 \u6211\u8B66\u544A\u904E\u4F60\u5011{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We may only have a matter of weeks.\
+        \ I warned you.{\\r}\r\nDialogue: 0,0:02:18.80,0:02:22.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u958B\u767C\u6838\u5FC3\u7684\u80FD\u6E90\
+        \u8207\u81EA\u6BBA\u7121\u7570{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Harvesting the core was suicide. It has accelerated...{\\r}\r\nDialogue:\
+        \ 0,0:02:22.54,0:02:25.28,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}- \u5167\u7206\u7684\u901F\u5EA6\u5DF2\u7D93\u52A0\u5FEB   - \u6211\
+        \u5011\u7684\u80FD\u6E90\u5132\u5099\u5DF2\u7D93\u8017\u76E1{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- ...the process of implosion.   \
+        \    - Our energy reserves...{\\r}\r\nDialogue: 0,0:02:25.51,0:02:27.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u9084\u80FD\u600E\u9EBC\u8FA6\
+        \ \u827E\u723E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...were\
+        \ exhausted. What would you have us do, El?{\\r}\r\nDialogue: 0,0:02:28.14,0:02:31.56,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u50CF\u6211\u5011\u7684\u7956\u5148\u4E00\
+        \u6A23 \u653E\u773C\u5B87\u5B99{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Look to the stars, like our ancestors did.{\\r}\r\nDialogue: 0,0:02:31.81,0:02:35.69,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9069\u5408\u5C45\u4F4F\u7684\u4E16\u754C\
+        \u89F8\u624B\u53EF\u53CA \u6211\u5011\u53EF\u4EE5\u5148\u7528\u90A3\u4E9B\u820A\
+        \u524D\u54E8\u7AD9{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}There\
+        \ are habitable worlds within reach. We can begin by using the old outposts.{\\\
+        r}\r\nDialogue: 0,0:02:35.95,0:02:39.66,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u771F\u7684\u60F3\u8981\u64A4\u96E2\u5168\u661F\
+        \u7403\u7684\u4EBA\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Are you seriously suggesting that we evacuate the entire planet?{\\\
+        r}\r\nDialogue: 0,0:02:39.89,0:02:43.34,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E0D \u6211\u5011\u5DF2\u7D93\u6551\u4E0D\u4E86\u9019\
+        \u88CF\u7684\u4EBA\u5011\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}No. Everybody here is already dead.{\\r}\r\nDialogue: 0,0:02:44.16,0:02:48.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u628A\u5BC6\u5178\u4EA4\u7D66\u6211 \u6211\
+        \u4FDD\u8B49\u8B93\u6211\u5011\u7A2E\u65CF\u5B58\u6D3B\u4E0B\u53BB{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Give me control of the\
+        \ Codex. I will ensure the survival of our race.{\\r}\r\nDialogue: 0,0:02:48.66,0:02:49.73,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9084\u6709\u5E0C\u671B{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}There is still hope.{\\r}\r\nDialogue:\
+        \ 0,0:02:50.00,0:02:53.00,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u5C07\u9019\u500B\u5E0C\u671B\u63E1\u5728\u4E86\u6211\u7684\
+        \u624B\u5FC3{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I have\
+        \ held that hope in my hands.{\\r}\r\nDialogue: 0,0:03:07.42,0:03:09.96,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9577\u8001\u6703\u5DF2\u7D93\u89E3\u6563\
+        \u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}This council\
+        \ has been disbanded.{\\r}\r\nDialogue: 0,0:03:10.05,0:03:11.90,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8AB0\u4E0B\u7684\u547D\u4EE4\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}On whose authority?{\\\
+        r}\r\nDialogue: 0,0:03:12.25,0:03:13.39,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Mine.{\\r}\r\nDialogue: 0,0:03:17.16,0:03:21.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5176\u9918\u7684\u4EBA\u5C07\u88AB\u5BE9\
+        \u5224 \u4E26\u914C\u60C5\u8655\u7F70{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}The rest of you will be tried and punished accordingly.{\\\
+        r}\r\nDialogue: 0,0:03:23.43,0:03:26.70,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u4F60\u5728\u5E79\u4EC0\u9EBC \u4F50\u5FB7\uFF1F\u4F60\
+        \u760B\u4E86   - \u6211\u5E7E\u5E74\u524D\u5C31\u8A72\u52D5\u624B\u4E86{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- What are you doing,\
+        \ Zod? This is madness.       - What I should have done years ago...{\\r}\r\
+        \nDialogue: 0,0:03:27.17,0:03:32.00,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u662F\u9019\u4E9B\u7ACB\u6CD5\u8005\u548C\u4ED6\u5011\
+        \u7121\u4F11\u6B62\u7684\u722D\u8AD6\u6BC0\u4E86\u6C2A\u661F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}These lawmakers with their endless\
+        \ debates have lead Krypton to ruin.{\\r}\r\nDialogue: 0,0:03:34.28,0:03:35.95,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C31\u7B97\u4F60\u7684\u8ECD\u968A\u52DD\
+        \u5229\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And\
+        \ if your forces prevail...{\\r}\r\nDialogue: 0,0:03:36.21,0:03:38.85,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4F60\u4E5F\u53EA\u80FD\u662F\u500B\u5149\
+        \u687F\u53F8\u4EE4   - \u90A3\u5C31\u52A0\u5165\u6211\u7684\u884C\u5217\u5427\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- ...you'll be the\
+        \ leader of nothing.       - Then join me.{\\r}\r\nDialogue: 0,0:03:39.08,0:03:42.19,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5354\u52A9\u6211\u62EF\u6551\u6211\u5011\
+        \u7684\u7A2E\u65CF \u6211\u5011\u91CD\u65B0\u958B\u59CB{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Help me save our race. We'll start\
+        \ anew.{\\r}\r\nDialogue: 0,0:03:42.42,0:03:46.60,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C07\u8B93\u6211\u5011\u6DEA\u843D\u5230\
+        \u5982\u6B64\u7530\u5730\u7684\u58AE\u843D\u8840\u8108\u5207\u65B7{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We'll sever the degenerative\
+        \ bloodlines that led us to this state.{\\r}\r\nDialogue: 0,0:03:46.72,0:03:49.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8AB0\u4F86\u6C7A\u5B9A\u8AB0\u53BB\u8AB0\
+        \u7559 \u4F50\u5FB7\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}And who will decide which bloodlines survive, Zod?{\\r}\r\nDialogue:\
+        \ 0,0:03:51.53,0:03:52.37,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You?{\\r}\r\nDialogue: 0,0:03:54.90,0:03:56.60,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5225\u9019\u6A23 \u827E\u723E{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Don't do this, El.{\\r}\r\n\
+        Dialogue: 0,0:03:56.87,0:03:59.31,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6211\u6700\u4E0D\u9858\u610F\u770B\u5230\u7684 \u5C31\u662F\
+        \u6211\u5011\u53CD\u76EE\u6210\u4EC7{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}The last thing I want is for us to be enemies.{\\r}\r\n\
+        Dialogue: 0,0:03:59.57,0:04:02.21,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4F60\u80CC\u68C4\u4E86\u6211\u5011\u76F8\u7D04\u7ACB\u4E0B\
+        \u7684\u539F\u5247{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You\
+        \ have abandoned the principles that bound us together.{\\r}\r\nDialogue:\
+        \ 0,0:04:02.44,0:04:06.00,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u5C07\u528D\u6307\u5411\u4E86\u81EA\u5DF1\u7684\u4EBA\u6C11\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You've taken up\
+        \ the sword against your own people.{\\r}\r\nDialogue: 0,0:04:06.48,0:04:09.39,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u656C\u91CD\u7684\u662F\u66FE\u7D93\
+        \u7684\u4F60 \u4F50\u5FB7{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I will honor the man you once were, Zod...{\\r}\r\nDialogue: 0,0:04:09.81,0:04:11.79,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u800C\u4E0D\u662F\u5982\u4ECA\u9019\u500B\
+        \u79BD\u7378{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...not\
+        \ this monster you've become.{\\r}\r\nDialogue: 0,0:04:15.08,0:04:16.43,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u628A\u4ED6\u5E36\u8D70{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Take him away.{\\r}\r\nDialogue: 0,0:04:22.59,0:04:23.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E3B\u4EBA \u4E00\u5207\u662F\u5426\u5B89\
+        \u597D\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Sir?\
+        \ Is everything all right?{\\r}\r\nDialogue: 0,0:04:24.16,0:04:25.47,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8B93\u958B{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Out of the way.{\\r}\r\nDialogue: 0,0:04:26.33,0:04:27.53,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u518D\u8AAA\u4E00\u904D{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I said...{\\r}\r\nDialogue:\
+        \ 0,0:04:43.81,0:04:44.85,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u53EB\u840A\u62C9\u904E\u4F86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Get me Lara.{\\r}\r\nDialogue: 0,0:04:46.18,0:04:48.35,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u55AC \u6CE8\u610F\u8EAB\u5F8C{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Jor. Behind you.{\\r}\r\nDialogue:\
+        \ 0,0:04:52.25,0:04:54.26,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u840A\u62C9 \u6E96\u5099\u597D\u767C\u5C04{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Lara, you have to ready the launch.{\\\
+        r}\r\nDialogue: 0,0:04:54.49,0:04:56.66,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u6703\u76E1\u5FEB\u8DDF\u4F60\u6703\u5408{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'll be with you as soon\
+        \ as I can.{\\r}\r\nDialogue: 0,0:05:10.97,0:05:12.54,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8D6B\u62C9\u5361{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}H'Raka!{\\r}\r\nDialogue: 0,0:05:51.58,0:05:54.32,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u80FD\u770B\u5230\u5BC6\u5178\u55CE\uFF1F\
+        \ - \u5C31\u5728\u4E2D\u6A1E\u7684\u4E0B\u65B9 \u4E3B\u4EBA{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Can you see the Codex?        -\
+        \ It's just beneath the central hub.{\\r}\r\nDialogue: 0,0:05:54.55,0:05:55.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u6211\u4E0D\u5F97\u4E0D\u8B66\u544A\
+        \u60A8{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}But I'm compelled\
+        \ to warn you.{\\r}\r\nDialogue: 0,0:05:55.92,0:05:58.23,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5165\u4FB5\u59CB\u6E90\u5BA4\u662FB\u7D1A\
+        \u72AF\u7F6A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Breaching\
+        \ the genesis chamber is a Class-B crime...{\\r}\r\nDialogue: 0,0:05:58.49,0:06:02.06,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6C92\u4EBA\u5728\u4E4E\u9019\u500B\u4E86\
+        \ \u57FA\u5217\u514B\u65AF \u9019\u500B\u4E16\u754C\u5C31\u8981\u6BC0\u6EC5\
+        \u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Nobody cares\
+        \ anymore, Kelex. The world is about to come to an end.{\\r}\r\nDialogue:\
+        \ 0,0:07:06.72,0:07:09.90,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u55AC\u2022\u827E\u723E \u4F50\u5FB7\u5C07\u8ECD\u6709\u4EE4{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Jor-El, by the authority\
+        \ of General Zod...{\\r}\r\nDialogue: 0,0:07:10.13,0:07:12.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4EA4\u51FA\u5BC6\u5178{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...surrender the Codex.{\\r}\r\nDialogue:\
+        \ 0,0:08:00.01,0:08:01.54,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5805\u6301\u4F4F \u8D6B\u62C9\u5361{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Easy, H'Raka.{\\r}\r\nDialogue: 0,0:08:22.50,0:08:24.14,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5011\u627E\u5230\u4E86\u90A3\u500B\
+        \u4E16\u754C\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Did you find a world?{\\r}\r\nDialogue: 0,0:08:24.33,0:08:26.65,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u627E\u5230\u4E86   - \u5B83\u7E5E\u8457\
+        \u4E00\u9846\u9EC3\u8272\u4E3B\u5E8F\u661F\u904B\u884C{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- We have.        - Orbiting a main\
+        \ sequence yellow star...{\\r}\r\nDialogue: 0,0:08:26.87,0:08:28.58,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6B63\u5982\u60A8\u6240\u8AAA{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...just as you said it would.{\\\
+        r}\r\nDialogue: 0,0:08:29.87,0:08:31.48,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u9019\u662F\u9846\u5E74\u8F15\u7684\u6046\u661F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}A young star.{\\r}\r\n\
+        Dialogue: 0,0:08:31.84,0:08:34.21,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4ED6\u7684\u7D30\u80DE\u80FD\u5438\u6536\u5B83\u7684\u8F3B\
+        \u5C04\u80FD{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}His\
+        \ cells will drink its radiation.{\\r}\r\nDialogue: 0,0:08:36.64,0:08:38.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F3C\u4E4E\u662F\u667A\u80FD\u751F\u7269\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's a seemingly\
+        \ intelligent population.{\\r}\r\nDialogue: 0,0:08:39.81,0:08:40.88,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u6703\u88AB\u907A\u68C4{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He'll be an outcast.{\\r}\r\
+        \nDialogue: 0,0:08:41.88,0:08:43.33,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u88AB\u7576\u6210\u602A\u7269{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}A freak.{\\r}\r\nDialogue: 0,0:08:44.55,0:08:45.36,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u6703\u88AB\u6BBA\u6389\u7684{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}They'll kill him.{\\\
+        r}\r\nDialogue: 0,0:08:45.59,0:08:47.03,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E0D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}How?{\\r}\r\nDialogue: 0,0:08:47.89,0:08:49.60,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u6703\u88AB\u7576\u6210\u4E0A\u5E1D\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He'll be a god to\
+        \ them.{\\r}\r\nDialogue: 0,0:08:51.43,0:08:53.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5982\u679C\u98DB\u8239\u5230\u4E0D\u4E86\
+        \u90A3\u88CF\u600E\u9EBC\u8FA6\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}What if the ship doesn't make it?{\\r}\r\nDialogue: 0,0:08:54.53,0:08:56.03,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u6703\u6B7B\u5728\u5916\u9762{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He'll die out there...{\\\
+        r}\r\nDialogue: 0,0:08:56.93,0:08:58.97,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5B64\u82E6\u4F36\u4EC3\u5730{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}...alone.{\\r}\r\nDialogue: 0,0:09:00.07,0:09:01.84,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u505A\u4E0D\u5230{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I can't do it.{\\r}\r\nDialogue: 0,0:09:02.07,0:09:03.45,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EE5\u70BA\u53EF\u4EE5 \u4F46...{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I thought I could,\
+        \ but...{\\r}\r\nDialogue: 0,0:09:03.71,0:09:05.45,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u840A\u62C9    - \u4ED6\u5C31\u5728\u6211\
+        \u773C\u524D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Lara.\
+        \         - ...now that he's here...{\\r}\r\nDialogue: 0,0:09:05.91,0:09:07.61,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6C2A\u661F\u5DF2\u7D93\u4E0D\u884C\u4E86\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Krypton is doomed.{\\\
+        r}\r\nDialogue: 0,0:09:08.84,0:09:10.69,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u9019\u662F\u4ED6\u552F\u4E00\u7684\u6A5F\u6703{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's his only chance now.{\\\
+        r}\r\nDialogue: 0,0:09:11.38,0:09:12.95,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u9019\u662F\u6211\u5011\u6C11\u65CF\u552F\u4E00\u7684\
+        \u5E0C\u671B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's\
+        \ our people's only hope.{\\r}\r\nDialogue: 0,0:09:14.42,0:09:15.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u600E\u9EBC\u4E86 \u57FA\u5217\u514B\u65AF\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What is it,\
+        \ Kelex?{\\r}\r\nDialogue: 0,0:09:15.88,0:09:17.86,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6709\u4E94\u8258\u653B\u64CA\u8266\u6B63\
+        \u5F9E\u6771\u9762\u9760\u8FD1{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Five attack ships converging from the east.{\\r}\r\nDialogue: 0,0:09:18.09,0:09:20.43,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u5011\u6B63\u5728\u6383\u7784\u4E26\
+        \u8A55\u4F30\u57CE\u5821\u7684\u9632\u79A6\u7CFB\u7D71{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Citadel's defenses are being scanned\
+        \ and evaluated.{\\r}\r\nDialogue: 0,0:09:20.69,0:09:21.60,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4F86\u4E0A\u50B3\u5BC6\u5178{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'll upload the Codex.{\\\
+        r}\r\nDialogue: 0,0:09:22.36,0:09:23.77,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E0D \u7B49\u7B49{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}No, wait.{\\r}\r\nDialogue: 0,0:09:24.39,0:09:25.23,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u840A\u62C9{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Lara.{\\r}\r\nDialogue: 0,0:09:25.46,0:09:28.37,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8B93\u6211\u518D\u770B\u770B\u4ED6{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Just let me look at\
+        \ him.{\\r}\r\nDialogue: 0,0:09:31.77,0:09:34.27,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u6C92\u6A5F\u6703\u770B\u4ED6\
+        \u8D70\u8DEF\u7684\u6A23\u5B50{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}We'll never get to see him walk.{\\r}\r\nDialogue: 0,0:09:36.70,0:09:39.22,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6C92\u6A5F\u6703\u807D\u4ED6\u558A\u7238\
+        \u7238\u5ABD\u5ABD{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Never\
+        \ hear him say our names.{\\r}\r\nDialogue: 0,0:09:44.05,0:09:45.46,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u6703\u5728{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}But out there...{\\r}\r\nDialogue: 0,0:09:45.71,0:09:47.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u832B\u832B\u5B87\u5B99\u9593{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...amongst the stars...{\\\
+        r}\r\nDialogue: 0,0:09:48.98,0:09:50.49,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6D3B\u4E0B\u4F86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}...he will live.{\\r}\r\nDialogue: 0,0:10:48.54,0:10:50.45,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u518D\u898B  \u5152\u5B50{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Goodbye, my son.{\\r}\r\nDialogue:\
+        \ 0,0:10:51.18,0:10:53.72,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u5011\u7684\u5E0C\u671B\u8207\u5922\u60F3\u8207\u4F60\u540C\
+        \u884C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Our hopes\
+        \ and dreams travel with you.{\\r}\r\nDialogue: 0,0:11:32.42,0:11:35.23,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5411\u4E3B\u9580\u96C6\u4E2D\u706B\u529B\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Concentrate fire\
+        \ on the main doors.{\\r}\r\nDialogue: 0,0:11:50.57,0:11:51.55,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u840A\u62C9\u592B\u4EBA{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Lady Lara.{\\r}\r\nDialogue: 0,0:11:51.77,0:11:54.85,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u5E7D\u9748\u5F15\u64CE\u5DF2\u555F\u52D5\
+        \   - \u9EDE\u706B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}-\
+        \ The phantom drives are coming online.       - Proceed to ignition.{\\r}\r\
+        \nDialogue: 0,0:11:55.61,0:11:56.61,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5C07\u8ECD{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}General.{\\r}\r\nDialogue: 0,0:11:56.88,0:12:00.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u57CE\u5821\u5167\u6709\u5F15\u64CE\u555F\
+        \u52D5{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We have identified\
+        \ an engine ignition within the citadel.{\\r}\r\nDialogue: 0,0:12:01.22,0:12:02.63,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u662F\u822A\u5929\u5668\u767C\u5C04{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}A launch.{\\r}\r\n\
+        Dialogue: 0,0:12:03.79,0:12:06.20,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u5B88\u4F4F\u9019\u5E73\u53F0 \u6307\u63EE\u5B98{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Hold this platform, commander.{\\\
+        r}\r\nDialogue: 0,0:12:18.60,0:12:21.15,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u77E5\u9053\u4F60\u5077\u4E86\u5BC6\u5178 \u55AC\
+        \u2022\u827E\u723E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I\
+        \ know you stole the Codex, Jor-El.{\\r}\r\nDialogue: 0,0:12:21.70,0:12:22.70,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u628A\u5B83\u4EA4\u51FA\u4F86{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Surrender it...{\\r}\r\nDialogue:\
+        \ 0,0:12:22.94,0:12:24.94,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u5C31\u9952\u4F60\u4E0D\u6B7B{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...and I'll let you live.{\\r}\r\nDialogue: 0,0:12:25.57,0:12:28.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9019\u6B21\u91CD\u751F\u7684\u6A5F\u6703\
+        \u5C6C\u65BC\u6C2A\u661F\u6240\u6709\u4EBA{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}This is a second chance for all of Krypton...{\\\
+        r}\r\nDialogue: 0,0:12:28.38,0:12:31.32,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u800C\u4E0D\u50C5\u50C5\u662F\u4F60\u89BA\u5F97\u91CD\
+        \u8981\u7684\u8840\u8108{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...not just the bloodlines you deem worthy.{\\r}\r\nDialogue: 0,0:12:32.25,0:12:33.42,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u505A\u4E86\u4EC0\u9EBC\u4E8B\uFF1F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What have you done?{\\\
+        r}\r\nDialogue: 0,0:12:33.65,0:12:35.96,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u5011\u6709\u4E00\u500B\u5B69\u5B50 \u4F50\u5FB7\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We've had a child,\
+        \ Zod.{\\r}\r\nDialogue: 0,0:12:36.95,0:12:38.33,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E00\u500B\u7537\u5B69{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}A boy child.{\\r}\r\nDialogue: 0,0:12:38.59,0:12:41.59,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u662F\u6C2A\u661F\u5E7E\u767E\u5E74\
+        \u4F86\u7B2C\u4E00\u500B\u81EA\u7136\u5206\u5A29\u7684\u5B69\u5B50{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Krypton's first natural\
+        \ birth in centuries.{\\r}\r\nDialogue: 0,0:12:42.56,0:12:44.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u5C07\u7372\u5F97\u81EA\u7531{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And he will be free.{\\\
+        r}\r\nDialogue: 0,0:12:44.76,0:12:47.24,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6C7A\u5B9A\u81EA\u5DF1\u547D\u904B\u7684\u81EA\u7531\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Free to forge his\
+        \ own destiny.{\\r}\r\nDialogue: 0,0:12:48.10,0:12:49.58,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u80E1\u8AAA\u516B\u9053{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Heresy.{\\r}\r\nDialogue: 0,0:12:51.47,0:12:52.14,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u628A\u5B83\u6BC0\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Destroy it.{\\r}\r\nDialogue: 0,0:13:45.62,0:13:46.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u840A\u62C9{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Lara...{\\r}\r\nDialogue: 0,0:13:46.79,0:13:48.17,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u807D\u6211\u8AAA{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}...listen to me.{\\r}\r\nDialogue: 0,0:13:48.39,0:13:52.03,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5BC6\u5178\u662F\u6C2A\u661F\u7684\u672A\
+        \u4F86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The Codex\
+        \ is Krypton's future.{\\r}\r\nDialogue: 0,0:13:52.29,0:13:54.74,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53D6\u6D88\u767C\u5C04{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Abort the launch.{\\r}\r\nDialogue:\
+        \ 0,0:14:13.92,0:14:15.69,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4E0D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}No!{\\\
+        r}\r\nDialogue: 0,0:14:45.61,0:14:47.49,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u840A\u62C9{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Your son, Lara...{\\r}\r\nDialogue: 0,0:14:48.18,0:14:50.69,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u628A\u4F60\u5011\u7684\u5152\u5B50\
+        \u9001\u5230\u54EA\u88CF\u53BB\u4E86\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...where have you sent him?{\\r}\r\nDialogue: 0,0:14:53.59,0:14:55.36,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u7684\u540D\u5B57{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}His name...{\\r}\r\nDialogue: 0,0:14:55.59,0:14:56.69,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u662F\u5361\u723E{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}...is Kal...{\\r}\r\nDialogue: 0,0:14:57.36,0:14:59.20,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u827E\u723E\u4E4B\u5B50{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...son of El.{\\r}\r\nDialogue: 0,0:15:02.30,0:15:05.14,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4F11\u60F3\u627E\u5230\u4ED6{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And he's beyond your\
+        \ reach.{\\r}\r\nDialogue: 0,0:15:15.28,0:15:16.78,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u628A\u90A3\u8258\u98DB\u8239\u6253\u4E0B\
+        \u4F86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Bring that\
+        \ ship down.{\\r}\r\nDialogue: 0,0:15:25.12,0:15:26.90,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u76EE\u6A19\u5DF2\u9396\u5B9A{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Target locked.{\\r}\r\nDialogue:\
+        \ 0,0:15:38.23,0:15:39.83,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u653E\u4E0B\u4F60\u5011\u7684\u6B66\u5668{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Lay down your weapons.{\\r}\r\nDialogue:\
+        \ 0,0:15:39.93,0:15:42.01,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u5011\u5DF2\u7D93\u88AB\u5305\u570D\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Your forces are surrounded.{\\r}\r\
+        \nDialogue: 0,0:15:52.11,0:15:53.59,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F50\u5FB7\u5C07\u8ECD{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}General Zod...{\\r}\r\nDialogue: 0,0:15:53.82,0:15:56.80,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u72AF\u4E0B\u4E86\u8B00\u6BBA\u7F6A\
+        \u8207\u53DB\u570B\u7F6A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...for the crimes of murder and high treason...{\\r}\r\nDialogue: 0,0:15:56.82,0:16:01.13,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9577\u8001\u6703\u5224\u8655\u4F60\u548C\
+        \u4F60\u7684\u540C\u8B00{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...the Council has sentenced you and your fellow insurgents...{\\r}\r\
+        \nDialogue: 0,0:16:01.19,0:16:04.66,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u56DA\u7981\u8089\u8EAB\u4E26\u6D41\u653E300\u5E74{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...to three hundred\
+        \ cycles of somatic reconditioning.{\\r}\r\nDialogue: 0,0:16:06.16,0:16:07.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6709\u4EC0\u9EBC\u907A\u8A00\u55CE\uFF1F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Do you have any\
+        \ last words?{\\r}\r\nDialogue: 0,0:16:11.27,0:16:12.35,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5011\u4E0D\u6562\u89AA\u624B\u6BBA\
+        \u6211\u5011{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You\
+        \ won't kill us yourself!{\\r}\r\nDialogue: 0,0:16:13.70,0:16:15.84,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6015\u5F04\u9AD2\u4E86\u81EA\u5DF1\u7684\
+        \u624B \u6240\u4EE5\u4F60\u5011...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}You wouldn't sully your hands! But you'll damn us...{\\\
+        r}\r\nDialogue: 0,0:16:16.10,0:16:18.28,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u628A\u6211\u5011\u6254\u5230\u9ED1\u6D1E\u88CF\u95DC\
+        \u4E00\u8F29\u5B50{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...to\
+        \ a black hole for eternity!{\\r}\r\nDialogue: 0,0:16:20.34,0:16:21.38,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u55AC\u2022\u827E\u723E\u8AAA\u5F97\u6C92\
+        \u932F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Jor-El was\
+        \ right.{\\r}\r\nDialogue: 0,0:16:21.64,0:16:25.32,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5011\u662F\u4E00\u7FA4\u8822\u8CA8\
+        \ \u6240\u6709\u4EBA\u90FD\u662F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You're a pack of fools, every last one of you.{\\r}\r\nDialogue: 0,0:16:26.21,0:16:27.39,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}And you.{\\r}\r\nDialogue: 0,0:16:29.12,0:16:31.56,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u89BA\u5F97\u4F60\u7684\u5152\u5B50\
+        \u5F88\u5B89\u5168\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You believe your son is safe?{\\r}\r\nDialogue: 0,0:16:32.29,0:16:33.99,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E00\u5B9A\u6703\u627E\u5230\u4ED6\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I will find him.{\\\
+        r}\r\nDialogue: 0,0:16:34.22,0:16:37.53,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u596A\u56DE\u4F60\u5F9E\u6211\u5011\u624B\u88CF\u6436\
+        \u8D70\u7684\u6771\u897F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I will reclaim what you have taken from us.{\\r}\r\nDialogue: 0,0:16:39.96,0:16:41.53,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E00\u5B9A\u6703\u627E\u5230\u4ED6\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I will find him.{\\\
+        r}\r\nDialogue: 0,0:16:42.73,0:16:45.34,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u4E00\u5B9A\u6703\u627E\u5230\u4ED6 \u840A\u62C9\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I will find him,\
+        \ Lara.{\\r}\r\nDialogue: 0,0:16:47.90,0:16:50.47,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E00\u5B9A\u6703\u627E\u5230\u4ED6\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I will find him!{\\\
+        r}\r\nDialogue: 0,0:17:00.31,0:17:02.06,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u554A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Argh!{\\r}\r\nDialogue: 0,0:18:31.67,0:18:35.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u840A\u62C9\u592B\u4EBA \u60A8\u4E0D\u8EB2\
+        \u8D77\u4F86\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Lady Lara, shouldn't you find refuge?{\\r}\r\nDialogue: 0,0:18:35.61,0:18:38.59,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6839\u672C\u7121\u8655\u53EF\u8EB2 \u57FA\
+        \u6D1B\u723E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}There\
+        \ is no refuge, Kelor.{\\r}\r\nDialogue: 0,0:18:39.51,0:18:41.49,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u55AC\u2022\u827E\u723E\u8AAA\u5F97\u5C0D\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Jor-El was right.{\\\
+        r}\r\nDialogue: 0,0:18:43.92,0:18:45.93,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6C2A\u661F\u7684\u672B\u65E5\u5230\u4E86{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}This is the end.{\\r}\r\nDialogue:\
+        \ 0,0:18:57.37,0:19:00.28,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5275\u9020\u4E00\u500B\u6BD4\u9019\u88CF\u597D\u7684\u4E16\u754C\
+        \ \u5361\u723E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Make\
+        \ a better world than ours, Kal.{\\r}\r\nDialogue: 0,0:20:32.43,0:20:33.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7576\u5FC3\u9EDE \u8822\u8CA8{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Watch it, dumb-ass!{\\r}\r\n\
+        Dialogue: 0,0:20:34.20,0:20:37.30,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4E0D\u7559\u5FC3\u5C31\u7B49\u8457\u88AB\u7838\u6210\u8089\
+        \u9905\u5427{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Keep\
+        \ your eyes open or you're gonna get squashed.{\\r}\r\nDialogue: 0,0:20:38.70,0:20:41.15,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u5011\u662F\u5728\u4EC0\u9EBC\u9B3C\
+        \u5730\u65B9\u627E\u5230\u4F60\u7684 \u83DC\u9CE5\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Where the hell did they find you,\
+        \ greenhorn?{\\r}\r\nDialogue: 0,0:20:41.40,0:20:42.88,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8B93\u6211\u5011\u5728\u7A7A\u4E2D\u5F04\
+        \u6389\u9019\u500B\u9677\u9631{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Let's get this trap in the air.{\\r}\r\nDialogue: 0,0:20:43.10,0:20:44.64,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5927\u5BB6\u56FA\u5B9A\u597D\u7532\u677F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Gentlemen, secure\
+        \ the deck.{\\r}\r\nDialogue: 0,0:20:44.91,0:20:47.91,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6B63\u897F\u65B9\u5411\u7684\u947D\u4E95\
+        \u8655\u6709\u4EBA\u5411\u6211\u5011\u6C42\u6551{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}We just got a distress call from a rig due west of\
+        \ us.{\\r}\r\nDialogue: 0,0:20:48.14,0:20:49.95,chs,,0000,0000,0000,,{\\fn\u534E\
+        \u6587\u6977\u4F53\\blur3}\u56FA\u5B9A\u597D\u7532\u677F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Secure the deck.{\\r}\r\nDialogue:\
+        \ 0,0:20:54.15,0:20:55.72,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u8ACB\u6240\u6709\u6C11\u7528\u8239\u96BB\u96E2\u958B{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}All civilian boats, stand clear.{\\\
+        r}\r\nDialogue: 0,0:20:55.95,0:20:58.62,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6D77\u4E0B\u95A5\u9580\u5DF2\u5931\u6548 \u947D\u53F0\
+        \u5FEB\u8981\u7206\u70B8\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}The sub-sea valves failed and the rig is about to explode.{\\r}\r\n\
+        Dialogue: 0,0:20:58.89,0:21:01.33,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6536\u5230 \u6D77\u5CB8\u8B66\u885B\u968A \u88AB\u56F0\u5728\
+        \u88CF\u9762\u7684\u4EBA\u600E\u9EBC\u8FA6\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Roger, Coast Guard. What about the men left inside?{\\\
+        r}\r\nDialogue: 0,0:21:01.46,0:21:03.80,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u5225\u7BA1\u4ED6\u5011\u4E86 \u4ED6\u5011\u6D3B\u4E0D\
+        \u4E86   - \u83DC\u9CE5{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}- Forget them. They're dead.        - Greenhorn...{\\r}\r\nDialogue:\
+        \ 0,0:21:04.06,0:21:06.10,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u628A\u6211\u7684\u671B\u9060\u93E1\u62FF\u4F86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...fetch me my binoculars.{\\r}\r\n\
+        Dialogue: 0,0:21:07.63,0:21:08.97,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u83DC\u9CE5{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Greenhorn.{\\r}\r\nDialogue: 0,0:21:17.30,0:21:20.84,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C31\u5269\u9019\u9EDE\u6C27\u6C23\u4E86\
+        \ \u6211\u4E0D\u77E5\u9053\u6211\u5011\u9084\u80FD\u6490\u591A\u4E45{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}This is the last of the\
+        \ oxygen. I don't know how much longer we can hold out.{\\r}\r\nDialogue:\
+        \ 0,0:21:30.39,0:21:32.26,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u9019\u88CF\u662F\u6D77\u5CB8\u8B66\u885B\u968A6510{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}This is Coast Guard 6510.{\\r}\r\n\
+        Dialogue: 0,0:21:32.26,0:21:34.59,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6211\u5011\u518D\u67E5\u770B\u4E00\u904D \u7136\u5F8C\u5C31\
+        \u96E2\u958B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We'll\
+        \ make one more pass then get out.{\\r}\r\nDialogue: 0,0:21:36.76,0:21:38.86,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7B49\u7B49 \u7B49\u7B49 \u6709\u4EBA\u5728\
+        \u76F4\u5347\u6A5F\u5347\u964D\u8655{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Wait, wait. I got some guys on the helipad.{\\r}\r\nDialogue:\
+        \ 0,0:21:39.13,0:21:39.77,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5C31\u5728\u9019\u88CF{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Right here!{\\r}\r\nDialogue: 0,0:21:45.27,0:21:47.14,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5FEB\u9EDE \u8D70\u554A{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Come on, come on! Let's go! Let's\
+        \ go!{\\r}\r\nDialogue: 0,0:21:47.33,0:21:49.14,chs,,0000,0000,0000,,{\\fn\u534E\
+        \u6587\u6977\u4F53\\blur3}- \u5FEB\u8D70   - \u8D70\u554A{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Let's go!       - Let's go!{\\r}\r\
+        \nDialogue: 0,0:21:59.68,0:22:00.96,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u53EB\u6700\u5F8C\u90A3\u500B\u4EBA\u4E0A\u4F86{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Get that last guy loaded.{\\\
+        r}\r\nDialogue: 0,0:22:01.12,0:22:02.49,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u5011\u5F97\u8D70\u4E86{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}We have got to go.{\\r}\r\nDialogue: 0,0:22:02.72,0:22:04.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5FEB\u8D70\u554A \u4F60\u5728\u5E79\u4EC0\
+        \u9EBC\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Hey,\
+        \ let's go. What are you doing?{\\r}\r\nDialogue: 0,0:22:10.52,0:22:11.63,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8D70 \u8D70{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Go! Go!{\\r}\r\nDialogue: 0,0:22:49.53,0:22:52.17,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u582A\u85A9\u65AF\u5DDE\u662F\u4EC0\u9EBC\
+        \u6642\u5019\u8B8A\u6210\u7F8E\u570B\u9818\u571F\u7684\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...when Kansas became a territory?{\\\
+        r}\r\nDialogue: 0,0:22:53.77,0:22:54.75,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Clark.{\\r}\r\nDialogue: 0,0:22:56.74,0:22:58.74,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5728\u807D\u8AB2\u55CE \u514B\u62C9\
+        \u514B\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Are\
+        \ you listening, Clark?{\\r}\r\nDialogue: 0,0:23:02.91,0:23:06.60,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u544A\u8A34\u6211 \u8AB0\u6700\u5148\u5728\
+        \u582A\u85A9\u65AF\u5DDE\u5B9A\u5C45{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}I asked if you could tell me who first settled Kansas.{\\\
+        r}\r\nDialogue: 0,0:23:19.36,0:23:20.93,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u6C92\u4E8B\u5427 \u514B\u62C9\u514B\uFF1F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Are you all right, Clark?{\\\
+        r}\r\nDialogue: 0,0:23:28.97,0:23:30.38,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Clark.{\\r}\r\nDialogue: 0,0:23:31.61,0:23:32.91,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark.{\\r}\r\nDialogue: 0,0:23:36.48,0:23:37.08,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark!{\\r}\r\nDialogue: 0,0:23:41.08,0:23:42.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B \u51FA\u4F86{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark, come out of there.{\\\
+        r}\r\nDialogue: 0,0:23:42.88,0:23:44.23,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5225\u7BA1\u6211{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Leave me alone.{\\r}\r\nDialogue: 0,0:23:45.25,0:23:46.82,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B \u6211\u5DF2\u7D93\u7D66\
+        \u4F60\u5ABD\u5ABD\u6253\u96FB\u8A71\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Clark, I have called your mother.{\\r}\r\nDialogue:\
+        \ 0,0:23:48.16,0:23:49.23,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Clark?{\\r}\r\nDialogue: 0,0:23:51.06,0:23:52.16,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u554A{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Ah!{\\r}\r\nDialogue: 0,0:23:52.33,0:23:53.33,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4F86\u4E86{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm here.{\\r}\r\nDialogue: 0,0:23:53.59,0:23:55.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B \u5BF6\u8C9D \u6211\u662F\
+        \u5ABD\u5ABD{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark,\
+        \ honey, it's Mom.{\\r}\r\nDialogue: 0,0:23:57.97,0:23:59.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u958B\u9580\u597D\u55CE\uFF1F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Will you open the door?{\\\
+        r}\r\nDialogue: 0,0:23:59.27,0:24:01.47,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u4ED6\u5230\u5E95\u6709\u4EC0\u9EBC\u6BDB\u75C5\uFF1F\
+        \ - \u4ED6\u5C31\u662F\u500B\u602A\u80CE{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}- What's wrong with him?       - He's such a freak.{\\\
+        r}\r\nDialogue: 0,0:24:01.47,0:24:02.31,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5A18\u5011{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Crybaby.{\\r}\r\nDialogue: 0,0:24:02.57,0:24:05.02,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u7236\u6BCD\u751A\u81F3\u4E0D\u8B93\
+        \u6211\u8DDF\u4ED6\u73A9{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}His parents won't even let him play with other kids.{\\r}\r\nDialogue:\
+        \ 0,0:24:05.27,0:24:06.27,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u77E5\u9053{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I know.{\\r}\r\nDialogue: 0,0:24:06.51,0:24:07.35,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5BF6\u8C9D{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Sweetie.{\\r}\r\nDialogue: 0,0:24:08.51,0:24:10.65,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4E0D\u8B93\u6211\u9032\u53BB \u6211\
+        \u600E\u9EBC\u5E6B\u4F60\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}How can I help you if you won't let me in?{\\r}\r\nDialogue: 0,0:24:10.91,0:24:13.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9019\u500B\u4E16\u754C\u592A\u5927\u4E86\
+        \ \u5ABD\u5ABD{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The\
+        \ world's too big, Mom.{\\r}\r\nDialogue: 0,0:24:13.48,0:24:15.12,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u5C31\u628A\u5B83\u8B8A\u5C0F\u9EDE\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Then make it small.{\\\
+        r}\r\nDialogue: 0,0:24:17.48,0:24:18.76,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u53EA\u8981...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Just, um...{\\r}\r\nDialogue: 0,0:24:21.59,0:24:23.39,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u96C6\u4E2D\u7CBE\u529B\u807D\u6211\u7684\
+        \u8072\u97F3{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...focus\
+        \ on my voice.{\\r}\r\nDialogue: 0,0:24:25.26,0:24:27.21,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u60F3\u50CF\u6709\u4E00\u5EA7\u5CF6\u5DBC\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Pretend ifs an island...{\\\
+        r}\r\nDialogue: 0,0:24:27.36,0:24:29.27,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5B83\u5C31\u5728\u5927\u6D77\u4E4B\u4E2D{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...out in the ocean.{\\r}\r\
+        \nDialogue: 0,0:24:30.80,0:24:32.11,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u80FD\u770B\u5230\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Can you see it?{\\r}\r\nDialogue: 0,0:24:35.80,0:24:36.84,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u770B\u5230\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I see it.{\\r}\r\nDialogue: 0,0:24:38.17,0:24:40.17,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u5C31\u5411\u5B83\u6E38\u904E\u53BB\
+        \ \u5BF6\u8C9D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Then\
+        \ swim towards it, honey.{\\r}\r\nDialogue: 0,0:24:53.45,0:24:55.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u600E\u9EBC\u4E86 \u5ABD\u5ABD\uFF1F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What's wrong with\
+        \ me, Mom?{\\r}\r\nDialogue: 0,0:24:57.89,0:24:59.39,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark.{\\r}\r\nDialogue: 0,0:24:59.66,0:25:01.16,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark.{\\r}\r\nDialogue: 0,0:25:29.82,0:25:31.70,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4F60\u62FF\u5230\u6211\u8981\u7684\u6771\
+        \u897F\u4E86\uFF1F   - \u662F\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}- Did you get everything I need?       - Yep.{\\r}\r\n\
+        Dialogue: 0,0:25:31.93,0:25:33.60,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u5225\u52D5 \u5225\u52D5{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Hold it, hold it.{\\r}\r\nDialogue: 0,0:26:23.44,0:26:24.98,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8822\u86CB{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Hey, ass-wipe.{\\r}\r\nDialogue: 0,0:26:25.55,0:26:27.22,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u89BA\u5F97\u600E\u6A23\uFF1F\u4F60\
+        \u770B\u4E86\u6BD4\u8CFD\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}What do you think? You see the game?{\\r}\r\nDialogue:\
+        \ 0,0:26:27.45,0:26:29.95,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}- \u5225\u800D\u4ED6 \u76AE\u7279   - \u4F60\u7B97\u54EA\u6839\u8525\
+        \ \u4ED6\u7684\u5973\u670B\u53CB\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}- Leave him alone, Pete.       - What are you, his\
+        \ girlfriend?{\\r}\r\nDialogue: 0,0:26:30.22,0:26:31.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u8981\u807D\u807D\u4ED6\u600E\u9EBC\
+        \u8AAA{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I wanna hear\
+        \ what he has to say.{\\r}\r\nDialogue: 0,0:26:34.25,0:26:34.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8AAA\u8A71\u554A{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Come on...{\\r}\r\nDialogue: 0,0:26:35.16,0:26:35.83,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7B28\u74DC{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...dick-splash.{\\r}\r\nDialogue: 0,0:28:16.82,0:28:17.82,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5152\u5B50\u5C31\u5728\u73FE\u5834\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}My son was there.{\\\
+        r}\r\nDialogue: 0,0:28:18.06,0:28:20.27,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4ED6\u5C31\u5728\u90A3\u8F1B\u6821\u8ECA\u88CF{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He was in the bus.{\\r}\r\
+        \nDialogue: 0,0:28:20.53,0:28:23.84,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u89AA\u773C\u770B\u898B\u514B\u62C9\u514B\u505A\u4E86\
+        \u4EC0\u9EBC   - \u6211\u77E5\u9053\u4ED6\u770B\u898B\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- He saw what Clark did.       - I\
+        \ know he did.{\\r}\r\nDialogue: 0,0:28:24.26,0:28:28.27,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4ED6\u770B\u5230\u7684\u4E00\u5B9A\u662F\
+        ...   - \u662F\u4E0A\u5E1D\u7684\u5B89\u6392 \u55AC\u7D0D\u68EE{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- I'm sure what he thought\
+        \ he saw was...       - Was an act of God, Jonathan.{\\r}\r\nDialogue: 0,0:28:29.34,0:28:31.71,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u662F\u5929\u610F{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}This was providence.{\\r}\r\nDialogue:\
+        \ 0,0:28:35.44,0:28:37.51,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u89BA\u5F97\u4F60\u9019\u6A23\u8AAA\u6709\u9EDE\u8A87\u5F35\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I think you're blowing\
+        \ it out of proportion.{\\r}\r\nDialogue: 0,0:28:37.74,0:28:41.02,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u6C92\u8A87\u5F35 \u62C9\u5A1C\u4E5F\
+        \u770B\u898B\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}No,\
+        \ I'm not. Lana saw it too.{\\r}\r\nDialogue: 0,0:28:41.25,0:28:42.25,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u500B\u53EB\u798F\u7279\u66FC\u7684\
+        \u7537\u5B69\u4E5F\u770B\u898B\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}And the Fordham boy.{\\r}\r\nDialogue: 0,0:28:42.52,0:28:43.72,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9019\u4E5F\u4E0D\u662F\u7B2C\u4E00\u6B21\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}This isn't the first\
+        \ time...{\\r}\r\nDialogue: 0,0:28:43.95,0:28:46.50,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B\u505A\u51FA\u9019\u7A2E\
+        \u4E8B\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...Clark's\
+        \ done something like this.{\\r}\r\nDialogue: 0,0:29:01.24,0:29:03.08,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u53EA\u662F\u60F3\u5E6B\u5FD9{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I just wanted to help.{\\\
+        r}\r\nDialogue: 0,0:29:03.54,0:29:06.28,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u77E5\u9053 \u4F46\u6211\u5011\u8AC7\u904E\u9019\
+        \u500B\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I know\
+        \ you did, but we talked about this.{\\r}\r\nDialogue: 0,0:29:06.54,0:29:07.81,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C0D\u5427\uFF1F{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Right?{\\r}\r\nDialogue: 0,0:29:08.28,0:29:10.98,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C0D\u5427 \u6211\u5011\u8AC7\u904E\u4E86\
+        \ \u4F60...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Right?\
+        \ We talked about this. You have...{\\r}\r\nDialogue: 0,0:29:11.48,0:29:14.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B \u4F60\u4E0D\u80FD\u8B93\
+        \u5225\u4EBA\u77E5\u9053\u4F60\u7684\u9019\u4E00\u9762{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark, you have to keep this side\
+        \ of yourself a secret.{\\r}\r\nDialogue: 0,0:29:15.38,0:29:19.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u6211\u8A72\u600E\u9EBC\u8FA6\uFF1F\
+        \u770B\u8457\u4ED6\u5011\u6B7B\u6389\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}What was I supposed to do? Just let them die?{\\\
+        r}\r\nDialogue: 0,0:29:24.06,0:29:25.47,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E5F\u8A31\u5427{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Maybe.{\\r}\r\nDialogue: 0,0:29:27.39,0:29:29.76,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5371\u5728\u65E6\u5915\u7684\u4E0D\u53EA\
+        \u662F\u6211\u5011\u7684\u6027\u547D \u514B\u62C9\u514B{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}There's more at stake here than just\
+        \ our lives, Clark,{\\r}\r\nDialogue: 0,0:29:29.76,0:29:31.80,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E5F\u4E0D\u53EA\u662F\u6211\u5011\u5468\
+        \u570D\u4EBA\u7684\u6027\u547D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}or the lives of those around us.{\\r}\r\nDialogue: 0,0:29:34.33,0:29:35.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5982\u679C\u9019\u500B\u4E16\u754C{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}When the world...{\\\
+        r}\r\nDialogue: 0,0:29:36.67,0:29:40.68,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u77E5\u9053\u4E86\u4F60\u7684\u80FD\u529B \u4E00\u5207\
+        \u90FD\u5C07\u6539\u8B8A \u5305\u62EC\u6211\u5011\u7684...{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}When the world finds out what you\
+        \ can do it's gonna change everything. Our...{\\r}\r\nDialogue: 0,0:29:40.94,0:29:43.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u7684\u4FE1\u4EF0...{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Our beliefs, our notions\
+        \ of...{\\r}\r\nDialogue: 0,0:29:43.78,0:29:46.49,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C0D\u4EBA\u985E\u7684\u6982\u5FF5 \u4E00\
+        \u5207{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...what it\
+        \ means to be human. Everything.{\\r}\r\nDialogue: 0,0:29:46.75,0:29:49.52,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u770B\u5230\u4E86\u76AE\u7279\u5ABD\
+        \u5ABD\u7684\u53CD\u61C9\u5427\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}You saw how Pete's mom reacted, right?{\\r}\r\nDialogue:\
+        \ 0,0:29:49.78,0:29:51.99,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5979\u5F88\u5BB3\u6015 \u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}She was scared, Clark.{\\r}\r\nDialogue:\
+        \ 0,0:29:53.12,0:29:53.96,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u70BA\u4EC0\u9EBC\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Why?{\\r}\r\nDialogue: 0,0:29:55.82,0:29:58.67,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4EBA\u5011\u5BB3\u6015\u4ED6\u5011\u4E0D\
+        \u77AD\u89E3\u7684\u6771\u897F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}People are afraid of what they don't understand.{\\r}\r\nDialogue: 0,0:29:58.93,0:29:59.84,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5979\u8AAA\u5F97\u5C0D\u55CE\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Is she right?{\\r}\r\
+        \nDialogue: 0,0:30:01.96,0:30:04.31,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u662F\u4E0A\u5E1D\u628A\u6211\u8B8A\u6210\u9019\u6A23\
+        \u7684\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Did\
+        \ God do this to me?{\\r}\r\nDialogue: 0,0:30:05.37,0:30:06.87,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u544A\u8A34\u6211{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Tell me.{\\r}\r\nDialogue: 0,0:30:21.65,0:30:23.92,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u662F\u6211\u5011\u5728\u9019\u500B\
+        \u6771\u897F\u88CF\u627E\u5230\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}We found you in this.{\\r}\r\nDialogue: 0,0:30:25.29,0:30:28.23,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u4EE5\u70BA\u653F\u5E9C\u4E00\
+        \u5B9A\u6703\u4F86\u627E\u6211\u5011{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}We were sure the government was gonna show up on our doorstep...{\\\
+        r}\r\nDialogue: 0,0:30:28.49,0:30:30.47,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F46\u4E00\u76F4\u6C92\u4EBA\u4F86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...but no one ever came.{\\r}\r\n\
+        Dialogue: 0,0:30:44.97,0:30:47.44,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u9019\u500B\u548C\u4F60\u4E00\u6A23 \u4E5F\u662F\u5728\u88CF\
+        \u9762\u627E\u5230\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}This was in that chamber with you.{\\r}\r\nDialogue: 0,0:30:49.18,0:30:52.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u628A\u5B83\u62FF\u7D66\u582A\u85A9\
+        \u65AF\u5DDE\u7684\u4E00\u500B\u51B6\u91D1\u5B78\u5BB6\u770B{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I took it to a metallurgist at Kansas\
+        \ State.{\\r}\r\nDialogue: 0,0:30:52.38,0:30:54.99,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u8AAA \u88FD\u6210\u5B83\u7684\u6750\
+        \u6599\u751A\u81F3...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}He said whatever it was made from didn't even...{\\r}\r\nDialogue: 0,0:30:55.92,0:30:58.69,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u751A\u81F3\u4E0D\u5B58\u5728\u65BC\u5143\
+        \u7D20\u9031\u671F\u8868\u4E0A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Didn't even exist on the periodic table.{\\r}\r\nDialogue: 0,0:31:00.65,0:31:01.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u610F\u601D\u662F\u8AAA{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}That's another way of saying...{\\\
+        r}\r\nDialogue: 0,0:31:02.06,0:31:04.33,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5B83\u4E0D\u4F86\u81EA\u65BC\u9019\u500B\u4E16\u754C\
+        \ \u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...that\
+        \ it's not from this world, Clark.{\\r}\r\nDialogue: 0,0:31:06.43,0:31:07.70,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4E5F\u4E00\u6A23{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And neither are you.{\\r}\r\nDialogue:\
+        \ 0,0:31:10.40,0:31:11.93,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u5C31\u662F\u7B54\u6848 \u5152\u5B50{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}You're the answer, son.{\\r}\r\nDialogue:\
+        \ 0,0:31:12.20,0:31:15.38,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\"\u4EBA\u985E\u662F\u5426\u5B64\u7368\u5730\u5B58\u5728\u65BC\u5B87\
+        \u5B99\u4E2D\"\u7684\u7B54\u6848{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You're the answer to \"Are we alone in the universe?\"{\\r}\r\nDialogue:\
+        \ 0,0:31:16.74,0:31:18.18,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u4E0D\u60F3\u7576\u9019\u500B\u7B54\u6848{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I don't wanna be.{\\r}\r\nDialogue:\
+        \ 0,0:31:18.41,0:31:20.28,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u4E0D\u602A\u4F60 \u5152\u5B50{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}And I don't blame you, son.{\\r}\r\nDialogue: 0,0:31:20.87,0:31:23.58,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E00\u822C\u4EBA\u96E3\u4EE5\u80CC\u8CA0\
+        \u9019\u7A2E\u91CD\u64D4{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}It'd be a huge burden for anyone to bear.{\\r}\r\nDialogue: 0,0:31:23.84,0:31:27.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u4F60\u4E0D\u662F\u4E00\u822C\u4EBA\
+        \ \u514B\u62C9\u514B \u800C\u4E14\u6211\u5FC5\u9808\u76F8\u4FE1\u4F60{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}But you're not just anyone,\
+        \ Clark, and I have to believe that you were...{\\r}\r\nDialogue: 0,0:31:28.42,0:31:30.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u88AB\u9001\u4F86\u9019\u88CF\u662F\
+        \u6709\u539F\u56E0\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}That you were sent here for a reason.{\\r}\r\nDialogue: 0,0:31:31.52,0:31:34.09,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6240\u7D93\u6B77\u7684\u9019\u4E9B\
+        \u6539\u8B8A \u7D42\u6709\u4E00\u5929...{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}All these changes that you're going through, one\
+        \ day...{\\r}\r\nDialogue: 0,0:31:34.35,0:31:37.70,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6703\u89BA\u5F97\u5B83\u5011\u662F\
+        \u4E0A\u5E1D\u7684\u6069\u8CDC \u7576\u90A3\u4E00\u5929\u5230\u4F86...{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}One day you're gonna\
+        \ think of them as a blessing. When that day comes...{\\r}\r\nDialogue: 0,0:31:37.92,0:31:39.37,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5C31\u5FC5\u9808\u4F5C\u51FA\u9078\
+        \u64C7{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...you have\
+        \ to make a choice.{\\r}\r\nDialogue: 0,0:31:39.59,0:31:44.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u662F\u5426\u8981\u5728\u4EBA\u985E\u9762\
+        \u524D\u9A55\u50B2\u5730\u633A\u8EAB\u800C\u51FA{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}A choice of whether to stand proud in front of the\
+        \ human race or not.{\\r}\r\nDialogue: 0,0:31:45.37,0:31:48.04,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5C31\u4E0D\u80FD\u7E7C\u7E8C\u5047\
+        \u88DD\u662F\u60A8\u7684\u5152\u5B50\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Can't I just keep pretending I'm your son?{\\r}\r\
+        \nDialogue: 0,0:31:48.74,0:31:50.65,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u5C31\u662F\u6211\u5152\u5B50{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You are my son.{\\r}\r\nDialogue:\
+        \ 0,0:31:55.11,0:31:57.11,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F46\u5728\u67D0\u500B\u5730\u65B9{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}But somewhere out there you've...{\\r}\r\nDialogue:\
+        \ 0,0:31:57.81,0:32:01.05,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u9084\u6709\u53E6\u5916\u4E00\u500B\u7236\u89AA \u4ED6\u7D66\
+        \u4E86\u4F60\u53E6\u5916\u4E00\u500B\u540D\u5B57{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}You have another father too, who gave you another\
+        \ name.{\\r}\r\nDialogue: 0,0:32:04.12,0:32:07.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u51FA\u65BC\u67D0\u7A2E\u539F\u56E0 \u4ED6\
+        \u628A\u4F60\u9001\u5230\u4E86\u9019\u88CF{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}And he sent you here for a reason, Clark.{\\r}\r\n\
+        Dialogue: 0,0:32:08.76,0:32:12.43,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u5C31\u7B97\u8981\u82B1\u4E00\u8F29\u5B50\u7684\u6642\u9593\
+        \ \u4F60\u4E5F\u8981\u70BA\u81EA\u5DF1...{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}And even if it takes you the rest of your life, you\
+        \ owe it to yourself...{\\r}\r\nDialogue: 0,0:32:12.66,0:32:14.80,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u627E\u5230\u90A3\u500B\u539F\u56E0{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...to find out what\
+        \ that reason is.{\\r}\r\nDialogue: 0,0:32:23.00,0:32:26.85,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u88AB\u72C2\u71B1\u7684\u617E\u671B\u6240\
+        \u675F\u7E1B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Bound\
+        \ by wild desire{\\r}\r\nDialogue: 0,0:32:27.07,0:32:30.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u6389\u9032\u4E86\u706B\u5708{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I fell into a ring\
+        \ of fire{\\r}\r\nDialogue: 0,0:32:30.28,0:32:32.45,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7B49\u4E00\u4E0B \u4F60\u4F86\u9019\u5152\
+        \u4E0D\u662F\u70BA\u4E86\u935B\u7149\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Wait a second. Aren't you here for the exercise?{\\\
+        r}\r\nDialogue: 0,0:32:32.68,0:32:34.40,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E0D \u90A3\u662F\u5728\u6539\u8B8A\u8A08\u5283{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}No, there was a change\
+        \ in the plans.{\\r}\r\nDialogue: 0,0:32:34.61,0:32:37.20,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u807D\u8AAA\u6709\u4EBA\u5728\u57C3\u723E\
+        \u65AF\u7C73\u723E\u627E\u5230\u4E9B\u5947\u602A\u7684\u6771\u897F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Somebody found something\
+        \ strange on Ellesmere.{\\r}\r\nDialogue: 0,0:32:37.25,0:32:38.91,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7A7A\u4E2D\u5075\u5BDF\u6A5F\u5DF2\u7D93\
+        \u5728\u90A3\u88CF\u98DB\u4E86\u4E00\u500B\u661F\u671F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Aircom's making runs out there all\
+        \ week.{\\r}\r\nDialogue: 0,0:32:38.91,0:32:39.92,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u500B\u8001\u9F20\u6D1E\u55CE\uFF1F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}That rat hole?{\\\
+        r}\r\nDialogue: 0,0:32:40.15,0:32:42.26,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u4F60\u958B\u73A9\u7B11\u7684\u5427   - \u4E0D\u53EF\
+        \u601D\u8B70 \u5C0D\u5427{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}- You gotta be kidding me.       - I know. It's crazy.{\\r}\r\nDialogue:\
+        \ 0,0:32:42.49,0:32:44.20,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u8A31\u591A\u7F8E\u570B\u4EBA\u4E5F\u53BB\u4E86\u90A3\u88CF{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The Americans are there\
+        \ too, lots of them.{\\r}\r\nDialogue: 0,0:32:44.46,0:32:47.29,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9084\u6709\u5225\u7684\u55CE\uFF1F\u4ED6\
+        \u5011\u7BA1\u5B83\u53EB\u7570\u5E38\u7269\u9AD4{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Anything else? They're calling it an anomalous object.{\\\
+        r}\r\nDialogue: 0,0:32:47.29,0:32:49.54,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u4E5F\u4E0D\u77E5\u9053\u4EC0\u9EBC\u610F\u601D   -\
+        \ \u8D70\u958B \u62C9\u5FB7\u6D1B \u6211\u8A8D\u771F\u7684{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Whatever that means.       - Back\
+        \ off, Ludlow. I'm serious.{\\r}\r\nDialogue: 0,0:32:49.80,0:32:51.64,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u5225\u4ECB \u514B\u9E97\u831C   - \u4F4F\
+        \u624B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Oh, come\
+        \ on, Chrissy.       - Knock it off.{\\r}\r\nDialogue: 0,0:32:51.83,0:32:53.28,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u5750\u4E0B   - \u653E\u6211\u8D70{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Sit down.       -\
+        \ Let me go.{\\r}\r\nDialogue: 0,0:32:53.50,0:32:55.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u653E\u958B\u5979 \u54E5\u5011{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Hey. Leave her alone, man.{\\\
+        r}\r\nDialogue: 0,0:32:59.51,0:33:01.21,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E0D\u653E\u53C8\u600E\u6A23 \u786C\u6F22\uFF1F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Or what, tough guy?{\\\
+        r}\r\nDialogue: 0,0:33:01.78,0:33:05.69,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E0D\u653E\u5C31\u53EA\u80FD\u8ACB\u4F60\u96E2\u958B\
+        \u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Or I'm gonna\
+        \ have to ask you to leave.{\\r}\r\nDialogue: 0,0:33:06.38,0:33:09.95,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u89BA\u5F97\u6211\u60F3\u8D70\u7684\
+        \u6642\u5019\u624D\u6703\u8D70{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I think I'll probably just leave when I'm good and ready.{\\r}\r\nDialogue:\
+        \ 0,0:33:19.39,0:33:21.07,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F86\u52C1\u4E86\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Oh, there he is.{\\r}\r\nDialogue: 0,0:33:28.37,0:33:30.37,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u72AF\u4E0D\u4E0A \u89AA\u611B\u7684{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's not worth it,\
+        \ sweetie.{\\r}\r\nDialogue: 0,0:33:38.51,0:33:40.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6DF7\u86CB \u5225\u5FD8\u4E86\u4F60\u7684\
+        \u5C0F\u8CBB{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Hey,\
+        \ asshole, don't forget your tip.{\\r}\r\nDialogue: 0,0:33:43.05,0:33:44.86,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53BB\u5427{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Strike.{\\r}\r\nDialogue: 0,0:34:35.40,0:34:36.81,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8B1D\u8B1D{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Thanks.{\\r}\r\nDialogue: 0,0:34:37.64,0:34:38.88,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u55E8{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Hi.{\\r}\r\nDialogue: 0,0:34:39.11,0:34:40.81,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u84EE\u6069\u5C0F\u59D0 \u4F60\u597D\u55CE\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Miss Lane.\
+        \ How you doing?{\\r}\r\nDialogue: 0,0:34:41.07,0:34:43.28,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4F60\u597D   - \u6211\u662F\u5091\u5FB7\
+        \u2022\u5C24\u73ED\u514B\u65AF \u4F86\u81EA\u5317\u6975\u8CA8\u904B{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Good.       - Jed Eubanks,\
+        \ Arctic Cargo.{\\r}\r\nDialogue: 0,0:34:43.54,0:34:45.78,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9019\u96E2\u99D0\u5730\u6709\u591A\u9060\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}How far to\
+        \ the station?{\\r}\r\nDialogue: 0,0:34:46.25,0:34:49.32,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u5BBF\u71DF\u5730\u5C31\u5728\u4E0A\u9762\
+        \ \u6211\u966A\u4F60\u8D70\u904E\u53BB   - \u592A\u597D\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Camp's just over the rise. I'll\
+        \ walk you over.       - Great.{\\r}\r\nDialogue: 0,0:34:49.58,0:34:51.79,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u55AC\u53EF\u4EE5\u5E6B\u4F60\u62FF\u5305\
+        \ \u55AC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Joe can\
+        \ take your bags. Joe.{\\r}\r\nDialogue: 0,0:34:52.05,0:34:53.29,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F86\u5E6B\u5E6B\u5FD9{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Help her out.{\\r}\r\nDialogue: 0,0:34:53.55,0:34:56.06,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C0F\u5FC3\u9EDE \u90A3\u4E9B\u6771\u897F\
+        \u5F88\u91CD{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Careful\
+        \ with those. They're heavy.{\\r}\r\nDialogue: 0,0:34:58.49,0:35:00.13,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5F97\u627F\u8A8D \u84EE\u6069\u5C0F\
+        \u59D0{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I gotta confess,\
+        \ Miss Lane...{\\r}\r\nDialogue: 0,0:35:00.39,0:35:03.24,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E0D\u662F\u300A\u661F\u7403\u65E5\
+        \u5831\u300B\u7684\u5FE0\u5BE6\u89C0\u773E{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...I'm not a fan of the Daily Planet.{\\r}\r\nDialogue:\
+        \ 0,0:35:03.63,0:35:07.60,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F46\u4F60\u6F5B\u5165\u7B2C\u4E00\u5E2B\u6642\u5BEB\u7684\u90A3\
+        \u4E9B\u6587\u7AE0\u90FD...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}But those pieces you wrote when you were embedded with the 1st Division\
+        \ were...{\\r}\r\nDialogue: 0,0:35:07.83,0:35:09.68,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8B93\u6211\u5370\u8C61\u5341\u5206\u6DF1\
+        \u523B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Well, they\
+        \ were pretty impressive.{\\r}\r\nDialogue: 0,0:35:09.94,0:35:14.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u80FD\u8AAA\u4EC0\u9EBC\u5462\uFF1F\
+        \u4E0D\u7A7F\u8ECD\u670D\u7684\u6642\u5019\u6211\u5C31\u5F97\u5BEB\u5C08\u6B04\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Well, what can I\
+        \ say? I get writer's block if I'm not wearing a flak jacket.{\\r}\r\nDialogue:\
+        \ 0,0:35:19.61,0:35:20.61,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u84EE\u6069\u5C0F\u59D0{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Miss Lane.{\\r}\r\nDialogue: 0,0:35:20.85,0:35:23.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u662F\u7F8E\u570B\u5317\u65B9\u53F8\
+        \u4EE4\u90E8\u7684\u54C8\u8FEA\u4E0A\u6821 {\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}I'm Colonel Hardy, U.S. Northcom. {\\r}\r\nDialogue:\
+        \ 0,0:35:23.00,0:35:24.85,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u9019\u4F4D\u662F\u9AD8\u7D1A\u7814\u7A76\u8A08\u5283\u5C40\u7684\
+        \u57C3\u7C73\u723E\u535A\u58EB{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Dr. Emil Hamilton from DARPA.{\\r}\r\nDialogue: 0,0:35:25.12,0:35:26.29,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4F60\u4F86\u65E9\u4E86   - \u55E8{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- You're early.   \
+        \    - Hi.{\\r}\r\nDialogue: 0,0:35:26.52,0:35:28.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u4EE5\u70BA\u4F60\u660E\u5929\
+        \u624D\u5230{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We were\
+        \ expecting you tomorrow.{\\r}\r\nDialogue: 0,0:35:28.25,0:35:30.70,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6240\u4EE5\u6211\u624D\u4ECA\u5929\u4F86\
+        \u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Which is why\
+        \ I showed up today.{\\r}\r\nDialogue: 0,0:35:31.36,0:35:33.53,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u6709\u53E5\u8A71\u5F97\u8AAA\
+        \u5728\u524D\u982D \u597D\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Look, let's get one thing straight, guys, okay?{\\r}\r\n\
+        Dialogue: 0,0:35:33.79,0:35:35.01,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6211\u5728\u9019\u7684\u552F\u4E00\u539F\u56E0\u662F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The only reason I'm here\
+        \ is{\\r}\r\nDialogue: 0,0:35:35.01,0:35:36.64,chs,,0000,0000,0000,,{\\fn\u534E\
+        \u6587\u6977\u4F53\\blur3}\u6211\u5011\u5728\u52A0\u62FF\u5927\u570B\u5883\
+        \u5167\u53D7\u7406\u4E0A\u8A34\u7684\u6CD5\u5EAD{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}because we're on Canadian soil...{\\r}\r\nDialogue:\
+        \ 0,0:35:36.86,0:35:40.31,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u99C1\u56DE\u4E86\u4F60\u5011\u8D95\u6211\u8D70\u7684\u7981\u4EE4\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...and the appellate\
+        \ court overruled your injunction to keep me away.{\\r}\r\nDialogue: 0,0:35:40.53,0:35:42.67,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u9EBC \u4F60\u5982\u679C\u73A9\u86CB\
+        \u73A9\u5920\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}So\
+        \ if we're done measuring dicks...{\\r}\r\nDialogue: 0,0:35:42.94,0:35:45.28,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u80FD\u6D3E\u4EBA\u5E36\u6211\u770B\u770B\
+        \u4F60\u5011\u7684\u767C\u73FE\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...can you have your people show me what you found?{\\\
+        r}\r\nDialogue: 0,0:35:47.34,0:35:50.70,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u7F8E\u570B\u822A\u7A7A\u822A\u5929\u5C40\u7684\u7DCA\
+        \u6025\u6551\u63F4\u885B\u661F\u9996\u5148\u767C\u73FE\u7570\u5E38{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}NASA's EOS satellites pinged\
+        \ the anomaly first.{\\r}\r\nDialogue: 0,0:35:50.71,0:35:53.19,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u51B0\u67B6\u7684\u56DE\u8072\u63A2\u6E2C\
+        \u986F\u793A\u5F88\u6DF7\u4E82{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}The ice shelf plays hell on the echo soundings.{\\r}\r\nDialogue: 0,0:35:53.45,0:35:55.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u90A3\u88CF\u7D55\u5C0D\u6709\u6771\
+        \u897F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}But there's\
+        \ something there.{\\r}\r\nDialogue: 0,0:35:55.30,0:35:57.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8AAA\u4E0D\u5B9A\u662F\u8607\u806F\u6642\
+        \u4EE3\u7684\u6F5B\u8247\u5462\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3} A submarine, maybe? Soviet-era?{\\r}\r\nDialogue: 0,0:35:57.05,0:35:58.65,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u4E00\u5B9A \u90A3\u73A9\u610F\u4E09\
+        \u767E\u7C73\u9577{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Doubtful.\
+        \ That's 300 meters.{\\r}\r\nDialogue: 0,0:35:58.89,0:36:01.87,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6BD4\u6211\u5011\u90A3\u6642\u5019\u80FD\
+        \u5EFA\u51FA\u4F86\u7684\u6771\u897F\u5927\u591A\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Considerably larger than anything\
+        \ we know they built back then.{\\r}\r\nDialogue: 0,0:36:02.12,0:36:03.36,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u662F\u8A6D\u7570\u7684\u5730\u65B9\
+        \u5728\u9019{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}But\
+        \ herds the spooky pan.{\\r}\r\nDialogue: 0,0:36:04.56,0:36:07.04,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u6771\u897F\u5468\u570D\u8986\u84CB\
+        \u7684\u51B0{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The\
+        \ ice surrounding the object...{\\r}\r\nDialogue: 0,0:36:07.29,0:36:10.87,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5927\u6982\u5728\u4E0A\u9762\u6709\u5169\
+        \u842C\u5E74\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...it's\
+        \ nearly twenty thousand years old.{\\r}\r\nDialogue: 0,0:36:11.83,0:36:12.67,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u84EE\u6069\u5C0F\u59D0{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Miss Lane?{\\r}\r\nDialogue: 0,0:36:14.03,0:36:15.31,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5225\u4E82\u8D70 \u9019\u88CF\u5230\u4E86\
+        \u534A\u591C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Try\
+        \ not to wander.{\\r}\r\nDialogue: 0,0:36:15.54,0:36:18.64,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6EAB\u5EA6\u6703\u964D\u5230\u96F6\u4E0B\
+        40\u5EA6{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Temperatures\
+        \ drop to minus 40 at night around here.{\\r}\r\nDialogue: 0,0:36:18.87,0:36:21.15,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6625\u5929\u904E\u5B8C\u4E86\u624D\u80FD\
+        \u627E\u5230\u4F60\u7684\u5C4D\u9AD4{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Wouldn't find your body till after spring.{\\r}\r\nDialogue:\
+        \ 0,0:36:24.14,0:36:25.65,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u90A3\u5C31\u9019\u6A23\u5427{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}And there you go.{\\r}\r\nDialogue: 0,0:36:29.22,0:36:30.69,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u60F3\u89E3\u624B\u600E\u9EBC\u8FA6\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What if I\
+        \ need to tinkle?{\\r}\r\nDialogue: 0,0:36:31.38,0:36:33.02,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u89D2\u843D\u88CF\u6709\u500B\u6876{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}There's a bucket in\
+        \ the corner.{\\r}\r\nDialogue: 0,0:37:07.22,0:37:09.39,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5230\u5E95\u8981\u53BB\u54EA\u5152\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Where the\
+        \ hell are you going?{\\r}\r\nDialogue: 0,0:39:18.72,0:39:20.10,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u597D\uFF1F{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Hello?{\\r}\r\nDialogue: 0,0:40:55.58,0:40:59.19,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6C92\u4E8B\u4E86 \u6C92\u4E8B\u4E86 \u6C92\
+        \u4E8B\u4E86 \u6C92\u4E8B\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}It's all right, it's all right, it's all right. It's all right.{\\r}\r\
+        \nDialogue: 0,0:41:13.00,0:41:14.88,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u5167\u51FA\u8840\u4E86{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}You're hemorrhaging internally...{\\r}\r\
+        \nDialogue: 0,0:41:15.13,0:41:17.51,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u8981\u662F\u73FE\u5728\u6211\u4E0D\u6B62\u8840{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...and if I don't cauterize\
+        \ this bleed...{\\r}\r\nDialogue: 0,0:41:18.67,0:41:19.34,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u600E\u9EBC\u80FD\u2026\uFF1F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}How can...?{\\r}\r\nDialogue:\
+        \ 0,0:41:19.61,0:41:22.14,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u6709\u5E38\u4EBA\u6C92\u6709\u7684\u80FD\u529B{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I can do things that other\
+        \ people can't.{\\r}\r\nDialogue: 0,0:41:23.14,0:41:24.28,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6293\u4F4F\u6211\u7684\u624B{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Now hold my hand.{\\r}\r\n\
+        Dialogue: 0,0:41:25.11,0:41:26.68,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6703\u75BC\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}This is gonna hurt.{\\r}\r\nDialogue: 0,0:42:28.37,0:42:30.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u54C8\u8FEA\u4E0A\u6821\u548C\u4ED6\u7684\
+        \u5718\u968A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What\
+        \ Colonel Hardy and his team surmised...{\\r}\r\nDialogue: 0,0:42:30.74,0:42:32.25,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u731C\u6E2C\u9019\u6703\u662F\u4E00\u8258\
+        \u8607\u806F\u6642\u4EE3\u7684\u6F5B\u8247{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...was a Soviet-era submarine...{\\r}\r\nDialogue:\
+        \ 0,0:42:32.51,0:42:34.96,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5B83\u7684\u771F\u9762\u76EE\u537B\u66F4\u52A0\u5947\u7279{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...was actually something\
+        \ much more exotic.{\\r}\r\nDialogue: 0,0:42:35.21,0:42:39.06,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5468\u570D\u51B0\u5B54\u7684\u540C\u4F4D\
+        \u7D20\u5206\u6790\u8868\u660E...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}An isotope analysis of the surrounding ice bores suggests that an object...{\\\
+        r}\r\nDialogue: 0,0:42:39.29,0:42:43.13,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u8A72\u7269\u9AD4\u5DF2\u88AB\u56F0\u65BC\u51B0\u5DDD\
+        \u4E4B\u4E2D\u8D85\u904E\u4E00\u842C\u516B\u5343\u5E74{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...had been trapped in the glacier\
+        \ for over 18,000 years.{\\r}\r\nDialogue: 0,0:42:43.39,0:42:44.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u800C\u6551\u6211\u7684\u4EBA{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}As for my rescuer?{\\r}\r\n\
+        Dialogue: 0,0:42:45.19,0:42:47.57,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u5728\u8A72\u7269\u9AD4\u8D77\u98DB\u7684\u540C\u6642\u6D88\
+        \u5931\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He disappeared\
+        \ during the object's departure...{\\r}\r\nDialogue: 0,0:42:47.96,0:42:50.37,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u80CC\u666F\u8ABF\u67E5\u767C\u73FE \u4ED6\
+        \u7684\u5DE5\u4F5C\u6B77\u53F2...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}A background check revealed that his work history...{\\r}\r\nDialogue:\
+        \ 0,0:42:50.60,0:42:52.70,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u548C\u8EAB\u4EFD\u5747\u70BA\u507D\u9020{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}...and identity had been falsified.{\\\
+        r}\r\nDialogue: 0,0:42:52.93,0:42:54.81,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u95DC\u65BC\u6551\u6211\u7684\u4EBA{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The questions raised by my rescuer's...{\\\
+        r}\r\nDialogue: 0,0:42:55.07,0:42:56.91,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5B58\u5728\u8207\u5426\u7684\u8003\u91CF\u78BA\u5BE6\
+        \u9A5A\u4EBA{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...existence\
+        \ are frightening to contemplate...{\\r}\r\nDialogue: 0,0:42:57.14,0:43:00.42,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u6211\u4E5F\u77E5\u9053\u81EA\u5DF1\
+        \u6240\u898B\u5C6C\u5BE6{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...but I also know what I saw.{\\r}\r\nDialogue: 0,0:43:00.71,0:43:03.28,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u56E0\u6B64\u6211\u5F97\u51FA\u4E86\u4E00\
+        \u500B\u5FC5\u7136\u7684\u7D50\u8AD6{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}\"And I have arrived at the inescapable conclusion...{\\\
+        r}\r\nDialogue: 0,0:43:03.54,0:43:05.55,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5373\u8A72\u7269\u9AD4\u8207\u5B83\u7684\u4E58\u5750\
+        \u8005{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...that the\
+        \ object and its occupant...{\\r}\r\nDialogue: 0,0:43:05.78,0:43:08.32,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E26\u975E\u5730\u7403\u7522\u7269{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...did not originate\
+        \ on Earth.\"{\\r}\r\nDialogue: 0,0:43:09.45,0:43:12.76,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9019\u6A23\u6C92\u6CD5\u4E0A\u5831 \u88CF\
+        \u9762\u53EF\u80FD\u6709\u4E00\u534A\u662F\u4F60\u7684\u5E7B\u89BA{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I can't print this, Lois.\
+        \ You might have hallucinated half of it.{\\r}\r\nDialogue: 0,0:43:12.99,0:43:15.98,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53EF\u5E73\u6C11\u627F\u5305\u5546\u8B49\
+        \u5BE6\u4E86\u6211\u7684\u6545\u4E8B\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}What about the contractors who corroborated my story?{\\\
+        r}\r\nDialogue: 0,0:43:15.98,0:43:18.50,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E94\u89D2\u5927\u6A13\u5426\u8A8D\u6709\u8239\u7684\
+        \u5B58\u5728{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The\
+        \ Pentagon is denying that there was a ship.{\\r}\r\nDialogue: 0,0:43:18.76,0:43:20.60,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u5011\u7576\u7136\u5426\u8A8D \u4ED6\
+        \u5011\u5C31\u8A72\u5426\u8A8D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Of course they are. They're supposed to.{\\r}\r\nDialogue: 0,0:43:20.83,0:43:22.33,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u56E0\u70BA\u4ED6\u5011\u662F\u4E94\u89D2\
+        \u5927\u6A13{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's\
+        \ the Pentagon.{\\r}\r\nDialogue: 0,0:43:22.60,0:43:24.27,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F69\u88CF \u62DC\u8A17 \u6211\u5011\u8AAA\
+        \u7684\u53EF\u662F\u6211{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Perry,come on, it's me we're talking about.{\\r}\r\nDialogue: 0,0:43:24.50,0:43:27.17,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u6211\u662F\u4E00\u500B\u666E\u5229\u7B56\
+        \u734E\u7372\u734E\u8A18\u8005   - \u90A3\u5C31\u6709\u9EDE\u540D\u8A18\u8005\
+        \u6A23{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- I'm a Pulitzer\
+        \ Prize-winning reporter.       - Then act like it.{\\r}\r\nDialogue: 0,0:43:27.43,0:43:29.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4E0D\u5831\u51FA\u53BB\u6211\u5C31\u8FAD\
+        \u8077   - \u8D70\u4E0D\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}- Print it or I walk.       - You can't.{\\r}\r\nDialogue: 0,0:43:29.80,0:43:30.84,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u7C3D\u4E86\u5408\u540C\u7684{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You're under contract.{\\\
+        r}\r\nDialogue: 0,0:43:33.31,0:43:37.31,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u4E0D\u6703\u5831\u9053\u5916\u661F\u4EBA\u96B1\
+        \u85CF\u65BC\u5C0B\u5E38\u4EBA\u4E4B\u4E2D\u7684\u6545\u4E8B{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm not running a story about aliens\
+        \ walking among us.{\\r}\r\nDialogue: 0,0:43:43.62,0:43:45.19,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7D55\u5C0D\u4E0D\u6703{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Never gonna happen.{\\r}\r\nDialogue:\
+        \ 0,0:43:48.45,0:43:50.83,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u9019\u4F4D\u5973\u58EB\u7684\u8607\u683C\u862D\u5A01\u58EB\u5FCC\
+        \u7D14\u98F2{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}That's\
+        \ a Scotch, straight-up, for the lady.{\\r}\r\nDialogue: 0,0:43:51.09,0:43:52.45,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u73FE\u5728\u5C31\u767C\u539F\u6587\
+        \u7D66\u4F60{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm\
+        \ sending you the article.{\\r}\r\nDialogue: 0,0:43:52.63,0:43:55.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u7684\u7DE8\u8F2F\u4E0D\u80AF\u5831\
+        \ \u4F46\u5982\u679C\u78B0\u5DE7\u5728\u7DB2\u4E0A\u6D29\u9732\u4E86\u7684\
+        \u8A71...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}My editor\
+        \ won't print it, but if it leaked online...{\\r}\r\nDialogue: 0,0:43:55.33,0:43:56.64,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u61C2\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Got it.{\\r}\r\nDialogue: 0,0:43:56.86,0:43:59.31,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u4F60\u4E0D\u662F\u66FE\u7D93\u628A\
+        \u6211\u7684\u7DB2\u7AD9\u5F62\u5BB9\u70BA...{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}But didn't you once describe my site...{\\r}\r\n\
+        Dialogue: 0,0:43:59.53,0:44:02.84,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6EFF\u6EA2\u8B0A\u8A00\u7684\u6BD2\u7624\u55CE\uFF1F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...as a creeping cancer\
+        \ of falsehoods?{\\r}\r\nDialogue: 0,0:44:02.94,0:44:06.53,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u9084\u9019\u9EBC\u8A8D\u70BA \u4F46\
+        \u6211\u60F3\u8B93\u9019\u500B\u6545\u4E8B\u898B\u5149{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I stand by my words, Woodburn, but\
+        \ I want this story out there.{\\r}\r\nDialogue: 0,0:44:06.53,0:44:07.94,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u70BA\u4EC0\u9EBC\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Why?{\\r}\r\nDialogue: 0,0:44:07.97,0:44:11.32,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u56E0\u70BA\u6211\u60F3\u8B93\u6211\u7684\
+        \u795E\u79D8\u7537\u5B50\u77E5\u9053\u6211\u77E5\u9053\u771F\u76F8{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Because I want my mystery\
+        \ man to know I know the truth.{\\r}\r\nDialogue: 0,0:44:25.66,0:44:27.64,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u905E\u6B78\u8A3A\u65B7\u5B8C\u6210{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Recursive diagnostics\
+        \ complete...{\\r}\r\nDialogue: 0,0:44:28.46,0:44:30.67,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C0E\u793A\u5F71\u50CF\u5DF2\u6388\u6B0A\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Guiding presence\
+        \ authenticated.{\\r}\r\nDialogue: 0,0:44:30.90,0:44:33.47,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7CFB\u7D71\u904B\u8F49\u6B63\u5E38{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}All systems operational.{\\\
+        r}\r\nDialogue: 0,0:44:45.55,0:44:49.99,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u770B\u898B\u4F60\u5728\u90A3\u88CF\u9577\u5927\u6210\
+        \u4EBA...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}To see\
+        \ you standing there having grown into an adult...{\\r}\r\nDialogue: 0,0:44:51.72,0:44:54.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8981\u662F\u840A\u62C9\u80FD\u89AA\u773C\
+        \u5F97\u898B\u5C31\u597D\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}If only Lara could have witnessed this.{\\r}\r\nDialogue: 0,0:44:54.69,0:44:55.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u662F\u8AB0\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Who are you?{\\r}\r\nDialogue: 0,0:44:56.89,0:44:58.87,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u662F\u4F60\u7684\u7236\u89AA \u5361\
+        \u723E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I am your\
+        \ father, Kal.{\\r}\r\nDialogue: 0,0:45:00.23,0:45:02.10,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8D77\u78BC\u662F\u4ED6\u7684\u8EAB\u5F71\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Or at least a shadow\
+        \ of him.{\\r}\r\nDialogue: 0,0:45:02.60,0:45:04.34,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u7684\u610F\u8B58{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}His consciousness.{\\r}\r\nDialogue:\
+        \ 0,0:45:06.10,0:45:09.20,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u53EB\u55AC\u2022\u827E\u723E{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}My name was Jor-El.{\\r}\r\nDialogue: 0,0:45:11.87,0:45:13.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u5361\u723E{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}And Kal?{\\r}\r\nDialogue: 0,0:45:16.74,0:45:17.95,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u662F\u6211\u7684\u540D\u5B57\u55CE\uFF1F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}That's my name.{\\\
+        r}\r\nDialogue: 0,0:45:18.84,0:45:22.05,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u53EB \u5361\u723E\u2022\u827E\u723E{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Kal-El. It is.{\\r}\r\nDialogue: 0,0:45:22.75,0:45:24.79,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u6709\u597D\u591A\u554F\u984C{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I have so many questions.{\\\
+        r}\r\nDialogue: 0,0:45:27.52,0:45:29.12,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u5F9E\u54EA\u88CF\u4F86\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Where do I come from?{\\r}\r\nDialogue:\
+        \ 0,0:45:30.86,0:45:32.73,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u70BA\u4EC0\u9EBC\u8981\u9001\u6211\u4F86\u9019\u88CF\uFF1F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Why did you send\
+        \ me here?{\\r}\r\nDialogue: 0,0:45:33.56,0:45:35.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4F86\u81EA\u6C2A\u661F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You came from Krypton.{\\r}\r\
+        \nDialogue: 0,0:45:38.13,0:45:42.14,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E00\u500B\u6BD4\u5730\u7403\u74B0\u5883\u66F4\u60E1\
+        \u52A3\u7684\u4E16\u754C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}A world with a much harsher environment than Earths.{\\r}\r\nDialogue:\
+        \ 0,0:45:45.94,0:45:47.58,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5F88\u4E45\u4EE5\u524D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Long ago...{\\r}\r\nDialogue: 0,0:45:47.81,0:45:50.05,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5728\u5927\u64F4\u5F35\u7684\u6642\u4EE3\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...in an era of\
+        \ expansion...{\\r}\r\nDialogue: 0,0:45:50.28,0:45:53.49,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u7684\u7A2E\u65CF\u63A2\u7D22\
+        \u4E00\u9846\u9846\u661F\u7403{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...our race spread out through the stars...{\\r}\r\nDialogue: 0,0:45:53.75,0:45:56.45,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C0B\u8993\u53EF\u4EE5\u5E38\u99D0\u7684\
+        \u65B0\u4E16\u754C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...seeking\
+        \ new worlds to settle upon.{\\r}\r\nDialogue: 0,0:45:57.58,0:46:01.09,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9019\u8258\u5075\u5BDF\u8239\u662F\u5C04\
+        \u5165\u865B\u7A7A\u7684\u6578\u5343\u8258\u4E4B\u4E00{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}This scout ship was one of thousands\
+        \ launched into the void.{\\r}\r\nDialogue: 0,0:46:03.66,0:46:06.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u5728\u5176\u4ED6\u884C\u661F\
+        \u4E0A\u5EFA\u9020\u524D\u54E8{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}We built outposts on other planets...{\\r}\r\nDialogue: 0,0:46:06.49,0:46:10.24,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7528\u5DE8\u5927\u7684\u6A5F\u5668\u6309\
+        \u6211\u5011\u7684\u9700\u6C42\u91CD\u5851\u74B0\u5883{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}musing great machines to reshape environments\
+        \ to our needs.{\\r}\r\nDialogue: 0,0:46:12.43,0:46:16.94,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5341\u842C\u5E74\u4F86\u6211\u5011\u7684\
+        \u6587\u660E\u84EC\u52C3\u767C\u5C55{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}For 100,000 years, our civilization flourished...{\\r}\r\
+        \nDialogue: 0,0:46:17.97,0:46:19.97,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5275\u9020\u4E86\u8A31\u591A\u5947\u8DE1{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...accomplishing wonders.{\\\
+        r}\r\nDialogue: 0,0:46:21.14,0:46:22.78,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u767C\u751F\u4E86\u4EC0\u9EBC\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What happened?{\\r}\r\nDialogue: 0,0:46:24.78,0:46:27.85,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u5275\u9020\u4E86\u4EBA\u9020\
+        \u4EBA\u53E3\u63A7\u5236\u7CFB\u7D71{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Artificial population control was established.{\\r}\r\n\
+        Dialogue: 0,0:46:28.58,0:46:32.19,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u907A\u68C4\u4E86\u592A\u7A7A\u63A2\u7D22\u7684\u524D\u54E8\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The outposts on\
+        \ space exploration were abandoned.{\\r}\r\nDialogue: 0,0:46:32.79,0:46:35.36,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u7528\u76E1\u4E86\u81EA\u7136\
+        \u8CC7\u6E90{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We exhausted\
+        \ our natural resources.{\\r}\r\nDialogue: 0,0:46:35.62,0:46:39.63,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u56E0\u6B64\u6211\u5011\u884C\u661F\u7684\
+        \u6838\u5FC3\u8B8A\u5F97\u4E0D\u7A69\u5B9A{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}As a result, our planet's core became unstable.{\\\
+        r}\r\nDialogue: 0,0:46:42.09,0:46:44.63,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6700\u7D42\u6211\u5011\u7684\u8ECD\u4E8B\u9818\u8896\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Eventually, our\
+        \ military leader...{\\r}\r\nDialogue: 0,0:46:44.86,0:46:48.78,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F50\u5FB7\u5C07\u8ECD\u4F01\u5716\u767C\
+        \u52D5\u653F\u8B8A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...General\
+        \ Zod, attempted a coup.{\\r}\r\nDialogue: 0,0:46:50.70,0:46:52.88,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u70BA\u6642\u5DF2\u665A{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}But by then it was too late.{\\\
+        r}\r\nDialogue: 0,0:46:54.14,0:46:56.78,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u5ABD\u5ABD\u548C\u6211\u9810\u898B\u4E86\u672A\
+        \u4F86\u707D\u96E3{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Your\
+        \ mother and I foresaw the coming calamity...{\\r}\r\nDialogue: 0,0:46:57.01,0:47:00.42,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u63A1\u53D6\u4E86\u67D0\u4E9B\
+        \u63AA\u65BD\u4EE5\u78BA\u4FDD\u4F60\u7684\u751F\u5B58{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...and we took certain steps to ensure\
+        \ your survival.{\\r}\r\nDialogue: 0,0:47:01.88,0:47:03.92,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9019\u662F\u59CB\u6E90\u5BA4{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}This is a genesis chamber.{\\\
+        r}\r\nDialogue: 0,0:47:04.38,0:47:07.52,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6240\u6709\u6C2A\u661F\u4EBA\u90FD\u5728\u9019\u6A23\
+        \u7684\u5C0F\u623F\u9593\u88CF\u88AB\u5B55\u80B2{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}All Kryptonians were conceived in chambers such as\
+        \ this.{\\r}\r\nDialogue: 0,0:47:07.79,0:47:11.50,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6BCF\u500B\u51FA\u751F\u7684\u5B69\u5B50\
+        \u90FD\u6709\u4E00\u500B\u9810\u5B9A\u7684\u89D2\u8272{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Every child was designed to fulfill\
+        \ a pre-determined role in our society...{\\r}\r\nDialogue: 0,0:47:11.72,0:47:12.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5DE5\u4EBA{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...as a worker...{\\r}\r\nDialogue: 0,0:47:12.83,0:47:15.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6230\u58EB \u9818\u5C0E\u8005\u7B49\u7B49\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...a warrior, a\
+        \ leader and so on.{\\r}\r\nDialogue: 0,0:47:16.20,0:47:19.47,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5ABD\u5ABD\u548C\u6211\u76F8\u4FE1\
+        \u6C2A\u661F\u5931\u53BB\u4E86\u4E00\u4E9B\u73CD\u8CB4\u7684\u6771\u897F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Your mother and I believed\
+        \ Krypton lost something precious.{\\r}\r\nDialogue: 0,0:47:19.70,0:47:21.91,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9078\u64C7\u548C\u6A5F\u6703\u7684\u8981\
+        \u7D20{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The element\
+        \ of choice, of chance.{\\r}\r\nDialogue: 0,0:47:22.40,0:47:24.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8981\u662F\u4E00\u500B\u5B69\u5B50\u7684\
+        \u5922\u60F3\u662F...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}What if a child dreamed of becoming something...{\\r}\r\nDialogue: 0,0:47:24.84,0:47:27.34,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6210\u70BA\u9810\u5B9A\u8F03\u8272\u4EE5\
+        \u5916\u7684\u89D2\u8272\u5462\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}mother than what society had intended for him or her?{\\\
+        r}\r\nDialogue: 0,0:47:28.87,0:47:31.48,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u8981\u662F\u4ED6\u6E34\u671B\u66F4\u5049\u5927\u7684\
+        \u6771\u897F\u5462\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}What if a child aspired to something greater?{\\r}\r\nDialogue: 0,0:47:32.24,0:47:34.25,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5C31\u662F\u9019\u7A2E\u4FE1\u5FF5\
+        \u7684\u9AD4\u73FE \u5361\u723E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You were the embodiment of that belief, Kal.{\\r}\r\nDialogue: 0,0:47:34.51,0:47:37.59,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5E7E\u4E16\u7D00\u4EE5\u4F86\u6C2A\u661F\
+        \u7684\u7B2C\u4E00\u500B\u81EA\u7136\u5206\u5A29\u7684\u5B69\u5B50{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Krypton's first natural\
+        \ birth in centuries.{\\r}\r\nDialogue: 0,0:47:38.08,0:47:40.76,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6240\u4EE5\u6211\u5011\u624D\u5192\u5982\
+        \u6B64\u5927\u7684\u98A8\u96AA\u6551\u4F60{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}That's why we risked so much to save you.{\\r}\r\n\
+        Dialogue: 0,0:47:41.89,0:47:43.33,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4F60\u5011\u70BA\u4EC0\u9EBC\u4E0D\u8DDF\u6211\u4E00\u8D77\
+        \u4F86\u5462\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Why\
+        \ didn't you come with me?{\\r}\r\nDialogue: 0,0:47:46.86,0:47:48.60,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u505A\u4E0D\u5230 \u5361\u723E\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We couldn't, Kal.{\\\
+        r}\r\nDialogue: 0,0:47:49.66,0:47:52.50,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E0D\u8AD6\u6211\u5011\u591A\u9EBC\u6E34\u671B{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}No matter how much we wanted\
+        \ to.{\\r}\r\nDialogue: 0,0:47:52.60,0:47:54.60,chs,,0000,0000,0000,,{\\fn\u534E\
+        \u6587\u6977\u4F53\\blur3}\u4E0D\u8AD6\u6211\u5011\u6709\u591A\u611B\u4F60\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}No matter how much\
+        \ we loved you.{\\r}\r\nDialogue: 0,0:47:55.37,0:47:56.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6BCD\u89AA\u840A\u62C9\u548C\u6211\
+        \ \u90FD\u8DDF\u4F50\u5FB7\u4E00\u6A23{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Your mother, Lara, and I...{\\r}\r\nDialogue: 0,0:47:57.00,0:48:00.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u662F\u6211\u5011\u4E16\u754C\u751F\u7522\
+        \u51FA\u4F86\u7684\u5931\u6557\u7522\u7269{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...were a product of the failures of our world as\
+        \ much as Zod was...{\\r}\r\nDialogue: 0,0:48:00.37,0:48:02.05,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u8207\u5B83\u7684\u547D\u904B\
+        \u7DCA\u7DCA\u76F8\u9023{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...tied to its fate.{\\r}\r\nDialogue: 0,0:48:02.27,0:48:04.35,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u90A3\u6211\u662F\u5B64\u55AE\u4E00\u4EBA\
+        \u4E86   - \u4E0D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}-\
+        \ So I'm alone.       - No.{\\r}\r\nDialogue: 0,0:48:06.08,0:48:09.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u65E2\u662F\u6C2A\u661F\u7684\u5B50\
+        \u55E3 \u4E5F\u662F\u5730\u7403\u7684\u5B69\u5B50{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}You're as much a child of Earth now as you are of\
+        \ Krypton.{\\r}\r\nDialogue: 0,0:48:10.02,0:48:13.19,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u80FD\u9AD4\u73FE\u5169\u500B\u4E16\
+        \u754C\u7684\u7CBE\u83EF{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You can embody the best of both worlds.{\\r}\r\nDialogue: 0,0:48:13.42,0:48:17.06,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6BCD\u89AA\u548C\u6211\u81F4\u529B\
+        \u4FDD\u8B77\u7684\u5922\u60F3{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}A dream your mother and I dedicated our lives to preserve.{\\r}\r\n\
+        Dialogue: 0,0:48:21.59,0:48:24.58,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u5730\u7403\u4EBA\u8207\u6211\u5011\u4E0D\u540C \u9019\u4E0D\
+        \u5047{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The people\
+        \ of Earth are different from us, it's true.{\\r}\r\nDialogue: 0,0:48:24.80,0:48:27.74,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u6700\u7D42\u6211\u76F8\u4FE1\u9019\
+        \u662F\u4EF6\u597D\u4E8B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}But, ultimately, I believe that's a good thing.{\\r}\r\nDialogue: 0,0:48:27.97,0:48:30.41,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u5011\u4E0D\u4E00\u5B9A\u6703\u72AF\
+        \u8207\u6211\u5011\u76F8\u540C\u7684\u932F\u8AA4{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}They won't necessarily make the same mistakes we\
+        \ did.{\\r}\r\nDialogue: 0,0:48:30.64,0:48:32.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53EA\u8981\u6709\u4F60\u7684\u5F15\u5C0E\
+        \ \u5361\u723E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Not\
+        \ if you guide them, Kal.{\\r}\r\nDialogue: 0,0:48:34.21,0:48:36.24,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53EA\u8981\u4F60\u5E36\u7D66\u4ED6\u5011\
+        \u5E0C\u671B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Not\
+        \ if you give them hope.{\\r}\r\nDialogue: 0,0:48:39.65,0:48:41.82,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9019\u500B\u7B26\u865F\u5C31\u662F\u9019\
+        \u500B\u610F\u601D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}That's\
+        \ what this symbol means.{\\r}\r\nDialogue: 0,0:48:42.55,0:48:44.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u827E\u723E\u5BB6\u65CF\u7684\u6A19\u8A8C\
+        \u4EE3\u8868\u5E0C\u671B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}The symbol of the house of El means hope.{\\r}\r\nDialogue: 0,0:48:45.12,0:48:47.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u7A2E\u5E0C\u671B\u7684\u9AD4\u73FE\
+        \u5728\u65BC...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Embodied\
+        \ within that hope is the fundamental belief...{\\r}\r\nDialogue: 0,0:48:47.89,0:48:52.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8B93\u6BCF\u500B\u4EBA\u7684\u6F5B\u529B\
+        \u6210\u70BA\u5584\u7684\u529B\u91CF{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}...in the potential of every person to be a force for good.{\\\
+        r}\r\nDialogue: 0,0:48:52.93,0:48:54.96,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u53EF\u4EE5\u5C07\u9019\u4E00\u9EDE\u5E36\u7D66\
+        \u4ED6\u5011{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}That's\
+        \ what you can bring them.{\\r}\r\nDialogue: 0,0:49:15.15,0:49:17.59,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u70BA\u4EC0\u9EBC\u6211\u9019\u9EBC\u8207\
+        \u773E\u4E0D\u540C\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Why am I so different from them?{\\r}\r\nDialogue: 0,0:49:18.25,0:49:21.45,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5730\u7403\u7684\u592A\u967D\u6BD4\u6C2A\
+        \u661F\u7684\u592A\u967D\u66F4\u5E74\u8F15\u66F4\u660E\u4EAE{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Earth's sun is younger and brighter\
+        \ than Krypton's was.{\\r}\r\nDialogue: 0,0:49:22.66,0:49:25.03,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u7684\u7D30\u80DE\u6C72\u53D6\u4E86\
+        \u5B83\u7684\u8F3B\u5C04{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Your cells have drunken its radiation...{\\r}\r\nDialogue: 0,0:49:25.29,0:49:29.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u52A0\u5F37\u4F60\u7684\u808C\u8089 \u76AE\
+        \u819A\u4EE5\u53CA\u611F\u5B98{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...strengthening your muscles, your skin, your senses.{\\r}\r\nDialogue:\
+        \ 0,0:49:29.83,0:49:33.83,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5730\u7403\u7684\u5F15\u529B\u8F03\u5F31 \u4F46\u5927\u6C23\u66F4\
+        \u52A0\u6ECB\u6F64{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Earth's\
+        \ gravity is weaker, yet its atmosphere is more nourishing.{\\r}\r\nDialogue:\
+        \ 0,0:49:35.13,0:49:38.14,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u5728\u9019\u88CF\u8B8A\u5F97\u6703\u6BD4\u6211\u60F3\u50CF\
+        \u4E2D\u7684\u66F4\u5F37{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You've grown stronger here than I ever could have imagined.{\\r}\r\n\
+        Dialogue: 0,0:49:38.37,0:49:41.00,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u77E5\u9053\u591A\u5F37\u7684\u552F\u4E00\u8FA6\u6CD5\u5C31\
+        \u662F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The only way\
+        \ to know how strong...{\\r}\r\nDialogue: 0,0:49:41.04,0:49:44.58,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u65B7\u6E2C\u8A66\u4F60\u7684\u6975\
+        \u9650{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...is to keep\
+        \ testing your limits.{\\r}\r\nDialogue: 0,0:50:36.43,0:50:40.43,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6703\u5E36\u7D66\u5730\u7403\u4EBA\
+        \u70BA\u4E4B\u596E\u9B25\u7684\u7406\u60F3{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}You will give the people of Earth an ideal lo strive\
+        \ towards.{\\r}\r\nDialogue: 0,0:50:42.10,0:50:43.91,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u5011\u6703\u5728\u4F60\u8EAB\u5F8C\
+        \u52AA\u529B\u8FFD\u8D95{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}They'll race behind you.{\\r}\r\nDialogue: 0,0:50:44.17,0:50:45.55,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u5011\u6703\u5931\u8DB3{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}They will stumble.{\\r}\r\n\
+        Dialogue: 0,0:50:45.77,0:50:46.91,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6703\u5012\u4E0B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}They will fall.{\\r}\r\nDialogue: 0,0:50:47.17,0:50:48.88,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u6700\u5F8C{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}But In time...{\\r}\r\nDialogue: 0,0:50:50.41,0:50:53.05,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u5011\u6703\u5728\u592A\u967D\u4E0B\
+        \u8207\u4F60\u6BD4\u80A9 \u5361\u723E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}...they will join you in the sun, Kal.{\\r}\r\nDialogue:\
+        \ 0,0:50:54.55,0:50:56.25,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5230\u6700\u5F8C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}In time...{\\r}\r\nDialogue: 0,0:50:56.58,0:50:59.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6703\u5E6B\u52A9\u4ED6\u5011\u5275\
+        \u9020\u5947\u8DE1{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}you\
+        \ will help them accomplish wonders.{\\r}\r\nDialogue: 0,0:52:25.94,0:52:27.54,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5148\u5F9E\u8FFD\u8E64\u6709\u4ED6\u51FA\
+        \u73FE\u7684\u90FD\u5E02\u50B3\u8AAA\u958B\u59CB{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}You start with the urban legends...{\\r}\r\nDialogue:\
+        \ 0,0:52:27.81,0:52:30.15,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}- \u4ED6\u9192\u4F86\u5F8C\u90FD\u6D8C\u73FE\u4E86\u51FA\u4F86   -\
+        \ \u9019\u662F\u55AC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}-\
+        \ ...that have sprung up in his wake.        - That's Joe.{\\r}\r\nDialogue:\
+        \ 0,0:52:30.38,0:52:32.85,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6240\u6709\u8072\u7A31\u898B\u904E\u4ED6\u7684\u670B\u53CB\u7684\
+        \u670B\u53CB{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The\
+        \ friends of a friend who have seen him.{\\r}\r\nDialogue: 0,0:52:32.85,0:52:34.01,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u904E\u53BB\u5728\u9019\u88CF\u5DE5\
+        \u4F5C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He worked\
+        \ here.{\\r}\r\nDialogue: 0,0:52:34.28,0:52:36.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C0D\u67D0\u4E9B\u4EBA\u800C\u8A00 \u4ED6\
+        \u662F\u5B88\u8B77\u5929\u4F7F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}For some he was a guardian angel.{\\r}\r\nDialogue: 0,0:52:36.26,0:52:39.80,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C0D\u5176\u4ED6\u4EBA\u4F86\u8B1B \u4ED6\
+        \u662F\u500B\u8B0E \u662F\u500B\u683C\u683C\u4E0D\u5165\u7684\u5E7D\u9748\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}For others, a cipher,\
+        \ a ghost who never quite fit in...{\\r}\r\nDialogue: 0,0:52:40.02,0:52:43.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u597D\u5427 \u6211\u662F\u8AAA\u6211\u5011\
+        \u5728\u9760\u8FD1\u77F3\u6CB9\u947D\u6A5F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Well, I was saying we were coming towards the oil\
+        \ rig.{\\r}\r\nDialogue: 0,0:52:43.19,0:52:47.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u96A8\u8457\u4F60\u6392\u9664\u56F0\u96E3\
+        \u8FFD\u6EAF\u904E\u53BB \u6545\u4E8B\u958B\u59CB\u6F38\u6F38\u6210\u578B\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}As you work your\
+        \ way back in time, the stories form a pattern.{\\r}\r\nDialogue: 0,0:52:47.06,0:52:49.13,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5728\u627E\u76AE\u7279\u2022\u7F85\
+        \u65AF \u4F60\u8A8D\u8B58\u4ED6\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}I'm looking for a Pete Ross. Do you know him?{\\\
+        r}\r\nDialogue: 0,0:52:54.13,0:52:55.44,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u662F\u76AE\u7279\u2022\u7F85\u65AF\u55CE\uFF1F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Pete Ross?{\\r}\r\nDialogue:\
+        \ 0,0:52:57.17,0:53:00.38,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u60F3\u8DDF\u60A8\u8AC7\u8AC7\u4F60\u5E74\u8F15\u6642\u5019\
+        \u7684\u4E00\u5834\u4E8B\u6545{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I'd like to talk to you about an accident when you were younger.{\\\
+        r}\r\nDialogue: 0,0:53:00.64,0:53:03.14,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E00\u8F1B\u885D\u9032\u6CB3\u88CF\u7684\u6821\u8ECA\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}A school bus that\
+        \ went into the river.{\\r}\r\nDialogue: 0,0:53:08.65,0:53:10.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5091\u65AF{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Dusty.{\\r}\r\nDialogue: 0,0:53:10.92,0:53:11.99,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u80AF\u7279\u592B\u4EBA\u55CE\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Mrs. Kent?{\\r}\r\n\
+        Dialogue: 0,0:53:12.92,0:53:15.36,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6211\u662F\u9732\u6613\u7D72\u2022\u84EE\u6069 \u4F86\u81EA\
+        \u300A\u661F\u7403\u65E5\u5831\u300B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}I'm Lois Lane. I'm from the  Daily Planet.{\\r}\r\nDialogue:\
+        \ 0,0:53:15.92,0:53:16.66,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5B89\u975C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Quiet.{\\\
+        r}\r\nDialogue: 0,0:53:18.26,0:53:21.73,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u4F86\u81EA\u300A\u661F\u7403\u65E5\u5831\u300B\
+        \ \u6211\u60F3\u8DDF\u60A8\u8AC7\u8AC7\u4F60\u7684\u5152\u5B50{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm from the Daily Planet and\
+        \ I'd like to talk to you about your son.{\\r}\r\nDialogue: 0,0:53:39.85,0:53:44.45,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u65E9\u5C31\u77E5\u9053\u8981\u662F\
+        \u6211\u67E5\u5F97\u5920\u4ED4\u7D30 \u4F60\u6700\u5F8C\u6703\u627E\u5230\u6211\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I figured if I turned\
+        \ over enough stones you'd eventually find me.{\\r}\r\nDialogue: 0,0:53:49.42,0:53:52.46,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5F9E\u54EA\u4F86\uFF1F\u5728\u9019\
+        \u88CF\u505A\u4EC0\u9EBC\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Where are you from? What are you doing here?{\\r}\r\nDialogue: 0,0:53:52.73,0:53:54.07,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8B93\u6211\u8B1B\u4F60\u7684\u6545\u4E8B\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Let me tell your\
+        \ story.{\\r}\r\nDialogue: 0,0:53:54.29,0:53:57.43,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8981\u662F\u6211\u4E0D\u60F3\u8B93\u6211\
+        \u7684\u6545\u4E8B\u88AB\u8B1B\u51FA\u53BB\u5462\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What if I don't want my story told?{\\\
+        r}\r\nDialogue: 0,0:53:57.70,0:53:59.47,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6700\u5F8C\u5B83\u7E3D\u6703\u88AB\u50B3\u51FA\u53BB\
+        \u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's going\
+        \ to come out eventually.{\\r}\r\nDialogue: 0,0:53:59.73,0:54:02.77,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6709\u4EBA\u6703\u62FF\u5230\u76F8\u7247\
+        \u6216\u662F\u67E5\u5230\u4F60\u7684\u4F4F\u8655{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Somebody's going to get a photograph or figure out\
+        \ where you live.{\\r}\r\nDialogue: 0,0:54:03.04,0:54:05.98,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u90A3\u6211\u5C31\u518D\u6B21\u6D88\u5931\
+        \   - \u552F\u4E00\u7684\u8FA6\u6CD5\u5C31\u662F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}- Then I'll disappear again.       - The only way\
+        \ you could disappear...{\\r}\r\nDialogue: 0,0:54:06.24,0:54:10.24,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u518D\u5E6B\u52A9\u4EBA\u5011 \u6211\
+        \u611F\u89BA\u4F60\u4E0D\u6703\u90A3\u6A23\u7684{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...is to stop helping people altogether, and I sense\
+        \ that's not an option for you.{\\r}\r\nDialogue: 0,0:54:14.41,0:54:18.42,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u7236\u89AA\u76F8\u4FE1\u8981\u662F\
+        \u4E16\u754C\u67E5\u51FA\u6211\u7684\u771F\u5BE6\u8EAB\u4EFD{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}My father believed that if the world\
+        \ found out who I really was...{\\r}\r\nDialogue: 0,0:54:20.42,0:54:21.92,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u5011\u6703\u62D2\u7D55\u6211{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...they'd reject me...{\\\
+        r}\r\nDialogue: 0,0:54:22.15,0:54:23.79,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u56E0\u70BA\u6050\u61FC{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...out of fear.{\\r}\r\nDialogue: 0,0:54:25.82,0:54:27.90,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u53AD\u5026\u4E86\u5B89\u5168{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm tired of safe.{\\\
+        r}\r\nDialogue: 0,0:54:28.13,0:54:30.23,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u53EA\u60F3\u6709\u751F\u4E4B\u5E74\u505A\u4E9B\
+        \u6709\u7528\u7684\u4E8B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I just wanna do something useful with my life.{\\r}\r\nDialogue: 0,0:54:30.46,0:54:33.07,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u9EBC\u958B\u8FB2\u5834 \u990A\u6D3B\
+        \u5927\u5BB6 \u5C31\u6C92\u6709\u7528\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}So farming, feeding people. That's not useful?{\\\
+        r}\r\nDialogue: 0,0:54:33.30,0:54:34.30,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u6C92\u90A3\u9EBC\u8AAA{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}I didn't say that.{\\r}\r\nDialogue: 0,0:54:34.40,0:54:36.64,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u7684\u5BB6\u65CF\u6574\u6574\
+        \u4E94\u4EE3\u90FD\u4EE5\u8FB2\u5834\u70BA\u751F \u514B\u62C9\u514B{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Our family's been farming\
+        \ for five generations.{\\r}\r\nDialogue: 0,0:54:36.77,0:54:38.68,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u7684\u5BB6\u65CF \u4E0D\u662F\u6211\
+        \u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Your family,\
+        \ not mine.{\\r}\r\nDialogue: 0,0:54:38.94,0:54:42.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u90FD\u4E0D\u77E5\u9053\u81EA\u5DF1\
+        \u70BA\u4EC0\u9EBC\u8981\u807D\u4F60\u8AAA \u4F60\u4E0D\u662F\u6211\u7238\u7238\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I don't even know\
+        \ why I'm listening to you. You're not my dad.{\\r}\r\nDialogue: 0,0:54:42.14,0:54:43.52,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u53EA\u662F\u67D0\u500B\u5728\u5730\
+        \u88CF\u64BF\u5230\u6211\u7684\u4EBA{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}You're just some guy who found me in a field.{\\r}\r\n\
+        Dialogue: 0,0:54:43.78,0:54:44.95,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Clark.{\\r}\r\nDialogue: 0,0:54:47.31,0:54:48.99,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6C92\u95DC\u4FC2 \u746A\u838E{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's all right, Martha.{\\\
+        r}\r\nDialogue: 0,0:54:50.82,0:54:52.92,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4ED6\u8AAA\u5F97\u5C0D \u514B\u62C9\u514B\u8AAA\u5F97\
+        \u6709\u9053\u7406{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He's\
+        \ right. Clark has a point.{\\r}\r\nDialogue: 0,0:54:53.49,0:54:54.52,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u4E0D\u662F\u4F60\u7684\u7236\
+        \u6BCD{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We're not\
+        \ your parents.{\\r}\r\nDialogue: 0,0:54:56.62,0:54:58.33,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u6211\u5011\u529B\u6C42\u505A\u5230\
+        \u6700\u597D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}But\
+        \ we've been doing the best we can.{\\r}\r\nDialogue: 0,0:54:58.59,0:55:01.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u4E5F\u5728\u76E1\u53EF\u80FD\
+        \u5730\u6539\u9032 \u4E5F\u8A31...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}And we've been making this up as we go along, so maybe...{\\\
+        r}\r\nDialogue: 0,0:55:02.19,0:55:05.11,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u5011\u6240\u8B02\u7684\u6700\u597D\u5DF2\u7D93\
+        \u4E0D\u5920\u597D\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Maybe our best isn't good enough anymore.{\\r}\r\nDialogue: 0,0:55:09.64,0:55:11.67,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u807D\u8457 \u7238{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Look, Dad...{\\r}\r\nDialogue: 0,0:55:11.94,0:55:13.38,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7B49\u4E00\u4E0B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Hold on.{\\r}\r\nDialogue: 0,0:55:33.13,0:55:34.83,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5FEB\u53BB\u5929\u6A4B\u8EB2\u8457{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Go for the overpass.{\\\
+        r}\r\nDialogue: 0,0:55:36.63,0:55:37.73,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5FEB\u9EDE\u53BB\u8EB2\u8D77\u4F86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Go for the overpass!{\\r}\r\nDialogue:\
+        \ 0,0:55:40.07,0:55:41.70,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u627E\u63A9\u8B77 \u5FEB\u627E\u63A9\u8B77{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Take cover! Take cover!{\\r}\r\nDialogue:\
+        \ 0,0:55:41.97,0:55:44.35,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}- \u5728\u90A3\u908A \u8DDF\u4E0A\u4ED6\u5011   - \u627E\u63A9\u8B77\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Over there. Just\
+        \ follow them.       - Take cover.{\\r}\r\nDialogue: 0,0:55:48.07,0:55:49.25,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5979\u88AB\u56F0\u4F4F\u4E86{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}She's stuck.{\\r}\r\nDialogue:\
+        \ 0,0:55:53.81,0:55:55.69,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6F22\u514B\u5728\u8ECA\u88CF{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Hank's still in the car.{\\r}\r\nDialogue: 0,0:55:56.52,0:55:57.55,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6F22\u514B\u5728\u8ECA\u88CF{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Hank's in the car.{\\r}\r\n\
+        Dialogue: 0,0:55:58.42,0:56:00.56,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}- \u6211\u53BB\u6551\u5B83 \u6211\u53BB\u6551   - \u4E0D{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- I'll get him, I'll\
+        \ get him.       - No, no.{\\r}\r\nDialogue: 0,0:56:01.09,0:56:03.33,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5E36\u4F60\u5ABD\u53BB\u5929\u6A4B{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Get your mom to the\
+        \ overpass.{\\r}\r\nDialogue: 0,0:56:21.71,0:56:23.52,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6F22\u514B \u5FEB\u4F86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Hank! Hank! Come!{\\r}\r\nDialogue:\
+        \ 0,0:56:54.64,0:56:56.09,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}- \u55AC\u7D0D\u68EE   - \u5ABD \u5F85\u5728\u9019{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Jonathan!       - Mom, stay here.{\\\
+        r}\r\nDialogue: 0,0:57:21.90,0:57:24.40,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u7238{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Dad!{\\r}\r\nDialogue: 0,0:57:26.94,0:57:30.81,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u56E0\u70BA\u6211\u7684\u4FE1\u4EFB \u7236\
+        \u89AA\u53BB\u4E16\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I let my father die because I trusted him.{\\r}\r\nDialogue: 0,0:57:30.91,0:57:34.82,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u56E0\u70BA\u4ED6\u76F8\u4FE1\u4E16\u754C\
+        \u9084\u6C92\u6709\u6E96\u5099\u597D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Because he was convinced that I had to wait.{\\r}\r\nDialogue:\
+        \ 0,0:57:35.58,0:57:37.75,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u5FC5\u9808\u7B49\u5F85\u4E0B\u53BB{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}That the world was not ready.{\\r}\r\n\
+        Dialogue: 0,0:57:39.48,0:57:41.12,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4F60\u600E\u9EBC\u60F3\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}What do you think?{\\r}\r\nDialogue: 0,0:57:46.02,0:57:47.66,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5F97\u5C0F\u5FC3\u4E86 \u9732\u6613\
+        \u7D72{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You better\
+        \ watch out, Lois.{\\r}\r\nDialogue: 0,0:57:48.16,0:57:50.47,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F69\u88CF\u8981\u885D\u4F60\u767C\u706B\
+        \u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Hey, Perry's\
+        \ gunning for you.{\\r}\r\nDialogue: 0,0:57:50.70,0:57:52.65,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u77E5\u9053\u4F60\u662F\u4F0D\u5FB7\
+        \u4F2F\u6069\u7684\u533F\u540D\u4FE1\u606F\u6E90{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}He knows you're Woodburn's anonymous source{\\r}\r\
+        \nDialogue: 0,0:57:52.65,0:57:54.97,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u90FD\u7B49\u4E0D\u53CA\u597D\u597D\u6559\u8A13\u4F60\
+        \u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}and cannot\
+        \ wait to rip you a new one.{\\r}\r\nDialogue: 0,0:57:56.84,0:57:58.28,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u770B\u770B\u5979 \u54C8\u54C8{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Oh, look at her. Ha, ha, ha.{\\\
+        r}\r\nDialogue: 0,0:58:00.27,0:58:02.81,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u544A\u8A34\u904E\u4F60\u4E0D\u8981\u8DDF\u9019\
+        \u689D\u7DDA \u7136\u5F8C\u5462\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}I told you not to run with this, and what do you do?{\\\
+        r}\r\nDialogue: 0,0:58:03.04,0:58:05.54,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u537B\u8B93\u4F0D\u5FB7\u4F2F\u6069\u5C07\u4E4B\
+        \u50B3\u904D\u4E86\u7DB2\u7D61{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You let Woodburn just shotgun it all over the Internet.{\\r}\r\nDialogue:\
+        \ 0,0:58:05.81,0:58:08.69,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u73FE\u5728\u51FA\u7248\u5546\u60F3\u8B93\u6211\u8D77\u8A34\u4F60\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Now the publishers\
+        \ want me to sue you.{\\r}\r\nDialogue: 0,0:58:08.95,0:58:12.19,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u597D\u5427 \u5982\u679C\u9084\u6709\u7528\
+        \u7684\u8A71 \u6211\u653E\u68C4{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Well, if it makes a difference, I'm dropping it.{\\r}\r\nDialogue: 0,0:58:12.45,0:58:13.45,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C31\u90A3\u6A23\u55CE\uFF1F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Whoa, just like that?{\\r}\r\
+        \nDialogue: 0,0:58:13.69,0:58:14.69,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6C92\u932F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Yep.{\\r}\r\nDialogue: 0,0:58:15.05,0:58:16.36,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u7684\u7DDA\u7D22\u600E\u9EBC\u4E86\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What happened\
+        \ to your leads?{\\r}\r\nDialogue: 0,0:58:17.02,0:58:19.66,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6C92\u4EC0\u9EBC\u610F\u601D \u6574\u500B\
+        \u6545\u4E8B\u90FD\u662F\u904E\u773C\u96F2\u7159{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}They didn't pan out. The story is smoke.{\\r}\r\n\
+        Dialogue: 0,0:58:19.89,0:58:22.44,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4E5F\u6709\u53EF\u80FD\u6C92\u5F15\u8D77\u4F60\u671F\u76FC\
+        \u7684\u516C\u773E\u6CE8\u610F\u7F77\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Or it didn't get the traction you hoped?{\\r}\r\n\
+        Dialogue: 0,0:58:24.20,0:58:25.04,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u5169\u5468\u7684\u7121\u85AA\u4F11\u5047{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Two weeks leave...{\\r}\r\nDialogue:\
+        \ 0,0:58:25.30,0:58:26.90,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u7B97\u662F\u61F2\u7F70\u4F60\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...no pay, that's your penance.{\\r}\r\nDialogue:\
+        \ 0,0:58:27.17,0:58:28.84,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u518D\u9019\u9EBC\u5F04\u4E00\u6B21{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}You try something like this again...{\\\
+        r}\r\nDialogue: 0,0:58:29.07,0:58:30.74,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u6211\u5C31\u958B\u9664\u4F60   - \u597D\u5427{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- ...you're done here.\
+        \       - Fine.{\\r}\r\nDialogue: 0,0:58:31.00,0:58:32.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u9019\u9EBC\u8FEB\u4E0D\u53CA\u5F85\
+        \u5730\u9644\u548C\u6211{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Let's make it three weeks{\\r}\r\nDialogue: 0,0:58:32.11,0:58:33.71,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6539\u6210\u4E09\u5468\u4F11\u5047\u6BD4\
+        \u8F03\u5408\u9069{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}since\
+        \ you're so willing to agree.{\\r}\r\nDialogue: 0,0:58:37.14,0:58:38.82,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9732\u6613\u7D72 \u6211\u7D55\u4E0D\u8A8D\
+        \u70BA{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I believe\
+        \ you saw something, Lois.{\\r}\r\nDialogue: 0,0:58:39.31,0:58:42.32,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u7684\u7DDA\u7D22\u6BEB\u7121\u50F9\
+        \u503C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}But not for\
+        \ a moment do I believe that your leads just went cold.{\\r}\r\nDialogue:\
+        \ 0,0:58:42.55,0:58:46.05,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u56E0\u6B64\u4E0D\u7BA1\u4F60\u653E\u68C4\u7684\u7406\u7531\u662F\
+        \u4EC0\u9EBC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}So whatever\
+        \ your reasons are for dropping it...{\\r}\r\nDialogue: 0,0:58:47.09,0:58:48.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u76F8\u4FE1\u4F60\u505A\u5F97\u6C92\
+        \u932F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...I think\
+        \ you're doing the right thing.{\\r}\r\nDialogue: 0,0:58:49.49,0:58:50.73,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u70BA\u4EC0\u9EBC\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Why?{\\r}\r\nDialogue: 0,0:58:52.09,0:58:55.73,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5982\u679C\u4EBA\u5011\u5F97\u77E5\u5730\
+        \u7403\u6709\u9019\u6A23\u7684\u4EBA\u7684\u5B58\u5728{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Can you imagine how people on this\
+        \ planet would react...{\\r}\r\nDialogue: 0,0:58:58.00,0:59:01.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u80FD\u60F3\u50CF\u4EBA\u5011\u6703\
+        \u6709\u4F55\u7A2E\u53CD\u61C9\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...if they knew there was someone like this out there?{\\\
+        r}\r\nDialogue: 0,0:59:19.58,0:59:20.99,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u53BB\u63A5\u63A5\u4ED6{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Go get him.{\\r}\r\nDialogue: 0,0:59:27.43,0:59:29.06,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u770B\u770B\u6211\u5152\u5B50{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Well, look at you.{\\r}\r\n\
+        Dialogue: 0,0:59:46.11,0:59:47.92,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4E00\u500B\u8A18\u8005\u4F86\u904E{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}A reporter came by here.{\\r}\r\nDialogue:\
+        \ 0,0:59:48.48,0:59:50.72,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u662F\u500B\u670B\u53CB \u5225\u64D4\u5FC3{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}She's a friend. Don't worry.{\\r}\r\n\
+        Dialogue: 0,0:59:53.72,0:59:54.59,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u5ABD\u5ABD{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Mom.{\\r}\r\nDialogue: 0,0:59:54.75,0:59:56.49,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u600E\u9EBC\u4E86\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What?{\\r}\r\nDialogue: 0,0:59:57.96,1:00:00.49,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u6211\u627E\u5230\u4E86   - \u8AB0\uFF1F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- I found them.\
+        \       - Who?{\\r}\r\nDialogue: 0,1:00:01.33,1:00:02.83,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u7684\u7236\u6BCD{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}My parents.{\\r}\r\nDialogue: 0,1:00:04.00,1:00:05.34,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u7684\u65CF\u4EBA{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}My People.{\\r}\r\nDialogue: 0,1:00:06.23,1:00:09.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u73FE\u5728\u77E5\u9053\u81EA\u5DF1\
+        \u7684\u8EAB\u4E16\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I know where I come from now.{\\r}\r\nDialogue: 0,1:00:10.84,1:00:12.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u54C7{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Wow.{\\r}\r\nDialogue: 0,1:00:13.17,1:00:14.95,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u771F\u662F\u592A\u597D\u4E86{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}That's wonderful.{\\\
+        r}\r\nDialogue: 0,1:00:16.81,1:00:19.25,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u592A\u70BA\u4F60\u9AD8\u8208\u4E86 \u514B\u62C9\u514B\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm so happy for\
+        \ you, Clark.{\\r}\r\nDialogue: 0,1:00:28.09,1:00:30.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u600E\u9EBC\u4E86\uFF1F - \u6C92\u4E8B\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- What?       -\
+        \ It's nothing.{\\r}\r\nDialogue: 0,1:00:33.33,1:00:36.27,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5C1A\u5728\u8941\u8913\u4E2D\u6642\
+        \ \u6211\u6574\u591C\u5728\u5B30\u5152\u5E8A\u908A\u966A\u4F60{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}When you were a baby I used\
+        \ to lay by your crib at night...{\\r}\r\nDialogue: 0,1:00:36.50,1:00:38.87,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u807D\u8457\u4F60\u7684\u547C\u5438{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...listening to you\
+        \ breathe.{\\r}\r\nDialogue: 0,1:00:39.93,1:00:41.54,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u5C0D\u4F60\u4F86\u8AAA\u4E0D\u5BB9\
+        \u6613{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It was hard\
+        \ for you.{\\r}\r\nDialogue: 0,1:00:42.77,1:00:44.14,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u52AA\u529B\u8457{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You struggled.{\\r}\r\nDialogue: 0,1:00:44.37,1:00:46.21,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u7121\u6642\u4E0D\u523B\u4E0D\u64D4\
+        \u5FC3\u4F60{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And\
+        \ I worried all the time.{\\r}\r\nDialogue: 0,1:00:46.47,1:00:48.31,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6015\u771F\u76F8\u66B4\u9732\u55CE\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You worried\
+        \ the truth would come out.{\\r}\r\nDialogue: 0,1:00:49.84,1:00:51.05,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}No.{\\r}\r\nDialogue: 0,1:00:52.01,1:00:54.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u7684\u771F\u76F8\u55CE\uFF1F\u90A3\
+        \u5C31\u662F\u4F60\u592A\u53EF\u611B\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}The truth about you is beautiful.{\\r}\r\nDialogue:\
+        \ 0,1:00:55.05,1:00:58.49,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u7B2C\u4E00\u773C\u898B\u5230\u4F60\u7684\u6642\u5019\u6211\u5011\
+        \u5C31\u77E5\u9053{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We\
+        \ saw that the moment we laid eyes on you.{\\r}\r\nDialogue: 0,1:01:00.79,1:01:04.79,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u77E5\u9053\u6709\u4E00\u5929 \u4E16\u4EBA\
+        \u4E5F\u7D42\u6B78\u6703\u767C\u73FE{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}We knew that one day, the whole world would see that.{\\\
+        r}\r\nDialogue: 0,1:01:07.23,1:01:08.86,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u53EA\u662F...{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}I'm just...{\\r}\r\nDialogue: 0,1:01:09.49,1:01:11.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u64D4\u5FC3\u4ED6\u5011\u6703\u8B93\u6211\
+        \u5011\u5206\u96E2{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm\
+        \ worried they'll take you away from me.{\\r}\r\nDialogue: 0,1:01:13.80,1:01:16.18,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u54EA\u4E5F\u4E0D\u53BB \u5ABD\u5ABD\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm not going anywhere,\
+        \ Mom.{\\r}\r\nDialogue: 0,1:01:18.00,1:01:19.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4FDD\u8B49{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}I promise.{\\r}\r\nDialogue: 0,1:01:25.71,1:01:27.88,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u65AF\u65FA\u5A01\u514B\u5C07\u8ECD \u9577\
+        \u5B98{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}General Swanwick,\
+        \ sir.{\\r}\r\nDialogue: 0,1:01:28.15,1:01:31.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9019\u662F\u4EC0\u9EBC \u535A\u58EB\uFF1F\
+        \u5F57\u661F\u9084\u662F\u5C0F\u884C\u661F\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}What am I looking at, doc? Comet? Asteroid?{\\r}\r\
+        \nDialogue: 0,1:01:33.05,1:01:37.06,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5F57\u661F\u53EF\u4E0D\u6703\u4FEE\u6B63\u822A\u9053\
+        \ \u5C07\u8ECD{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Comets\
+        \ don't make course corrections, general.{\\r}\r\nDialogue: 0,1:01:39.86,1:01:43.86,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5728\u67D0\u500B\u5929\u6587\u611B\u597D\
+        \u8005\u770B\u5230\u4E26\u5F15\u8D77\u6050\u614C\u524D \u6211\u60F3\u8B93\u4F60\
+        \u597D\u597D\u770B\u4E00\u4E0B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Wanted you to see this before some amateur with a telescope creates\
+        \ a worldwide panic.{\\r}\r\nDialogue: 0,1:01:45.53,1:01:46.91,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9019\u8258\u8239\u4F3C\u4E4E{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The ship appears to have...{\\\
+        r}\r\nDialogue: 0,1:01:47.17,1:01:49.91,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5C07\u81EA\u5DF1\u9001\u5165\u4E86\u6708\u7403\u540C\
+        \u6B65\u8ECC\u9053{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...inserted\
+        \ itself into a lunar synchronous orbit...{\\r}\r\nDialogue: 0,1:01:50.17,1:01:52.34,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E0D\u77E5\u9053\u70BA\u4EC0\u9EBC\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...though I have\
+        \ no idea why.{\\r}\r\nDialogue: 0,1:01:52.57,1:01:55.42,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6709\u8A66\u904E\u548C\u5B83\u53D6\
+        \u5F97\u806F\u7E6B\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Have you tried... communicating with it?{\\r}\r\nDialogue: 0,1:01:55.67,1:01:59.68,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u5011\u81F3\u4ECA\u6C92\u6709\u56DE\
+        \u61C9{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Well, they\
+        \ haven't responded as of yet.{\\r}\r\nDialogue: 0,1:02:00.95,1:02:04.95,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u500B\u4EBA\u7684\u731C\u6E2C\u662F\
+        \ \u4E0D\u7BA1\u662F\u8AB0\u5728\u64CD\u7E31\u98DB\u8239...{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm just speculating, but I think\
+        \ whoever's at the helm of that thing...{\\r}\r\nDialogue: 0,1:02:05.22,1:02:07.72,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4E00\u5B9A\u60F3\u4F86\u500B\u9A5A\
+        \u4EBA\u7684\u8457\u9678{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...is looking to make a dramatic entrance.{\\r}\r\nDialogue: 0,1:02:14.59,1:02:16.07,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6709\u4EBA\u77E5\u9053\u58A8\u76D2\u653E\
+        \u5728\u54EA\u4E86\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Anybody know where we keep the toner?{\\r}\r\nDialogue: 0,1:02:17.03,1:02:18.94,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u600E\u9EBC\u4E86\uFF1F - \u65B0\u805E\
+        \u90FD\u5728\u5831\u9053{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}- What's going on?       - It's all over the news.{\\r}\r\nDialogue:\
+        \ 0,1:02:19.20,1:02:21.14,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u5F97\u4F86\u770B\u770B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}You gotta see this.{\\r}\r\nDialogue: 0,1:02:48.13,1:02:49.63,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark.{\\r}\r\nDialogue: 0,1:02:50.00,1:02:51.13,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u55EF\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Yeah?{\\r}\r\nDialogue: 0,1:02:51.40,1:02:52.74,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F86\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Coming.{\\r}\r\nDialogue: 0,1:02:53.06,1:02:55.27,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9019\u662F\u500B\u7A81\u767C\u65B0\u805E\
+        \ \u8EAB\u4EFD\u4E0D\u660E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}This is a breaking news. An unidentified...{\\r}\r\nDialogue: 0,1:03:36.98,1:03:39.05,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4E26\u4E0D\u662F\u4E00\u500B\u4EBA\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You are not alone.{\\\
+        r}\r\nDialogue: 0,1:03:40.71,1:03:43.06,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u4E26\u4E0D\u662F\u4E00\u500B\u4EBA{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You are not alone.{\\r}\r\n\
+        Dialogue: 0,1:03:44.98,1:03:47.22,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4F60\u4E26\u4E0D\u662F\u4E00\u500B\u4EBA{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You are not alone.{\\r}\r\nDialogue:\
+        \ 0,1:03:52.89,1:03:55.50,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60 \u4E26\u4E0D\u662F \u4E00\u500B\u4EBA{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}You are not alone.{\\r}\r\nDialogue: 0,1:04:20.92,1:04:22.48,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}RSS\u4E5F\u6709\u9019\u4FE1\u606F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's coming in on the RSS\
+        \ feeds.{\\r}\r\nDialogue: 0,1:04:22.69,1:04:24.56,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4E26\u4E0D\u662F\u4E00\u500B\u4EBA\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You are not alone.{\\\
+        r}\r\nDialogue: 0,1:04:25.19,1:04:27.23,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u624B\u6A5F\u4E0A\u4E5F\u6709{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's on my phone too.{\\r}\r\nDialogue:\
+        \ 0,1:04:29.39,1:04:31.84,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u662F\u4F50\u5FB7\u5C07\u8ECD{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}My name is General Zod.{\\r}\r\nDialogue: 0,1:04:33.67,1:04:36.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4F86\u81EA\u4E00\u500B\u9059\u9060\
+        \u7684\u661F\u7403{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I\
+        \ come from a world far from yours.{\\r}\r\nDialogue: 0,1:04:37.84,1:04:42.34,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u7A7F\u8D8A\u4E86\u832B\u832B\u661F\
+        \u6D77\u4F86\u627E\u4F60\u5011{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I have journeyed across an ocean of stars to reach you.{\\r}\r\nDialogue:\
+        \ 0,1:04:43.94,1:04:47.95,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u5011\u5E87\u8B77\u4E86\u6211\u7684\u4E00\u500B\u5B50\u6C11\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}For some time, your\
+        \ world has sheltered one of my citizens.{\\r}\r\nDialogue: 0,1:04:48.58,1:04:51.79,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u73FE\u5728\u6211\u8981\u6C42\u4F60\u5011\
+        \u628A\u4ED6\u4EA4\u51FA\u4F86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I request that you return this individual...{\\r}\r\nDialogue: 0,1:04:52.05,1:04:54.19,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7D66\u6211\u8655\u7406{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...to my custody.{\\r}\r\nDialogue:\
+        \ 0,1:04:54.42,1:05:00.80,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u56E0\u70BA\u67D0\u4E9B\u539F\u56E0 \u4ED6\u9078\u64C7\u5411\u4F60\
+        \u5011\u96B1\u779E\u4ED6\u7684\u5B58\u5728{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}For reasons unknown, he has chosen to keep his existence\
+        \ a secret from you.{\\r}\r\nDialogue: 0,1:05:01.59,1:05:04.77,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u7AED\u76E1\u5168\u529B\u878D\u5165\
+        \u4F60\u5011{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He will\
+        \ have made efforts to blend in.{\\r}\r\nDialogue: 0,1:05:05.36,1:05:07.04,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u770B\u8D77\u4F86\u548C\u4F60\u5011\
+        \u76F8\u4F3C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He will\
+        \ look like you.{\\r}\r\nDialogue: 0,1:05:07.77,1:05:10.37,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u4ED6\u4E0D\u662F\u540C\u65CF{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}But he is not one of\
+        \ you.{\\r}\r\nDialogue: 0,1:05:11.57,1:05:13.41,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5982\u679C\u6709\u8AB0\u77E5\u9053{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}To those of you who\
+        \ may know...{\\r}\r\nDialogue: 0,1:05:13.64,1:05:15.64,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u7684\u4F4D\u7F6E{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...of his current location.{\\r}\r\
+        \nDialogue: 0,1:05:15.91,1:05:18.44,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u90A3\u4F60\u5011\u661F\u7403\u7684\u547D\u904B{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...the fate of your planet...{\\\
+        r}\r\nDialogue: 0,1:05:18.71,1:05:21.38,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5C31\u5728\u4F60\u624B\u4E2D\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...rests in your hands.{\\r}\r\nDialogue:\
+        \ 0,1:05:22.45,1:05:25.49,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5361\u723E\u2022\u827E\u723E \u807D\u5230\u4E86\u55CE\uFF1F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}To Kai-El, I say this:{\\\
+        r}\r\nDialogue: 0,1:05:27.55,1:05:30.23,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}24\u5C0F\u6642\u5167\u51FA\u4F86\u6295\u964D{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Surrender within 24 hours...{\\\
+        r}\r\nDialogue: 0,1:05:34.49,1:05:37.97,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6216\u8005\u8B93\u6574\u500B\u4E16\u754C\u4F86\u627F\
+        \u64D4\u5F8C\u679C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...or\
+        \ watch this world suffer the consequences...{\\r}\r\nDialogue: 0,1:05:53.24,1:05:55.09,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u5C0D\u4ED6\u4E00\u7121\u6240\
+        \u77E5 \u5C0D\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}We hardly know anything about him, isn't that right?{\\r}\r\nDialogue:\
+        \ 0,1:05:55.25,1:05:57.25,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5982\u679C\u4ED6\u771F\u7684\u4E0D\u60F3\u5BB3\u6211\u5011{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}If he truly means us no\
+        \ harm...{\\r}\r\nDialogue: 0,1:05:57.48,1:05:59.98,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u4ED6\u61C9\u8A72\u56DE\u6B78\u4ED6\
+        \u7684\u65CF\u4EBA \u53BB\u627F\u64D4\u5F8C\u679C{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...he'll turn himself in and face the consequences.{\\\
+        r}\r\nDialogue: 0,1:06:00.12,1:06:01.32,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5982\u679C\u4ED6\u4E0D\u80AF\u53BB{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And if he won't do that...{\\r}\r\n\
+        Dialogue: 0,1:06:01.59,1:06:03.59,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4E5F\u8A31\u6211\u5011\u8A72\u9001\u4ED6\u53BB{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...then maybe we should.{\\\
+        r}\r\nDialogue: 0,1:06:03.82,1:06:06.80,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u300A\u661F\u7403\u65E5\u5831\u300B\u7684\u9732\u6613\
+        \u7D72\u2022\u84EE\u6069\u77E5\u9053\u4ED6\u662F\u8AB0{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The Daily Planet's Lois Lane knows\
+        \ who this guy is. She's...{\\r}\r\nDialogue: 0,1:06:07.03,1:06:08.43,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u8A8D\u70BA\u5979\u662F\u6211\u5011\
+        \u8A72\u8CEA\u554F\u7684\u4EBA{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...the one we should be questioning.{\\r}\r\nDialogue: 0,1:06:08.93,1:06:11.67,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u7B49\u7B49 \u4F60\u662F\u8AAA\u9732\u6613\
+        \u7D72\u2022\u84EE\u6069   - \u4F60\u597D{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}- Hold on. You're saying Lois Lane...        - Hello?{\\\
+        r}\r\nDialogue: 0,1:06:11.93,1:06:14.43,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u5728\u770B\u65B0\u805E\u55CE\uFF1F\u64AD\u4E86\
+        \u4E00\u65E9\u4E0A\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Are you watching this crap? Been running all morning.{\\r}\r\nDialogue:\
+        \ 0,1:06:14.67,1:06:16.98,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u9019\u6B21\u6211\u7ADF\u7136\u5B8C\u5168\u540C\u610F\u4F0D\u5FB7\
+        \u4F2F\u6069\u7684\u89C0\u9EDE \u4F60\u898B\u904E\u4ED6\u55CE\uFF1F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}For once I agree with Woodburn.\
+        \ Have you seen him?{\\r}\r\nDialogue: 0,1:06:17.20,1:06:20.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u77E5\u9053\u4ED6\u5728\u54EA\u55CE\uFF1F\
+        \ - \u4E0D\u77E5\u9053 \u5373\u4F7F\u77E5\u9053 \u6211\u4E5F\u4E0D\u6703\u8AAA\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Do you know where\
+        \ he is?        - No. Even if I did, I wouldn't say.{\\r}\r\nDialogue: 0,1:06:20.77,1:06:23.95,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6574\u500B\u4E16\u754C\u5C8C\u5C8C\u53EF\
+        \u5371{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The entire\
+        \ world is being threatened here.{\\r}\r\nDialogue: 0,1:06:24.18,1:06:28.60,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9019\u53EF\u4E0D\u662F\u4F60\u5C55\u73FE\
+        \u65B0\u805E\u9053\u5FB7\u7684\u6642\u5019{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}This is not time for you to fall back on journalistic\
+        \ integrity.{\\r}\r\nDialogue: 0,1:06:28.65,1:06:30.13,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E8B\u614B\u56B4\u91CD\u4E86 \u9732\u6613\
+        \u7D72{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}This is serious,\
+        \ Lois.{\\r}\r\nDialogue: 0,1:06:30.35,1:06:33.33,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}FBI\u90FD\u4F86\u4E86 \u4ED6\u5011\u5728\
+        \u8AAA\u53DB\u570B\u7F6A\u4EC0\u9EBC\u7684{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}The FBI is here. They're throwing around words like\
+        \ \"treason.\"{\\r}\r\nDialogue: 0,1:06:33.55,1:06:35.22,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5F97\u8D70\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I gotta go.{\\r}\r\nDialogue: 0,1:06:51.37,1:06:52.71,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}FBI \u8209\u8D77\u624B\u4F86{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}FBI. Hands up.{\\r}\r\nDialogue:\
+        \ 0,1:06:52.97,1:06:54.75,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6254\u4E86\u888B\u5B50 \u99AC\u4E0A{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Drop the bag. Now.{\\r}\r\nDialogue: 0,1:07:01.65,1:07:04.01,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u64DA\u6211\u63A1\u8A2A\u7684\u653F\u5E9C\
+        \u5B98\u54E1\u8AAA{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Regarding\
+        \ the visitors themselves we know...{\\r}\r\nDialogue: 0,1:07:04.15,1:07:06.59,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u73FE\u5728\u6211\u5011\u6240\u77E5\u751A\
+        \u5C11{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...very little.\
+        \ According to government officials...{\\r}\r\nDialogue: 0,1:07:06.85,1:07:09.33,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5118\u7BA1\u4ED6\u5011\u7684\u8A9E\u8ABF\
+        \u4E26\u4E0D\u53CB\u5584{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...the visitors do not represent a threat...{\\r}\r\nDialogue: 0,1:07:09.55,1:07:11.73,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u4F86\u5BA2\u4E26\u4E0D\u4EE3\u8868\
+        \u8457\u5A01\u8105{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...despite\
+        \ the ominous tone of their message.{\\r}\r\nDialogue: 0,1:07:11.99,1:07:14.49,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7576\u7136\u4E86 \u5927\u5BB6\u5FC3\u4E2D\
+        \u90FD\u6709\u4E00\u500B\u7591\u554F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Then of course there's the question on everyone's mind:{\\\
+        r}\r\nDialogue: 0,1:07:14.73,1:07:18.54,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u9019\u500B\u5361\u723E\u2022\u827E\u723E\u662F\u8AB0\
+        \uFF1F\u4ED6\u771F\u7684\u5B58\u5728\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}\"Who is this Kai-El person? Does he actually exist?\"\
+        {\\r}\r\nDialogue: 0,1:07:18.76,1:07:21.44,chs,,0000,0000,0000,,{\\fn\u534E\
+        \u6587\u6977\u4F53\\blur3}\u4ED6\u5982\u4F55\u5728\u6211\u5011\u4E4B\u4E2D\
+        \u96B1\u85CF\u4E86\u9019\u9EBC\u4E45\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}\"How could he have remained hidden from us for so\
+        \ long?\"{\\r}\r\nDialogue: 0,1:07:26.07,1:07:27.38,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F86\u554A \u80AF\u7279{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Come on, Kent.{\\r}\r\nDialogue: 0,1:07:34.45,1:07:35.55,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F86\u554A \u6253\u56DE\u4F86\u554A{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Come on. Fight back.{\\\
+        r}\r\nDialogue: 0,1:07:35.78,1:07:37.38,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u7AD9\u8D77\u4F86 \u80AF\u7279{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Get up, Kent.{\\r}\r\nDialogue: 0,1:07:40.69,1:07:42.06,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C31\u9019\u9EDE\u6C34\u5E73{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}So is that it?{\\r}\r\nDialogue:\
+        \ 0,1:07:42.52,1:07:44.02,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u5C31\u9019\u9EDE\u5BE6\u529B\u55CE\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Is that all you've got?{\\r}\r\nDialogue:\
+        \ 0,1:07:45.69,1:07:47.19,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F86\u554A \u80AF\u7279{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Come on, Kent.{\\r}\r\nDialogue: 0,1:07:48.43,1:07:49.80,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u904E\u4F86{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Come on!{\\r}\r\nDialogue: 0,1:08:18.42,1:08:19.56,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u5011\u50B7\u5230\u4F60\u4E86\u55CE\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Did they hurl\
+        \ you?{\\r}\r\nDialogue: 0,1:08:20.83,1:08:22.54,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u77E5\u9053\u90A3\u4E0D\u53EF\u80FD\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You know they can't.{\\\
+        r}\r\nDialogue: 0,1:08:22.59,1:08:25.47,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u4E0D\u662F\u90A3\u500B\u610F\u601D \u6211\u662F\
+        \u8AAA \u4F60\u9084\u597D\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}That's not what I meant. I meant, are you all right?{\\\
+        r}\r\nDialogue: 0,1:08:27.47,1:08:29.78,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u60F3\u75DB\u6241\u90A3\u500B\u5C41\u5B69 \u6211\
+        \u60F3\u72E0\u72E0\u5730\u63CD\u4ED6{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}I wanted to hit that kid. I wanted to hit him bad.{\\r}\r\
+        \nDialogue: 0,1:08:30.00,1:08:31.48,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u77E5\u9053\u4F60\u60F3{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}I know you did. I mean...{\\r}\r\nDialogue:\
+        \ 0,1:08:31.74,1:08:34.44,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u751A\u81F3\u4E5F\u60F3\u8B93\u4F60\u63CD\u4ED6 \u53EF\u662F\
+        \u7136\u5F8C\u5462\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...part of me even wanted you to, but then what?{\\r}\r\nDialogue: 0,1:08:35.14,1:08:36.91,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5C31\u6703\u9AD8\u8208\u4E86\u55CE\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Make you feel\
+        \ any better?{\\r}\r\nDialogue: 0,1:08:39.68,1:08:43.68,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u53EA\u9700\u8981\u6C7A\u5B9A\u4F60\
+        \u60F3\u6210\u9577\u70BA\u4EC0\u9EBC\u6A23\u7684\u4EBA \u514B\u62C9\u514B\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You just have to\
+        \ decide what kind of man you want to grow up to be, Clark.{\\r}\r\nDialogue:\
+        \ 0,1:08:43.95,1:08:47.66,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u56E0\u70BA\u7121\u8AD6\u6210\u70BA\u4EC0\u9EBC\u6A23 \u597D\u4EBA\
+        \u6216\u662F\u58DE\u4EBA \u4F60\u90FD\u6703...{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Because whoever that man is, good character or bad,\
+        \ he's...{\\r}\r\nDialogue: 0,1:08:49.29,1:08:51.43,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6539\u8B8A\u9019\u500B\u4E16\u754C{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He's gonna change the\
+        \ world.{\\r}\r\nDialogue: 0,1:08:56.66,1:08:58.02,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u8166\u4E2D\u6240\u616E\u70BA\u4F55\
+        \u4E8B\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What's\
+        \ on your mind?{\\r}\r\nDialogue: 0,1:09:03.77,1:09:05.04,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E0D\u77E5\u5F9E\u4F55\u8AAA\u8D77\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I don't know where\
+        \ to start.{\\r}\r\nDialogue: 0,1:09:05.67,1:09:07.27,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6089\u807D\u5C0A\u4FBF{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Wherever you want.{\\r}\r\nDialogue:\
+        \ 0,1:09:09.44,1:09:11.55,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6628\u665A\u51FA\u73FE\u7684\u98DB\u8239{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}That ship that appeared last night.{\\\
+        r}\r\nDialogue: 0,1:09:12.88,1:09:14.69,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u5C31\u662F\u4ED6\u5011\u8981\u627E\u7684\u4EBA\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm the one they're\
+        \ looking for.{\\r}\r\nDialogue: 0,1:09:19.18,1:09:20.69,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u77E5\u9053{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Do you know...{\\r}\r\nDialogue: 0,1:09:21.49,1:09:22.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u5011\u627E\u4F60\u7684\u539F\u56E0\
+        \u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...why\
+        \ they want you?{\\r}\r\nDialogue: 0,1:09:22.85,1:09:25.46,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D \u4F46\u9019\u500B\u4F50\u5FB7\u5C07\
+        \u8ECD{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}No. But this\
+        \ General Zod...{\\r}\r\nDialogue: 0,1:09:25.69,1:09:29.70,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5373\u4F7F\u6211\u6295\u964D \u4ED6\u4E5F\
+        \u672A\u5FC5\u6703\u4FE1\u5B88\u8AFE\u8A00{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...even if I surrender, there's no guarantee he'll\
+        \ keep his word, but...{\\r}\r\nDialogue: 0,1:09:29.96,1:09:33.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u82E5\u6211\u6295\u964D\u5C31\u53EF\
+        \u4EE5\u62EF\u6551\u5730\u7403\u7684\u8A71{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...if there's a chance I can save Earth by turning\
+        \ myself in...{\\r}\r\nDialogue: 0,1:09:35.57,1:09:37.40,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u96E3\u9053\u6211\u4E0D\u8A72\u9019\u9EBC\
+        \u505A\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...shouldn't\
+        \ I take it?{\\r}\r\nDialogue: 0,1:09:38.20,1:09:40.08,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u7684\u76F4\u89BA\u5462\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What does your gut\
+        \ tell you?{\\r}\r\nDialogue: 0,1:09:40.81,1:09:42.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F50\u5FB7\u4E0D\u53EF\u4FE1{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Zod can't be trusted.{\\r}\r\
+        \nDialogue: 0,1:09:45.14,1:09:46.71,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u554F\u984C\u662F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}The problem is...{\\r}\r\nDialogue: 0,1:09:47.75,1:09:50.95,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E5F\u4E0D\u77E5\u9053\u5730\u7403\
+        \u7684\u4EBA\u6C11\u53EF\u4E0D\u53EF\u4FE1{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...I'm not sure the people of Earth can be either.{\\\
+        r}\r\nDialogue: 0,1:09:58.36,1:10:01.34,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6709\u6642\u5019\u4F60\u5FC5\u9808\u5805\u4FE1\u4E0D\
+        \u7591{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Sometimes\
+        \ you have to take a leap of faith first.{\\r}\r\nDialogue: 0,1:10:02.73,1:10:04.76,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4FE1\u4EFB\u6703\u96A8\u4E4B\u800C\u4F86\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The trust part comes\
+        \ later.{\\r}\r\nDialogue: 0,1:10:28.92,1:10:32.03,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u597D\u4E86 \u6211\u5011\u6CE8\u610F\u5230\
+        \u4F60\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}All\
+        \ right. You've got our attention.{\\r}\r\nDialogue: 0,1:10:32.12,1:10:33.12,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u60F3\u600E\u9EBC\u6A23\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What is it you want?{\\\
+        r}\r\nDialogue: 0,1:10:33.39,1:10:35.20,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u8981\u548C\u9732\u6613\u7D72\u2022\u84EE\u6069\
+        \u8AC7\u8A71{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I would\
+        \ like to speak to Lois Lane.{\\r}\r\nDialogue: 0,1:10:35.43,1:10:37.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6191\u4EC0\u9EBC\u8A8D\u70BA\u5979\
+        \u5728\u9019\u88CF\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}What makes you think she's here?{\\r}\r\nDialogue: 0,1:10:37.63,1:10:39.70,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5225\u6D6A\u8CBB\u6642\u9593 \u5C07\u8ECD\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Don't play games\
+        \ with me, general.{\\r}\r\nDialogue: 0,1:10:39.93,1:10:43.94,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53EA\u8981\u4F60\u5011\u80FD\u4FDD\u8B49\
+        \u9732\u6613\u7D72\u7684\u81EA\u7531 \u6211\u5C31\u6295\u964D{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'll surrender, but only if you guarantee\
+        \ Lois's freedom.{\\r}\r\nDialogue: 0,1:10:54.05,1:10:55.99,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u70BA\u4EC0\u9EBC\u5411\u4F50\u5FB7\
+        \u6295\u964D\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Why\
+        \ are you surrendering to Zod?{\\r}\r\nDialogue: 0,1:10:57.22,1:11:00.82,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u662F\u5411\u4EBA\u985E\u5C48\u670D\
+        \ \u9019\u4E26\u4E0D\u4E00\u6A23{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I'm surrendering to mankind. There's a difference.{\\r}\r\nDialogue:\
+        \ 0,1:11:01.95,1:11:03.90,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u8B93\u4ED6\u5011\u628A\u4F60\u92AC\u8D77\u4F86\u4E86\u55CE\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You let them\
+        \ handcuff you?{\\r}\r\nDialogue: 0,1:11:04.62,1:11:07.07,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u8981\u662F\u62B5\u6297 \u5C31\u4E0D\
+        \u7B97\u662F\u6295\u964D\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Wouldn't be much of a surrender if I resisted.{\\r}\r\nDialogue: 0,1:11:08.56,1:11:10.60,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5982\u679C\u4ED6\u5011\u9019\u6A23\u505A\
+        \u611F\u5230\u5B89\u5168{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}And if it makes them feel more secure...{\\r}\r\nDialogue: 0,1:11:11.66,1:11:13.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u9EBC \u5982\u4ED6\u5011\u6240\u9858\
+        \u5427{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...then all\
+        \ the better for it.{\\r}\r\nDialogue: 0,1:11:17.94,1:11:19.81,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}S\u9019\u500B\u5B57\u6BCD\u6709\u542B\u7FA9\
+        \u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What's\
+        \ the S stand for?{\\r}\r\nDialogue: 0,1:11:22.74,1:11:24.31,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u4E0D\u662FS{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's not an S.{\\r}\r\nDialogue: 0,1:11:25.78,1:11:27.95,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5728\u6211\u7684\u661F\u7403 \u90A3\u4EE3\
+        \u8868\u5E0C\u671B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}On\
+        \ my world it means hope.{\\r}\r\nDialogue: 0,1:11:29.31,1:11:33.42,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u597D\u5427 \u5728\u5730\u7403\u9019\u5C31\
+        \u662F\u500BS{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Well,\
+        \ here, it's an S.{\\r}\r\nDialogue: 0,1:11:34.85,1:11:36.42,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u60F3\u60F3{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}How about...{\\r}\r\nDialogue: 0,1:11:41.99,1:11:43.03,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5148\u751F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Sir?{\\r}\r\nDialogue: 0,1:11:43.29,1:11:46.64,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u55E8 \u6211\u662F\u2026\u535A\u58EB\
+        \   - \u57C3\u7C73\u723E\u2022\u6F22\u5BC6\u723E\u9813{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Hi, my name is Dr. E...       -\
+        \ Emil Hamilton.{\\r}\r\nDialogue: 0,1:11:46.86,1:11:49.85,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u77E5\u9053 \u6211\u53EF\u4EE5\u770B\
+        \u5230\u4F60\u4E0A\u8863\u53E3\u888B\u88CF\u7684\u8EAB\u4EFD\u5361{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I know, I can see your\
+        \ ID tag in your breast pocket.{\\r}\r\nDialogue: 0,1:11:50.10,1:11:52.74,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9084\u6709\u4E00\u888B\u5403\u4E86\u4E00\
+        \u534A\u7684\u7CD6{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Along\
+        \ with a half-eaten roll of Lifesavers.{\\r}\r\nDialogue: 0,1:11:53.30,1:11:55.65,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E5F\u80FD\u770B\u5230\u9694\u58C1\
+        \u623F\u9593\u7684\u4E00\u968A\u58EB\u5175{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}I can also see the soldiers in the next room...{\\\
+        r}\r\nDialogue: 0,1:11:55.87,1:11:58.18,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u9084\u6709\u4F60\u7684\u93AE\u58D3\u7528\u7279\u5DE5\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...preparing that\
+        \ tranquilizing agent of yours.{\\r}\r\nDialogue: 0,1:11:58.44,1:11:59.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6C92\u5FC5\u8981\u7684{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You won't need it.{\\r}\r\nDialogue:\
+        \ 0,1:12:00.14,1:12:03.18,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5148\u751F \u6211\u5011\u4E0D\u53EF\u80FD\u6BEB\u7121\u6E96\u5099\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Sir, you can't expect\
+        \ us to not take precautions.{\\r}\r\nDialogue: 0,1:12:03.45,1:12:05.86,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5F88\u53EF\u80FD\u651C\u5E36\u4E86\
+        \u5916\u661F\u75C5\u539F\u9AD4{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You could be carrying some kind of alien pathogen.{\\r}\r\nDialogue:\
+        \ 0,1:12:06.12,1:12:07.56,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u5DF2\u7D93\u5728\u9019\u88CF\u751F\u6D3B\u4E8633\u5E74\u4E86\
+        \ \u535A\u58EB{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Been\
+        \ here for 33 years, doctor.{\\r}\r\nDialogue: 0,1:12:07.82,1:12:10.83,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u9084\u6C92\u611F\u67D3\u4EFB\u4F55\u4EBA\
+        \   - \u4E00\u9762\u4E4B\u8FAD\u800C\u5DF2{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}- Haven't infected anyone yet.       - That you know\
+        \ of. {\\r}\r\nDialogue: 0,1:12:10.83,1:12:12.68,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u6709\u5B89\u5168\u65B9\u9762\
+        \u7684\u8003\u616E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We\
+        \ have legitimate security concerns.{\\r}\r\nDialogue: 0,1:12:12.68,1:12:15.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u65E2\u7136\u4F60\u5411\u84EE\u6069\u5C0F\
+        \u59D0\u900F\u9732\u4E86\u8EAB\u4EFD{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}You revealed your identity to Miss Lane over there.{\\\
+        r}\r\nDialogue: 0,1:12:16.36,1:12:18.57,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u70BA\u4EC0\u9EBC\u6C92\u544A\u8A34\u6211\u5011\uFF1F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Why won't you do\
+        \ the same with us?{\\r}\r\nDialogue: 0,1:12:19.53,1:12:21.87,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u628A\u8A71\u8AAA\u958B\u4E86\
+        \u5427 \u5C07\u8ECD{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Let's\
+        \ put our cards on the table here, general.{\\r}\r\nDialogue: 0,1:12:23.33,1:12:25.05,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5011\u6015\u6211\u662F\u56E0\u70BA\
+        \u4F60\u5011\u7121\u6CD5\u63A7\u5236\u6211{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}You're scared because you can't control me.{\\r}\r\
+        \nDialogue: 0,1:12:25.64,1:12:28.17,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u73FE\u5728\u4E0D\u80FD \u4EE5\u5F8C\u4E5F\u4E0D\u80FD\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You don't, and you\
+        \ never will.{\\r}\r\nDialogue: 0,1:12:29.01,1:12:30.99,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u90A3\u4E26\u4E0D\u610F\u5473\u8457\
+        \u6211\u662F\u6575\u4EBA{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}But that doesn't' mean I'm your enemy.{\\r}\r\nDialogue: 0,1:12:31.21,1:12:32.71,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u8AB0\u662F\u6575\u4EBA\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Then who is?{\\r}\r\
+        \nDialogue: 0,1:12:32.98,1:12:34.39,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F50\u5FB7\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Zod?{\\r}\r\nDialogue: 0,1:12:35.01,1:12:36.92,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u6B63\u662F\u64D4\u5FC3\u9019\u4E00\
+        \u9EDE{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}That's what\
+        \ I'm worried about.{\\r}\r\nDialogue: 0,1:12:37.01,1:12:38.72,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C31\u7B97\u662F\u9019\u6A23{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Be that as it may...{\\r}\r\
+        \nDialogue: 0,1:12:38.98,1:12:42.36,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u4E5F\u6536\u5230\u4E86\u547D\u4EE4\u8981\u628A\
+        \u4F60\u4EA4\u7D66\u4ED6{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...I've been given orders to hand you over to him.{\\r}\r\nDialogue:\
+        \ 0,1:12:42.99,1:12:44.86,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u505A\u4F60\u5FC5\u9808\u505A\u7684\u5427 \u5C07\u8ECD{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Do what you have to do, general.{\\\
+        r}\r\nDialogue: 0,1:12:49.66,1:12:50.43,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u8B1D\u8B1D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Thank you.{\\r}\r\nDialogue: 0,1:12:51.56,1:12:52.54,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8B1D\u4EC0\u9EBC\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}For what?{\\r}\r\nDialogue: 0,1:12:53.70,1:12:55.27,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8B1D\u8B1D\u4F60\u4FE1\u4EFB\u6211{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}For believing in me.{\\\
+        r}\r\nDialogue: 0,1:12:58.34,1:13:00.37,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5230\u6700\u5F8C\u4E5F\u6C92\u6539\u8B8A\u4EC0\u9EBC\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Didn't make much\
+        \ difference in the end.{\\r}\r\nDialogue: 0,1:13:01.21,1:13:02.74,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6539\u8B8A\u4E86\u6211{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It did to me.{\\r}\r\nDialogue: 0,1:13:23.36,1:13:24.90,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u5011\u4F86\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}They're coming.{\\r}\r\nDialogue:\
+        \ 0,1:13:25.70,1:13:27.20,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u8A72\u8D70\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You should leave now.{\\r}\r\nDialogue: 0,1:13:30.30,1:13:31.87,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5FEB\u8D70 \u9732\u6613\u7D72{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Go, Lois.{\\r}\r\nDialogue:\
+        \ 0,1:14:42.77,1:14:44.15,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5361\u723E\u2022\u827E\u723E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Kal-El.{\\r}\r\nDialogue: 0,1:14:44.68,1:14:46.71,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u662F\u526F\u6307\u63EE\u5B98\u8299\
+        \u62C9\u2022\u5967{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm\
+        \ sub-commander Faora-UI.{\\r}\r\nDialogue: 0,1:14:47.38,1:14:51.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4EE3\u8868\u4F50\u5FB7\u5C07\u8ECD \u5411\
+        \u4F60\u554F\u5019{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}On\
+        \ behalf of General Zod, I extend you his greetings.{\\r}\r\nDialogue: 0,1:14:56.69,1:14:59.79,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4F60\u662F\u6307\u63EE\u5B98\u55CE\uFF1F\
+        \ - \u6211\u662F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}-\
+        \ Are you the ranking officer here?       - I am.{\\r}\r\nDialogue: 0,1:15:00.02,1:15:04.20,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F50\u5FB7\u5C07\u8ECD\u5E0C\u671B\u9019\
+        \u500B\u5973\u4EBA\u966A\u6211\u8D70{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}General Zod would like this woman to accompany me.{\\r}\r\
+        \nDialogue: 0,1:15:04.83,1:15:06.67,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u8981\u7684\u53EA\u662F\u4F60\u7684\u65CF\u4EBA\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You asked for the\
+        \ alien.{\\r}\r\nDialogue: 0,1:15:07.40,1:15:10.35,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4E26\u6C92\u6709\u8AAA\u8981\u5E36\
+        \u8D70\u6211\u5011\u7684\u4EBA{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You didn't say anything about one of our own.{\\r}\r\nDialogue: 0,1:15:10.57,1:15:13.71,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9700\u8981\u6211\u544A\u8A34\u5C07\u8ECD\
+        \u4F60\u4E0D\u7B54\u61C9\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Shall I tell the general you're unwilling to comply?{\\\
+        r}\r\nDialogue: 0,1:15:13.97,1:15:15.85,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u4E0D\u5728\u4E4E\u4F60\u600E\u9EBC\u544A\u8A34\
+        \u4ED6{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I don't care\
+        \ what you tell him.{\\r}\r\nDialogue: 0,1:15:18.84,1:15:20.25,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6C92\u95DC\u4FC2{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's all right.{\\r}\r\nDialogue: 0,1:15:21.35,1:15:22.55,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u53BB{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}I'll go.{\\r}\r\nDialogue: 0,1:16:05.39,1:16:09.24,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4EBA\u985E\u7121\u6CD5\u9069\u61C9\u6211\
+        \u5011\u98DB\u8239\u4E2D\u7684\u5927\u6C23\u6210\u5206{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The atmospheric composition on our\
+        \ ship is not compatible with humans.{\\r}\r\nDialogue: 0,1:16:09.46,1:16:10.87,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u904E\u53BB\u4EE5\u5F8C \u4F60\u5FC5\u9808\
+        \u5E36\u4E0A\u547C\u5438\u5668{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You need to wear a breather...{\\r}\r\nDialogue: 0,1:16:11.10,1:16:12.77,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u8981\u9760\u8FD1{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...beyond this point.{\\r}\r\nDialogue:\
+        \ 0,1:16:37.92,1:16:38.83,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5361\u723E\u2022\u827E\u723E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Kal-El.{\\r}\r\nDialogue: 0,1:16:40.79,1:16:42.43,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u90FD\u4E0D\u77E5\u9053{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You have no idea how long...{\\\
+        r}\r\nDialogue: 0,1:16:42.66,1:16:44.73,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u5011\u627E\u4E86\u4F60\u591A\u4E45{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...we've been searching for\
+        \ you.{\\r}\r\nDialogue: 0,1:16:45.16,1:16:46.16,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u60F3\u4F60\u5C31\u662F\u4F50\u5FB7\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I take it you're\
+        \ Zod?{\\r}\r\nDialogue: 0,1:16:46.43,1:16:47.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u662F\u4F50\u5FB7\u5C07\u8ECD{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}General Zod.{\\r}\r\nDialogue:\
+        \ 0,1:16:47.80,1:16:49.61,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}- \u6211\u5011\u7684\u7D71\u9818   - \u6C92\u95DC\u4FC2 \u8299\u62C9\
+        \u2022\u5967{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Our\
+        \ commander.       - It's all right, Faora.{\\r}\r\nDialogue: 0,1:16:49.83,1:16:52.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u539F\u8AD2\u5361\u723E\u7684\u7121\u79AE\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We can forgive Kal\
+        \ any lapses in decorum.{\\r}\r\nDialogue: 0,1:16:52.77,1:16:54.68,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u9084\u4E0D\u719F\u6089\u6211\u5011\
+        \u7684\u79AE\u5100{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He's\
+        \ a stranger to our ways.{\\r}\r\nDialogue: 0,1:16:54.94,1:16:58.40,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u61C9\u8A72\u597D\u597D\u6176\
+        \u795D\u4E00\u4E0B \u800C\u4E0D\u8A72\u722D\u5435{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}This should be cause for celebration, not conflict.{\\\
+        r}\r\nDialogue: 0,1:16:59.51,1:17:01.68,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5225\u885D\u7A81{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Not conflict.{\\r}\r\nDialogue: 0,1:17:04.12,1:17:05.15,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211...{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}I...{\\r}\r\nDialogue: 0,1:17:05.42,1:17:06.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u611F\u89BA\u4E0D\u8212\u670D{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...feel strange.{\\r}\r\nDialogue:\
+        \ 0,1:17:09.35,1:17:10.66,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5F88\u865B\u5F31{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Weak.{\\r}\r\nDialogue: 0,1:17:12.86,1:17:14.06,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u600E\u9EBC\u4E86\uFF1F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What's happening to him?{\\\
+        r}\r\nDialogue: 0,1:17:14.26,1:17:16.80,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4ED6\u7684\u8EAB\u9AD4\u5C0D\u8239\u4E0A\u7684\u5927\
+        \u6C23\u6709\u6392\u65A5{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}He's rejecting our ship's atmospherics.{\\r}\r\nDialogue: 0,1:17:17.03,1:17:17.63,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark.{\\r}\r\nDialogue: 0,1:17:17.86,1:17:20.54,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u7528\u4E86\u4E00\u8F29\u5B50\u4F86\
+        \u9069\u61C9\u5730\u7403\u7684\u74B0\u5883{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}You've spent a lifetime adapting to Earth's ecology...{\\\
+        r}\r\nDialogue: 0,1:17:20.70,1:17:21.64,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u537B\u9069\u61C9\u4E0D\u4E86\u6211\u5011\u81EA\u5DF1\
+        \u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...but never\
+        \ adapted to ours.{\\r}\r\nDialogue: 0,1:17:21.80,1:17:22.83,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5FEB\u5E6B\u5E6B\u4ED6{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Help him.{\\r}\r\nDialogue: 0,1:17:24.87,1:17:27.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark.{\\r}\r\nDialogue: 0,1:17:28.47,1:17:29.78,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5E6B\u5E6B\u4ED6{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Help him.{\\r}\r\nDialogue: 0,1:17:31.54,1:17:32.71,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5FEB\u5E6B\u5E6B\u4ED6{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Help him.{\\r}\r\nDialogue: 0,1:17:44.36,1:17:45.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u597D \u5361\u723E{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Hello, Kal.{\\r}\r\nDialogue: 0,1:17:47.56,1:17:49.63,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9084\u662F\u4F60\u66F4\u559C\u6B61\u6211\
+        \u53EB\u4F60\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Or do you prefer Clark?{\\r}\r\nDialogue: 0,1:17:50.36,1:17:51.74,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u662F\u4ED6\u5011\u7D66\u4F60\u8D77\
+        \u7684\u540D\u5B57{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}That's\
+        \ the name they gave you.{\\r}\r\nDialogue: 0,1:17:52.00,1:17:53.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u662F\u55CE\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Isn't it?{\\r}\r\nDialogue: 0,1:17:54.57,1:17:56.31,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u66FE\u662F\u6C2A\u661F\u7684\u8ECD\
+        \u4E8B\u7D71\u9818{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I\
+        \ was Krypton's military leader...{\\r}\r\nDialogue: 0,1:17:56.53,1:17:58.98,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u800C\u4F60\u7236\u89AA\u662F\u6211\u5011\
+        \u7684\u9996\u5E2D\u79D1\u5B78\u5BB6{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}...your father our foremost scientist.{\\r}\r\nDialogue:\
+        \ 0,1:17:59.20,1:18:00.65,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u5011\u552F\u4E00\u9054\u6210\u5171\u8B58\u7684\u4E00\u9EDE\
+        \u5C31\u662F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The\
+        \ only thing we agreed on...{\\r}\r\nDialogue: 0,1:18:00.87,1:18:02.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6C2A\u661F\u5C31\u8981\u6BC0\u6EC5\u4E86\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...was that Krypton\
+        \ was dying. {\\r}\r\nDialogue: 0,1:18:02.75,1:18:06.41,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u62DA\u547D\u4FDD\u8B77\u6211\u5011\
+        \u7684\u6587\u5316{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}In\
+        \ return for my efforts to protect our civilization...{\\r}\r\nDialogue: 0,1:18:06.68,1:18:08.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4FDD\u885B\u6211\u5011\u7684\u661F\u7403\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...and save our\
+        \ planet...{\\r}\r\nDialogue: 0,1:18:09.01,1:18:13.02,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5F97\u5230\u7684\u56DE\u5831\u537B\u662F\
+        \u6211\u5011\u90FD\u88AB\u653E\u9010\u5230\u5E7D\u9748\u5340{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...I and my fellow officers were sentenced\
+        \ to the Phantom Zone.{\\r}\r\nDialogue: 0,1:18:15.99,1:18:21.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u800C\u6211\u5011\u661F\u7403\u7684\u6BC0\
+        \u6EC5\u537B\u8B93\u6211\u5011\u91CD\u7372\u81EA\u7531{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And then the destruction of our world\
+        \ freed us.{\\r}\r\nDialogue: 0,1:18:26.16,1:18:27.92,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u56DB\u8655\u6F02\u6CCA{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We were adrift, {\\\
+        r}\r\nDialogue: 0,1:18:27.92,1:18:31.85,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6CE8\u5B9A\u6F02\u6D41\u5728\u6211\u5011\u661F\u7403\
+        \u7684\u6B98\u9AB8\u4E4B\u4E2D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}destined to float amongst the ruins of our planet...{\\r}\r\nDialogue:\
+        \ 0,1:18:32.07,1:18:33.95,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u76F4\u81F3\u6B7B\u4EA1{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...until we starved.{\\r}\r\nDialogue: 0,1:18:34.84,1:18:36.52,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5011\u662F\u600E\u9EBC\u627E\u5230\
+        \u5730\u7403\u4F86\u7684\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}How did you find your way to Earth?{\\r}\r\nDialogue: 0,1:18:37.21,1:18:41.21,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u628A\u5E7D\u9748\u63A8\u9032\
+        \u5668\u6539\u9020\u6210\u4E86\u9AD8\u901F\u98DB\u884C\u5668{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We managed to retrofit the phantom\
+        \ projector into a hyperdrive.{\\r}\r\nDialogue: 0,1:18:41.71,1:18:45.49,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u7236\u89AA\u4E5F\u662F\u5C0D\u98DB\
+        \u8239\u505A\u4E86\u985E\u4F3C\u7684\u4FEE\u6539 \u628A\u4F60\u9001\u5230\u4E86\
+        \u9019\u88CF{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Your\
+        \ father made a similar modification to the craft that brought you here.{\\\
+        r}\r\nDialogue: 0,1:18:46.92,1:18:50.02,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6240\u4EE5\u56DA\u7981\u6211\u5011\u7684\u5DE5\u5177\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And so the instrument\
+        \ of our damnation...{\\r}\r\nDialogue: 0,1:18:52.06,1:18:53.87,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u540C\u6642\u4E5F\u62EF\u6551\u4E86\u6211\
+        \u5011{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...became\
+        \ our salvation.{\\r}\r\nDialogue: 0,1:18:58.80,1:19:01.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u627E\u904D\u4E86\u820A\u6B96\
+        \u6C11\u5730\u7684\u524D\u54E8\u7AD9{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}We sought out the old colonial outposts...{\\r}\r\nDialogue:\
+        \ 0,1:19:01.57,1:19:03.77,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u60F3\u8981\u5C0B\u627E\u751F\u547D\u7684\u8DE1\u8C61{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...looking for signs of life.{\\\
+        r}\r\nDialogue: 0,1:19:06.24,1:19:09.05,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F46\u627E\u5230\u7684\u53EA\u6709\u6B7B\u4EA1{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}But all we found was death.{\\\
+        r}\r\nDialogue: 0,1:19:10.04,1:19:12.61,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u9019\u4E9B\u524D\u54E8\u7AD9\u65E9\u548C\u6C2A\u661F\
+        \u5931\u53BB\u806F\u7D61{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Cut off from Krypton, these outposts...{\\r}\r\nDialogue: 0,1:19:12.88,1:19:15.08,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4EE5\u5F8C\u5C31\u5EE2\u68C4\u4E86{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...withered and died\
+        \ long ago.{\\r}\r\nDialogue: 0,1:19:15.58,1:19:17.56,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u628A\u80FD\u7528\u7684\u90FD\
+        \u5E36\u8D70\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We\
+        \ salvaged what we could...{\\r}\r\nDialogue: 0,1:19:17.78,1:19:19.49,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u76D4\u7532 \u6B66\u5668{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...armor, weapons...{\\r}\r\nDialogue:\
+        \ 0,1:19:19.75,1:19:21.66,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u9084\u6709\u4E00\u500B\u4E16\u754C\u5F15\u64CE{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...even a world engine.{\\r}\r\nDialogue:\
+        \ 0,1:19:23.42,1:19:25.30,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u5011\u6E96\u5099\u4E8633\u5E74{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}For 33 years we prepared...{\\r}\r\nDialogue: 0,1:19:26.79,1:19:29.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u76F4\u5230\u6211\u5011\u5075\u6E2C\u5230\
+        \u4E00\u500B\u6C42\u6551\u4FE1\u865F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}...until finally we detected a distress beacon...{\\r}\r\
+        \nDialogue: 0,1:19:29.79,1:19:34.50,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u662F\u4F60\u5728\u8001\u5075\u5BDF\u6A5F\u88CF\u767C\
+        \u51FA\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...which\
+        \ you triggered when you accessed the ancient scout ship.{\\r}\r\nDialogue:\
+        \ 0,1:19:35.47,1:19:38.00,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u662F\u4F60\u628A\u6211\u5011\u5E36\u5230\u9019\u88CF\u7684 \u5361\
+        \u723E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You led us\
+        \ here, Kal.{\\r}\r\nDialogue: 0,1:19:39.14,1:19:44.70,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u73FE\u5728\u4F60\u6709\u80FD\u529B\u62EF\
+        \u6551\u6211\u5011\u7684\u7A2E\u65CF{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Now it's within your power to save what remains of your\
+        \ race.{\\r}\r\nDialogue: 0,1:19:49.11,1:19:50.35,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5728\u6C2A\u661F\u4E0A{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}On Krypton...{\\r}\r\nDialogue: 0,1:19:50.61,1:19:53.25,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6240\u6709\u672A\u51FA\u751F\u5B69\u5B50\
+        \u7684\u907A\u50B3\u57FA\u56E0{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...the genetic template for every being yet to be born...{\\r}\r\nDialogue:\
+        \ 0,1:19:53.48,1:19:56.02,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u90FD\u88AB\u7DE8\u5BEB\u5728\u516C\u6C11\u6A94\u6848\u88CF{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...is encoded in the registry\
+        \ of citizens.{\\r}\r\nDialogue: 0,1:19:56.69,1:19:58.83,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u7236\u89AA\u5077\u8D70\u4E86\u6A94\
+        \u6848\u7684\u5BC6\u5178{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Your father stole the registry's Codex...{\\r}\r\nDialogue: 0,1:19:59.09,1:20:01.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u85CF\u5728\u4E86\u5E36\u4F60\u4F86\u7684\
+        \u592A\u7A7A\u8259\u88CF{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...and stored it in the capsule that brought you here.{\\r}\r\nDialogue:\
+        \ 0,1:20:02.63,1:20:03.47,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u70BA\u4EC0\u9EBC\u5462\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}For what purpose?{\\r}\r\nDialogue: 0,1:20:04.53,1:20:09.90,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9019\u6A23\u6C2A\u661F\u5C31\u80FD\u5728\
+        \u5730\u7403\u4E0A\u91CD\u751F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}So that Krypton can live again on Earth.{\\r}\r\nDialogue: 0,1:20:29.52,1:20:31.63,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5BC6\u5178\u5728\u54EA\u88CF \u5361\u723E\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Where is the\
+        \ Codex, Kal?{\\r}\r\nDialogue: 0,1:20:33.29,1:20:35.13,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5982\u679C\u6C2A\u661F\u91CD\u751F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}If Krypton lives again...{\\\
+        r}\r\nDialogue: 0,1:20:36.29,1:20:37.67,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5730\u7403\u6703\u600E\u9EBC\u6A23\uFF1F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...what happens to Earth?{\\\
+        r}\r\nDialogue: 0,1:20:38.70,1:20:42.20,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u91CD\u751F\u7E3D\u9700\u8981\u5EFA\u7ACB\u5728\u6BC0\
+        \u6EC5\u4E4B\u4E0A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The\
+        \ foundation has to be built on something.{\\r}\r\nDialogue: 0,1:20:42.47,1:20:45.24,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9023\u4F60\u7236\u89AA\u90FD\u77E5\u9053\
+        \u9019\u4E00\u9EDE{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Even\
+        \ your father recognized that.{\\r}\r\nDialogue: 0,1:20:51.71,1:20:54.02,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D \u4F50\u5FB7{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}No, Zod.{\\r}\r\nDialogue: 0,1:20:55.18,1:20:56.79,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E0D\u6703\u5E6B\u4F60\u7684{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I can't be a part of\
+        \ this.{\\r}\r\nDialogue: 0,1:20:57.21,1:20:58.92,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u9EBC\u4F60\u6703\u5E6B\u8AB0\u5462\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Then what\
+        \ can you be a part of?{\\r}\r\nDialogue: 0,1:20:59.52,1:21:00.72,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}No!{\\r}\r\nDialogue: 0,1:21:01.92,1:21:02.52,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F50\u5FB7{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Zod!{\\r}\r\nDialogue: 0,1:21:04.02,1:21:04.73,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}No!{\\r}\r\nDialogue: 0,1:21:05.89,1:21:07.53,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}No!{\\r}\r\nDialogue: 0,1:21:13.56,1:21:17.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u7684\u7236\u89AA\u70BA\u69AE\u8B7D\
+        \u737B\u51FA\u4E86\u81EA\u5DF1{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Your father acquitted himself with honor, Kal.{\\r}\r\nDialogue: 0,1:21:19.84,1:21:21.78,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u662F\u4F60\u6BBA\u4E86\u4ED6\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You killed him?{\\\
+        r}\r\nDialogue: 0,1:21:22.17,1:21:23.52,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u662F\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I did.{\\r}\r\nDialogue: 0,1:21:24.11,1:21:27.52,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u6C38\u9060\u90FD\u64FA\u812B\u4E0D\
+        \u4E86\u9019\u4EF6\u4E8B\u7684\u9670\u5F71{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}And not a day goes by where it doesn't haunt me.{\\\
+        r}\r\nDialogue: 0,1:21:28.88,1:21:31.22,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F46\u5982\u679C\u91CD\u4F86\u4E00\u6B21 \u6211\u9084\
+        \u662F\u6703\u9019\u9EBC\u505A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}But if I had to do it again, I would.{\\r}\r\nDialogue: 0,1:21:31.45,1:21:34.92,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u8981\u5C0D\u6211\u7684\u4EBA\u6C11\
+        \u8CA0\u8CAC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I have\
+        \ a duty to my people...{\\r}\r\nDialogue: 0,1:21:35.19,1:21:39.59,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E0D\u6703\u8B93\u4EFB\u4F55\u4EBA\
+        \u963B\u6B62\u6211{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...and\
+        \ I will not allow anyone to prevent me from carrying it out.{\\r}\r\nDialogue:\
+        \ 0,1:21:55.64,1:21:57.28,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u90A3\u662F\u4EC0\u9EBC \u5C11\u6821\uFF1F{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}What's the sit-rep, major?{\\r}\r\nDialogue:\
+        \ 0,1:21:57.91,1:22:00.29,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5075\u6E2C\u5230\u5169\u67B6\u6575\u6A5F\u5F9E\u5916\u661F\u98DB\
+        \u8239\u4E2D\u767C\u5C04{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}DSP pinged two bogeys launching from the alien ship.{\\r}\r\nDialogue:\
+        \ 0,1:22:00.54,1:22:02.65,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}- \u87A2\u5E55\u986F\u793A   - \u597D\u7684 \u9577\u5B98{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Put it up.       - Yes, sir.{\\\
+        r}\r\nDialogue: 0,1:22:03.08,1:22:04.15,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5C31\u662F\u9019\u500B{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}There it is.{\\r}\r\nDialogue: 0,1:22:04.42,1:22:05.22,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u63A5\u7121\u7DDA\u96FB4\u865F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Re-task IKon-4...{\\r}\r\n\
+        Dialogue: 0,1:22:05.45,1:22:07.90,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}-  \u518D\u62C9\u8FD1\u9EDE   - \u597D\u7684{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- ...and get me a closer look.   \
+        \    - Yes, sir.{\\r}\r\nDialogue: 0,1:22:08.22,1:22:09.39,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6307\u63EE\u90E8{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Command, the word...{\\r}\r\nDialogue:\
+        \ 0,1:22:09.39,1:22:10.56,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4ECA\u5929\u7684\u6697\u865F\u662F\u4E09\u53C9\u621F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...of the day is trident.{\\\
+        r}\r\nDialogue: 0,1:22:10.79,1:22:12.89,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6709\u5169\u67B6\u5916\u661F\u98DB\u8239\u6B63\u5728\
+        \u63A5\u8FD1{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We have\
+        \ two alien craft on aggressive approach.{\\r}\r\nDialogue: 0,1:22:13.12,1:22:14.76,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7121\u7DDA\u96FB4\u865F\u5DF2\u63A5\u901A\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Ikon-4 coming online.{\\\
+        r}\r\nDialogue: 0,1:22:14.99,1:22:15.80,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u901F\u5EA6\u6709\u591A\u5FEB\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Air speed?{\\r}\r\nDialogue: 0,1:22:16.06,1:22:17.58,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}380\u6D77\u91CC \u6B63\u5728\u9032\u5165\
+        \u582A\u85A9\u65AF\u5DDE\u4E0A\u7A7A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}380 knots, entering Kansas...{\\r}\r\nDialogue: 0,1:22:17.73,1:22:19.73,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u5011\u4E0D\u56DE\u61C9\u6211\u5011\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...airspace. Not\
+        \ responding to our hails.{\\r}\r\nDialogue: 0,1:22:19.96,1:22:22.17,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4E0D\u8981\u6D6A\u8CBB\u9AD4\u529B\
+        \u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You're wasting\
+        \ your efforts.{\\r}\r\nDialogue: 0,1:22:23.10,1:22:25.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5F9E\u5730\u7403\u7684\u592A\u967D\
+        \u5F97\u5230\u7684\u529B\u91CF{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}The strength you derived from the Earth's sun...{\\r}\r\nDialogue: 0,1:22:25.67,1:22:27.77,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5728\u6211\u5011\u7684\u8239\u4E0A\u5B8C\
+        \u5168\u6C92\u6709\u7528{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...has been neutralized aboard our ship.{\\r}\r\nDialogue: 0,1:22:28.44,1:22:29.58,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5728\u9019\u88CF{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Here...{\\r}\r\nDialogue: 0,1:22:29.81,1:22:31.41,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9019\u6A23\u7684\u74B0\u5883\u4E0B{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...in this environment...{\\\
+        r}\r\nDialogue: 0,1:22:32.18,1:22:33.66,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u5C31\u8DDF\u4EBA\u985E\u4E00\u6A23\u8106\u5F31\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...you are as weak\
+        \ as a human.{\\r}\r\nDialogue: 0,1:23:32.20,1:23:34.05,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5F9E\u54EA\u5192\u51FA\u4F86\u7684\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Where did\
+        \ you come from?{\\r}\r\nDialogue: 0,1:23:34.57,1:23:36.02,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E3B\u63A7\u9470\u5319\u88CF \u84EE\u6069\
+        \u5C0F\u59D0{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The\
+        \ command key, Miss Lane.{\\r}\r\nDialogue: 0,1:23:36.24,1:23:39.39,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u591A\u8667\u4E86\u4F60 \u6211\u6B63\u5728\
+        \u88AB\u4E0A\u50B3\u5230\u9019\u8258\u8239\u7684\u4E3B\u7A0B\u5E8F\u88CF{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Thanks to you, I'm\
+        \ uploading to the ship's mainframe.{\\r}\r\nDialogue: 0,1:23:39.91,1:23:40.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u662F\u8AB0\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Who are you?{\\r}\r\nDialogue: 0,1:23:41.85,1:23:43.15,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u662F\u5361\u723E\u7684\u7236\u89AA\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I am Kai's father.{\\\
+        r}\r\nDialogue: 0,1:23:44.82,1:23:45.96,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u80FD\u5E6B\u6211\u5011\u55CE\uFF1F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Can you help us?{\\r}\r\nDialogue:\
+        \ 0,1:23:47.52,1:23:49.36,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u9019\u8258\u8239\u662F\u6211\u8A2D\u8A08\u7684{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I designed this ship.{\\r}\r\nDialogue:\
+        \ 0,1:23:49.59,1:23:51.76,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u80FD\u6539\u9020\u5B83\u7684\u5927\u6C23\u7D50\u69CB{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I can modify its atmospheric\
+        \ composition...{\\r}\r\nDialogue: 0,1:23:52.02,1:23:53.76,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F7F\u4EBA\u985E\u9069\u61C9{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...to human compatibility.{\\\
+        r}\r\nDialogue: 0,1:23:54.02,1:23:54.87,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u5011\u80FD\u963B\u6B62\u4ED6\u5011{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We can stop them.{\\r}\r\n\
+        Dialogue: 0,1:23:55.09,1:23:57.57,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6211\u5011\u80FD\u628A\u4ED6\u5011\u9001\u56DE\u5E7D\u9748\
+        \u5340{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We can send\
+        \ them back to the Phantom Zone.{\\r}\r\nDialogue: 0,1:23:58.53,1:23:59.17,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u600E\u9EBC\u505A\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}How?{\\r}\r\nDialogue: 0,1:23:59.40,1:24:00.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4F86\u6559\u4F60{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I can teach you.{\\r}\r\nDialogue:\
+        \ 0,1:24:01.20,1:24:03.01,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u7136\u5F8C\u4F60\u518D\u6559\u7D66\u5361\u723E{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And in turn, you can teach Kal.{\\\
+        r}\r\nDialogue: 0,1:24:03.23,1:24:04.94,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u6703\u5E6B\u6211\u55CE\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Will you help me?{\\r}\r\nDialogue:\
+        \ 0,1:24:18.78,1:24:20.22,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u8239\u4E0A\u7684\u8B66\u5831\u97FF\u4E86{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}The ship's crew are alerted.{\\r}\r\n\
+        Dialogue: 0,1:24:20.35,1:24:21.39,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6211\u5011\u5F97\u5FEB\u9EDE{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}We need to move quickly.{\\r}\r\nDialogue: 0,1:24:21.62,1:24:23.29,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u628A\u4E3B\u63A7\u9470\u5319\u62FF\u4E0A\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Retrieve the command\
+        \ key.{\\r}\r\nDialogue: 0,1:24:30.93,1:24:33.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u662F\u4F60\u505A\u7684\u55CE\uFF1F -\
+        \ \u662F\u7684 \u628A\u5979\u7684\u6B66\u5668\u62FF\u4E0A{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Did you do that?       - Yes. Pick\
+        \ up her sidearm.{\\r}\r\nDialogue: 0,1:24:43.37,1:24:44.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u767C\u751F\u4E86\u4EC0\u9EBC\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What's happening?{\\\
+        r}\r\nDialogue: 0,1:25:05.73,1:25:06.40,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u53F3\u908A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}To your right.{\\r}\r\nDialogue: 0,1:25:06.63,1:25:07.27,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u958B\u706B{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Fire.{\\r}\r\nDialogue: 0,1:25:08.83,1:25:09.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5F8C\u9762{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Behind you.{\\r}\r\nDialogue: 0,1:25:23.08,1:25:25.12,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5B89\u5168\u5F85\u5728\u6551\u751F\u8259\
+        \u88CF{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Secure yourself\
+        \ inside the open pod.{\\r}\r\nDialogue: 0,1:25:26.15,1:25:28.43,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u65C5\u9014\u5E73\u5B89 \u84EE\u6069\u5C0F\
+        \u59D0{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Safe travels,\
+        \ Miss Lane. It's unlikely...{\\r}\r\nDialogue: 0,1:25:28.65,1:25:30.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u61C9\u8A72\u4E0D\u53EF\u80FD\
+        \u518D\u898B\u9762\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...we'll see each other again.{\\r}\r\nDialogue: 0,1:25:31.82,1:25:34.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8A18\u4F4F \u5E7D\u9748\u5F15\u64CE\u662F\
+        \u963B\u6B62\u4ED6\u5011\u7684\u95DC\u9375{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Remember, the phantom drives are essential in stopping\
+        \ them.{\\r}\r\nDialogue: 0,1:25:35.79,1:25:37.03,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u628A\u982D\u504F\u5411\u5DE6\u908A{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Move your head to the\
+        \ left.{\\r}\r\nDialogue: 0,1:26:04.62,1:26:07.23,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F50\u5FB7\u8AAA\u7684\u95DC\u65BC\u5BC6\
+        \u5178\u7684\u4E8B\u662F\u771F\u7684\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Is it true what Zod said about the Codex?{\\r}\r\n\
+        Dialogue: 0,1:26:07.66,1:26:09.04,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u628A\u8239\u58C1\u6253\u7834{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Strike that panel.{\\r}\r\nDialogue: 0,1:26:12.70,1:26:16.80,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u60F3\u8981\u4F60\u5B78\u7FD2\
+        \u4EBA\u985E\u6700\u91CD\u8981\u7684\u662F\u4EC0\u9EBC{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We wanted you to learn what it meant\
+        \ to be human first...{\\r}\r\nDialogue: 0,1:26:16.87,1:26:18.90,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6240\u4EE5\u5982\u679C\u6709\u4E00\u5929\
+        \ \u6642\u6A5F\u6210\u719F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...so that one day, when the time was right, {\\r}\r\nDialogue: 0,1:26:18.90,1:26:22.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6703\u6210\u70BA\u5169\u500B\u7A2E\
+        \u65CF\u6E9D\u901A\u7684\u6A4B\u6A11{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}you could be the bridge between two peoples.{\\r}\r\nDialogue:\
+        \ 0,1:26:25.24,1:26:26.02,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u770B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Look.{\\\
+        r}\r\nDialogue: 0,1:26:29.18,1:26:30.42,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u9732\u6613\u7D72{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Lois.{\\r}\r\nDialogue: 0,1:26:31.01,1:26:32.05,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u80FD\u6551\u5979 \u5361\u723E{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You can save her, Kal.{\\\
+        r}\r\nDialogue: 0,1:26:35.19,1:26:37.06,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u80FD\u62EF\u6551\u6240\u6709\u4EBA{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You can save all of them.{\\\
+        r}\r\nDialogue: 0,1:27:55.97,1:27:57.50,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u5B89\u5168\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}You'll be safe here.{\\r}\r\nDialogue: 0,1:27:59.84,1:28:02.41,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4F60\u6C92\u4E8B\u5427\uFF1F - \u6C92\
+        \u4E8B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Are you\
+        \ all right?       - Yeah.{\\r}\r\nDialogue: 0,1:28:05.64,1:28:07.12,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C0D\u4E0D\u8D77{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm sorry.{\\r}\r\nDialogue: 0,1:28:07.84,1:28:10.83,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E0D\u662F\u6545\u610F\u544A\u8A34\
+        \u4ED6\u5011\u4F60\u7684\u4E8B \u4ED6\u5011\u5C0D\u6211\u52D5\u4E86\u624B\u8173\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I didn't wanna tell\
+        \ them anything, but they did something to me.{\\r}\r\nDialogue: 0,1:28:11.08,1:28:13.25,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4ED6\u5011\u770B\u7A7F\u4E86\u6211\u7684\
+        \u5FC3\u601D   - \u6C92\u95DC\u4FC2 \u9732\u6613\u7D72{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- They looked inside my mind...  \
+        \     - It's okay, Lois.{\\r}\r\nDialogue: 0,1:28:13.48,1:28:15.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u5011\u4E5F\u5C0D\u6211\u505A\u4E86\
+        \u540C\u6A23\u7684\u4E8B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}They did the same thing to me.{\\r}\r\nDialogue: 0,1:28:28.33,1:28:29.67,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark!{\\r}\r\nDialogue: 0,1:28:38.68,1:28:40.45,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5E36\u4ED6\u4F86\u7684\u90A3\u8258\u8239\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The craft he arrived\
+        \ in...{\\r}\r\nDialogue: 0,1:28:40.98,1:28:42.15,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5B83\u5728\u54EA\u88CF\uFF1F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...where is it?{\\r}\r\nDialogue:\
+        \ 0,1:28:44.05,1:28:45.22,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u53BB\u6B7B\u5427{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Go to hell.{\\r}\r\nDialogue: 0,1:28:56.53,1:28:57.50,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5728\u90A3\u908A{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}There.{\\r}\r\nDialogue: 0,1:29:20.52,1:29:22.66,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5BC6\u5178\u4E0D\u5728\u9019\u88CF{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The Codex is not here.{\\\
+        r}\r\nDialogue: 0,1:29:29.39,1:29:30.51,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4ED6\u85CF\u5728\u54EA\u4E86\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Where has he hidden it?{\\r}\r\nDialogue:\
+        \ 0,1:29:30.69,1:29:31.33,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u4E0D\u77E5\u9053{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I don't know.{\\r}\r\nDialogue: 0,1:29:31.56,1:29:32.67,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5BC6\u5178\u5728\u54EA\u88CF\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Where is the Codex?!{\\\
+        r}\r\nDialogue: 0,1:29:48.68,1:29:50.62,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u5C45\u7136\u6562\u5A01\u8105\u6211\u5ABD\u5ABD\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You think you can\
+        \ threaten my mother?!{\\r}\r\nDialogue: 0,1:30:32.42,1:30:33.90,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5C0D\u6211\u505A\u4E86\u4EC0\u9EBC\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What have\
+        \ you done to me?{\\r}\r\nDialogue: 0,1:30:34.12,1:30:38.50,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u7236\u6BCD\u6559\u6211\u8981\u78E8\
+        \u7DF4\u6211\u7684\u611F\u5B98 \u4F50\u5FB7{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}My parents taught me to hone my senses, Zod.{\\r}\r\
+        \nDialogue: 0,1:30:39.96,1:30:41.57,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5C08\u6CE8{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Focus...{\\r}\r\nDialogue: 0,1:30:42.13,1:30:43.84,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5728\u81EA\u5DF1\u60F3\u770B\u7684\u6771\
+        \u897F\u4E0A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...on\
+        \ just what I wanted to see.{\\r}\r\nDialogue: 0,1:30:44.10,1:30:45.14,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6C92\u4E86\u982D\u76D4{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Without your helmet...{\\r}\r\
+        \nDialogue: 0,1:30:45.40,1:30:46.97,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u53EF\u4EE5\u611F\u53D7\u5230\u66F4\u591A\u6771\u897F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...you're getting\
+        \ everything.{\\r}\r\nDialogue: 0,1:30:48.24,1:30:49.65,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5F88\u96E3\u53D7{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}And it hurts...{\\r}\r\nDialogue: 0,1:30:50.24,1:30:51.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u662F\u5427\uFF1F{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}...doesn't it?{\\r}\r\nDialogue: 0,1:31:36.45,1:31:37.73,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5225\u7AD9\u5728\u7A97\u6236\u908A\u4E0A\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Get away from the\
+        \ window.{\\r}\r\nDialogue: 0,1:31:40.69,1:31:42.90,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90FD\u9032\u53BB \u9019\u88CF\u4E0D\u5B89\
+        \u5168{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Get inside.\
+        \ It's not safe.{\\r}\r\nDialogue: 0,1:31:47.83,1:31:50.71,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5168\u9AD4\u807D\u547D \u9019\u88CF\u662F\
+        \u5B88\u8B77\u8005 \u6211\u662F\u7A7A\u4E2D\u6307\u63EE\u5B98{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}All players, this is Guardian. I am\
+        \ airborne mission commander.{\\r}\r\nDialogue: 0,1:31:50.97,1:31:53.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5DF2\u7D93\u4E8B\u5148\u63A5\u89F8\
+        \u904E\u4E26\u89C0\u5BDF\u904E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I have previously encountered and observed...{\\r}\r\nDialogue: 0,1:31:53.24,1:31:55.38,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u5C07\u8981\u63A5\u8FD1\u7684\
+        \u76EE\u6A19{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...the\
+        \ beings we're about to engage.{\\r}\r\nDialogue: 0,1:31:55.64,1:31:58.35,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u5011\u975E\u5E38\u5371\u96AA \u6211\
+        \u5011\u53EF\u4EE5...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}They are extremely dangerous and we have been authorized...{\\r}\r\n\
+        Dialogue: 0,1:31:58.58,1:32:00.08,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4F7F\u7528\u81F4\u547D\u6B66\u5668{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}...to use deadly force.{\\r}\r\nDialogue:\
+        \ 0,1:32:02.05,1:32:04.09,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6536\u5230 \u5B88\u8B77\u8005 \u6211\u5011\u6B63\u63A5\u8FD1\u76EE\
+        \u6A19{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Roger, Guardian,\
+        \ we are inbound to target.{\\r}\r\nDialogue: 0,1:32:09.69,1:32:11.15,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u958B\u706B{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Cleared hot. Weapons free.{\\r}\r\nDialogue: 0,1:32:11.15,1:32:12.76,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}11\u865F \u958B\u706B{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Copy, 11. Weapons free.{\\r}\r\nDialogue:\
+        \ 0,1:32:15.56,1:32:16.44,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u9019\u88CF\u662F\u96F7\u96FB11\u865F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Thunder 11...{\\r}\r\nDialogue: 0,1:32:16.56,1:32:17.59,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9396\u5B9A\u4E09\u500B\u76EE\u6A19{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...tally three targets.{\\\
+        r}\r\nDialogue: 0,1:32:35.21,1:32:36.02,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u96F7\u96FB11\u865F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Thunder 11...{\\r}\r\nDialogue: 0,1:32:36.25,1:32:38.69,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5E79\u5F97\u6F02\u4EAE \u8ACB\u6C42\u7ACB\
+        \u5373\u518D\u6B21\u653B\u64CA{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...good hit. Request immediate re-attack.{\\r}\r\nDialogue: 0,1:32:38.92,1:32:41.12,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6536\u5230 \u5B88\u8B77\u8005 \u6E96\u5099\
+        \u4E8C\u6B21\u653B\u64CA{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Roger, Guardian. We'll make a second gun run...{\\r}\r\nDialogue: 0,1:32:41.28,1:32:43.39,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u822A\u5411212\u5EA6{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...on a heading of 212 degrees.{\\\
+        r}\r\nDialogue: 0,1:32:50.39,1:32:51.47,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u96F7\u96FB11\u865F \u5FEB\u5F48\u51FA\u9003\u751F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Thunder 11, eject!{\\\
+        r}\r\nDialogue: 0,1:32:51.59,1:32:52.97,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5FEB\u5F48\u51FA\u9003\u751F{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Eject!{\\r}\r\nDialogue: 0,1:32:53.30,1:32:54.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u96F7\u96FB11\u865F \u5FEB\u5F48\u51FA\u9003\
+        \u751F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Thunder 11,\
+        \ eject!{\\r}\r\nDialogue: 0,1:33:05.08,1:33:06.65,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6709\u6575\u4EBA\u5411\u6211\u885D\u4F86\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I have a bogey incoming!{\\\
+        r}\r\nDialogue: 0,1:33:07.48,1:33:08.92,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u8A72\u6B7B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Oh, shit.{\\r}\r\nDialogue: 0,1:33:27.10,1:33:27.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u592A\u5F31\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You are weak...{\\r}\r\nDialogue:\
+        \ 0,1:33:28.23,1:33:29.34,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u827E\u723E\u4E4B\u5B50{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...son of El.{\\r}\r\nDialogue: 0,1:33:29.60,1:33:30.74,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C0D\u81EA\u5DF1\u6C92\u4FE1\u5FC3{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Unsure of yourself.{\\\
+        r}\r\nDialogue: 0,1:33:35.97,1:33:38.95,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u5011\u4E26\u4E0D\u50CF\u4F60{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The fact that you possess a sense\
+        \ of morality...{\\r}\r\nDialogue: 0,1:33:39.18,1:33:40.95,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53D7\u9053\u5FB7\u6E96\u5247\u7684\u675F\
+        \u7E1B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...and we\
+        \ do not...{\\r}\r\nDialogue: 0,1:33:41.18,1:33:43.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u800C\u9019\u6B63\u662F\u6211\u5011\u9032\
+        \u5316\u7684\u512A\u52E2{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...gives us an evolutionary advantage.{\\r}\r\nDialogue: 0,1:33:47.25,1:33:49.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5982\u679C\u8AAA\u6B77\u53F2\u8B49\u660E\
+        \u4E86\u4EC0\u9EBC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And\
+        \ if history has proven anything...{\\r}\r\nDialogue: 0,1:33:59.63,1:34:03.20,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u5C31\u662F\u9032\u5316\u8005\u6C38\
+        \u9060\u66F4\u5F37\u5927{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...it is that evolution always wins.{\\r}\r\nDialogue: 0,1:34:24.52,1:34:26.02,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u4F86\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}CCT, we're approaching...{\\r}\r\n\
+        Dialogue: 0,1:34:26.29,1:34:28.13,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u8457\u9678 \u5168\u529B\u4E0B\u964D{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}...LZ Jayhawk. Get down in five.{\\r}\r\
+        \nDialogue: 0,1:34:28.36,1:34:30.20,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u8D70\u5427 \u524D\u9032{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Let's go. Go to the LZ.{\\r}\r\nDialogue: 0,1:34:30.99,1:34:32.32,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6536\u5230 \u4E2D\u58EB \u51FA\u767C{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Roger, sarge. let's\
+        \ go!{\\r}\r\nDialogue: 0,1:35:09.77,1:35:11.09,chs,,0000,0000,0000,,{\\fn\u534E\
+        \u6587\u6977\u4F53\\blur3}\u516C\u725B\u6D41\u6D6A\u8005\u865F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}All rangers, I need you...{\\\
+        r}\r\nDialogue: 0,1:35:11.33,1:35:12.51,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u7784\u6E96\u6240\u6709\u76EE\u6A19{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...to engage the targets.{\\r}\r\n\
+        Dialogue: 0,1:35:13.00,1:35:14.12,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u5B88\u8B77\u8005 \u9019\u88CF\u662F\u4E00\u865F\u6230\u5834\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Guardian, this is\
+        \ Badger 01.{\\r}\r\nDialogue: 0,1:35:14.34,1:35:15.61,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u500B\u7A7F\u85CD\u8863\u670D\u7684\
+        \u50A2\u4F19\u600E\u9EBC\u8FA6\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}What about the guy in blue?{\\r}\r\nDialogue: 0,1:35:15.87,1:35:16.91,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u8AAA\u4E86{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}I said engage...{\\r}\r\nDialogue: 0,1:35:17.17,1:35:18.35,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u653B\u64CA\u6240\u6709\u76EE\u6A19{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...all targets.{\\\
+        r}\r\nDialogue: 0,1:35:29.52,1:35:30.56,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6230\u9B25 \u6230\u9B25{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Contact. Contact.{\\r}\r\nDialogue: 0,1:35:40.73,1:35:41.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6C92\u4E8B\u5427\uFF1F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You okay?{\\r}\r\nDialogue:\
+        \ 0,1:35:47.30,1:35:49.41,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u5011\u88AB\u64CA\u4E2D\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}We're auto-rotating, going in hard.{\\r}\r\nDialogue:\
+        \ 0,1:35:50.14,1:35:51.31,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u5011\u53D7\u5230\u4E86\u649E\u64CA{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Brace for impact.{\\r}\r\nDialogue: 0,1:35:52.11,1:35:53.25,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u53D7\u649E\u64CA{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Brace for impact.{\\r}\r\n\
+        Dialogue: 0,1:35:53.48,1:35:54.45,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6B63\u5728\u589C\u843D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}We're going in hard!{\\r}\r\nDialogue: 0,1:35:59.55,1:36:03.55,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5B88\u8B77\u8005\u5DF2\u589C\u6BC0 \u91CD\
+        \u8907\u4E00\u6B21 \u5B88\u8B77\u8005\u5DF2\u589C\u6BC0{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Fallen angel. Fallen angel. Guardian\
+        \ is down. I repeat, Guardian is down.{\\r}\r\nDialogue: 0,1:36:25.48,1:36:26.98,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5B88\u8B77\u8005 \u807D\u5230\u8ACB\u56DE\
+        \u7B54{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Guardian,\
+        \ do you read?{\\r}\r\nDialogue: 0,1:36:27.24,1:36:28.59,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u96F7\u96FB12\u865F\u547C\u53EB\u5B88\u8B77\
+        \u8005{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Thunder 12,\
+        \ calling Guardian.{\\r}\r\nDialogue: 0,1:36:28.81,1:36:30.15,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u80FD\u6536\u5230\u55CE\uFF1F - \u96F7\
+        \u96FB12\u865F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}-\
+        \ Do you read?        - Thunder 12...{\\r}\r\nDialogue: 0,1:36:30.41,1:36:31.32,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9019\u88CF\u662F\u5B88\u8B77\u8005{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...this is Guardian.{\\\
+        r}\r\nDialogue: 0,1:36:31.58,1:36:33.96,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u706B\u529B\u5168\u90E8\u5C0D\u6E96\u9019\u88CF \u4E0D\
+        \u7528\u7BA1\u6211\u5011{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Put down everything you've got north of my position.{\\r}\r\nDialogue:\
+        \ 0,1:36:34.18,1:36:36.36,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}- \u9019\u88CF\u662F\u5371\u96AA\u5340\u57DF   - \u6536\u5230 \u5371\
+        \u96AA\u5340\u57DF{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}-\
+        \ This will be danger-close.        - Copy, danger-close.{\\r}\r\nDialogue:\
+        \ 0,1:36:36.62,1:36:37.86,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u795D\u4F60\u597D\u904B \u9577\u5B98{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Good luck, sir.{\\r}\r\nDialogue: 0,1:37:17.73,1:37:20.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6B7B\u5F97\u5149\u69AE\u5C31\u662F\u6B7B\
+        \u5F97\u5176\u6240{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}A\
+        \ good death is its own reward.{\\r}\r\nDialogue: 0,1:37:34.18,1:37:35.55,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u8D0F\u4E0D\u4E86\u7684{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You will not win.{\\r}\r\n\
+        Dialogue: 0,1:37:36.98,1:37:38.52,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4F60\u6BCF\u6551\u4E00\u500B\u4EBA{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}For every human you save...{\\r}\r\nDialogue:\
+        \ 0,1:37:38.75,1:37:41.42,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u5011\u6703\u591A\u6BBA\u4E00\u767E\u842C{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...we will kill a million more. Unh!{\\\
+        r}\r\nDialogue: 0,1:38:32.74,1:38:35.91,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u9084\u6709\u6575\u4EBA\u55CE\uFF1F\u9084\u6709\u6575\
+        \u4EBA\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Do\
+        \ we have an all clear? Do we have an all clear?{\\r}\r\nDialogue: 0,1:38:36.14,1:38:38.42,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}A\u5C0F\u968A{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Alpha team, sit-rep. Alpha team.{\\r}\r\nDialogue:\
+        \ 0,1:38:38.64,1:38:40.25,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6536\u5230\u8ACB\u56DE\u7B54{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Do you copy? Alpha team.{\\r}\r\nDialogue: 0,1:39:29.76,1:39:31.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9019\u500B\u4EBA\u4E0D\u662F\u6211\u5011\
+        \u7684\u6575\u4EBA{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}This\
+        \ man is not our enemy.{\\r}\r\nDialogue: 0,1:39:34.43,1:39:35.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8B1D\u8B1D\u4F60 \u4E0A\u6821{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Thank you, colonel.{\\r}\r\n\
+        Dialogue: 0,1:39:53.82,1:39:54.66,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u5ABD\u5ABD{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Mom?{\\r}\r\nDialogue: 0,1:39:55.95,1:39:57.63,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u6C92\u4E8B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm all right.{\\r}\r\nDialogue: 0,1:40:09.67,1:40:11.65,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8863\u670D\u5F88\u6F02\u4EAE \u5152\u5B50\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Nice suit, son.{\\\
+        r}\r\nDialogue: 0,1:40:12.70,1:40:14.01,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5C0D\u4E0D\u8D77{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}I'm so sorry.{\\r}\r\nDialogue: 0,1:40:15.04,1:40:17.35,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9019\u4E9B\u53EA\u662F\u8EAB\u5916\u4E4B\
+        \u7269 \u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}It's only stuff, Clark.{\\r}\r\nDialogue: 0,1:40:18.51,1:40:20.92,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7E3D\u662F\u6703\u88AB\u53D6\u4EE3\u7684\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It can always be\
+        \ replaced.{\\r}\r\nDialogue: 0,1:40:23.38,1:40:24.65,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u4F60\u4E0D\u80FD\u88AB\u53D6\u4EE3\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}But you can't be.{\\\
+        r}\r\nDialogue: 0,1:40:25.98,1:40:28.39,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5ABD\u5ABD \u4F50\u5FB7\u8AAA\u4ED6\u8981\u627E\u7684\
+        \u5BC6\u5178{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Mom,\
+        \ Zod said this Codex...{\\r}\r\nDialogue: 0,1:40:28.65,1:40:30.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53EF\u4EE5\u8B93\u6211\u7684\u7A2E\u65CF\
+        \u91CD\u751F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...he's\
+        \ looking for can bring my people back.{\\r}\r\nDialogue: 0,1:40:31.25,1:40:32.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9019\u4E0D\u662F\u5F88\u597D\u55CE\uFF1F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Isn't that a good\
+        \ thing?{\\r}\r\nDialogue: 0,1:40:37.16,1:40:39.66,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E0D\u8A8D\u70BA\u4ED6\u5011\u60F3\
+        \u8981\u5206\u4EAB\u9019\u500B\u4E16\u754C{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}I don't think they're interested in sharing this\
+        \ world.{\\r}\r\nDialogue: 0,1:40:40.26,1:40:41.50,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark.{\\r}\r\nDialogue: 0,1:40:42.23,1:40:43.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark.{\\r}\r\nDialogue: 0,1:40:45.00,1:40:46.88,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u77E5\u9053\u600E\u9EBC\u963B\u6B62\
+        \u4ED6\u5011{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I know\
+        \ how to stop them.{\\r}\r\nDialogue: 0,1:40:48.94,1:40:50.38,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u767C\u751F\u4E86\u4EC0\u9EBC\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What happened down\
+        \ there?{\\r}\r\nDialogue: 0,1:40:50.61,1:40:53.45,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u767C\u73FE\u4E86\u6211\u5011\u4E00\
+        \u500B\u66AB\u6642\u7684\u5F31\u9EDE{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}He exposed a temporary weakness.{\\r}\r\nDialogue: 0,1:40:54.34,1:40:56.19,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9019\u5DF2\u7D93\u4E0D\u91CD\u8981\u4E86\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It is of little\
+        \ consequence...{\\r}\r\nDialogue: 0,1:40:57.55,1:41:00.46,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u56E0\u70BA\u6211\u77E5\u9053\u5BC6\u5178\
+        \u5728\u54EA\u5152\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...because I have located the Codex.{\\r}\r\nDialogue: 0,1:41:01.25,1:41:03.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6839\u672C\u5C31\u4E0D\u5728\u592A\u7A7A\
+        \u8259\u88CF{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It was\
+        \ never in the capsule.{\\r}\r\nDialogue: 0,1:41:04.12,1:41:05.79,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u55AC\u2022\u827E\u723E\u62FF\u8D70\u4E86\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Jor-el took the\
+        \ Codex...{\\r}\r\nDialogue: 0,1:41:06.06,1:41:08.54,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8A18\u9304\u8457\u6578\u5341\u5104\u4EBA\
+        \u57FA\u56E0\u7684\u5BC6\u5178{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...the DNA of a billion people, then he bonded it...{\\r}\r\nDialogue:\
+        \ 0,1:41:08.76,1:41:11.90,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u628A\u5B83\u85CF\u5728\u4ED6\u5152\u5B50\u7684\u6BCF\u4E00\u500B\
+        \u7D30\u80DE\u7576\u4E2D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...within his son's individual cells.{\\r}\r\nDialogue: 0,1:41:11.96,1:41:13.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6240\u6709\u6C2A\u661F\u4EBA\u7684\u5F8C\
+        \u4EE3{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}All of Krypton's\
+        \ heirs...{\\r}\r\nDialogue: 0,1:41:13.80,1:41:17.24,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C31\u85CF\u5728\u4E00\u500B\u5916\u661F\
+        \u96E3\u6C11\u7684\u8EAB\u9AD4\u88CF{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}...living hidden in one refugee's body.{\\r}\r\nDialogue:\
+        \ 0,1:41:21.30,1:41:23.28,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u8981\u5F9E\u5361\u723E\u2022\u827E\u723E\u7684\u7D30\u80DE\u88CF\
+        \u62FF\u5230\u5BC6\u5178{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Does Kal-El need to be alive...{\\r}\r\nDialogue: 0,1:41:23.54,1:41:26.71,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9700\u8981\u4ED6\u6D3B\u8457\u55CE\uFF1F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...for us to extract\
+        \ the Codex from his cells?{\\r}\r\nDialogue: 0,1:41:28.08,1:41:29.25,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u7528{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}No.{\\r}\r\nDialogue: 0,1:41:35.15,1:41:37.43,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u555F\u52D5\u4E16\u754C\u5F15\u64CE{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Release the world engine.{\\\
+        r}\r\nDialogue: 0,1:42:09.65,1:42:10.60,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u767C\u751F\u4E86\u4EC0\u9EBC\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What just happened?{\\r}\r\nDialogue:\
+        \ 0,1:42:10.75,1:42:11.93,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u90A3\u8258\u8239\u4E00\u5206\u70BA\u4E8C{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}The ship just split in two.{\\r}\r\nDialogue:\
+        \ 0,1:42:12.15,1:42:15.26,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4E00\u8258\u5F80\u6771\u98DB\u53BB\u4E86 \u53E6\u4E00\u8258\u5411\
+        \u5357\u534A\u7403\u53BB\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Track one is heading east, track two to the southern hemisphere.{\\\
+        r}\r\nDialogue: 0,1:42:15.49,1:42:18.16,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u901F\u5EA6\u6709\u591A\u5FEB\uFF1F - \u63A5\u8FD1\
+        ...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- How fast is\
+        \ that bogey moving?       - Approaching...{\\r}\r\nDialogue: 0,1:42:18.16,1:42:19.61,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}24\u99AC\u8D6B \u4E26\u4E14\u9084\u5728\u52A0\
+        \u901F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...Mach 24\
+        \ and accelerating.{\\r}\r\nDialogue: 0,1:42:19.83,1:42:22.90,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u770B\u8D77\u4F86\u50CF\u662F\u8981\u964D\
+        \u843D\u5728\u5357\u5370\u5EA6\u6D0B\u7684\u67D0\u500B\u5730\u65B9{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's gonna impact somewhere\
+        \ in the Indian Ocean.{\\r}\r\nDialogue: 0,1:42:41.22,1:42:42.86,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53E6\u4E00\u8258\u8239\u4E5F\u5728\u964D\
+        \u843D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The rest of\
+        \ the ship is descending.{\\r}\r\nDialogue: 0,1:42:43.85,1:42:45.22,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u87A2\u5E55\u986F\u793A{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Put it on the board now.{\\r}\r\n\
+        Dialogue: 0,1:42:45.22,1:42:46.29,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u9075\u547D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Yes, sir.{\\r}\r\nDialogue: 0,1:42:47.32,1:42:48.50,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5929\u554A{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Oh, my God.{\\r}\r\nDialogue: 0,1:43:29.00,1:43:31.77,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8B93\u5E7D\u9748\u5F15\u64CE\u5F85\u547D\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Bring the phantom\
+        \ drive online.{\\r}\r\nDialogue: 0,1:43:53.39,1:43:55.83,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5DF2\u7D93\u8207\u4E16\u754C\u5F15\u64CE\
+        \u5EFA\u7ACB\u9023\u63A5{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}We are now slave to the world engine.{\\r}\r\nDialogue: 0,1:43:56.96,1:43:58.37,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u555F\u52D5{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Initiate.{\\r}\r\nDialogue: 0,1:44:31.63,1:44:33.67,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u5011\u767C\u5C04\u904E\u4F86\u7684\
+        \u662F\u4EC0\u9EBC\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}What have they hit us with?{\\r}\r\nDialogue: 0,1:44:33.67,1:44:35.84,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3} \u770B\u4E0A\u53BB\u50CF\u662F\u67D0\u7A2E\
+        \u91CD\u529B\u6B66\u5668{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Looks like some kind of gravity...{\\r}\r\nDialogue: 0,1:44:36.10,1:44:39.34,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u548C\u4ED6\u5011\u7684\u98DB\u8239\u540C\
+        \u6B65\u5DE5\u4F5C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...weapon.\
+        \ It's working in tandem with their ship.{\\r}\r\nDialogue: 0,1:44:40.07,1:44:43.14,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E00\u7A2E\u53EF\u4EE5\u589E\u52A0\u5730\
+        \u7403\u8CEA\u91CF\u7684\u6771\u897F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Somehow they're increasing the Earth's mass...{\\r}\r\n\
+        Dialogue: 0,1:44:43.41,1:44:45.51,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u5229\u7528\u5FAE\u5875\u6C61\u6FC1\u5927\u6C23{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...clouding the atmosphere\
+        \ with particulates.{\\r}\r\nDialogue: 0,1:44:47.24,1:44:48.85,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5929\u54EA{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Oh, my God.{\\r}\r\nDialogue: 0,1:44:50.18,1:44:51.88,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u5011\u5728\u9032\u884C\u74B0\u5883\
+        \u6539\u9020{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}They're\
+        \ terraforming.{\\r}\r\nDialogue: 0,1:44:51.95,1:44:52.76,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u662F\u4EC0\u9EBC\uFF1F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What's that?{\\r}\r\nDialogue:\
+        \ 0,1:44:53.58,1:44:54.69,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u884C\u661F\u5DE5\u7A0B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Planetary engineering...{\\r}\r\nDialogue: 0,1:44:54.95,1:44:58.16,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4FEE\u6539\u5730\u7403\u4E0A\u7684\u5927\
+        \u6C23\u548C\u5730\u5F62{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...modifying the Earth's atmosphere and topography.{\\r}\r\nDialogue:\
+        \ 0,1:44:58.42,1:44:59.66,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4ED6\u5011\u8981\u628A\u5730\u7403\u8F49\u5316\u6210\u6C2A\u661F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Turning Earth into\
+        \ Krypton.{\\r}\r\nDialogue: 0,1:45:00.36,1:45:03.50,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4F46\u662F\u6211\u5011\u6703\u600E\u9EBC\
+        \u6A23\uFF1F - \u7406\u8AD6\u4E0A\u8AAA...{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}- But what happens to us?       - Based on these\
+        \ readings...{\\r}\r\nDialogue: 0,1:45:03.76,1:45:06.76,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4E0D\u518D\u6709\"\u6211\u5011\"\u4E86\
+        \    - \u65AF\u65FA\u5A01\u514B\u5C07\u8ECD{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}- ...there won't be an \"us.\"       - General Swanwick,\
+        \ sir.{\\r}\r\nDialogue: 0,1:45:07.16,1:45:08.54,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u63A7\u5236\u5854\u4F86\u96FB{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm on with the control tower.{\\\
+        r}\r\nDialogue: 0,1:45:08.80,1:45:11.64,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u54C8\u8FEA\u4E0A\u6821\u6B63\u5728\u8DEF\u4E0A \u548C\
+        \u4ED6\u5728\u4E00\u8D77\u7684\u9084\u6709\u8D85\u4EBA{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Colonel Hardy's on his way and he's\
+        \ got Superman in tow.{\\r}\r\nDialogue: 0,1:45:11.77,1:45:12.84,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8D85\u4EBA\uFF1F{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Superman?{\\r}\r\nDialogue: 0,1:45:13.37,1:45:14.54,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u500B\u5916\u661F\u4EBA \u5148\u751F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The alien, sir.{\\\
+        r}\r\nDialogue: 0,1:45:14.80,1:45:17.18,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4ED6\u5011\u53EB\u4ED6\u8D85\u4EBA{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}That's what they're calling him. Superman.{\\\
+        r}\r\nDialogue: 0,1:45:22.68,1:45:23.88,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u5011\u6709\u500B\u8A08\u5283 \u5C07\u8ECD{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We have a plan, general.{\\\
+        r}\r\nDialogue: 0,1:45:24.15,1:45:26.23,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u548C\u6211\u60F3\u7684\u4E00\u6A23\u55CE\uFF1F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Is that what I think it\
+        \ is?{\\r}\r\nDialogue: 0,1:45:26.78,1:45:28.56,chs,,0000,0000,0000,,{\\fn\u534E\
+        \u6587\u6977\u4F53\\blur3}\u9019\u662F\u4ED6\u5750\u7684\u98DB\u8239{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's the ship he arrived\
+        \ in.{\\r}\r\nDialogue: 0,1:45:30.22,1:45:32.86,chs,,0000,0000,0000,,{\\fn\u534E\
+        \u6587\u6977\u4F53\\blur3}\u9019\u8258\u98DB\u8239\u7531\u67D0\u7A2E\u53EB\
+        \u5E7D\u9748\u5F15\u64CE\u7684\u7269\u8CEA\u9A45\u52D5{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}This ship is powered by something\
+        \ called a phantom drive.{\\r}\r\nDialogue: 0,1:45:33.12,1:45:34.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5B83\u80FD\u5920\u626D\u66F2\u6642\u7A7A\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It bends space.{\\\
+        r}\r\nDialogue: 0,1:45:34.82,1:45:38.80,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F50\u5FB7\u7684\u98DB\u8239\u904B\u7528\u4E86\u540C\
+        \u6A23\u7684\u539F\u7406 \u5982\u679C\u6211\u5011\u80FD\u8B93\u5169\u8005\u5C0D\
+        \u649E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Zod's ship\
+        \ uses the same technology, and if we can make the two drives collide...{\\\
+        r}\r\nDialogue: 0,1:45:39.03,1:45:40.87,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5C31\u80FD\u5275\u9020\u51FA\u4E00\u500B\u5947\u7570\
+        \u9EDE{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}A singularity\
+        \ can be created.{\\r}\r\nDialogue: 0,1:45:41.13,1:45:42.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u5C31\u50CF\u9ED1\u6D1E   - \u5C0D{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Like a black hole.\
+        \       - Yes.{\\r}\r\nDialogue: 0,1:45:42.70,1:45:44.20,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6240\u4EE5\u5982\u679C\u6211\u5011\u6253\
+        \u958B\u901A\u9053{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}So\
+        \ if we open up this doorway...{\\r}\r\nDialogue: 0,1:45:44.47,1:45:46.07,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7406\u8AD6\u4E0A\u4F86\u8AAA\u4ED6\u5011\
+        \u5C31\u61C9\u8A72\u88AB\u5438\u9032\u53BB{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...they should be pulled back in.{\\r}\r\nDialogue:\
+        \ 0,1:45:46.34,1:45:48.84,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6240\u4EE5\u4F60\u60F3\u6211\u5011\u7528\u90A3\u500B\u70B8\u6389\
+        \u4ED6\u5011{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}So you\
+        \ want us to bomb them with that?{\\r}\r\nDialogue: 0,1:45:49.07,1:45:51.05,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C07\u8ECD \u5982\u679C\u592A\u7A7A\u8239\
+        \u9054\u5230{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}General,\
+        \ that craft maxes out...{\\r}\r\nDialogue: 0,1:45:51.31,1:45:54.69,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}17000\u78C5 \u53EF\u4EE5\u5F9EC-17\u6295\
+        \u64F2\u4E0B\u4F86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...17,000\
+        \ pounds, we can drop it from a C-17.{\\r}\r\nDialogue: 0,1:45:54.91,1:45:56.05,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9019\u662F\u53EF\u884C\u7684{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's a viable plan.{\\r}\r\n\
+        Dialogue: 0,1:45:56.31,1:45:58.42,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u5982\u679C\u6211\u4E0D\u963B\u6B62\u5370\u5EA6\u6D0B\u4E0A\
+        \u7684\u6A5F\u5668{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}If\
+        \ I don't stop that machine over the Indian Ocean...{\\r}\r\nDialogue: 0,1:45:58.68,1:46:02.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u91CD\u529B\u5834\u9084\u6703\u7E7C\u7E8C\
+        \u64F4\u5927{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...the\
+        \ gravity field will continue to expand.{\\r}\r\nDialogue: 0,1:46:07.76,1:46:10.53,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5982\u679C\u90A3\u500B\u6771\u897F\u662F\
+        \u4F7F\u5730\u7403\u6C2A\u661F\u5316{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}If that thing is making Earth more like Krypton...{\\r}\r\
+        \nDialogue: 0,1:46:10.89,1:46:12.93,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u5728\u5B83\u9644\u8FD1\u4E0D\u6703\u66F4\u8106\
+        \u5F31\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...won't\
+        \ you be weaker around it?{\\r}\r\nDialogue: 0,1:46:14.23,1:46:15.54,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6709\u53EF\u80FD{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Maybe.{\\r}\r\nDialogue: 0,1:46:16.40,1:46:18.88,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u6211\u4E0D\u6703\u8B93\u5B83\u963B\
+        \u6B62\u6211\u8A66\u4E00\u8A66{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I'm not about to let that stop me from trying.{\\r}\r\nDialogue: 0,1:46:19.84,1:46:22.04,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u53EF\u80FD\u60F3\u5F8C\u9000\u4E00\
+        \u9EDE{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You might\
+        \ want to step back a little bit.{\\r}\r\nDialogue: 0,1:46:24.11,1:46:25.94,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53EF\u80FD\u8981\u518D\u9000\u4E00\u9EDE\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Maybe a little bit\
+        \ more.{\\r}\r\nDialogue: 0,1:46:57.71,1:46:58.31,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8299\u62C9{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Faora.{\\r}\r\nDialogue: 0,1:46:59.31,1:47:00.41,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4F86\u6307\u63EE{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Take command.{\\r}\r\nDialogue: 0,1:47:00.64,1:47:03.78,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u9075\u547D   - \u6211\u8981\u4FDD\u8B49\
+        \u59CB\u6E90\u5BA4\u7684\u5B89\u5168{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}- Yes, sir.       - I need to secure the genesis chamber...{\\\
+        r}\r\nDialogue: 0,1:47:04.21,1:47:06.96,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u9084\u8981\u5411\u4E00\u500B\u8001\u670B\u53CB\u81F4\
+        \u610F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...and pay\
+        \ my respects to an old friend.{\\r}\r\nDialogue: 0,1:47:14.72,1:47:16.83,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5B88\u8B77\u8005\u524D\u5F80\u5927\u90FD\
+        \u6703{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Guardian en\
+        \ route to Metropolis...{\\r}\r\nDialogue: 0,1:47:17.63,1:47:18.83,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u651C\u5E36\u5305\u88F9{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...package in tow.{\\r}\r\nDialogue:\
+        \ 0,1:47:24.10,1:47:27.01,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u88AB\u544A\u77E5\u4E86F-35\u6230\u6A5F\u5165\u5883\u7684\u6703\u5408\
+        \u9EDE{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Be advised,\
+        \ F-35s inbound to rendezvous point.{\\r}\r\nDialogue: 0,1:47:27.27,1:47:29.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u73FE\u5728\u61C9\u8A72\u5728\u8996\
+        \u89BA\u63A5\u89F8{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You\
+        \ should have visual contact now.{\\r}\r\nDialogue: 0,1:48:14.45,1:48:18.13,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E3B\u63A7\u9470\u5319\u8B58\u5225\u6B63\
+        \u78BA \u59CB\u6E90\u5BA4\u5F85\u547D \u5148\u751F{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Command key accepted. Genesis chamber\
+        \ coming online, sir.{\\r}\r\nDialogue: 0,1:48:18.52,1:48:19.52,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F4F\u624B \u4F50\u5FB7{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Stop this, Zod...{\\r}\r\nDialogue:\
+        \ 0,1:48:19.69,1:48:21.83,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u8D81\u9084\u6709\u6642\u9593{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}...while there's still time.{\\r}\r\nDialogue: 0,1:48:23.06,1:48:26.37,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9084\u6C92\u653E\u68C4\u5C0D\u6211\u8AAA\
+        \u6559\u5462 \u662F\u5427 \u54EA\u6015\u662F\u6B7B\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Haven't given up lecturing me, have\
+        \ you, even in death?{\\r}\r\nDialogue: 0,1:48:26.73,1:48:28.73,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E0D\u6703\u8B93\u4F60\u7528\u5BC6\
+        \u5178\u505A\u9019\u4E9B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I will not let you use the Codex like this.{\\r}\r\nDialogue: 0,1:48:29.00,1:48:30.71,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6C92\u6B0A\u529B\u963B\u6B62\u6211\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You don't have the\
+        \ power to stop me.{\\r}\r\nDialogue: 0,1:48:30.97,1:48:34.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u63D2\u5165\u7684\u4E3B\u63A7\u9470\
+        \u5319\u5DF2\u7D93\u5EE2\u9664\u4E86\u4F60\u7684\u6B0A\u9650{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The command key I have entered is\
+        \ revoking your authority.{\\r}\r\nDialogue: 0,1:48:34.24,1:48:37.15,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u98DB\u8239\u5728\u6211\u638C\u63A7\u4E4B\
+        \u4E0B\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}This\
+        \ ship is now under my control.{\\r}\r\nDialogue: 0,1:49:08.67,1:49:10.35,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5317\u65B9\u53F8\u4EE4\u90E8 \u9019\u88CF\
+        \u662F\u9583\u96FB1\u865F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Northcom, Lightning 1, request...{\\r}\r\nDialogue: 0,1:49:10.51,1:49:12.03,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8ACB\u6C42\u91CB\u653E\u5C0E\u5F48{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...permission to unleash\
+        \ the hounds.{\\r}\r\nDialogue: 0,1:49:12.03,1:49:16.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5468\u570D\u5B89\u5168 \u53EF\u4EE5\u8972\
+        \u64CA \u53EF\u80FD\u7684\u8A71\u767C\u751F\u4F5C\u6230\u640D\u58DE\u8A55\u4F30\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Lightning 1, you\
+        \ are clear to engage. Send battle damage assessment when able. Out.{\\r}\r\
+        \nDialogue: 0,1:49:30.19,1:49:32.57,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u96FB\u5B50\u8A2D\u5099\u9677\u5165\u6DF7\u4E82{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Avionics are going haywire.\
+        \ The gravity field...{\\r}\r\nDialogue: 0,1:49:32.80,1:49:35.14,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u91CD\u529B\u5834\u727D\u5F15\u6211\u5011\
+        \u7684\u5C0E\u5F48\u4E0B\u589C \u6211\u5011\u9700\u8981\u66F4\u52A0\u63A5\u8FD1\
+        \u76EE\u6A19{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...is\
+        \ pulling our missiles down. We gotta get closer.{\\r}\r\nDialogue: 0,1:49:40.24,1:49:41.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u597D\u4E86\u5404\u4F4D{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}All right, everybody...{\\r}\r\nDialogue:\
+        \ 0,1:49:41.54,1:49:44.42,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u5011\u96E2\u958B\u4E86 \u73FE\u5728\u5C31\u96E2\u958B\u5927\
+        \u6A13{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...we're leaving.\
+        \ We're leaving the building now.{\\r}\r\nDialogue: 0,1:50:07.56,1:50:09.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5931\u53BB\u4E86\u6211\u7684\u50DA\
+        \u6A5F\u99D5\u99DB\u54E1{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I just lost my wingman.{\\r}\r\nDialogue: 0,1:50:11.80,1:50:12.94,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u98DB\u6A5F\u5931\u63A7 \u98DB\u6A5F\u5931\
+        \u63A7 \u98DB\u6A5F\u5931\u63A7{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Mayday! Mayday! Mayday!{\\r}\r\nDialogue: 0,1:50:24.51,1:50:26.49,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5404\u4F4D \u9019\u908A{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Everybody, this way! Come on!{\\r}\r\
+        \nDialogue: 0,1:50:26.75,1:50:29.82,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5404\u4F4D \u5FEB\u9EDE \u5FEB \u5FEB{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Everybody, come on! Keep moving, keep\
+        \ moving.{\\r}\r\nDialogue: 0,1:50:36.66,1:50:37.69,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8A79\u59AE{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Jenny!{\\r}\r\nDialogue: 0,1:50:41.66,1:50:42.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5929\u54EA{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Oh, my God.{\\r}\r\nDialogue: 0,1:50:42.76,1:50:43.77,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u746A\u9E97{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Perry!{\\r}\r\nDialogue: 0,1:50:48.20,1:50:50.15,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8D70\u9019\u908A \u5FEB{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Go! There! Go!{\\r}\r\nDialogue: 0,1:50:56.01,1:50:57.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u53EF\u4EE5\u5171\u5B58{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Our people can co-exist.{\\\
+        r}\r\nDialogue: 0,1:50:58.15,1:51:00.12,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u9019\u6A23\u6211\u5011\u5C31\u50CF\u4F60\u5152\u5B50\
+        \u90A3\u6A23{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}So we\
+        \ can suffer through years of pain{\\r}\r\nDialogue: 0,1:51:00.12,1:51:02.65,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6490\u904E\u6578\u5E74\u7684\u50B7\u75DB\
+        \u4F86\u9069\u61C9\u74B0\u5883\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}trying to adapt like your son has?{\\r}\r\nDialogue: 0,1:51:02.99,1:51:04.66,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4F60\u8AAA\u7684\u662F\u7A2E\u65CF\u5C60\
+        \u6BBA   - \u662F\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}- You're talking about genocide.       - Yes.{\\r}\r\nDialogue: 0,1:51:04.89,1:51:07.99,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u800C\u4E14\u6211\u6B63\u548C\u4E00\u500B\
+        \u9B3C\u9B42\u722D\u8AD6\u5176\u529F\u904E{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}And I'm arguing its merits with a ghost.{\\r}\r\n\
+        Dialogue: 0,1:51:08.86,1:51:10.67,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6211\u5011\u90FD\u662F\u9B3C\u9B42 \u4F50\u5FB7{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We're both ghosts, Zod.{\\\
+        r}\r\nDialogue: 0,1:51:10.89,1:51:14.40,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u4E0D\u660E\u767D\u55CE\uFF1F\u4F60\u4E0D\u9858\
+        \u653E\u68C4\u7684\u6C2A\u661F\u5DF2\u7D93\u6C92\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Can't you see that? The Krypton you're\
+        \ clinging onto is gone.{\\r}\r\nDialogue: 0,1:51:14.66,1:51:17.23,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6AA2\u67E5\u597D\u5165\u4FB5\u7684\
+        \u60C5\u5831\u4E86\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Ship, have you managed to quarantine this invasive intelligence?{\\\
+        r}\r\nDialogue: 0,1:51:17.50,1:51:18.42,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u5931\u6557\u4E86   - \u597D\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- You'll fail.        - I have.{\\\
+        r}\r\nDialogue: 0,1:51:18.63,1:51:20.05,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6E96\u5099\u597D\u7D42\u7D50\u9019\u4E00\u5207{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Then prepare to terminate\
+        \ it.{\\r}\r\nDialogue: 0,1:51:20.30,1:51:22.08,chs,,0000,0000,0000,,{\\fn\u534E\
+        \u6587\u6977\u4F53\\blur3}\u6211\u4E0D\u60F3\u722D\u5435\u4E86 \u8B93\u6211\
+        \u9589\u5634{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm\
+        \ tired of this debate. Silencing me...{\\r}\r\nDialogue: 0,1:51:22.34,1:51:23.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6539\u8B8A\u4E0D\u4E86\u4EFB\u4F55\u4E8B\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...won't change\
+        \ anything.{\\r}\r\nDialogue: 0,1:51:26.01,1:51:27.32,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5152\u5B50...{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}My son...{\\r}\r\nDialogue: 0,1:51:28.14,1:51:29.49,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6BD4\u4F60\u5F37\u5169\u500D{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...is twice the man you were.{\\\
+        r}\r\nDialogue: 0,1:51:32.48,1:51:34.15,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4ED6\u6703\u7D50\u675F\u6211\u5011\u767C\u8D77\u7684\
+        \u7A2E\u7A2E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And\
+        \ he will finish what we started.{\\r}\r\nDialogue: 0,1:51:35.08,1:51:36.32,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4FDD\u8B49{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}I can promise you that.{\\r}\r\nDialogue:\
+        \ 0,1:51:41.52,1:51:42.90,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u544A\u8A34\u6211{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Tell me...{\\r}\r\nDialogue: 0,1:51:43.16,1:51:46.73,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6709\u55AC\u2022\u827E\u723E\u7684\
+        \u8A18\u61B6\u548C\u826F\u77E5{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...you have Jor-El's memories, his conscience.{\\r}\r\nDialogue: 0,1:51:47.43,1:51:50.20,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53EF\u4F60\u7D93\u6B77\u904E\u4ED6\u7684\
+        \u75DB\u82E6\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Can you experience his pain?{\\r}\r\nDialogue: 0,1:51:51.87,1:51:55.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u6703\u5F9E\u4F60\u5152\u5B50\u7684\
+        \u5C4D\u9AD4\u88CF\u63D0\u53D6\u5BC6\u5178{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}I will harvest the Codex from your son's corpse...{\\\
+        r}\r\nDialogue: 0,1:51:55.90,1:52:01.21,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5728\u4ED6\u7684\u5C4D\u9AA8\u4E4B\u4E0A\u91CD\u5EFA\
+        \u6C2A\u661F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...and\
+        \ I will rebuild Krypton atop his bones.{\\r}\r\nDialogue: 0,1:52:58.63,1:52:59.34,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8A79\u59AE{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Jenny.{\\r}\r\nDialogue: 0,1:52:59.60,1:53:02.34,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u8A79\u59AE \u8A79\u59AE \u4F60\u5728\
+        \u54EA\uFF1F - \u6211\u5728\u9019\u88CF{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}- Jenny. Jenny, where are you?       - I'm here!{\\r}\r\
+        \nDialogue: 0,1:53:02.60,1:53:03.90,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u9019\u88CF \u9019\u88CF   - \u8A79\u59AE{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- I'm here. Here.       - Jenny.{\\\
+        r}\r\nDialogue: 0,1:53:03.91,1:53:05.41,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6490\u4F4F \u6490\u4F4F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Hold on, hold on.{\\r}\r\nDialogue: 0,1:53:05.64,1:53:06.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5361\u4F4F\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm stuck.{\\r}\r\nDialogue: 0,1:53:06.84,1:53:08.52,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u6211\u52D5\u4E0D\u4E86 \u5361\u4F4F\u4E86\
+        \   - \u597D\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}-\
+        \ I can't get free. I'm stuck.       - Okay.{\\r}\r\nDialogue: 0,1:53:08.78,1:53:11.31,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u6703\u628A\u4F60\u6551\u51FA\
+        \u53BB \u4F60\u5225\u52D5{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}We'll get you out of there, all right? Just sit tight.{\\r}\r\nDialogue:\
+        \ 0,1:53:11.58,1:53:12.15,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4E0D\u4E0D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}No,\
+        \ no, no!{\\r}\r\nDialogue: 0,1:53:12.41,1:53:14.22,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u5225\u96E2\u958B\u6211   - \u6211\u4E0D\
+        \u6703\u96E2\u958B\u4F60{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}- Don't leave me.       - We're not gonna leave you.{\\r}\r\nDialogue:\
+        \ 0,1:53:14.35,1:53:15.52,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}- \u597D   - \u502B\u5DF4\u7B2C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}- Okay.       - Lombard!{\\r}\r\nDialogue: 0,1:53:15.78,1:53:19.13,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4ED6\u5ABD\u7684\u5FEB\u904E\u4F86\u5E6B\
+        \u5FD9   - \u8A72\u6B7B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}- Get your ass over here and help me.       - Damn it.{\\r}\r\nDialogue:\
+        \ 0,1:53:21.12,1:53:23.10,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}- \u7528\u9019\u500B\u64AC   - \u7D66\u4F60{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}- We just gotta move this.       - Here.{\\\
+        r}\r\nDialogue: 0,1:53:23.33,1:53:25.36,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u7528\u529B\u8A66\u8A66\u770B \u597D\u4E86\u55CE\uFF1F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Slide that in. You\
+        \ push, I'll pull, okay?{\\r}\r\nDialogue: 0,1:53:25.63,1:53:26.66,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F86\u5427{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Go.{\\r}\r\nDialogue: 0,1:53:30.87,1:53:32.17,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u7528\u529B   - \u5929\u554A{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Push!       - Oh, my God.{\\\
+        r}\r\nDialogue: 0,1:53:32.43,1:53:34.27,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u8D8A\u4F86\u8D8A\u8FD1\u4E86 \u7528\u529B{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's getting closer! Come on,\
+        \ push!{\\r}\r\nDialogue: 0,1:53:36.10,1:53:38.31,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5317\u65B9\u53F8\u4EE4\u90E8 \u9019\u88CF\
+        \u662F\u5B88\u8B77\u8005 \u53EF\u4EE5\u6295\u64F2\u55CE\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Northcom, this is Guardian. Are we\
+        \ cleared?{\\r}\r\nDialogue: 0,1:53:38.84,1:53:39.84,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u884C \u5B88\u8B77\u8005{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Negative, Guardian.{\\r}\r\n\
+        Dialogue: 0,1:54:04.57,1:54:07.01,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u5FEB \u7528\u529B\u554A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Come on! Push!{\\r}\r\nDialogue: 0,1:54:59.02,1:55:00.36,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u505A\u5230\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He did it.{\\r}\r\nDialogue: 0,1:55:02.56,1:55:03.80,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5317\u65B9\u53F8\u4EE4\u90E8 \u9019\u88CF\
+        \u662F\u5B88\u8B77\u8005{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Northcom, this is Guardian.{\\r}\r\nDialogue: 0,1:55:04.06,1:55:06.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u6B63\u7D93\u904E\u8ABF\u6574\
+        \u7DDA \u4E00\u5207\u826F\u597D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}We're passing through phase line red. Good to go.{\\r}\r\nDialogue:\
+        \ 0,1:55:06.56,1:55:07.73,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4E00\u8DEF\u5E73\u5B89 \u5B88\u8B77\u8005{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Godspeed, Guardian.{\\r}\r\nDialogue:\
+        \ 0,1:55:07.73,1:55:10.14,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6574\u7406\u5305\u88F9 \u6E96\u5099\u6295\u64F2{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Arm the package. You are cleared hot.{\\\
+        r}\r\nDialogue: 0,1:55:10.40,1:55:12.47,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6E96\u5099\u767C\u51FA\u6700\u5F8C\u4E00\u64CA{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We're lining up for the\
+        \ final run.{\\r}\r\nDialogue: 0,1:55:13.27,1:55:15.27,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u73FE\u5728\u770B\u4F60\u548C\u6F22\u5BC6\
+        \u723E\u9813\u7684\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}It's up to you and Hamilton now.{\\r}\r\nDialogue: 0,1:55:55.44,1:55:56.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u641E\u4EC0\u9EBC{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}You gotta be kidding me.{\\r}\r\nDialogue:\
+        \ 0,1:55:56.45,1:55:59.30,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u7406\u8CA8\u54E1 \u5305\u88F9\u662F\u5426\u6B66\u88DD\u5B8C\u7562\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Loadmaster,\
+        \ is the package ready to drop?{\\r}\r\nDialogue: 0,1:55:59.35,1:56:00.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u884C \u5B88\u8B77\u8005{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Negative, Guardian.{\\r}\r\n\
+        Dialogue: 0,1:56:00.85,1:56:02.42,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u51FA\u554F\u984C\u4E86 \u4E0D\u8A72\u9019\u6A23\u7684{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}There's something wrong.\
+        \ It's not supposed to do this.{\\r}\r\nDialogue: 0,1:56:02.65,1:56:04.43,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u61C9\u8A72\u600E\u6A23\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What's it supposed\
+        \ to do?{\\r}\r\nDialogue: 0,1:56:04.65,1:56:07.69,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u61C9\u8A72\u5B8C\u5168\u63D2\u9032\u53BB\
+        \   - \u6211\u770B\u770B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}- It's supposed to go in all the way.       - Let me take a look.{\\\
+        r}\r\nDialogue: 0,1:56:07.96,1:56:09.53,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u526F\u99D5\u99DB\u63A5\u7BA1\u98DB\u6A5F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Co-pilot's aircraft.{\\r}\r\
+        \nDialogue: 0,1:56:10.26,1:56:11.76,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u526F\u99D5\u99DB\u63A5\u7BA1\u98DB\u6A5F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Co-pilot's aircraft.{\\r}\r\
+        \nDialogue: 0,1:56:18.50,1:56:21.17,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u5011\u5DF2\u7D93\u6392\u5217\u597D\u6E96\u5099\
+        \u6295\u64F2\u4E86 \u9084\u5728\u7B49\u4EC0\u9EBC\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We are lined up for the drop. What's\
+        \ the hold up?{\\r}\r\nDialogue: 0,1:56:21.44,1:56:22.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u51FA\u73FE\u4E86\u9EDE\u554F\u984C{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We've had a setback.{\\\
+        r}\r\nDialogue: 0,1:56:38.19,1:56:39.69,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u7784\u6E96\u98DB\u6A5F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Target that aircraft.{\\r}\r\nDialogue: 0,1:56:43.56,1:56:45.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9396\u5B9A\u76EE\u6A19{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Target locked.{\\r}\r\nDialogue: 0,1:56:54.80,1:56:55.68,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u8981{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Stop!{\\r}\r\nDialogue: 0,1:56:55.90,1:56:58.01,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5982\u679C\u4F60\u6BC0\u4E86\u9019\u8258\
+        \u98DB\u8239{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}If you\
+        \ destroy this ship...{\\r}\r\nDialogue: 0,1:56:58.24,1:57:00.91,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C31\u662F\u6BC0\u4E86\u6C2A\u661F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...you destroy Krypton!{\\\
+        r}\r\nDialogue: 0,1:57:03.71,1:57:05.89,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6C2A\u661F\u672C\u4F86\u9084\u6709\u6A5F\u6703\u7684\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Krypton had its\
+        \ chance.{\\r}\r\nDialogue: 0,1:57:59.87,1:58:01.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u84EE\u6069\u5C0F\u59D0 \u9019\u5152\u4E0D\
+        \u5B89\u5168{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Miss\
+        \ Lane! It's not safe for you...{\\r}\r\nDialogue: 0,1:58:01.97,1:58:02.88,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u96E2\u958B\u90A3\u5152{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...over there!{\\r}\r\nDialogue: 0,1:58:03.10,1:58:03.71,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u84EE\u6069\u5C0F\u59D0{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Miss Lane!{\\r}\r\nDialogue: 0,1:58:33.60,1:58:35.34,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u96E2\u958B \u5FEB{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Move now! Go!{\\r}\r\nDialogue: 0,1:58:56.19,1:58:57.19,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6B7B\u5F97\u5149\u69AE{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}A good death...{\\r}\r\nDialogue:\
+        \ 0,1:58:57.46,1:58:59.03,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5C31\u662F\u6B7B\u5F97\u5176\u6240{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...is its own reward.{\\r}\r\nDialogue: 0,2:00:01.49,2:00:02.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u5011\u8D70\u4E86\u55CE\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Are they gone?{\\r}\r\
+        \nDialogue: 0,2:00:04.09,2:00:05.50,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u60F3\u662F\u7684{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}I think so.{\\r}\r\nDialogue: 0,2:00:07.40,2:00:08.74,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u6551\u4E86\u6211\u5011{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He saved us.{\\r}\r\nDialogue:\
+        \ 0,2:00:34.22,2:00:37.43,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4ED6\u5011\u8AAA\u521D\u543B\u4E4B\u5F8C\u5C31\u6BCF\u6CC1\u6108\
+        \u4E0B\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You\
+        \ know, they say it's all downhill after the first kiss.{\\r}\r\nDialogue:\
+        \ 0,2:00:40.90,2:00:43.93,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u5F88\u78BA\u5B9A \u4ED6\u5011\u53EA\u7D71\u8A08\u4E86\u89AA\
+        \u543B\u4EBA\u985E\u7684\u6578\u64DA{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}I'm pretty sure that only counts when you're kissing a\
+        \ human.{\\r}\r\nDialogue: 0,2:01:13.29,2:01:14.77,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u770B\u9019\u500B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Look at this.{\\r}\r\nDialogue: 0,2:01:17.07,2:01:21.10,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5011\u672C\u53EF\u4EE5\u5728\u9019\
+        \u7247\u5EE2\u589F\u4E0A\u5EFA\u7ACB\u8D77\u4E00\u500B\u65B0\u7684\u6C2A\u661F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We could have built\
+        \ a new Krypton in this squalor.{\\r}\r\nDialogue: 0,2:01:21.24,2:01:24.34,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u662F\u5728\u6211\u5011\u548C\u4EBA\
+        \u985E\u4E4B\u9593 \u4F60\u9078\u64C7\u4E86\u5F8C\u8005{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}But you chose the humans over us.{\\\
+        r}\r\nDialogue: 0,2:01:25.77,2:01:27.31,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u7684\u5B58\u5728{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}I exist...{\\r}\r\nDialogue: 0,2:01:27.58,2:01:29.99,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u50C5\u662F\u70BA\u4E86\u5B88\u8B77\u6C2A\
+        \u661F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...only to\
+        \ protect Krypton.{\\r}\r\nDialogue: 0,2:01:31.75,2:01:35.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9019\u662F\u81EA\u6211\u51FA\u751F\u4EE5\
+        \u4F86\u7684\u552F\u4E00\u76EE\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}That is the sole purpose for which I was born.{\\r}\r\n\
+        Dialogue: 0,2:01:36.99,2:01:39.12,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6211\u6240\u505A\u7684\u4E00\u5207{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}And every action I take...{\\r}\r\nDialogue:\
+        \ 0,2:01:39.35,2:01:41.36,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u7121\u8AD6\u591A\u66B4\u529B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}...no matter how violent...{\\r}\r\nDialogue: 0,2:01:41.62,2:01:43.33,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u591A\u9EBC\u6B98\u5FCD{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...or how cruel...{\\r}\r\nDialogue:\
+        \ 0,2:01:44.53,2:01:49.11,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u7686\u662F\u70BA\u4E86\u6211\u7684\u4EBA\u6C11\u7684\u798F\u7949\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...is for the greater\
+        \ good of my people.{\\r}\r\nDialogue: 0,2:01:53.43,2:01:54.85,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u73FE\u5728{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}And now...{\\r}\r\nDialogue: 0,2:01:55.10,2:01:57.38,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u6C92\u6709\u4EBA\u6C11\u4E86{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...I have no people.{\\\
+        r}\r\nDialogue: 0,2:02:00.81,2:02:10.00,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u662F\u4F60\u596A\u8D70\u4E86\u6211\u7684\u9748\u9B42\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}My soul that is\
+        \ what you have taken from me.{\\r}\r\nDialogue: 0,2:02:16.79,2:02:19.29,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u8981\u8B93\u4ED6\u5011\u627F\u64D4\
+        \u75DB\u82E6{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm\
+        \ going to make them suffer, Kal.{\\r}\r\nDialogue: 0,2:02:19.53,2:02:22.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6551\u4E0B\u7684\u4EBA\u985E \u6211\
+        \u8981\u5F9E\u4F60\u624B\u88CF...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}These humans you've adopted, I will take them all from you...{\\r}\r\
+        \nDialogue: 0,2:02:23.20,2:02:26.18,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u4E00\u500B\u4E00\u500B\u596A\u8D70   - \u4F60\u9019\
+        \u500B\u602A\u7269 \u4F50\u5FB7{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}- ...one by one.       - You're a monster, Zod...{\\r}\r\nDialogue:\
+        \ 0,2:02:28.80,2:02:30.61,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u6703\u963B\u6B62\u4F60\u7684{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...and I'm gonna stop you.{\\r}\r\nDialogue: 0,2:04:11.61,2:04:14.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7D50\u675F\u9019\u4E00\u5207\u53EA\u6709\
+        \u4E00\u500B\u8FA6\u6CD5{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}There's only one way this ends, Kal.{\\r}\r\nDialogue: 0,2:04:14.14,2:04:15.99,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u662F\u4F60\u6B7B{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Either you die...{\\r}\r\nDialogue:\
+        \ 0,2:04:16.24,2:04:17.52,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5C31\u662F\u6211\u4EA1{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...or I do.{\\r}\r\nDialogue: 0,2:04:48.68,2:04:50.82,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u88AB\u7576\u505A\u4E00\u500B\u6230\
+        \u58EB\u8A13\u7DF4{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I\
+        \ was bred to be a warrior, Kal.{\\r}\r\nDialogue: 0,2:04:51.68,2:04:55.70,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u7D42\u751F\u90FD\u5728\u53D7\u8A13\
+        \u63A7\u5236\u611F\u5B98{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Trained my entire life to master my senses.{\\r}\r\nDialogue: 0,2:04:55.88,2:04:59.49,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5728\u54EA\u53D7\u8A13\u7684\uFF1F\
+        \u8FB2\u5834\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Where did you train? On a farm?{\\r}\r\nDialogue: 0,2:07:08.42,2:07:12.80,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5982\u679C\u4F60\u6DF1\u611B\u8457\u9019\
+        \u7FA4\u4EBA\u985E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}If\
+        \ you love these people so much...{\\r}\r\nDialogue: 0,2:07:13.19,2:07:15.46,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C31\u70BA\u4ED6\u5011\u8FFD\u60BC\u5427\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...you can mourn\
+        \ for them.{\\r}\r\nDialogue: 0,2:07:19.93,2:07:21.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u8981{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Don't do this!{\\r}\r\nDialogue: 0,2:07:24.20,2:07:25.01,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F4F\u624B{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Stop!{\\r}\r\nDialogue: 0,2:07:31.37,2:07:32.35,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Stop!{\\r}\r\nDialogue: 0,2:07:34.71,2:07:35.85,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u53EF\u80FD{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Never.{\\r}\r\nDialogue: 0,2:09:10.54,2:09:11.92,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4ED6\u5ABD\u662F\u8822\u86CB\u55CE\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Are you effing\
+        \ stupid?{\\r}\r\nDialogue: 0,2:09:12.14,2:09:14.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6709\u90A3\u9EBC\u591A\u7A7A\u4E2D\
+        \u5075\u5BDF\u6A5F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's\
+        \ one of your surveillance drones.{\\r}\r\nDialogue: 0,2:09:14.11,2:09:16.61,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9019\u73A9\u610F\u503C1200\u842C{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}That's a $12,000,000 piece\
+        \ of hardware.{\\r}\r\nDialogue: 0,2:09:16.78,2:09:17.81,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u66FE\u7D93\u503C{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}It was.{\\r}\r\nDialogue: 0,2:09:18.61,2:09:21.15,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u77E5\u9053\u4F60\u60F3\u8FFD\u8E64\
+        \u6211{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I know you're\
+        \ trying to find out where I hang my cape.{\\r}\r\nDialogue: 0,2:09:21.75,2:09:25.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4F46\u662F\u6C92\u9580   - \u90A3\u6211\
+        \u660E\u78BA\u554F\u4F60\u4E00\u500B\u554F\u984C{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}- You won't.       - Then I'll ask the obvious question:{\\\
+        r}\r\nDialogue: 0,2:09:25.22,2:09:28.82,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u5011\u600E\u9EBC\u77E5\u9053\u6709\u4E00\u5929\
+        \ \u4F60\u4E0D\u6703\u640D\u5BB3\u7F8E\u570B\u7684\u5229\u76CA\uFF1F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}How do we know you won't\
+        \ one day act against America's interests?{\\r}\r\nDialogue: 0,2:09:28.92,2:09:30.77,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5728\u582A\u85A9\u65AF\u9577\u5927\
+        \ \u5C07\u8ECD{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I\
+        \ grew up in Kansas, general.{\\r}\r\nDialogue: 0,2:09:31.23,2:09:33.40,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E5F\u7B97\u662F\u7F8E\u570B\u4EBA\
+        \u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm about\
+        \ as American as it gets.{\\r}\r\nDialogue: 0,2:09:33.66,2:09:34.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u770B{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Look...{\\r}\r\nDialogue: 0,2:09:34.80,2:09:36.27,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u9858\u610F\u5E6B\u5FD9{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...I'm here to help...{\\r}\r\
+        \nDialogue: 0,2:09:36.50,2:09:38.74,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F46\u5FC5\u9808\u662F\u6211\u5FC3\u7518\u60C5\u9858\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...but it has to\
+        \ be on my own terms.{\\r}\r\nDialogue: 0,2:09:38.97,2:09:40.81,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u53EF\u4EE5\u9019\u6A23\u8AAA\u670D\
+        \u83EF\u76DB\u9813{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You\
+        \ have to convince Washington of that.{\\r}\r\nDialogue: 0,2:09:41.07,2:09:45.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C31\u7B97\u6211\u9858\u610F\u8AAA \u4F60\
+        \u8A8D\u70BA\u4ED6\u5011\u6703\u807D\u55CE\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Even if I were willing to try, what makes you think\
+        \ they'd listen?{\\r}\r\nDialogue: 0,2:09:46.14,2:09:47.74,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u77E5\u9053 \u5C07\u8ECD{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I don't know, general.{\\r}\r\
+        \nDialogue: 0,2:09:49.14,2:09:50.85,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F46\u662F\u6211\u53EA\u80FD\u76F8\u4FE1\u4F60{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Guess I'll just have to\
+        \ trust you.{\\r}\r\nDialogue: 0,2:10:00.42,2:10:03.87,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4F60\u7B11\u4EC0\u9EBC \u4E0A\u5C09\uFF1F\
+        \  - \u6C92\u4EC0\u9EBC \u9577\u5B98{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}- What are you smiling about?       - Nothing, Sir.{\\\
+        r}\r\nDialogue: 0,2:10:07.13,2:10:09.71,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u89BA\u5F97\u4ED6\u5E25\u7206\u4E86{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I just think he's kind of hot.{\\\
+        r}\r\nDialogue: 0,2:10:11.27,2:10:13.37,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u4E0A\u8ECA \u4E0A\u5C09   - \u9075\u547D{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Get in the car, captain.\
+        \       - Mm-hm. Yes, sir.{\\r}\r\nDialogue: 0,2:10:23.34,2:10:26.55,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4E00\u76F4\u5805\u4FE1\u4F60\u751F\
+        \u4F86\u8981\u505A\u5927\u4E8B\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}He always believed you were meant for greater things.{\\\
+        r}\r\nDialogue: 0,2:10:26.81,2:10:28.32,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u7576\u9019\u4E00\u5929\u4F86\u81E8\u6642{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And that when the day came...{\\\
+        r}\r\nDialogue: 0,2:10:28.55,2:10:31.36,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u7684\u80A9\u8180\u8981\u80FD\u625B\u8D77\u5343\
+        \u65A4{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...your shoulders\
+        \ would be able to bear the weight.{\\r}\r\nDialogue: 0,2:10:31.62,2:10:35.47,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u662F\u554A \u6211\u5E0C\u671B\u4ED6\u80FD\
+        \u5920\u770B\u5230\u9019\u4E00\u5207{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Yeah, I just wish he could have been here to see it finally\
+        \ happen.{\\r}\r\nDialogue: 0,2:10:35.89,2:10:38.47,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u770B\u5230\u4E86 \u514B\u62C9\u514B\
+        \ \u76F8\u4FE1\u6211{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He\
+        \ saw it, Clark, believe me.{\\r}\r\nDialogue: 0,2:11:25.37,2:11:28.22,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4E0D\u62EF\u6551\u5730\u7403\u7684\
+        \u6642\u5019 \u60F3\u5E79\u9EDE\u4EC0\u9EBC\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}What are you going to do when you're not saving the\
+        \ world?{\\r}\r\nDialogue: 0,2:11:28.44,2:11:32.19,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u6709\u60F3\u904E\u55CE\uFF1F - \u60F3\
+        \u904E \u771F\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}-\
+        \ Have you given any thought to that?       - I have, actually. Heh, heh.{\\\
+        r}\r\nDialogue: 0,2:11:33.78,2:11:37.79,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u6703\u627E\u4E00\u4EFD\u5DE5\u4F5C \u80FD\u5920\
+        \u4FDD\u6301\u9AD8\u5EA6\u8B66\u89BA{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}I gotta find a job where I can keep my ear to the ground.{\\\
+        r}\r\nDialogue: 0,2:11:43.02,2:11:45.09,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4EBA\u5011\u4E0D\u6703\u591A\u770B\u6211\u5169\u773C\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Where people won't\
+        \ look twice...{\\r}\r\nDialogue: 0,2:11:45.36,2:11:49.14,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7576\u6211\u8981\u53BB\u5371\u96AA\u7684\
+        \u5730\u65B9 \u4E0D\u6703\u554F\u6211\u554F\u984C{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...when I want to go somewhere dangerous and start\
+        \ asking questions...{\\r}\r\nDialogue: 0,2:12:03.24,2:12:06.28,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u884C\u884C\u597D \u9732\u6613\u7D72 \u4F60\
+        \u4EC0\u9EBC\u6642\u5019\u80FD\u53EF\u6190\u6211\u4E00\u4E0B\u5462\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Come on, Lois. When\
+        \ are you gonna throw me a bone?{\\r}\r\nDialogue: 0,2:12:07.55,2:12:09.22,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ECA\u665A\u6BD4\u8CFD\u7684\u7D55\u4F73\
+        \u4F4D\u5B50 \u600E\u9EBC\u6A23\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Courtside seats to the game tonight.{\\r}\r\nDialogue:\
+        \ 0,2:12:09.65,2:12:11.22,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}- \u4EC0\u9EBC\uFF1F - \u6211\u8AAA...{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}- What do you say?       - I say...{\\r}\r\nDialogue:\
+        \ 0,2:12:11.45,2:12:13.99,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u61C9\u8A72\u53BB\u91E3\u91E3\u5BE6\u7FD2\u751F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...you should go back to trolling\
+        \ the intern pool.{\\r}\r\nDialogue: 0,2:12:14.26,2:12:17.63,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53EF\u80FD\u6703\u6709\u597D\u904B \u62B1\
+        \u6B49{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You'll probably\
+        \ have more luck. Sorry.{\\r}\r\nDialogue: 0,2:12:19.43,2:12:20.10,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u770B\u6BD4\u8CFD\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Courtside?{\\r}\r\nDialogue: 0,2:12:20.33,2:12:22.07,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u5225\u53BB   - \u4E0D\u53BB{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Don't. Ha, ha, ha.      \
+        \ - No.{\\r}\r\nDialogue: 0,2:12:22.30,2:12:25.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u502B\u5DF4\u7B2C \u84EE\u6069 \u4F86\u898B\
+        \u898B\u65B0\u7684\u7279\u7D04\u901A\u8A0A\u54E1{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Lombard, Lane, I want you to meet our new stringer.{\\\
+        r}\r\nDialogue: 0,2:12:25.33,2:12:28.58,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u7D66\u4ED6\u50B3\u6388\u50B3\u6388\u7AC5\u9580\
+        \ \u4ED6\u53EB\u5361\u62C9\u514B\u2022\u80AF\u7279{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}I want you to show him the ropes. This\
+        \ is Clark Kent.{\\r}\r\nDialogue: 0,2:12:28.80,2:12:30.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u597D\u904B \u5B69\u5B50{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Good luck, kid.{\\r}\r\nDialogue:\
+        \ 0,2:12:31.64,2:12:32.91,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u53EB\u65AF\u8482\u592B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Hey. Steve.{\\r}\r\nDialogue: 0,2:12:33.14,2:12:34.64,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u5E78\u6703   - \u5E78\u6703{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Nice to meet you.       -\
+        \ You too.{\\r}\r\nDialogue: 0,2:12:34.64,2:12:35.48,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u55E8{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Hi.{\\r}\r\nDialogue: 0,2:12:36.41,2:12:37.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u53EB\u9732\u6613\u7D72\u2022\u84EE\
+        \u6069{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Lois Lane.{\\\
+        r}\r\nDialogue: 0,2:12:38.58,2:12:40.12,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6B61\u8FCE\u4F86\u300A\u661F\u7403\u65E5\u5831\u300B\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Welcome to the \
+        \ Planet.{\\r}\r\nDialogue: 0,2:12:43.85,2:12:46.33,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5F88\u9AD8\u8208\u4F86\u9019 \u9732\u6613\
+        \u7D72{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Glad to be\
+        \ here, Lois.{\\r}\r\n\r\n"
+    headers:
+      cache-control:
+      - max-age=2678400
+      connection:
+      - keep-alive
+      # content-disposition:
+      # - !!python/str "subtitle; filename=\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7E41\
+        # \u4F53&\u82F1\u6587.ass\""
+      content-length:
+      - '239578'
+      content-type:
+      - application/octet-stream
+      date:
+      - Sat, 30 Nov 2019 07:14:40 GMT
+      expires:
+      - Tue, 31 Dec 2019 07:14:40 GMT
+      master:
+      - Windu
+      server:
+      - nginx
+      x-cache:
+      - HIT
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/assrt/test_download_subtitle_zh.yaml
+++ b/tests/cassettes/assrt/test_download_subtitle_zh.yaml
@@ -1,0 +1,3933 @@
+interactions:
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - Sub-Zero/2
+    method: GET
+    uri: https://api.assrt.net/v1/sub/search?q=%5B%27Man+of+Steel+2013%27%5D&token=SECRET&is_file=%5B%271%27%5D
+  response:
+    body:
+      string: "{\"status\":0,\"sub\":{\"keyword\":\"Man of Steel 2013\",\"result\"\
+        :\"succeed\",\"subs\":[{\"subtype\":\"SSA\",\"id\":618185,\"lang\":{\"desc\"\
+        :\"\u82F1 \u7B80 \u7E41 \u53CC\u8BED\",\"langlist\":{\"langchs\":true,\"langeng\"\
+        :true,\"langdou\":true,\"langcht\":true}},\"vote_score\":0,\"upload_time\"\
+        :\"2018-01-26 12:19:27\",\"release_site\":\"CMCT\",\"native_name\":\"\u8D85\
+        \u4EBA\uFF1A\u94A2\u94C1\u4E4B\u8EAF.Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7B80\
+        \u7E41\u82F1\u53CC\u8BED\u5B57\u5E55\",\"videoname\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT\"\
+        ,\"revision\":0},{\"subtype\":\"SSA\",\"id\":316973,\"vote_score\":0,\"upload_time\"\
+        :\"2014-12-06 04:13:44\",\"native_name\":\"\u8D85\u4EBA\uFF1A\u94A2\u94C1\u4E4B\
+        \u8EAF\\/\u8D85\u4EBA\uFF1A\u94A2\u94C1\u82F1\u96C4\",\"videoname\":\"Man\
+        \ of Steel 2013 720p BluRay x264 DTS-WiKi\",\"revision\":0},{\"subtype\":\"\
+        Subrip(srt)\",\"id\":253629,\"lang\":{\"desc\":\"\u7E41\",\"langlist\":{\"\
+        langcht\":true}},\"vote_score\":0,\"upload_time\":\"2014-03-17 15:30:19\"\
+        ,\"native_name\":\"\",\"videoname\":\"[\u8D85\u4EBA \u92FC\u9435\u82F1\u96C4\
+        ]Man.of.Steel.(2013).BDRip.720p.DTS.X264-Felony\",\"revision\":0},{\"subtype\"\
+        :\"SSA\",\"id\":252930,\"lang\":{\"desc\":\"\u82F1 \u7E41 \u53CC\u8BED\",\"\
+        langlist\":{\"langeng\":true,\"langdou\":true,\"langcht\":true}},\"vote_score\"\
+        :45,\"upload_time\":\"2014-03-05 18:10:39\",\"native_name\":\"\u8D85\u4EBA\
+        \uFF1A\u92FC\u9435\u82F1\u96C4\",\"videoname\":\"Man of Steel\",\"revision\"\
+        :0},{\"subtype\":\"Subrip(srt)\",\"id\":246016,\"lang\":{\"desc\":\"\u82F1\
+        \ \u7B80 \u7E41\",\"langlist\":{\"langeng\":true,\"langcht\":true,\"langchs\"\
+        :true}},\"vote_score\":0,\"upload_time\":\"2013-11-09 10:43:13\",\"native_name\"\
+        :\"\u8D85\u4EBA\uFF1A\u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA\uFF1A\u94A2\u94C1\
+        \u82F1\u96C4\\/\u3010TLF\u5B57\u5E55\u7EC4\u3011Man of Steel\",\"videoname\"\
+        :\"Man.of.Steel.2013.720p.BluRay.x264.YIFY\",\"revision\":0},{\"subtype\"\
+        :\"SSA\",\"id\":245602,\"lang\":{\"desc\":\"\u7B80 \u7E41 \u53CC\u8BED\",\"\
+        langlist\":{\"langchs\":true,\"langdou\":true,\"langcht\":true}},\"vote_score\"\
+        :0,\"upload_time\":\"2013-11-02 05:56:40\",\"native_name\":\"\u8D85\u4EBA\uFF1A\
+        \u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA\uFF1A\u94A2\u94C1\u82F1\u96C4\\/\u7279\
+        \u6548\u53CC\u8BED\\/\u84DD\u5149\u5B57\u5E55\",\"videoname\":\"Man of Steel\
+        \ 1080p.bluray.x264-sector7\",\"revision\":0},{\"subtype\":\"\u5176\u4ED6\"\
+        ,\"id\":245568,\"lang\":{\"desc\":\"\u7B80\",\"langlist\":{\"langchs\":true}},\"\
+        vote_score\":0,\"upload_time\":\"2013-10-31 23:41:07\",\"native_name\":\"\u8D85\
+        \u4EBA: \u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA: \u94A2\u94C1\u82F1\u96C4\"\
+        ,\"videoname\":\"Man.of.Steel.2013\",\"revision\":0},{\"subtype\":\"VobSub\"\
+        ,\"id\":245259,\"vote_score\":100,\"upload_time\":\"2013-10-27 07:04:18\"\
+        ,\"native_name\":\"\",\"videoname\":\"Man.Of.Steel.3D.2013.1080p.BluRay.Half-SBS.DTS.x264-PublicHD\"\
+        ,\"revision\":0},{\"subtype\":\"Subrip(srt)\",\"id\":245131,\"lang\":{\"desc\"\
+        :\"\u7B80\",\"langlist\":{\"langchs\":true}},\"vote_score\":80,\"upload_time\"\
+        :\"2013-10-25 04:50:37\",\"native_name\":\"\u8D85\u4EBA-\u94A2\u94C1\u4E4B\
+        \u8EAF\",\"videoname\":\"Man.Of.Steel\",\"revision\":0},{\"subtype\":\"SSA\"\
+        ,\"id\":245056,\"lang\":{\"desc\":\"\u7E41\",\"langlist\":{\"langcht\":true}},\"\
+        vote_score\":0,\"upload_time\":\"2013-10-24 07:52:31\",\"native_name\":\"\"\
+        ,\"videoname\":\"\u8D85\u4EBA \u92FC\u9435\u82F1\u96C4 Man of Steel (2013)\
+        \ 1080p.cht\",\"revision\":0},{\"subtype\":\"Subrip(srt)\",\"id\":244971,\"\
+        lang\":{\"desc\":\"\u7B80 \u7E41\",\"langlist\":{\"langchs\":true,\"langcht\"\
+        :true}},\"vote_score\":10,\"upload_time\":\"2013-10-23 00:46:40\",\"native_name\"\
+        :\"\u84DD\u5149\u539F\u76D8\u5B57\u5E55\",\"videoname\":\"\u8D85\u4EBA: \u94A2\
+        \u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA: \u94A2\u94C1\u82F1\u96C4(\u6E2F\\/\u53F0\
+        ).Man.of.Steel.2013.BluRay CEE\u7248\u84DD\u5149\u539F\u76D8\",\"revision\"\
+        :0},{\"subtype\":\"Subrip(srt)\",\"id\":244969,\"lang\":{\"desc\":\"\",\"\
+        langlist\":{}},\"vote_score\":0,\"upload_time\":\"2013-10-22 23:39:00\",\"\
+        native_name\":\"\u8D85\u4EBA\uFF1A\u94A2\u94C1\u4E4B\u8EAF 3D\\/\u8D85\u4EBA\
+        \uFF1A\u94A2\u94C1\u82F1\u96C4\\/Man of Steel 3D\",\"videoname\":\"Man.Of.Steel.3D.2013.1080p.BluRay.Half-SBS.DTS.x264-PublicHD\"\
+        ,\"revision\":0},{\"subtype\":\"SSA\",\"id\":244960,\"lang\":{\"desc\":\"\u82F1\
+        \ \u7B80\",\"langlist\":{\"langeng\":true,\"langchs\":true}},\"vote_score\"\
+        :0,\"upload_time\":\"2013-10-22 22:06:42\",\"native_name\":\"\u8D85\u4EBA\
+        :\u94A2\u94C1\u4E4B\u8EAF\",\"videoname\":\"Superman: Man of Steel BD\",\"\
+        revision\":0},{\"subtype\":\"\u5176\u4ED6\",\"id\":244939,\"lang\":{\"desc\"\
+        :\"\",\"langlist\":{}},\"vote_score\":0,\"upload_time\":\"2013-10-22 17:42:45\"\
+        ,\"native_name\":\"\",\"videoname\":\"\u8D85\u4EBA\uFF1A\u94A2\u94C1\u4E4B\
+        \u8EAF.Man.of.Steel.2013.1080p-PublicHD 2D.1080p\u62163D.1080p.HSBS-PublicHD\"\
+        ,\"revision\":0},{\"subtype\":\"Subrip(srt)\",\"id\":244863,\"lang\":{\"desc\"\
+        :\"\u82F1 \u7B80 \u7E41\",\"langlist\":{\"langeng\":true,\"langcht\":true,\"\
+        langchs\":true}},\"vote_score\":0,\"upload_time\":\"2013-10-21 16:52:23\"\
+        ,\"native_name\":\"\\/Man of Steel \\/\u8D85\u4EBA:\u94A2\u94C1\u4E4B\u8EAF\
+        \\/\u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA:\u94A2\u94C1\u82F1\u96C4\",\"videoname\"\
+        :\"man.of.steel.2013.720p.bluray.x264-felony.mkv\",\"revision\":0}],\"action\"\
+        :\"search\"}}\n"
+    headers:
+      access-control-allow-origin:
+      - '*'
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Sat, 30 Nov 2019 14:07:59 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - Sub-Zero/2
+    method: GET
+    uri: https://api.assrt.net/v1/sub/detail?token=SECRET&id=%5B%27618185%27%5D
+  response:
+    body:
+      string: "{\"status\":0,\"sub\":{\"result\":\"succeed\",\"subs\":[{\"id\":618185,\"\
+        filelist\":[{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\/618185\\/-\\\
+        /1\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E7%AE%80%E4%BD%93%26%E8%8B%B1%E6%96%87.ass?_=1575122879&-=159cbd264a1c51aaa40ba10021f3c849&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7B80\u4F53\
+        &\u82F1\u6587.ass\",\"s\":\"233KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\\
+        /onthefly\\/618185\\/-\\/2\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E7%AE%80%E4%BD%93%26%E8%8B%B1%E6%96%87.srt?_=1575122879&-=dc85cb7adad4bd68bdbc72bd53c95f64&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7B80\u4F53\
+        &\u82F1\u6587.srt\",\"s\":\"200KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\\
+        /onthefly\\/618185\\/-\\/3\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E7%AE%80%E4%BD%93.ass?_=1575122879&-=6803dae74a248f4cd25322084863fc5d&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7B80\u4F53\
+        .ass\",\"s\":\"133KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\\
+        /618185\\/-\\/4\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E7%AE%80%E4%BD%93.srt?_=1575122879&-=f827dc4d357b85d428ee017b1828e506&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7B80\u4F53\
+        .srt\",\"s\":\"80KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\\
+        /618185\\/-\\/5\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E7%B9%81%E4%BD%93%26%E8%8B%B1%E6%96%87.ass?_=1575122879&-=aecf7aa091e84874ae736d9679eeba15&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7E41\u4F53\
+        &\u82F1\u6587.ass\",\"s\":\"233KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\\
+        /onthefly\\/618185\\/-\\/6\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E7%B9%81%E4%BD%93%26%E8%8B%B1%E6%96%87.srt?_=1575122879&-=ec15b55356564b55c55972723a72267e&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7E41\u4F53\
+        &\u82F1\u6587.srt\",\"s\":\"200KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\\
+        /onthefly\\/618185\\/-\\/7\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E7%B9%81%E4%BD%93.ass?_=1575122879&-=10f05c7cd25cde35a11fda2c94a21d75&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7E41\u4F53\
+        .ass\",\"s\":\"133KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\\
+        /618185\\/-\\/8\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E7%B9%81%E4%BD%93.srt?_=1575122879&-=99dd118570607efd6674d56a6612b4f9&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7E41\u4F53\
+        .srt\",\"s\":\"119KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\/onthefly\\\
+        /618185\\/-\\/9\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E8%8B%B1%E6%96%87%26%E7%AE%80%E4%BD%93.ass?_=1575122879&-=31d1f66db3d9508dbd8062f602691af0&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u82F1\u6587\
+        &\u7B80\u4F53.ass\",\"s\":\"233KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\\
+        /onthefly\\/618185\\/-\\/10\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E8%8B%B1%E6%96%87%26%E7%AE%80%E4%BD%93.srt?_=1575122879&-=d32b0be444d0f33f8a64e283bb602f25&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u82F1\u6587\
+        &\u7B80\u4F53.srt\",\"s\":\"200KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\\
+        /onthefly\\/618185\\/-\\/11\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E8%8B%B1%E6%96%87%26%E7%B9%81%E4%BD%93.ass?_=1575122879&-=b76ea6918bee991b256a740b2fd6f925&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u82F1\u6587\
+        &\u7E41\u4F53.ass\",\"s\":\"233KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\\
+        /onthefly\\/618185\\/-\\/12\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E8%8B%B1%E6%96%87%26%E7%B9%81%E4%BD%93.srt?_=1575122879&-=a9161834e513e8b851cb2cec03b05764&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u82F1\u6587\
+        &\u7E41\u4F53.srt\",\"s\":\"200KB\"},{\"url\":\"http:\\/\\/file0.assrt.net\\\
+        /onthefly\\/618185\\/-\\/13\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E8%8B%B1%E6%96%87.srt?_=1575122879&-=56a3a0099aa8670bd8b5ccc21e18656a&api=1\"\
+        ,\"f\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u82F1\u6587\
+        .srt\",\"s\":\"85KB\"}],\"url\":\"http:\\/\\/file0.assrt.net\\/download\\\
+        /618185\\/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.zip?_=1575122879&-=efab65827fa22ae6a013202d29af471b&api=1\"\
+        ,\"release_site\":\"CMCT\",\"revision\":0,\"filename\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.zip\"\
+        ,\"subtype\":\"SSA\",\"lang\":{\"desc\":\"\u82F1 \u7B80 \u7E41 \u53CC\u8BED\
+        \",\"langlist\":{\"langchs\":true,\"langeng\":true,\"langdou\":true,\"langcht\"\
+        :true}},\"videoname\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT\"\
+        ,\"vote_score\":0,\"upload_time\":\"2018-01-26 12:19:27\",\"title\":\"\u8D85\
+        \u4EBA\uFF1A\u94A2\u94C1\u4E4B\u8EAF.Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7B80\
+        \u7E41\u82F1\u53CC\u8BED\u5B57\u5E55\",\"view_count\":2542,\"native_name\"\
+        :\"\u8D85\u4EBA\uFF1A\u94A2\u94C1\u4E4B\u8EAF.Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7B80\
+        \u7E41\u82F1\u53CC\u8BED\u5B57\u5E55\",\"producer\":{\"source\":\"\u539F\u521B\
+        \u7FFB\u8BD1\",\"verifier\":\"\",\"producer\":\"\",\"uploader\":\"\"},\"size\"\
+        :627625,\"down_count\":1291}],\"action\":\"detail\"}}\n"
+    headers:
+      access-control-allow-origin:
+      - '*'
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Sat, 30 Nov 2019 14:07:59 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - Sub-Zero/2
+    method: GET
+    uri: http://file0.assrt.net/onthefly/618185/-/1/Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.%E7%AE%80%E4%BD%93%26%E8%8B%B1%E6%96%87.ass?api=%5B%271%27%5D&-=%5B%27159cbd264a1c51aaa40ba10021f3c849%27%5D&_=%5B%271575122879%27%5D
+  response:
+    body:
+      string: "\uFEFF[Script Info]\r\n;SrtEdit 6.0.2011.1205\r\n;Copyright(C) 2005-2011\
+        \ Yuan Weiguo\r\n\r\nTitle: \r\nOriginal Script: \r\nOriginal Translation:\
+        \ \r\nOriginal Timing: \r\nOriginal Editing: \r\nScript Updated By: \r\nUpdate\
+        \ Details: \r\nScriptType: v4.00+\r\nCollisions: Normal\r\nPlayResX: 384\r\
+        \nPlayResY: 288\r\nTimer: 100.0000\r\nSynch Point: \r\nWrapStyle: 0\r\nScaledBorderAndShadow:\
+        \ no\r\n\r\n[V4+ Styles]\r\nFormat: Name, Fontname, Fontsize, PrimaryColour,\
+        \ SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut,\
+        \ ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment,\
+        \ MarginL, MarginR, MarginV, Encoding\r\nStyle: chs,Arial,20,&H00E0E0E0,&H00000000,&H00000000,&H80000000,0,0,0,0,100,100,0,0,0,2,1,2,1,1,1,1\r\
+        \nStyle: Default,Arial,18,&H00FFFFFF,&H0000FFFF,&H00000000,&H00000000,-1,0,0,0,100,100,0,0,1,2,3,2,20,20,20,1\r\
+        \n\r\n[Events]\r\nFormat: Layer, Start, End, Style, Name, MarginL, MarginR,\
+        \ MarginV, Effect, Text\r\nDialogue: 0,0:00:01.00,0:00:05.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\fs18\\1c&H00FFFF&}--==\u672C\u5F71\u7247\u7531\
+        \ {\\1c&HFF8000&\\b1}CMCT \u56E2\u961F{\\r\\fn\u534E\u6587\u6977\u4F53\\fs18\\\
+        1c&H00FFFF&} \u8363\u8A89\u51FA\u54C1==--\\N\u66F4\u591A\u7CBE\u5F69\u5F71\
+        \u89C6 \u8BF7\u8BBF\u95EE {\\fnCronos Pro Light Subhead\\1c&HFF00FF&\\b1}http://cmct.cc{\\\
+        r\\fn\u534E\u6587\u6977\u4F53\\fs18\\1c&H00FFFF&}{\\r}\r\nDialogue: 0,0:00:06.00,0:00:10.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\fs16\\1c&H00FFFF&}\u5F71\u7247\u538B\u5236: \u66AE\
+        \u96E8\u6F47\u6F47   \u5B57\u5E55\u8C03\u6821\uFF1A\u4E5D\u5929     \u62DB\
+        \u52DFQ\u53F7: 76846146{\\r}\r\nDialogue: 0,0:00:58.52,0:01:00.02,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5FEB\u70B9{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Hurry!{\\r}\r\nDialogue: 0,0:02:11.03,0:02:14.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4EEC\u8FD8\u4E0D\u660E\u767D\u5417\
+        \uFF1F\u6C2A\u661F\u7684\u6838\u5FC3\u6B63\u5728\u574D\u584C{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Do you not understand? Krypton's core\
+        \ is collapsing.{\\r}\r\nDialogue: 0,0:02:15.20,0:02:18.54,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u4E5F\u8BB8\u53EA\u5269\u51E0\
+        \u4E2A\u661F\u671F\u4E86 \u6211\u8B66\u544A\u8FC7\u4F60\u4EEC{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We may only have a matter of weeks.\
+        \ I warned you.{\\r}\r\nDialogue: 0,0:02:18.80,0:02:22.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5F00\u53D1\u6838\u5FC3\u7684\u80FD\u6E90\
+        \u4E0E\u81EA\u6740\u65E0\u5F02{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Harvesting the core was suicide. It has accelerated...{\\r}\r\nDialogue:\
+        \ 0,0:02:22.54,0:02:25.28,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}- \u5185\u7206\u7684\u901F\u5EA6\u5DF2\u7ECF\u52A0\u5FEB   - \u6211\
+        \u4EEC\u7684\u80FD\u6E90\u50A8\u5907\u5DF2\u7ECF\u8017\u5C3D{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- ...the process of implosion.   \
+        \    - Our energy reserves...{\\r}\r\nDialogue: 0,0:02:25.51,0:02:27.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u8FD8\u80FD\u600E\u4E48\u529E\
+        \ \u827E\u5C14{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...were\
+        \ exhausted. What would you have us do, El?{\\r}\r\nDialogue: 0,0:02:28.14,0:02:31.56,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u50CF\u6211\u4EEC\u7684\u7956\u5148\u4E00\
+        \u6837 \u653E\u773C\u5B87\u5B99{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Look to the stars, like our ancestors did.{\\r}\r\nDialogue: 0,0:02:31.81,0:02:35.69,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9002\u5408\u5C45\u4F4F\u7684\u4E16\u754C\
+        \u89E6\u624B\u53EF\u53CA \u6211\u4EEC\u53EF\u4EE5\u5148\u7528\u90A3\u4E9B\u65E7\
+        \u524D\u54E8\u7AD9{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}There\
+        \ are habitable worlds within reach. We can begin by using the old outposts.{\\\
+        r}\r\nDialogue: 0,0:02:35.95,0:02:39.66,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u771F\u7684\u60F3\u8981\u64A4\u79BB\u5168\u661F\
+        \u7403\u7684\u4EBA\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Are you seriously suggesting that we evacuate the entire planet?{\\\
+        r}\r\nDialogue: 0,0:02:39.89,0:02:43.34,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E0D \u6211\u4EEC\u5DF2\u7ECF\u6551\u4E0D\u4E86\u8FD9\
+        \u91CC\u7684\u4EBA\u4EEC\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}No. Everybody here is already dead.{\\r}\r\nDialogue: 0,0:02:44.16,0:02:48.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u628A\u5BC6\u5178\u4EA4\u7ED9\u6211 \u6211\
+        \u4FDD\u8BC1\u8BA9\u6211\u4EEC\u79CD\u65CF\u5B58\u6D3B\u4E0B\u53BB{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Give me control of the\
+        \ Codex. I will ensure the survival of our race.{\\r}\r\nDialogue: 0,0:02:48.66,0:02:49.73,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD8\u6709\u5E0C\u671B{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}There is still hope.{\\r}\r\nDialogue:\
+        \ 0,0:02:50.00,0:02:53.00,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u5C06\u8FD9\u4E2A\u5E0C\u671B\u63E1\u5728\u4E86\u6211\u7684\
+        \u624B\u5FC3{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I have\
+        \ held that hope in my hands.{\\r}\r\nDialogue: 0,0:03:07.42,0:03:09.96,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u957F\u8001\u4F1A\u5DF2\u7ECF\u89E3\u6563\
+        \u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}This council\
+        \ has been disbanded.{\\r}\r\nDialogue: 0,0:03:10.05,0:03:11.90,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8C01\u4E0B\u7684\u547D\u4EE4\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}On whose authority?{\\\
+        r}\r\nDialogue: 0,0:03:12.25,0:03:13.39,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Mine.{\\r}\r\nDialogue: 0,0:03:17.16,0:03:21.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5176\u4F59\u7684\u4EBA\u5C06\u88AB\u5BA1\
+        \u5224 \u5E76\u914C\u60C5\u5904\u7F5A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}The rest of you will be tried and punished accordingly.{\\\
+        r}\r\nDialogue: 0,0:03:23.43,0:03:26.70,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u4F60\u5728\u5E72\u4EC0\u4E48 \u4F50\u5FB7\uFF1F\u4F60\
+        \u75AF\u4E86   - \u6211\u51E0\u5E74\u524D\u5C31\u8BE5\u52A8\u624B\u4E86{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- What are you doing,\
+        \ Zod? This is madness.       - What I should have done years ago...{\\r}\r\
+        \nDialogue: 0,0:03:27.17,0:03:32.00,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u662F\u8FD9\u4E9B\u7ACB\u6CD5\u8005\u548C\u4ED6\u4EEC\
+        \u65E0\u4F11\u6B62\u7684\u4E89\u8BBA\u6BC1\u4E86\u6C2A\u661F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}These lawmakers with their endless\
+        \ debates have lead Krypton to ruin.{\\r}\r\nDialogue: 0,0:03:34.28,0:03:35.95,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C31\u7B97\u4F60\u7684\u519B\u961F\u80DC\
+        \u5229\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And\
+        \ if your forces prevail...{\\r}\r\nDialogue: 0,0:03:36.21,0:03:38.85,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4F60\u4E5F\u53EA\u80FD\u662F\u4E2A\u5149\
+        \u6746\u53F8\u4EE4   - \u90A3\u5C31\u52A0\u5165\u6211\u7684\u884C\u5217\u5427\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- ...you'll be the\
+        \ leader of nothing.       - Then join me.{\\r}\r\nDialogue: 0,0:03:39.08,0:03:42.19,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u534F\u52A9\u6211\u62EF\u6551\u6211\u4EEC\
+        \u7684\u79CD\u65CF \u6211\u4EEC\u91CD\u65B0\u5F00\u59CB{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Help me save our race. We'll start\
+        \ anew.{\\r}\r\nDialogue: 0,0:03:42.42,0:03:46.60,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C06\u8BA9\u6211\u4EEC\u6CA6\u843D\u5230\
+        \u5982\u6B64\u7530\u5730\u7684\u5815\u843D\u8840\u8109\u5207\u65AD{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We'll sever the degenerative\
+        \ bloodlines that led us to this state.{\\r}\r\nDialogue: 0,0:03:46.72,0:03:49.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8C01\u6765\u51B3\u5B9A\u8C01\u53BB\u8C01\
+        \u7559 \u4F50\u5FB7\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}And who will decide which bloodlines survive, Zod?{\\r}\r\nDialogue:\
+        \ 0,0:03:51.53,0:03:52.37,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You?{\\r}\r\nDialogue: 0,0:03:54.90,0:03:56.60,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u522B\u8FD9\u6837 \u827E\u5C14{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Don't do this, El.{\\r}\r\n\
+        Dialogue: 0,0:03:56.87,0:03:59.31,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6211\u6700\u4E0D\u613F\u610F\u770B\u5230\u7684 \u5C31\u662F\
+        \u6211\u4EEC\u53CD\u76EE\u6210\u4EC7{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}The last thing I want is for us to be enemies.{\\r}\r\n\
+        Dialogue: 0,0:03:59.57,0:04:02.21,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4F60\u80CC\u5F03\u4E86\u6211\u4EEC\u76F8\u7EA6\u7ACB\u4E0B\
+        \u7684\u539F\u5219{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You\
+        \ have abandoned the principles that bound us together.{\\r}\r\nDialogue:\
+        \ 0,0:04:02.44,0:04:06.00,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u5C06\u5251\u6307\u5411\u4E86\u81EA\u5DF1\u7684\u4EBA\u6C11\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You've taken up\
+        \ the sword against your own people.{\\r}\r\nDialogue: 0,0:04:06.48,0:04:09.39,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u656C\u91CD\u7684\u662F\u66FE\u7ECF\
+        \u7684\u4F60 \u4F50\u5FB7{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I will honor the man you once were, Zod...{\\r}\r\nDialogue: 0,0:04:09.81,0:04:11.79,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u800C\u4E0D\u662F\u5982\u4ECA\u8FD9\u4E2A\
+        \u79BD\u517D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...not\
+        \ this monster you've become.{\\r}\r\nDialogue: 0,0:04:15.08,0:04:16.43,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u628A\u4ED6\u5E26\u8D70{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Take him away.{\\r}\r\nDialogue: 0,0:04:22.59,0:04:23.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E3B\u4EBA \u4E00\u5207\u662F\u5426\u5B89\
+        \u597D\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Sir?\
+        \ Is everything all right?{\\r}\r\nDialogue: 0,0:04:24.16,0:04:25.47,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8BA9\u5F00{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Out of the way.{\\r}\r\nDialogue: 0,0:04:26.33,0:04:27.53,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u518D\u8BF4\u4E00\u904D{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I said...{\\r}\r\nDialogue:\
+        \ 0,0:04:43.81,0:04:44.85,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u53EB\u83B1\u62C9\u8FC7\u6765{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Get me Lara.{\\r}\r\nDialogue: 0,0:04:46.18,0:04:48.35,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E54 \u6CE8\u610F\u8EAB\u540E{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Jor. Behind you.{\\r}\r\nDialogue:\
+        \ 0,0:04:52.25,0:04:54.26,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u83B1\u62C9 \u51C6\u5907\u597D\u53D1\u5C04{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Lara, you have to ready the launch.{\\\
+        r}\r\nDialogue: 0,0:04:54.49,0:04:56.66,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u4F1A\u5C3D\u5FEB\u8DDF\u4F60\u4F1A\u5408{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'll be with you as soon\
+        \ as I can.{\\r}\r\nDialogue: 0,0:05:10.97,0:05:12.54,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8D6B\u62C9\u5361{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}H'Raka!{\\r}\r\nDialogue: 0,0:05:51.58,0:05:54.32,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u80FD\u770B\u5230\u5BC6\u5178\u5417\uFF1F\
+        \ - \u5C31\u5728\u4E2D\u67A2\u7684\u4E0B\u65B9 \u4E3B\u4EBA{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Can you see the Codex?        -\
+        \ It's just beneath the central hub.{\\r}\r\nDialogue: 0,0:05:54.55,0:05:55.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u6211\u4E0D\u5F97\u4E0D\u8B66\u544A\
+        \u60A8{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}But I'm compelled\
+        \ to warn you.{\\r}\r\nDialogue: 0,0:05:55.92,0:05:58.23,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5165\u4FB5\u59CB\u6E90\u5BA4\u662FB\u7EA7\
+        \u72AF\u7F6A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Breaching\
+        \ the genesis chamber is a Class-B crime...{\\r}\r\nDialogue: 0,0:05:58.49,0:06:02.06,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6CA1\u4EBA\u5728\u4E4E\u8FD9\u4E2A\u4E86\
+        \ \u57FA\u5217\u514B\u65AF \u8FD9\u4E2A\u4E16\u754C\u5C31\u8981\u6BC1\u706D\
+        \u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Nobody cares\
+        \ anymore, Kelex. The world is about to come to an end.{\\r}\r\nDialogue:\
+        \ 0,0:07:06.72,0:07:09.90,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4E54\u2022\u827E\u5C14 \u4F50\u5FB7\u5C06\u519B\u6709\u4EE4{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Jor-El, by the authority\
+        \ of General Zod...{\\r}\r\nDialogue: 0,0:07:10.13,0:07:12.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4EA4\u51FA\u5BC6\u5178{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...surrender the Codex.{\\r}\r\nDialogue:\
+        \ 0,0:08:00.01,0:08:01.54,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u575A\u6301\u4F4F \u8D6B\u62C9\u5361{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Easy, H'Raka.{\\r}\r\nDialogue: 0,0:08:22.50,0:08:24.14,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4EEC\u627E\u5230\u4E86\u90A3\u4E2A\
+        \u4E16\u754C\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Did you find a world?{\\r}\r\nDialogue: 0,0:08:24.33,0:08:26.65,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u627E\u5230\u4E86   - \u5B83\u7ED5\u7740\
+        \u4E00\u9897\u9EC4\u8272\u4E3B\u5E8F\u661F\u8FD0\u884C{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- We have.        - Orbiting a main\
+        \ sequence yellow star...{\\r}\r\nDialogue: 0,0:08:26.87,0:08:28.58,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6B63\u5982\u60A8\u6240\u8BF4{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...just as you said it would.{\\\
+        r}\r\nDialogue: 0,0:08:29.87,0:08:31.48,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u8FD9\u662F\u9897\u5E74\u8F7B\u7684\u6052\u661F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}A young star.{\\r}\r\n\
+        Dialogue: 0,0:08:31.84,0:08:34.21,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4ED6\u7684\u7EC6\u80DE\u80FD\u5438\u6536\u5B83\u7684\u8F90\
+        \u5C04\u80FD{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}His\
+        \ cells will drink its radiation.{\\r}\r\nDialogue: 0,0:08:36.64,0:08:38.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F3C\u4E4E\u662F\u667A\u80FD\u751F\u7269\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's a seemingly\
+        \ intelligent population.{\\r}\r\nDialogue: 0,0:08:39.81,0:08:40.88,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4F1A\u88AB\u9057\u5F03{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He'll be an outcast.{\\r}\r\
+        \nDialogue: 0,0:08:41.88,0:08:43.33,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u88AB\u5F53\u6210\u602A\u7269{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}A freak.{\\r}\r\nDialogue: 0,0:08:44.55,0:08:45.36,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4F1A\u88AB\u6740\u6389\u7684{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}They'll kill him.{\\\
+        r}\r\nDialogue: 0,0:08:45.59,0:08:47.03,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E0D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}How?{\\r}\r\nDialogue: 0,0:08:47.89,0:08:49.60,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4F1A\u88AB\u5F53\u6210\u4E0A\u5E1D\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He'll be a god to\
+        \ them.{\\r}\r\nDialogue: 0,0:08:51.43,0:08:53.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5982\u679C\u98DE\u8239\u5230\u4E0D\u4E86\
+        \u90A3\u91CC\u600E\u4E48\u529E\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}What if the ship doesn't make it?{\\r}\r\nDialogue: 0,0:08:54.53,0:08:56.03,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4F1A\u6B7B\u5728\u5916\u9762{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He'll die out there...{\\\
+        r}\r\nDialogue: 0,0:08:56.93,0:08:58.97,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5B64\u82E6\u4F36\u4EC3\u5730{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}...alone.{\\r}\r\nDialogue: 0,0:09:00.07,0:09:01.84,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u505A\u4E0D\u5230{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I can't do it.{\\r}\r\nDialogue: 0,0:09:02.07,0:09:03.45,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EE5\u4E3A\u53EF\u4EE5 \u4F46...{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I thought I could,\
+        \ but...{\\r}\r\nDialogue: 0,0:09:03.71,0:09:05.45,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u83B1\u62C9    - \u4ED6\u5C31\u5728\u6211\
+        \u773C\u524D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Lara.\
+        \         - ...now that he's here...{\\r}\r\nDialogue: 0,0:09:05.91,0:09:07.61,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6C2A\u661F\u5DF2\u7ECF\u4E0D\u884C\u4E86\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Krypton is doomed.{\\\
+        r}\r\nDialogue: 0,0:09:08.84,0:09:10.69,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u8FD9\u662F\u4ED6\u552F\u4E00\u7684\u673A\u4F1A{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's his only chance now.{\\\
+        r}\r\nDialogue: 0,0:09:11.38,0:09:12.95,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u8FD9\u662F\u6211\u4EEC\u6C11\u65CF\u552F\u4E00\u7684\
+        \u5E0C\u671B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's\
+        \ our people's only hope.{\\r}\r\nDialogue: 0,0:09:14.42,0:09:15.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u600E\u4E48\u4E86 \u57FA\u5217\u514B\u65AF\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What is it,\
+        \ Kelex?{\\r}\r\nDialogue: 0,0:09:15.88,0:09:17.86,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6709\u4E94\u8258\u653B\u51FB\u8230\u6B63\
+        \u4ECE\u4E1C\u9762\u9760\u8FD1{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Five attack ships converging from the east.{\\r}\r\nDialogue: 0,0:09:18.09,0:09:20.43,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4EEC\u6B63\u5728\u626B\u63CF\u5E76\
+        \u8BC4\u4F30\u57CE\u5821\u7684\u9632\u5FA1\u7CFB\u7EDF{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Citadel's defenses are being scanned\
+        \ and evaluated.{\\r}\r\nDialogue: 0,0:09:20.69,0:09:21.60,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u6765\u4E0A\u4F20\u5BC6\u5178{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'll upload the Codex.{\\\
+        r}\r\nDialogue: 0,0:09:22.36,0:09:23.77,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E0D \u7B49\u7B49{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}No, wait.{\\r}\r\nDialogue: 0,0:09:24.39,0:09:25.23,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u83B1\u62C9{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Lara.{\\r}\r\nDialogue: 0,0:09:25.46,0:09:28.37,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8BA9\u6211\u518D\u770B\u770B\u4ED6{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Just let me look at\
+        \ him.{\\r}\r\nDialogue: 0,0:09:31.77,0:09:34.27,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u6CA1\u673A\u4F1A\u770B\u4ED6\
+        \u8D70\u8DEF\u7684\u6837\u5B50{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}We'll never get to see him walk.{\\r}\r\nDialogue: 0,0:09:36.70,0:09:39.22,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6CA1\u673A\u4F1A\u542C\u4ED6\u558A\u7238\
+        \u7238\u5988\u5988{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Never\
+        \ hear him say our names.{\\r}\r\nDialogue: 0,0:09:44.05,0:09:45.46,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4F1A\u5728{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}But out there...{\\r}\r\nDialogue: 0,0:09:45.71,0:09:47.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u832B\u832B\u5B87\u5B99\u95F4{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...amongst the stars...{\\\
+        r}\r\nDialogue: 0,0:09:48.98,0:09:50.49,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6D3B\u4E0B\u6765{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}...he will live.{\\r}\r\nDialogue: 0,0:10:48.54,0:10:50.45,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u518D\u89C1  \u513F\u5B50{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Goodbye, my son.{\\r}\r\nDialogue:\
+        \ 0,0:10:51.18,0:10:53.72,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u4EEC\u7684\u5E0C\u671B\u4E0E\u68A6\u60F3\u4E0E\u4F60\u540C\
+        \u884C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Our hopes\
+        \ and dreams travel with you.{\\r}\r\nDialogue: 0,0:11:32.42,0:11:35.23,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5411\u4E3B\u95E8\u96C6\u4E2D\u706B\u529B\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Concentrate fire\
+        \ on the main doors.{\\r}\r\nDialogue: 0,0:11:50.57,0:11:51.55,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u83B1\u62C9\u592B\u4EBA{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Lady Lara.{\\r}\r\nDialogue: 0,0:11:51.77,0:11:54.85,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u5E7D\u7075\u5F15\u64CE\u5DF2\u542F\u52A8\
+        \   - \u70B9\u706B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}-\
+        \ The phantom drives are coming online.       - Proceed to ignition.{\\r}\r\
+        \nDialogue: 0,0:11:55.61,0:11:56.61,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5C06\u519B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}General.{\\r}\r\nDialogue: 0,0:11:56.88,0:12:00.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u57CE\u5821\u5185\u6709\u5F15\u64CE\u542F\
+        \u52A8{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We have identified\
+        \ an engine ignition within the citadel.{\\r}\r\nDialogue: 0,0:12:01.22,0:12:02.63,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u662F\u822A\u5929\u5668\u53D1\u5C04{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}A launch.{\\r}\r\n\
+        Dialogue: 0,0:12:03.79,0:12:06.20,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u5B88\u4F4F\u8FD9\u5E73\u53F0 \u6307\u6325\u5B98{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Hold this platform, commander.{\\\
+        r}\r\nDialogue: 0,0:12:18.60,0:12:21.15,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u77E5\u9053\u4F60\u5077\u4E86\u5BC6\u5178 \u4E54\
+        \u2022\u827E\u5C14{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I\
+        \ know you stole the Codex, Jor-El.{\\r}\r\nDialogue: 0,0:12:21.70,0:12:22.70,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u628A\u5B83\u4EA4\u51FA\u6765{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Surrender it...{\\r}\r\nDialogue:\
+        \ 0,0:12:22.94,0:12:24.94,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u5C31\u9976\u4F60\u4E0D\u6B7B{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...and I'll let you live.{\\r}\r\nDialogue: 0,0:12:25.57,0:12:28.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD9\u6B21\u91CD\u751F\u7684\u673A\u4F1A\
+        \u5C5E\u4E8E\u6C2A\u661F\u6240\u6709\u4EBA{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}This is a second chance for all of Krypton...{\\\
+        r}\r\nDialogue: 0,0:12:28.38,0:12:31.32,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u800C\u4E0D\u4EC5\u4EC5\u662F\u4F60\u89C9\u5F97\u91CD\
+        \u8981\u7684\u8840\u8109{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...not just the bloodlines you deem worthy.{\\r}\r\nDialogue: 0,0:12:32.25,0:12:33.42,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u505A\u4E86\u4EC0\u4E48\u4E8B\uFF1F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What have you done?{\\\
+        r}\r\nDialogue: 0,0:12:33.65,0:12:35.96,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u4EEC\u6709\u4E00\u4E2A\u5B69\u5B50 \u4F50\u5FB7\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We've had a child,\
+        \ Zod.{\\r}\r\nDialogue: 0,0:12:36.95,0:12:38.33,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E00\u4E2A\u7537\u5B69{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}A boy child.{\\r}\r\nDialogue: 0,0:12:38.59,0:12:41.59,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u662F\u6C2A\u661F\u51E0\u767E\u5E74\
+        \u6765\u7B2C\u4E00\u4E2A\u81EA\u7136\u5206\u5A29\u7684\u5B69\u5B50{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Krypton's first natural\
+        \ birth in centuries.{\\r}\r\nDialogue: 0,0:12:42.56,0:12:44.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u5C06\u83B7\u5F97\u81EA\u7531{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And he will be free.{\\\
+        r}\r\nDialogue: 0,0:12:44.76,0:12:47.24,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u51B3\u5B9A\u81EA\u5DF1\u547D\u8FD0\u7684\u81EA\u7531\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Free to forge his\
+        \ own destiny.{\\r}\r\nDialogue: 0,0:12:48.10,0:12:49.58,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u80E1\u8BF4\u516B\u9053{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Heresy.{\\r}\r\nDialogue: 0,0:12:51.47,0:12:52.14,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u628A\u5B83\u6BC1\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Destroy it.{\\r}\r\nDialogue: 0,0:13:45.62,0:13:46.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u83B1\u62C9{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Lara...{\\r}\r\nDialogue: 0,0:13:46.79,0:13:48.17,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u542C\u6211\u8BF4{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}...listen to me.{\\r}\r\nDialogue: 0,0:13:48.39,0:13:52.03,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5BC6\u5178\u662F\u6C2A\u661F\u7684\u672A\
+        \u6765{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The Codex\
+        \ is Krypton's future.{\\r}\r\nDialogue: 0,0:13:52.29,0:13:54.74,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53D6\u6D88\u53D1\u5C04{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Abort the launch.{\\r}\r\nDialogue:\
+        \ 0,0:14:13.92,0:14:15.69,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4E0D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}No!{\\\
+        r}\r\nDialogue: 0,0:14:45.61,0:14:47.49,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u83B1\u62C9{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Your son, Lara...{\\r}\r\nDialogue: 0,0:14:48.18,0:14:50.69,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u628A\u4F60\u4EEC\u7684\u513F\u5B50\
+        \u9001\u5230\u54EA\u91CC\u53BB\u4E86\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...where have you sent him?{\\r}\r\nDialogue: 0,0:14:53.59,0:14:55.36,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u7684\u540D\u5B57{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}His name...{\\r}\r\nDialogue: 0,0:14:55.59,0:14:56.69,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u662F\u5361\u5C14{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}...is Kal...{\\r}\r\nDialogue: 0,0:14:57.36,0:14:59.20,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u827E\u5C14\u4E4B\u5B50{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...son of El.{\\r}\r\nDialogue: 0,0:15:02.30,0:15:05.14,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4F11\u60F3\u627E\u5230\u4ED6{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And he's beyond your\
+        \ reach.{\\r}\r\nDialogue: 0,0:15:15.28,0:15:16.78,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u628A\u90A3\u8258\u98DE\u8239\u6253\u4E0B\
+        \u6765{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Bring that\
+        \ ship down.{\\r}\r\nDialogue: 0,0:15:25.12,0:15:26.90,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u76EE\u6807\u5DF2\u9501\u5B9A{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Target locked.{\\r}\r\nDialogue:\
+        \ 0,0:15:38.23,0:15:39.83,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u653E\u4E0B\u4F60\u4EEC\u7684\u6B66\u5668{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Lay down your weapons.{\\r}\r\nDialogue:\
+        \ 0,0:15:39.93,0:15:42.01,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u4EEC\u5DF2\u7ECF\u88AB\u5305\u56F4\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Your forces are surrounded.{\\r}\r\
+        \nDialogue: 0,0:15:52.11,0:15:53.59,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F50\u5FB7\u5C06\u519B{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}General Zod...{\\r}\r\nDialogue: 0,0:15:53.82,0:15:56.80,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u72AF\u4E0B\u4E86\u8C0B\u6740\u7F6A\
+        \u4E0E\u53DB\u56FD\u7F6A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...for the crimes of murder and high treason...{\\r}\r\nDialogue: 0,0:15:56.82,0:16:01.13,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u957F\u8001\u4F1A\u5224\u5904\u4F60\u548C\
+        \u4F60\u7684\u540C\u8C0B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...the Council has sentenced you and your fellow insurgents...{\\r}\r\
+        \nDialogue: 0,0:16:01.19,0:16:04.66,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u56DA\u7981\u8089\u8EAB\u5E76\u6D41\u653E300\u5E74{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...to three hundred\
+        \ cycles of somatic reconditioning.{\\r}\r\nDialogue: 0,0:16:06.16,0:16:07.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6709\u4EC0\u4E48\u9057\u8A00\u5417\uFF1F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Do you have any\
+        \ last words?{\\r}\r\nDialogue: 0,0:16:11.27,0:16:12.35,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4EEC\u4E0D\u6562\u4EB2\u624B\u6740\
+        \u6211\u4EEC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You\
+        \ won't kill us yourself!{\\r}\r\nDialogue: 0,0:16:13.70,0:16:15.84,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6015\u5F04\u810F\u4E86\u81EA\u5DF1\u7684\
+        \u624B \u6240\u4EE5\u4F60\u4EEC...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}You wouldn't sully your hands! But you'll damn us...{\\\
+        r}\r\nDialogue: 0,0:16:16.10,0:16:18.28,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u628A\u6211\u4EEC\u6254\u5230\u9ED1\u6D1E\u91CC\u5173\
+        \u4E00\u8F88\u5B50{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...to\
+        \ a black hole for eternity!{\\r}\r\nDialogue: 0,0:16:20.34,0:16:21.38,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E54\u2022\u827E\u5C14\u8BF4\u5F97\u6CA1\
+        \u9519{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Jor-El was\
+        \ right.{\\r}\r\nDialogue: 0,0:16:21.64,0:16:25.32,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4EEC\u662F\u4E00\u7FA4\u8822\u8D27\
+        \ \u6240\u6709\u4EBA\u90FD\u662F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You're a pack of fools, every last one of you.{\\r}\r\nDialogue: 0,0:16:26.21,0:16:27.39,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}And you.{\\r}\r\nDialogue: 0,0:16:29.12,0:16:31.56,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u89C9\u5F97\u4F60\u7684\u513F\u5B50\
+        \u5F88\u5B89\u5168\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You believe your son is safe?{\\r}\r\nDialogue: 0,0:16:32.29,0:16:33.99,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E00\u5B9A\u4F1A\u627E\u5230\u4ED6\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I will find him.{\\\
+        r}\r\nDialogue: 0,0:16:34.22,0:16:37.53,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u593A\u56DE\u4F60\u4ECE\u6211\u4EEC\u624B\u91CC\u62A2\
+        \u8D70\u7684\u4E1C\u897F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I will reclaim what you have taken from us.{\\r}\r\nDialogue: 0,0:16:39.96,0:16:41.53,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E00\u5B9A\u4F1A\u627E\u5230\u4ED6\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I will find him.{\\\
+        r}\r\nDialogue: 0,0:16:42.73,0:16:45.34,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u4E00\u5B9A\u4F1A\u627E\u5230\u4ED6 \u83B1\u62C9\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I will find him,\
+        \ Lara.{\\r}\r\nDialogue: 0,0:16:47.90,0:16:50.47,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E00\u5B9A\u4F1A\u627E\u5230\u4ED6\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I will find him!{\\\
+        r}\r\nDialogue: 0,0:17:00.31,0:17:02.06,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u554A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Argh!{\\r}\r\nDialogue: 0,0:18:31.67,0:18:35.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u83B1\u62C9\u592B\u4EBA \u60A8\u4E0D\u8EB2\
+        \u8D77\u6765\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Lady Lara, shouldn't you find refuge?{\\r}\r\nDialogue: 0,0:18:35.61,0:18:38.59,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6839\u672C\u65E0\u5904\u53EF\u8EB2 \u57FA\
+        \u6D1B\u5C14{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}There\
+        \ is no refuge, Kelor.{\\r}\r\nDialogue: 0,0:18:39.51,0:18:41.49,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E54\u2022\u827E\u5C14\u8BF4\u5F97\u5BF9\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Jor-El was right.{\\\
+        r}\r\nDialogue: 0,0:18:43.92,0:18:45.93,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6C2A\u661F\u7684\u672B\u65E5\u5230\u4E86{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}This is the end.{\\r}\r\nDialogue:\
+        \ 0,0:18:57.37,0:19:00.28,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u521B\u9020\u4E00\u4E2A\u6BD4\u8FD9\u91CC\u597D\u7684\u4E16\u754C\
+        \ \u5361\u5C14{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Make\
+        \ a better world than ours, Kal.{\\r}\r\nDialogue: 0,0:20:32.43,0:20:33.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5F53\u5FC3\u70B9 \u8822\u8D27{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Watch it, dumb-ass!{\\r}\r\n\
+        Dialogue: 0,0:20:34.20,0:20:37.30,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4E0D\u7559\u5FC3\u5C31\u7B49\u7740\u88AB\u7838\u6210\u8089\
+        \u997C\u5427{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Keep\
+        \ your eyes open or you're gonna get squashed.{\\r}\r\nDialogue: 0,0:20:38.70,0:20:41.15,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4EEC\u662F\u5728\u4EC0\u4E48\u9B3C\
+        \u5730\u65B9\u627E\u5230\u4F60\u7684 \u83DC\u9E1F\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Where the hell did they find you,\
+        \ greenhorn?{\\r}\r\nDialogue: 0,0:20:41.40,0:20:42.88,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8BA9\u6211\u4EEC\u5728\u7A7A\u4E2D\u5F04\
+        \u6389\u8FD9\u4E2A\u9677\u9631{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Let's get this trap in the air.{\\r}\r\nDialogue: 0,0:20:43.10,0:20:44.64,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5927\u5BB6\u56FA\u5B9A\u597D\u7532\u677F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Gentlemen, secure\
+        \ the deck.{\\r}\r\nDialogue: 0,0:20:44.91,0:20:47.91,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6B63\u897F\u65B9\u5411\u7684\u94BB\u4E95\
+        \u5904\u6709\u4EBA\u5411\u6211\u4EEC\u6C42\u6551{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}We just got a distress call from a rig due west of\
+        \ us.{\\r}\r\nDialogue: 0,0:20:48.14,0:20:49.95,chs,,0000,0000,0000,,{\\fn\u534E\
+        \u6587\u6977\u4F53\\blur3}\u56FA\u5B9A\u597D\u7532\u677F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Secure the deck.{\\r}\r\nDialogue:\
+        \ 0,0:20:54.15,0:20:55.72,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u8BF7\u6240\u6709\u6C11\u7528\u8239\u53EA\u79BB\u5F00{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}All civilian boats, stand clear.{\\\
+        r}\r\nDialogue: 0,0:20:55.95,0:20:58.62,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6D77\u4E0B\u9600\u95E8\u5DF2\u5931\u6548 \u94BB\u53F0\
+        \u5FEB\u8981\u7206\u70B8\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}The sub-sea valves failed and the rig is about to explode.{\\r}\r\n\
+        Dialogue: 0,0:20:58.89,0:21:01.33,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6536\u5230 \u6D77\u5CB8\u8B66\u536B\u961F \u88AB\u56F0\u5728\
+        \u91CC\u9762\u7684\u4EBA\u600E\u4E48\u529E\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Roger, Coast Guard. What about the men left inside?{\\\
+        r}\r\nDialogue: 0,0:21:01.46,0:21:03.80,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u522B\u7BA1\u4ED6\u4EEC\u4E86 \u4ED6\u4EEC\u6D3B\u4E0D\
+        \u4E86   - \u83DC\u9E1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}- Forget them. They're dead.        - Greenhorn...{\\r}\r\nDialogue:\
+        \ 0,0:21:04.06,0:21:06.10,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u628A\u6211\u7684\u671B\u8FDC\u955C\u62FF\u6765{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...fetch me my binoculars.{\\r}\r\n\
+        Dialogue: 0,0:21:07.63,0:21:08.97,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u83DC\u9E1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Greenhorn.{\\r}\r\nDialogue: 0,0:21:17.30,0:21:20.84,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C31\u5269\u8FD9\u70B9\u6C27\u6C14\u4E86\
+        \ \u6211\u4E0D\u77E5\u9053\u6211\u4EEC\u8FD8\u80FD\u6491\u591A\u4E45{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}This is the last of the\
+        \ oxygen. I don't know how much longer we can hold out.{\\r}\r\nDialogue:\
+        \ 0,0:21:30.39,0:21:32.26,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u8FD9\u91CC\u662F\u6D77\u5CB8\u8B66\u536B\u961F6510{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}This is Coast Guard 6510.{\\r}\r\n\
+        Dialogue: 0,0:21:32.26,0:21:34.59,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6211\u4EEC\u518D\u67E5\u770B\u4E00\u904D \u7136\u540E\u5C31\
+        \u79BB\u5F00{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We'll\
+        \ make one more pass then get out.{\\r}\r\nDialogue: 0,0:21:36.76,0:21:38.86,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7B49\u7B49 \u7B49\u7B49 \u6709\u4EBA\u5728\
+        \u76F4\u5347\u673A\u5347\u964D\u5904{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Wait, wait. I got some guys on the helipad.{\\r}\r\nDialogue:\
+        \ 0,0:21:39.13,0:21:39.77,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5C31\u5728\u8FD9\u91CC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Right here!{\\r}\r\nDialogue: 0,0:21:45.27,0:21:47.14,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5FEB\u70B9 \u8D70\u554A{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Come on, come on! Let's go! Let's\
+        \ go!{\\r}\r\nDialogue: 0,0:21:47.33,0:21:49.14,chs,,0000,0000,0000,,{\\fn\u534E\
+        \u6587\u6977\u4F53\\blur3}- \u5FEB\u8D70   - \u8D70\u554A{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Let's go!       - Let's go!{\\r}\r\
+        \nDialogue: 0,0:21:59.68,0:22:00.96,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u53EB\u6700\u540E\u90A3\u4E2A\u4EBA\u4E0A\u6765{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Get that last guy loaded.{\\\
+        r}\r\nDialogue: 0,0:22:01.12,0:22:02.49,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u4EEC\u5F97\u8D70\u4E86{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}We have got to go.{\\r}\r\nDialogue: 0,0:22:02.72,0:22:04.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5FEB\u8D70\u554A \u4F60\u5728\u5E72\u4EC0\
+        \u4E48\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Hey,\
+        \ let's go. What are you doing?{\\r}\r\nDialogue: 0,0:22:10.52,0:22:11.63,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8D70 \u8D70{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Go! Go!{\\r}\r\nDialogue: 0,0:22:49.53,0:22:52.17,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u582A\u8428\u65AF\u5DDE\u662F\u4EC0\u4E48\
+        \u65F6\u5019\u53D8\u6210\u7F8E\u56FD\u9886\u571F\u7684\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...when Kansas became a territory?{\\\
+        r}\r\nDialogue: 0,0:22:53.77,0:22:54.75,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Clark.{\\r}\r\nDialogue: 0,0:22:56.74,0:22:58.74,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5728\u542C\u8BFE\u5417 \u514B\u62C9\
+        \u514B\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Are\
+        \ you listening, Clark?{\\r}\r\nDialogue: 0,0:23:02.91,0:23:06.60,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u544A\u8BC9\u6211 \u8C01\u6700\u5148\u5728\
+        \u582A\u8428\u65AF\u5DDE\u5B9A\u5C45{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}I asked if you could tell me who first settled Kansas.{\\\
+        r}\r\nDialogue: 0,0:23:19.36,0:23:20.93,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u6CA1\u4E8B\u5427 \u514B\u62C9\u514B\uFF1F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Are you all right, Clark?{\\\
+        r}\r\nDialogue: 0,0:23:28.97,0:23:30.38,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Clark.{\\r}\r\nDialogue: 0,0:23:31.61,0:23:32.91,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark.{\\r}\r\nDialogue: 0,0:23:36.48,0:23:37.08,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark!{\\r}\r\nDialogue: 0,0:23:41.08,0:23:42.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B \u51FA\u6765{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark, come out of there.{\\\
+        r}\r\nDialogue: 0,0:23:42.88,0:23:44.23,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u522B\u7BA1\u6211{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Leave me alone.{\\r}\r\nDialogue: 0,0:23:45.25,0:23:46.82,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B \u6211\u5DF2\u7ECF\u7ED9\
+        \u4F60\u5988\u5988\u6253\u7535\u8BDD\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Clark, I have called your mother.{\\r}\r\nDialogue:\
+        \ 0,0:23:48.16,0:23:49.23,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Clark?{\\r}\r\nDialogue: 0,0:23:51.06,0:23:52.16,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u554A{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Ah!{\\r}\r\nDialogue: 0,0:23:52.33,0:23:53.33,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u6765\u4E86{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm here.{\\r}\r\nDialogue: 0,0:23:53.59,0:23:55.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B \u5B9D\u8D1D \u6211\u662F\
+        \u5988\u5988{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark,\
+        \ honey, it's Mom.{\\r}\r\nDialogue: 0,0:23:57.97,0:23:59.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5F00\u95E8\u597D\u5417\uFF1F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Will you open the door?{\\\
+        r}\r\nDialogue: 0,0:23:59.27,0:24:01.47,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u4ED6\u5230\u5E95\u6709\u4EC0\u4E48\u6BDB\u75C5\uFF1F\
+        \ - \u4ED6\u5C31\u662F\u4E2A\u602A\u80CE{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}- What's wrong with him?       - He's such a freak.{\\\
+        r}\r\nDialogue: 0,0:24:01.47,0:24:02.31,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5A18\u4EEC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Crybaby.{\\r}\r\nDialogue: 0,0:24:02.57,0:24:05.02,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u7236\u6BCD\u751A\u81F3\u4E0D\u8BA9\
+        \u6211\u8DDF\u4ED6\u73A9{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}His parents won't even let him play with other kids.{\\r}\r\nDialogue:\
+        \ 0,0:24:05.27,0:24:06.27,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u77E5\u9053{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I know.{\\r}\r\nDialogue: 0,0:24:06.51,0:24:07.35,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5B9D\u8D1D{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Sweetie.{\\r}\r\nDialogue: 0,0:24:08.51,0:24:10.65,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4E0D\u8BA9\u6211\u8FDB\u53BB \u6211\
+        \u600E\u4E48\u5E2E\u4F60\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}How can I help you if you won't let me in?{\\r}\r\nDialogue: 0,0:24:10.91,0:24:13.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD9\u4E2A\u4E16\u754C\u592A\u5927\u4E86\
+        \ \u5988\u5988{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The\
+        \ world's too big, Mom.{\\r}\r\nDialogue: 0,0:24:13.48,0:24:15.12,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u5C31\u628A\u5B83\u53D8\u5C0F\u70B9\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Then make it small.{\\\
+        r}\r\nDialogue: 0,0:24:17.48,0:24:18.76,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u53EA\u8981...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Just, um...{\\r}\r\nDialogue: 0,0:24:21.59,0:24:23.39,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u96C6\u4E2D\u7CBE\u529B\u542C\u6211\u7684\
+        \u58F0\u97F3{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...focus\
+        \ on my voice.{\\r}\r\nDialogue: 0,0:24:25.26,0:24:27.21,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u60F3\u8C61\u6709\u4E00\u5EA7\u5C9B\u5C7F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Pretend ifs an island...{\\\
+        r}\r\nDialogue: 0,0:24:27.36,0:24:29.27,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5B83\u5C31\u5728\u5927\u6D77\u4E4B\u4E2D{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...out in the ocean.{\\r}\r\
+        \nDialogue: 0,0:24:30.80,0:24:32.11,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u80FD\u770B\u5230\u5417\uFF1F{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Can you see it?{\\r}\r\nDialogue: 0,0:24:35.80,0:24:36.84,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u770B\u5230\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I see it.{\\r}\r\nDialogue: 0,0:24:38.17,0:24:40.17,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u5C31\u5411\u5B83\u6E38\u8FC7\u53BB\
+        \ \u5B9D\u8D1D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Then\
+        \ swim towards it, honey.{\\r}\r\nDialogue: 0,0:24:53.45,0:24:55.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u600E\u4E48\u4E86 \u5988\u5988\uFF1F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What's wrong with\
+        \ me, Mom?{\\r}\r\nDialogue: 0,0:24:57.89,0:24:59.39,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark.{\\r}\r\nDialogue: 0,0:24:59.66,0:25:01.16,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark.{\\r}\r\nDialogue: 0,0:25:29.82,0:25:31.70,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4F60\u62FF\u5230\u6211\u8981\u7684\u4E1C\
+        \u897F\u4E86\uFF1F   - \u662F\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}- Did you get everything I need?       - Yep.{\\r}\r\n\
+        Dialogue: 0,0:25:31.93,0:25:33.60,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u522B\u52A8 \u522B\u52A8{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Hold it, hold it.{\\r}\r\nDialogue: 0,0:26:23.44,0:26:24.98,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8822\u86CB{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Hey, ass-wipe.{\\r}\r\nDialogue: 0,0:26:25.55,0:26:27.22,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u89C9\u5F97\u600E\u6837\uFF1F\u4F60\
+        \u770B\u4E86\u6BD4\u8D5B\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}What do you think? You see the game?{\\r}\r\nDialogue:\
+        \ 0,0:26:27.45,0:26:29.95,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}- \u522B\u800D\u4ED6 \u76AE\u7279   - \u4F60\u7B97\u54EA\u6839\u8471\
+        \ \u4ED6\u7684\u5973\u670B\u53CB\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}- Leave him alone, Pete.       - What are you, his\
+        \ girlfriend?{\\r}\r\nDialogue: 0,0:26:30.22,0:26:31.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u8981\u542C\u542C\u4ED6\u600E\u4E48\
+        \u8BF4{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I wanna hear\
+        \ what he has to say.{\\r}\r\nDialogue: 0,0:26:34.25,0:26:34.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8BF4\u8BDD\u554A{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Come on...{\\r}\r\nDialogue: 0,0:26:35.16,0:26:35.83,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7B28\u74DC{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...dick-splash.{\\r}\r\nDialogue: 0,0:28:16.82,0:28:17.82,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u513F\u5B50\u5C31\u5728\u73B0\u573A\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}My son was there.{\\\
+        r}\r\nDialogue: 0,0:28:18.06,0:28:20.27,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4ED6\u5C31\u5728\u90A3\u8F86\u6821\u8F66\u91CC{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He was in the bus.{\\r}\r\
+        \nDialogue: 0,0:28:20.53,0:28:23.84,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u4EB2\u773C\u770B\u89C1\u514B\u62C9\u514B\u505A\u4E86\
+        \u4EC0\u4E48   - \u6211\u77E5\u9053\u4ED6\u770B\u89C1\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- He saw what Clark did.       - I\
+        \ know he did.{\\r}\r\nDialogue: 0,0:28:24.26,0:28:28.27,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4ED6\u770B\u5230\u7684\u4E00\u5B9A\u662F\
+        ...   - \u662F\u4E0A\u5E1D\u7684\u5B89\u6392 \u4E54\u7EB3\u68EE{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- I'm sure what he thought\
+        \ he saw was...       - Was an act of God, Jonathan.{\\r}\r\nDialogue: 0,0:28:29.34,0:28:31.71,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u662F\u5929\u610F{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}This was providence.{\\r}\r\nDialogue:\
+        \ 0,0:28:35.44,0:28:37.51,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u89C9\u5F97\u4F60\u8FD9\u6837\u8BF4\u6709\u70B9\u5938\u5F20\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I think you're blowing\
+        \ it out of proportion.{\\r}\r\nDialogue: 0,0:28:37.74,0:28:41.02,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u6CA1\u5938\u5F20 \u62C9\u5A1C\u4E5F\
+        \u770B\u89C1\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}No,\
+        \ I'm not. Lana saw it too.{\\r}\r\nDialogue: 0,0:28:41.25,0:28:42.25,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u4E2A\u53EB\u798F\u7279\u66FC\u7684\
+        \u7537\u5B69\u4E5F\u770B\u89C1\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}And the Fordham boy.{\\r}\r\nDialogue: 0,0:28:42.52,0:28:43.72,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD9\u4E5F\u4E0D\u662F\u7B2C\u4E00\u6B21\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}This isn't the first\
+        \ time...{\\r}\r\nDialogue: 0,0:28:43.95,0:28:46.50,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B\u505A\u51FA\u8FD9\u79CD\
+        \u4E8B\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...Clark's\
+        \ done something like this.{\\r}\r\nDialogue: 0,0:29:01.24,0:29:03.08,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u53EA\u662F\u60F3\u5E2E\u5FD9{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I just wanted to help.{\\\
+        r}\r\nDialogue: 0,0:29:03.54,0:29:06.28,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u77E5\u9053 \u4F46\u6211\u4EEC\u8C08\u8FC7\u8FD9\
+        \u4E2A\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I know\
+        \ you did, but we talked about this.{\\r}\r\nDialogue: 0,0:29:06.54,0:29:07.81,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5BF9\u5427\uFF1F{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Right?{\\r}\r\nDialogue: 0,0:29:08.28,0:29:10.98,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5BF9\u5427 \u6211\u4EEC\u8C08\u8FC7\u4E86\
+        \ \u4F60...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Right?\
+        \ We talked about this. You have...{\\r}\r\nDialogue: 0,0:29:11.48,0:29:14.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B \u4F60\u4E0D\u80FD\u8BA9\
+        \u522B\u4EBA\u77E5\u9053\u4F60\u7684\u8FD9\u4E00\u9762{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark, you have to keep this side\
+        \ of yourself a secret.{\\r}\r\nDialogue: 0,0:29:15.38,0:29:19.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u6211\u8BE5\u600E\u4E48\u529E\uFF1F\
+        \u770B\u7740\u4ED6\u4EEC\u6B7B\u6389\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}What was I supposed to do? Just let them die?{\\\
+        r}\r\nDialogue: 0,0:29:24.06,0:29:25.47,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E5F\u8BB8\u5427{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Maybe.{\\r}\r\nDialogue: 0,0:29:27.39,0:29:29.76,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5371\u5728\u65E6\u5915\u7684\u4E0D\u53EA\
+        \u662F\u6211\u4EEC\u7684\u6027\u547D \u514B\u62C9\u514B{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}There's more at stake here than just\
+        \ our lives, Clark,{\\r}\r\nDialogue: 0,0:29:29.76,0:29:31.80,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E5F\u4E0D\u53EA\u662F\u6211\u4EEC\u5468\
+        \u56F4\u4EBA\u7684\u6027\u547D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}or the lives of those around us.{\\r}\r\nDialogue: 0,0:29:34.33,0:29:35.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5982\u679C\u8FD9\u4E2A\u4E16\u754C{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}When the world...{\\\
+        r}\r\nDialogue: 0,0:29:36.67,0:29:40.68,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u77E5\u9053\u4E86\u4F60\u7684\u80FD\u529B \u4E00\u5207\
+        \u90FD\u5C06\u6539\u53D8 \u5305\u62EC\u6211\u4EEC\u7684...{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}When the world finds out what you\
+        \ can do it's gonna change everything. Our...{\\r}\r\nDialogue: 0,0:29:40.94,0:29:43.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u7684\u4FE1\u4EF0...{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Our beliefs, our notions\
+        \ of...{\\r}\r\nDialogue: 0,0:29:43.78,0:29:46.49,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5BF9\u4EBA\u7C7B\u7684\u6982\u5FF5 \u4E00\
+        \u5207{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...what it\
+        \ means to be human. Everything.{\\r}\r\nDialogue: 0,0:29:46.75,0:29:49.52,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u770B\u5230\u4E86\u76AE\u7279\u5988\
+        \u5988\u7684\u53CD\u5E94\u5427\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}You saw how Pete's mom reacted, right?{\\r}\r\nDialogue:\
+        \ 0,0:29:49.78,0:29:51.99,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5979\u5F88\u5BB3\u6015 \u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}She was scared, Clark.{\\r}\r\nDialogue:\
+        \ 0,0:29:53.12,0:29:53.96,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4E3A\u4EC0\u4E48\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Why?{\\r}\r\nDialogue: 0,0:29:55.82,0:29:58.67,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4EBA\u4EEC\u5BB3\u6015\u4ED6\u4EEC\u4E0D\
+        \u4E86\u89E3\u7684\u4E1C\u897F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}People are afraid of what they don't understand.{\\r}\r\nDialogue: 0,0:29:58.93,0:29:59.84,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5979\u8BF4\u5F97\u5BF9\u5417\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Is she right?{\\r}\r\
+        \nDialogue: 0,0:30:01.96,0:30:04.31,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u662F\u4E0A\u5E1D\u628A\u6211\u53D8\u6210\u8FD9\u6837\
+        \u7684\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Did\
+        \ God do this to me?{\\r}\r\nDialogue: 0,0:30:05.37,0:30:06.87,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u544A\u8BC9\u6211{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Tell me.{\\r}\r\nDialogue: 0,0:30:21.65,0:30:23.92,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u662F\u6211\u4EEC\u5728\u8FD9\u4E2A\
+        \u4E1C\u897F\u91CC\u627E\u5230\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}We found you in this.{\\r}\r\nDialogue: 0,0:30:25.29,0:30:28.23,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u4EE5\u4E3A\u653F\u5E9C\u4E00\
+        \u5B9A\u4F1A\u6765\u627E\u6211\u4EEC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}We were sure the government was gonna show up on our doorstep...{\\\
+        r}\r\nDialogue: 0,0:30:28.49,0:30:30.47,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F46\u4E00\u76F4\u6CA1\u4EBA\u6765{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...but no one ever came.{\\r}\r\n\
+        Dialogue: 0,0:30:44.97,0:30:47.44,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u8FD9\u4E2A\u548C\u4F60\u4E00\u6837 \u4E5F\u662F\u5728\u91CC\
+        \u9762\u627E\u5230\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}This was in that chamber with you.{\\r}\r\nDialogue: 0,0:30:49.18,0:30:52.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u628A\u5B83\u62FF\u7ED9\u582A\u8428\
+        \u65AF\u5DDE\u7684\u4E00\u4E2A\u51B6\u91D1\u5B66\u5BB6\u770B{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I took it to a metallurgist at Kansas\
+        \ State.{\\r}\r\nDialogue: 0,0:30:52.38,0:30:54.99,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u8BF4 \u5236\u6210\u5B83\u7684\u6750\
+        \u6599\u751A\u81F3...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}He said whatever it was made from didn't even...{\\r}\r\nDialogue: 0,0:30:55.92,0:30:58.69,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u751A\u81F3\u4E0D\u5B58\u5728\u4E8E\u5143\
+        \u7D20\u5468\u671F\u8868\u4E0A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Didn't even exist on the periodic table.{\\r}\r\nDialogue: 0,0:31:00.65,0:31:01.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u610F\u601D\u662F\u8BF4{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}That's another way of saying...{\\\
+        r}\r\nDialogue: 0,0:31:02.06,0:31:04.33,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5B83\u4E0D\u6765\u81EA\u4E8E\u8FD9\u4E2A\u4E16\u754C\
+        \ \u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...that\
+        \ it's not from this world, Clark.{\\r}\r\nDialogue: 0,0:31:06.43,0:31:07.70,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4E5F\u4E00\u6837{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And neither are you.{\\r}\r\nDialogue:\
+        \ 0,0:31:10.40,0:31:11.93,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u5C31\u662F\u7B54\u6848 \u513F\u5B50{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}You're the answer, son.{\\r}\r\nDialogue:\
+        \ 0,0:31:12.20,0:31:15.38,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\"\u4EBA\u7C7B\u662F\u5426\u5B64\u72EC\u5730\u5B58\u5728\u4E8E\u5B87\
+        \u5B99\u4E2D\"\u7684\u7B54\u6848{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You're the answer to \"Are we alone in the universe?\"{\\r}\r\nDialogue:\
+        \ 0,0:31:16.74,0:31:18.18,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u4E0D\u60F3\u5F53\u8FD9\u4E2A\u7B54\u6848{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I don't wanna be.{\\r}\r\nDialogue:\
+        \ 0,0:31:18.41,0:31:20.28,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u4E0D\u602A\u4F60 \u513F\u5B50{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}And I don't blame you, son.{\\r}\r\nDialogue: 0,0:31:20.87,0:31:23.58,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E00\u822C\u4EBA\u96BE\u4EE5\u80CC\u8D1F\
+        \u8FD9\u79CD\u91CD\u62C5{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}It'd be a huge burden for anyone to bear.{\\r}\r\nDialogue: 0,0:31:23.84,0:31:27.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u4F60\u4E0D\u662F\u4E00\u822C\u4EBA\
+        \ \u514B\u62C9\u514B \u800C\u4E14\u6211\u5FC5\u987B\u76F8\u4FE1\u4F60{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}But you're not just anyone,\
+        \ Clark, and I have to believe that you were...{\\r}\r\nDialogue: 0,0:31:28.42,0:31:30.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u88AB\u9001\u6765\u8FD9\u91CC\u662F\
+        \u6709\u539F\u56E0\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}That you were sent here for a reason.{\\r}\r\nDialogue: 0,0:31:31.52,0:31:34.09,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6240\u7ECF\u5386\u7684\u8FD9\u4E9B\
+        \u6539\u53D8 \u7EC8\u6709\u4E00\u5929...{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}All these changes that you're going through, one\
+        \ day...{\\r}\r\nDialogue: 0,0:31:34.35,0:31:37.70,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4F1A\u89C9\u5F97\u5B83\u4EEC\u662F\
+        \u4E0A\u5E1D\u7684\u6069\u8D50 \u5F53\u90A3\u4E00\u5929\u5230\u6765...{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}One day you're gonna\
+        \ think of them as a blessing. When that day comes...{\\r}\r\nDialogue: 0,0:31:37.92,0:31:39.37,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5C31\u5FC5\u987B\u4F5C\u51FA\u9009\
+        \u62E9{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...you have\
+        \ to make a choice.{\\r}\r\nDialogue: 0,0:31:39.59,0:31:44.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u662F\u5426\u8981\u5728\u4EBA\u7C7B\u9762\
+        \u524D\u9A84\u50B2\u5730\u633A\u8EAB\u800C\u51FA{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}A choice of whether to stand proud in front of the\
+        \ human race or not.{\\r}\r\nDialogue: 0,0:31:45.37,0:31:48.04,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5C31\u4E0D\u80FD\u7EE7\u7EED\u5047\
+        \u88C5\u662F\u60A8\u7684\u513F\u5B50\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Can't I just keep pretending I'm your son?{\\r}\r\
+        \nDialogue: 0,0:31:48.74,0:31:50.65,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u5C31\u662F\u6211\u513F\u5B50{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You are my son.{\\r}\r\nDialogue:\
+        \ 0,0:31:55.11,0:31:57.11,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F46\u5728\u67D0\u4E2A\u5730\u65B9{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}But somewhere out there you've...{\\r}\r\nDialogue:\
+        \ 0,0:31:57.81,0:32:01.05,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u8FD8\u6709\u53E6\u5916\u4E00\u4E2A\u7236\u4EB2 \u4ED6\u7ED9\
+        \u4E86\u4F60\u53E6\u5916\u4E00\u4E2A\u540D\u5B57{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}You have another father too, who gave you another\
+        \ name.{\\r}\r\nDialogue: 0,0:32:04.12,0:32:07.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u51FA\u4E8E\u67D0\u79CD\u539F\u56E0 \u4ED6\
+        \u628A\u4F60\u9001\u5230\u4E86\u8FD9\u91CC{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}And he sent you here for a reason, Clark.{\\r}\r\n\
+        Dialogue: 0,0:32:08.76,0:32:12.43,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u5C31\u7B97\u8981\u82B1\u4E00\u8F88\u5B50\u7684\u65F6\u95F4\
+        \ \u4F60\u4E5F\u8981\u4E3A\u81EA\u5DF1...{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}And even if it takes you the rest of your life, you\
+        \ owe it to yourself...{\\r}\r\nDialogue: 0,0:32:12.66,0:32:14.80,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u627E\u5230\u90A3\u4E2A\u539F\u56E0{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...to find out what\
+        \ that reason is.{\\r}\r\nDialogue: 0,0:32:23.00,0:32:26.85,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u88AB\u72C2\u70ED\u7684\u6B32\u671B\u6240\
+        \u675F\u7F1A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Bound\
+        \ by wild desire{\\r}\r\nDialogue: 0,0:32:27.07,0:32:30.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u6389\u8FDB\u4E86\u706B\u5708{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I fell into a ring\
+        \ of fire{\\r}\r\nDialogue: 0,0:32:30.28,0:32:32.45,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7B49\u4E00\u4E0B \u4F60\u6765\u8FD9\u513F\
+        \u4E0D\u662F\u4E3A\u4E86\u953B\u70BC\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Wait a second. Aren't you here for the exercise?{\\\
+        r}\r\nDialogue: 0,0:32:32.68,0:32:34.40,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E0D \u90A3\u662F\u5728\u6539\u53D8\u8BA1\u5212{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}No, there was a change\
+        \ in the plans.{\\r}\r\nDialogue: 0,0:32:34.61,0:32:37.20,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u542C\u8BF4\u6709\u4EBA\u5728\u57C3\u5C14\
+        \u65AF\u7C73\u5C14\u627E\u5230\u4E9B\u5947\u602A\u7684\u4E1C\u897F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Somebody found something\
+        \ strange on Ellesmere.{\\r}\r\nDialogue: 0,0:32:37.25,0:32:38.91,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7A7A\u4E2D\u4FA6\u5BDF\u673A\u5DF2\u7ECF\
+        \u5728\u90A3\u91CC\u98DE\u4E86\u4E00\u4E2A\u661F\u671F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Aircom's making runs out there all\
+        \ week.{\\r}\r\nDialogue: 0,0:32:38.91,0:32:39.92,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u4E2A\u8001\u9F20\u6D1E\u5417\uFF1F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}That rat hole?{\\\
+        r}\r\nDialogue: 0,0:32:40.15,0:32:42.26,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u4F60\u5F00\u73A9\u7B11\u7684\u5427   - \u4E0D\u53EF\
+        \u601D\u8BAE \u5BF9\u5427{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}- You gotta be kidding me.       - I know. It's crazy.{\\r}\r\nDialogue:\
+        \ 0,0:32:42.49,0:32:44.20,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u8BB8\u591A\u7F8E\u56FD\u4EBA\u4E5F\u53BB\u4E86\u90A3\u91CC{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The Americans are there\
+        \ too, lots of them.{\\r}\r\nDialogue: 0,0:32:44.46,0:32:47.29,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD8\u6709\u522B\u7684\u5417\uFF1F\u4ED6\
+        \u4EEC\u7BA1\u5B83\u53EB\u5F02\u5E38\u7269\u4F53{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Anything else? They're calling it an anomalous object.{\\\
+        r}\r\nDialogue: 0,0:32:47.29,0:32:49.54,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u4E5F\u4E0D\u77E5\u9053\u4EC0\u4E48\u610F\u601D   -\
+        \ \u8D70\u5F00 \u62C9\u5FB7\u6D1B \u6211\u8BA4\u771F\u7684{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Whatever that means.       - Back\
+        \ off, Ludlow. I'm serious.{\\r}\r\nDialogue: 0,0:32:49.80,0:32:51.64,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u522B\u4ECB \u514B\u4E3D\u831C   - \u4F4F\
+        \u624B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Oh, come\
+        \ on, Chrissy.       - Knock it off.{\\r}\r\nDialogue: 0,0:32:51.83,0:32:53.28,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u5750\u4E0B   - \u653E\u6211\u8D70{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Sit down.       -\
+        \ Let me go.{\\r}\r\nDialogue: 0,0:32:53.50,0:32:55.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u653E\u5F00\u5979 \u54E5\u4EEC{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Hey. Leave her alone, man.{\\\
+        r}\r\nDialogue: 0,0:32:59.51,0:33:01.21,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E0D\u653E\u53C8\u600E\u6837 \u786C\u6C49\uFF1F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Or what, tough guy?{\\\
+        r}\r\nDialogue: 0,0:33:01.78,0:33:05.69,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E0D\u653E\u5C31\u53EA\u80FD\u8BF7\u4F60\u79BB\u5F00\
+        \u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Or I'm gonna\
+        \ have to ask you to leave.{\\r}\r\nDialogue: 0,0:33:06.38,0:33:09.95,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u89C9\u5F97\u6211\u60F3\u8D70\u7684\
+        \u65F6\u5019\u624D\u4F1A\u8D70{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I think I'll probably just leave when I'm good and ready.{\\r}\r\nDialogue:\
+        \ 0,0:33:19.39,0:33:21.07,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6765\u52B2\u4E86\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Oh, there he is.{\\r}\r\nDialogue: 0,0:33:28.37,0:33:30.37,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u72AF\u4E0D\u4E0A \u4EB2\u7231\u7684{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's not worth it,\
+        \ sweetie.{\\r}\r\nDialogue: 0,0:33:38.51,0:33:40.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6DF7\u86CB \u522B\u5FD8\u4E86\u4F60\u7684\
+        \u5C0F\u8D39{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Hey,\
+        \ asshole, don't forget your tip.{\\r}\r\nDialogue: 0,0:33:43.05,0:33:44.86,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53BB\u5427{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Strike.{\\r}\r\nDialogue: 0,0:34:35.40,0:34:36.81,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8C22\u8C22{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Thanks.{\\r}\r\nDialogue: 0,0:34:37.64,0:34:38.88,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u55E8{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Hi.{\\r}\r\nDialogue: 0,0:34:39.11,0:34:40.81,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u83B2\u6069\u5C0F\u59D0 \u4F60\u597D\u5417\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Miss Lane.\
+        \ How you doing?{\\r}\r\nDialogue: 0,0:34:41.07,0:34:43.28,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4F60\u597D   - \u6211\u662F\u6770\u5FB7\
+        \u2022\u5C24\u73ED\u514B\u65AF \u6765\u81EA\u5317\u6781\u8D27\u8FD0{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Good.       - Jed Eubanks,\
+        \ Arctic Cargo.{\\r}\r\nDialogue: 0,0:34:43.54,0:34:45.78,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD9\u79BB\u9A7B\u5730\u6709\u591A\u8FDC\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}How far to\
+        \ the station?{\\r}\r\nDialogue: 0,0:34:46.25,0:34:49.32,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u5BBF\u8425\u5730\u5C31\u5728\u4E0A\u9762\
+        \ \u6211\u966A\u4F60\u8D70\u8FC7\u53BB   - \u592A\u597D\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Camp's just over the rise. I'll\
+        \ walk you over.       - Great.{\\r}\r\nDialogue: 0,0:34:49.58,0:34:51.79,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E54\u53EF\u4EE5\u5E2E\u4F60\u62FF\u5305\
+        \ \u4E54{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Joe can\
+        \ take your bags. Joe.{\\r}\r\nDialogue: 0,0:34:52.05,0:34:53.29,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6765\u5E2E\u5E2E\u5FD9{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Help her out.{\\r}\r\nDialogue: 0,0:34:53.55,0:34:56.06,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C0F\u5FC3\u70B9 \u90A3\u4E9B\u4E1C\u897F\
+        \u5F88\u91CD{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Careful\
+        \ with those. They're heavy.{\\r}\r\nDialogue: 0,0:34:58.49,0:35:00.13,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5F97\u627F\u8BA4 \u83B2\u6069\u5C0F\
+        \u59D0{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I gotta confess,\
+        \ Miss Lane...{\\r}\r\nDialogue: 0,0:35:00.39,0:35:03.24,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E0D\u662F\u300A\u661F\u7403\u65E5\
+        \u62A5\u300B\u7684\u5FE0\u5B9E\u89C2\u4F17{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...I'm not a fan of the Daily Planet.{\\r}\r\nDialogue:\
+        \ 0,0:35:03.63,0:35:07.60,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F46\u4F60\u6F5C\u5165\u7B2C\u4E00\u5E08\u65F6\u5199\u7684\u90A3\
+        \u4E9B\u6587\u7AE0\u90FD...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}But those pieces you wrote when you were embedded with the 1st Division\
+        \ were...{\\r}\r\nDialogue: 0,0:35:07.83,0:35:09.68,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8BA9\u6211\u5370\u8C61\u5341\u5206\u6DF1\
+        \u523B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Well, they\
+        \ were pretty impressive.{\\r}\r\nDialogue: 0,0:35:09.94,0:35:14.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u80FD\u8BF4\u4EC0\u4E48\u5462\uFF1F\
+        \u4E0D\u7A7F\u519B\u670D\u7684\u65F6\u5019\u6211\u5C31\u5F97\u5199\u4E13\u680F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Well, what can I\
+        \ say? I get writer's block if I'm not wearing a flak jacket.{\\r}\r\nDialogue:\
+        \ 0,0:35:19.61,0:35:20.61,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u83B2\u6069\u5C0F\u59D0{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Miss Lane.{\\r}\r\nDialogue: 0,0:35:20.85,0:35:23.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u662F\u7F8E\u56FD\u5317\u65B9\u53F8\
+        \u4EE4\u90E8\u7684\u54C8\u8FEA\u4E0A\u6821 {\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}I'm Colonel Hardy, U.S. Northcom. {\\r}\r\nDialogue:\
+        \ 0,0:35:23.00,0:35:24.85,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u8FD9\u4F4D\u662F\u9AD8\u7EA7\u7814\u7A76\u8BA1\u5212\u5C40\u7684\
+        \u57C3\u7C73\u5C14\u535A\u58EB{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Dr. Emil Hamilton from DARPA.{\\r}\r\nDialogue: 0,0:35:25.12,0:35:26.29,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4F60\u6765\u65E9\u4E86   - \u55E8{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- You're early.   \
+        \    - Hi.{\\r}\r\nDialogue: 0,0:35:26.52,0:35:28.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u4EE5\u4E3A\u4F60\u660E\u5929\
+        \u624D\u5230{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We were\
+        \ expecting you tomorrow.{\\r}\r\nDialogue: 0,0:35:28.25,0:35:30.70,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6240\u4EE5\u6211\u624D\u4ECA\u5929\u6765\
+        \u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Which is why\
+        \ I showed up today.{\\r}\r\nDialogue: 0,0:35:31.36,0:35:33.53,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u6709\u53E5\u8BDD\u5F97\u8BF4\
+        \u5728\u524D\u5934 \u597D\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Look, let's get one thing straight, guys, okay?{\\r}\r\n\
+        Dialogue: 0,0:35:33.79,0:35:35.01,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6211\u5728\u8FD9\u7684\u552F\u4E00\u539F\u56E0\u662F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The only reason I'm here\
+        \ is{\\r}\r\nDialogue: 0,0:35:35.01,0:35:36.64,chs,,0000,0000,0000,,{\\fn\u534E\
+        \u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u5728\u52A0\u62FF\u5927\u56FD\u5883\
+        \u5185\u53D7\u7406\u4E0A\u8BC9\u7684\u6CD5\u5EAD{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}because we're on Canadian soil...{\\r}\r\nDialogue:\
+        \ 0,0:35:36.86,0:35:40.31,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u9A73\u56DE\u4E86\u4F60\u4EEC\u8D76\u6211\u8D70\u7684\u7981\u4EE4\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...and the appellate\
+        \ court overruled your injunction to keep me away.{\\r}\r\nDialogue: 0,0:35:40.53,0:35:42.67,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u4E48 \u4F60\u5982\u679C\u73A9\u86CB\
+        \u73A9\u591F\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}So\
+        \ if we're done measuring dicks...{\\r}\r\nDialogue: 0,0:35:42.94,0:35:45.28,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u80FD\u6D3E\u4EBA\u5E26\u6211\u770B\u770B\
+        \u4F60\u4EEC\u7684\u53D1\u73B0\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...can you have your people show me what you found?{\\\
+        r}\r\nDialogue: 0,0:35:47.34,0:35:50.70,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u7F8E\u56FD\u822A\u7A7A\u822A\u5929\u5C40\u7684\u7D27\
+        \u6025\u6551\u63F4\u536B\u661F\u9996\u5148\u53D1\u73B0\u5F02\u5E38{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}NASA's EOS satellites pinged\
+        \ the anomaly first.{\\r}\r\nDialogue: 0,0:35:50.71,0:35:53.19,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u51B0\u67B6\u7684\u56DE\u58F0\u63A2\u6D4B\
+        \u663E\u793A\u5F88\u6DF7\u4E71{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}The ice shelf plays hell on the echo soundings.{\\r}\r\nDialogue: 0,0:35:53.45,0:35:55.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u90A3\u91CC\u7EDD\u5BF9\u6709\u4E1C\
+        \u897F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}But there's\
+        \ something there.{\\r}\r\nDialogue: 0,0:35:55.30,0:35:57.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8BF4\u4E0D\u5B9A\u662F\u82CF\u8054\u65F6\
+        \u4EE3\u7684\u6F5C\u8247\u5462\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3} A submarine, maybe? Soviet-era?{\\r}\r\nDialogue: 0,0:35:57.05,0:35:58.65,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u4E00\u5B9A \u90A3\u73A9\u610F\u4E09\
+        \u767E\u7C73\u957F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Doubtful.\
+        \ That's 300 meters.{\\r}\r\nDialogue: 0,0:35:58.89,0:36:01.87,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6BD4\u6211\u4EEC\u90A3\u65F6\u5019\u80FD\
+        \u5EFA\u51FA\u6765\u7684\u4E1C\u897F\u5927\u591A\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Considerably larger than anything\
+        \ we know they built back then.{\\r}\r\nDialogue: 0,0:36:02.12,0:36:03.36,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u662F\u8BE1\u5F02\u7684\u5730\u65B9\
+        \u5728\u8FD9{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}But\
+        \ herds the spooky pan.{\\r}\r\nDialogue: 0,0:36:04.56,0:36:07.04,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u4E1C\u897F\u5468\u56F4\u8986\u76D6\
+        \u7684\u51B0{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The\
+        \ ice surrounding the object...{\\r}\r\nDialogue: 0,0:36:07.29,0:36:10.87,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5927\u6982\u5728\u4E0A\u9762\u6709\u4E24\
+        \u4E07\u5E74\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...it's\
+        \ nearly twenty thousand years old.{\\r}\r\nDialogue: 0,0:36:11.83,0:36:12.67,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u83B2\u6069\u5C0F\u59D0{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Miss Lane?{\\r}\r\nDialogue: 0,0:36:14.03,0:36:15.31,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u522B\u4E71\u8D70 \u8FD9\u91CC\u5230\u4E86\
+        \u534A\u591C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Try\
+        \ not to wander.{\\r}\r\nDialogue: 0,0:36:15.54,0:36:18.64,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6E29\u5EA6\u4F1A\u964D\u5230\u96F6\u4E0B\
+        40\u5EA6{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Temperatures\
+        \ drop to minus 40 at night around here.{\\r}\r\nDialogue: 0,0:36:18.87,0:36:21.15,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6625\u5929\u8FC7\u5B8C\u4E86\u624D\u80FD\
+        \u627E\u5230\u4F60\u7684\u5C38\u4F53{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Wouldn't find your body till after spring.{\\r}\r\nDialogue:\
+        \ 0,0:36:24.14,0:36:25.65,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u90A3\u5C31\u8FD9\u6837\u5427{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}And there you go.{\\r}\r\nDialogue: 0,0:36:29.22,0:36:30.69,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u60F3\u89E3\u624B\u600E\u4E48\u529E\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What if I\
+        \ need to tinkle?{\\r}\r\nDialogue: 0,0:36:31.38,0:36:33.02,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u89D2\u843D\u91CC\u6709\u4E2A\u6876{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}There's a bucket in\
+        \ the corner.{\\r}\r\nDialogue: 0,0:37:07.22,0:37:09.39,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5230\u5E95\u8981\u53BB\u54EA\u513F\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Where the\
+        \ hell are you going?{\\r}\r\nDialogue: 0,0:39:18.72,0:39:20.10,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u597D\uFF1F{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Hello?{\\r}\r\nDialogue: 0,0:40:55.58,0:40:59.19,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6CA1\u4E8B\u4E86 \u6CA1\u4E8B\u4E86 \u6CA1\
+        \u4E8B\u4E86 \u6CA1\u4E8B\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}It's all right, it's all right, it's all right. It's all right.{\\r}\r\
+        \nDialogue: 0,0:41:13.00,0:41:14.88,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u5185\u51FA\u8840\u4E86{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}You're hemorrhaging internally...{\\r}\r\
+        \nDialogue: 0,0:41:15.13,0:41:17.51,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u8981\u662F\u73B0\u5728\u6211\u4E0D\u6B62\u8840{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...and if I don't cauterize\
+        \ this bleed...{\\r}\r\nDialogue: 0,0:41:18.67,0:41:19.34,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u600E\u4E48\u80FD\u2026\uFF1F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}How can...?{\\r}\r\nDialogue:\
+        \ 0,0:41:19.61,0:41:22.14,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u6709\u5E38\u4EBA\u6CA1\u6709\u7684\u80FD\u529B{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I can do things that other\
+        \ people can't.{\\r}\r\nDialogue: 0,0:41:23.14,0:41:24.28,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6293\u4F4F\u6211\u7684\u624B{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Now hold my hand.{\\r}\r\n\
+        Dialogue: 0,0:41:25.11,0:41:26.68,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4F1A\u75BC\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}This is gonna hurt.{\\r}\r\nDialogue: 0,0:42:28.37,0:42:30.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u54C8\u8FEA\u4E0A\u6821\u548C\u4ED6\u7684\
+        \u56E2\u961F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What\
+        \ Colonel Hardy and his team surmised...{\\r}\r\nDialogue: 0,0:42:30.74,0:42:32.25,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u731C\u6D4B\u8FD9\u4F1A\u662F\u4E00\u8258\
+        \u82CF\u8054\u65F6\u4EE3\u7684\u6F5C\u8247{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...was a Soviet-era submarine...{\\r}\r\nDialogue:\
+        \ 0,0:42:32.51,0:42:34.96,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5B83\u7684\u771F\u9762\u76EE\u5374\u66F4\u52A0\u5947\u7279{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...was actually something\
+        \ much more exotic.{\\r}\r\nDialogue: 0,0:42:35.21,0:42:39.06,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5468\u56F4\u51B0\u5B54\u7684\u540C\u4F4D\
+        \u7D20\u5206\u6790\u8868\u660E...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}An isotope analysis of the surrounding ice bores suggests that an object...{\\\
+        r}\r\nDialogue: 0,0:42:39.29,0:42:43.13,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u8BE5\u7269\u4F53\u5DF2\u88AB\u56F0\u4E8E\u51B0\u5DDD\
+        \u4E4B\u4E2D\u8D85\u8FC7\u4E00\u4E07\u516B\u5343\u5E74{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...had been trapped in the glacier\
+        \ for over 18,000 years.{\\r}\r\nDialogue: 0,0:42:43.39,0:42:44.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u800C\u6551\u6211\u7684\u4EBA{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}As for my rescuer?{\\r}\r\n\
+        Dialogue: 0,0:42:45.19,0:42:47.57,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u5728\u8BE5\u7269\u4F53\u8D77\u98DE\u7684\u540C\u65F6\u6D88\
+        \u5931\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He disappeared\
+        \ during the object's departure...{\\r}\r\nDialogue: 0,0:42:47.96,0:42:50.37,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u80CC\u666F\u8C03\u67E5\u53D1\u73B0 \u4ED6\
+        \u7684\u5DE5\u4F5C\u5386\u53F2...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}A background check revealed that his work history...{\\r}\r\nDialogue:\
+        \ 0,0:42:50.60,0:42:52.70,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u548C\u8EAB\u4EFD\u5747\u4E3A\u4F2A\u9020{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}...and identity had been falsified.{\\\
+        r}\r\nDialogue: 0,0:42:52.93,0:42:54.81,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5173\u4E8E\u6551\u6211\u7684\u4EBA{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The questions raised by my rescuer's...{\\\
+        r}\r\nDialogue: 0,0:42:55.07,0:42:56.91,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5B58\u5728\u4E0E\u5426\u7684\u8003\u91CF\u786E\u5B9E\
+        \u60CA\u4EBA{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...existence\
+        \ are frightening to contemplate...{\\r}\r\nDialogue: 0,0:42:57.14,0:43:00.42,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u6211\u4E5F\u77E5\u9053\u81EA\u5DF1\
+        \u6240\u89C1\u5C5E\u5B9E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...but I also know what I saw.{\\r}\r\nDialogue: 0,0:43:00.71,0:43:03.28,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u56E0\u6B64\u6211\u5F97\u51FA\u4E86\u4E00\
+        \u4E2A\u5FC5\u7136\u7684\u7ED3\u8BBA{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}\"And I have arrived at the inescapable conclusion...{\\\
+        r}\r\nDialogue: 0,0:43:03.54,0:43:05.55,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5373\u8BE5\u7269\u4F53\u4E0E\u5B83\u7684\u4E58\u5750\
+        \u8005{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...that the\
+        \ object and its occupant...{\\r}\r\nDialogue: 0,0:43:05.78,0:43:08.32,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5E76\u975E\u5730\u7403\u4EA7\u7269{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...did not originate\
+        \ on Earth.\"{\\r}\r\nDialogue: 0,0:43:09.45,0:43:12.76,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD9\u6837\u6CA1\u6CD5\u4E0A\u62A5 \u91CC\
+        \u9762\u53EF\u80FD\u6709\u4E00\u534A\u662F\u4F60\u7684\u5E7B\u89C9{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I can't print this, Lois.\
+        \ You might have hallucinated half of it.{\\r}\r\nDialogue: 0,0:43:12.99,0:43:15.98,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53EF\u5E73\u6C11\u627F\u5305\u5546\u8BC1\
+        \u5B9E\u4E86\u6211\u7684\u6545\u4E8B\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}What about the contractors who corroborated my story?{\\\
+        r}\r\nDialogue: 0,0:43:15.98,0:43:18.50,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E94\u89D2\u5927\u697C\u5426\u8BA4\u6709\u8239\u7684\
+        \u5B58\u5728{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The\
+        \ Pentagon is denying that there was a ship.{\\r}\r\nDialogue: 0,0:43:18.76,0:43:20.60,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4EEC\u5F53\u7136\u5426\u8BA4 \u4ED6\
+        \u4EEC\u5C31\u8BE5\u5426\u8BA4{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Of course they are. They're supposed to.{\\r}\r\nDialogue: 0,0:43:20.83,0:43:22.33,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u56E0\u4E3A\u4ED6\u4EEC\u662F\u4E94\u89D2\
+        \u5927\u697C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's\
+        \ the Pentagon.{\\r}\r\nDialogue: 0,0:43:22.60,0:43:24.27,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F69\u91CC \u62DC\u6258 \u6211\u4EEC\u8BF4\
+        \u7684\u53EF\u662F\u6211{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Perry,come on, it's me we're talking about.{\\r}\r\nDialogue: 0,0:43:24.50,0:43:27.17,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u6211\u662F\u4E00\u4E2A\u666E\u5229\u7B56\
+        \u5956\u83B7\u5956\u8BB0\u8005   - \u90A3\u5C31\u6709\u70B9\u540D\u8BB0\u8005\
+        \u6837{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- I'm a Pulitzer\
+        \ Prize-winning reporter.       - Then act like it.{\\r}\r\nDialogue: 0,0:43:27.43,0:43:29.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4E0D\u62A5\u51FA\u53BB\u6211\u5C31\u8F9E\
+        \u804C   - \u8D70\u4E0D\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}- Print it or I walk.       - You can't.{\\r}\r\nDialogue: 0,0:43:29.80,0:43:30.84,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u7B7E\u4E86\u5408\u540C\u7684{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You're under contract.{\\\
+        r}\r\nDialogue: 0,0:43:33.31,0:43:37.31,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u4E0D\u4F1A\u62A5\u9053\u5916\u661F\u4EBA\u9690\
+        \u85CF\u4E8E\u5BFB\u5E38\u4EBA\u4E4B\u4E2D\u7684\u6545\u4E8B{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm not running a story about aliens\
+        \ walking among us.{\\r}\r\nDialogue: 0,0:43:43.62,0:43:45.19,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7EDD\u5BF9\u4E0D\u4F1A{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Never gonna happen.{\\r}\r\nDialogue:\
+        \ 0,0:43:48.45,0:43:50.83,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u8FD9\u4F4D\u5973\u58EB\u7684\u82CF\u683C\u5170\u5A01\u58EB\u5FCC\
+        \u7EAF\u996E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}That's\
+        \ a Scotch, straight-up, for the lady.{\\r}\r\nDialogue: 0,0:43:51.09,0:43:52.45,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u73B0\u5728\u5C31\u53D1\u539F\u6587\
+        \u7ED9\u4F60{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm\
+        \ sending you the article.{\\r}\r\nDialogue: 0,0:43:52.63,0:43:55.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u7684\u7F16\u8F91\u4E0D\u80AF\u62A5\
+        \ \u4F46\u5982\u679C\u78B0\u5DE7\u5728\u7F51\u4E0A\u6CC4\u9732\u4E86\u7684\
+        \u8BDD...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}My editor\
+        \ won't print it, but if it leaked online...{\\r}\r\nDialogue: 0,0:43:55.33,0:43:56.64,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u61C2\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Got it.{\\r}\r\nDialogue: 0,0:43:56.86,0:43:59.31,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u4F60\u4E0D\u662F\u66FE\u7ECF\u628A\
+        \u6211\u7684\u7F51\u7AD9\u5F62\u5BB9\u4E3A...{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}But didn't you once describe my site...{\\r}\r\n\
+        Dialogue: 0,0:43:59.53,0:44:02.84,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6EE1\u6EA2\u8C0E\u8A00\u7684\u6BD2\u7624\u5417\uFF1F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...as a creeping cancer\
+        \ of falsehoods?{\\r}\r\nDialogue: 0,0:44:02.94,0:44:06.53,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u8FD8\u8FD9\u4E48\u8BA4\u4E3A \u4F46\
+        \u6211\u60F3\u8BA9\u8FD9\u4E2A\u6545\u4E8B\u89C1\u5149{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I stand by my words, Woodburn, but\
+        \ I want this story out there.{\\r}\r\nDialogue: 0,0:44:06.53,0:44:07.94,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E3A\u4EC0\u4E48\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Why?{\\r}\r\nDialogue: 0,0:44:07.97,0:44:11.32,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u56E0\u4E3A\u6211\u60F3\u8BA9\u6211\u7684\
+        \u795E\u79D8\u7537\u5B50\u77E5\u9053\u6211\u77E5\u9053\u771F\u76F8{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Because I want my mystery\
+        \ man to know I know the truth.{\\r}\r\nDialogue: 0,0:44:25.66,0:44:27.64,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9012\u5F52\u8BCA\u65AD\u5B8C\u6210{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Recursive diagnostics\
+        \ complete...{\\r}\r\nDialogue: 0,0:44:28.46,0:44:30.67,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5BFC\u793A\u5F71\u50CF\u5DF2\u6388\u6743\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Guiding presence\
+        \ authenticated.{\\r}\r\nDialogue: 0,0:44:30.90,0:44:33.47,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7CFB\u7EDF\u8FD0\u8F6C\u6B63\u5E38{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}All systems operational.{\\\
+        r}\r\nDialogue: 0,0:44:45.55,0:44:49.99,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u770B\u89C1\u4F60\u5728\u90A3\u91CC\u957F\u5927\u6210\
+        \u4EBA...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}To see\
+        \ you standing there having grown into an adult...{\\r}\r\nDialogue: 0,0:44:51.72,0:44:54.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8981\u662F\u83B1\u62C9\u80FD\u4EB2\u773C\
+        \u5F97\u89C1\u5C31\u597D\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}If only Lara could have witnessed this.{\\r}\r\nDialogue: 0,0:44:54.69,0:44:55.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u662F\u8C01\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Who are you?{\\r}\r\nDialogue: 0,0:44:56.89,0:44:58.87,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u662F\u4F60\u7684\u7236\u4EB2 \u5361\
+        \u5C14{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I am your\
+        \ father, Kal.{\\r}\r\nDialogue: 0,0:45:00.23,0:45:02.10,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8D77\u7801\u662F\u4ED6\u7684\u8EAB\u5F71\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Or at least a shadow\
+        \ of him.{\\r}\r\nDialogue: 0,0:45:02.60,0:45:04.34,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u7684\u610F\u8BC6{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}His consciousness.{\\r}\r\nDialogue:\
+        \ 0,0:45:06.10,0:45:09.20,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u53EB\u4E54\u2022\u827E\u5C14{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}My name was Jor-El.{\\r}\r\nDialogue: 0,0:45:11.87,0:45:13.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u5361\u5C14{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}And Kal?{\\r}\r\nDialogue: 0,0:45:16.74,0:45:17.95,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u662F\u6211\u7684\u540D\u5B57\u5417\uFF1F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}That's my name.{\\\
+        r}\r\nDialogue: 0,0:45:18.84,0:45:22.05,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u53EB \u5361\u5C14\u2022\u827E\u5C14{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Kal-El. It is.{\\r}\r\nDialogue: 0,0:45:22.75,0:45:24.79,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u6709\u597D\u591A\u95EE\u9898{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I have so many questions.{\\\
+        r}\r\nDialogue: 0,0:45:27.52,0:45:29.12,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u4ECE\u54EA\u91CC\u6765\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Where do I come from?{\\r}\r\nDialogue:\
+        \ 0,0:45:30.86,0:45:32.73,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u4E3A\u4EC0\u4E48\u8981\u9001\u6211\u6765\u8FD9\u91CC\uFF1F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Why did you send\
+        \ me here?{\\r}\r\nDialogue: 0,0:45:33.56,0:45:35.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6765\u81EA\u6C2A\u661F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You came from Krypton.{\\r}\r\
+        \nDialogue: 0,0:45:38.13,0:45:42.14,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E00\u4E2A\u6BD4\u5730\u7403\u73AF\u5883\u66F4\u6076\
+        \u52A3\u7684\u4E16\u754C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}A world with a much harsher environment than Earths.{\\r}\r\nDialogue:\
+        \ 0,0:45:45.94,0:45:47.58,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5F88\u4E45\u4EE5\u524D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Long ago...{\\r}\r\nDialogue: 0,0:45:47.81,0:45:50.05,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5728\u5927\u6269\u5F20\u7684\u65F6\u4EE3\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...in an era of\
+        \ expansion...{\\r}\r\nDialogue: 0,0:45:50.28,0:45:53.49,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u7684\u79CD\u65CF\u63A2\u7D22\
+        \u4E00\u9897\u9897\u661F\u7403{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...our race spread out through the stars...{\\r}\r\nDialogue: 0,0:45:53.75,0:45:56.45,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5BFB\u89C5\u53EF\u4EE5\u5E38\u9A7B\u7684\
+        \u65B0\u4E16\u754C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...seeking\
+        \ new worlds to settle upon.{\\r}\r\nDialogue: 0,0:45:57.58,0:46:01.09,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD9\u8258\u4FA6\u5BDF\u8239\u662F\u5C04\
+        \u5165\u865A\u7A7A\u7684\u6570\u5343\u8258\u4E4B\u4E00{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}This scout ship was one of thousands\
+        \ launched into the void.{\\r}\r\nDialogue: 0,0:46:03.66,0:46:06.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u5728\u5176\u4ED6\u884C\u661F\
+        \u4E0A\u5EFA\u9020\u524D\u54E8{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}We built outposts on other planets...{\\r}\r\nDialogue: 0,0:46:06.49,0:46:10.24,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7528\u5DE8\u5927\u7684\u673A\u5668\u6309\
+        \u6211\u4EEC\u7684\u9700\u6C42\u91CD\u5851\u73AF\u5883{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}musing great machines to reshape environments\
+        \ to our needs.{\\r}\r\nDialogue: 0,0:46:12.43,0:46:16.94,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5341\u4E07\u5E74\u6765\u6211\u4EEC\u7684\
+        \u6587\u660E\u84EC\u52C3\u53D1\u5C55{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}For 100,000 years, our civilization flourished...{\\r}\r\
+        \nDialogue: 0,0:46:17.97,0:46:19.97,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u521B\u9020\u4E86\u8BB8\u591A\u5947\u8FF9{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...accomplishing wonders.{\\\
+        r}\r\nDialogue: 0,0:46:21.14,0:46:22.78,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u53D1\u751F\u4E86\u4EC0\u4E48\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What happened?{\\r}\r\nDialogue: 0,0:46:24.78,0:46:27.85,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u521B\u9020\u4E86\u4EBA\u9020\
+        \u4EBA\u53E3\u63A7\u5236\u7CFB\u7EDF{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Artificial population control was established.{\\r}\r\n\
+        Dialogue: 0,0:46:28.58,0:46:32.19,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u9057\u5F03\u4E86\u592A\u7A7A\u63A2\u7D22\u7684\u524D\u54E8\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The outposts on\
+        \ space exploration were abandoned.{\\r}\r\nDialogue: 0,0:46:32.79,0:46:35.36,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u7528\u5C3D\u4E86\u81EA\u7136\
+        \u8D44\u6E90{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We exhausted\
+        \ our natural resources.{\\r}\r\nDialogue: 0,0:46:35.62,0:46:39.63,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u56E0\u6B64\u6211\u4EEC\u884C\u661F\u7684\
+        \u6838\u5FC3\u53D8\u5F97\u4E0D\u7A33\u5B9A{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}As a result, our planet's core became unstable.{\\\
+        r}\r\nDialogue: 0,0:46:42.09,0:46:44.63,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6700\u7EC8\u6211\u4EEC\u7684\u519B\u4E8B\u9886\u8896\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Eventually, our\
+        \ military leader...{\\r}\r\nDialogue: 0,0:46:44.86,0:46:48.78,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F50\u5FB7\u5C06\u519B\u4F01\u56FE\u53D1\
+        \u52A8\u653F\u53D8{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...General\
+        \ Zod, attempted a coup.{\\r}\r\nDialogue: 0,0:46:50.70,0:46:52.88,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u4E3A\u65F6\u5DF2\u665A{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}But by then it was too late.{\\\
+        r}\r\nDialogue: 0,0:46:54.14,0:46:56.78,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u5988\u5988\u548C\u6211\u9884\u89C1\u4E86\u672A\
+        \u6765\u707E\u96BE{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Your\
+        \ mother and I foresaw the coming calamity...{\\r}\r\nDialogue: 0,0:46:57.01,0:47:00.42,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u91C7\u53D6\u4E86\u67D0\u4E9B\
+        \u63AA\u65BD\u4EE5\u786E\u4FDD\u4F60\u7684\u751F\u5B58{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...and we took certain steps to ensure\
+        \ your survival.{\\r}\r\nDialogue: 0,0:47:01.88,0:47:03.92,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD9\u662F\u59CB\u6E90\u5BA4{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}This is a genesis chamber.{\\\
+        r}\r\nDialogue: 0,0:47:04.38,0:47:07.52,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6240\u6709\u6C2A\u661F\u4EBA\u90FD\u5728\u8FD9\u6837\
+        \u7684\u5C0F\u623F\u95F4\u91CC\u88AB\u5B55\u80B2{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}All Kryptonians were conceived in chambers such as\
+        \ this.{\\r}\r\nDialogue: 0,0:47:07.79,0:47:11.50,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6BCF\u4E2A\u51FA\u751F\u7684\u5B69\u5B50\
+        \u90FD\u6709\u4E00\u4E2A\u9884\u5B9A\u7684\u89D2\u8272{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Every child was designed to fulfill\
+        \ a pre-determined role in our society...{\\r}\r\nDialogue: 0,0:47:11.72,0:47:12.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5DE5\u4EBA{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...as a worker...{\\r}\r\nDialogue: 0,0:47:12.83,0:47:15.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6218\u58EB \u9886\u5BFC\u8005\u7B49\u7B49\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...a warrior, a\
+        \ leader and so on.{\\r}\r\nDialogue: 0,0:47:16.20,0:47:19.47,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5988\u5988\u548C\u6211\u76F8\u4FE1\
+        \u6C2A\u661F\u5931\u53BB\u4E86\u4E00\u4E9B\u73CD\u8D35\u7684\u4E1C\u897F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Your mother and I believed\
+        \ Krypton lost something precious.{\\r}\r\nDialogue: 0,0:47:19.70,0:47:21.91,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9009\u62E9\u548C\u673A\u4F1A\u7684\u8981\
+        \u7D20{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The element\
+        \ of choice, of chance.{\\r}\r\nDialogue: 0,0:47:22.40,0:47:24.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8981\u662F\u4E00\u4E2A\u5B69\u5B50\u7684\
+        \u68A6\u60F3\u662F...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}What if a child dreamed of becoming something...{\\r}\r\nDialogue: 0,0:47:24.84,0:47:27.34,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6210\u4E3A\u9884\u5B9A\u8F83\u8272\u4EE5\
+        \u5916\u7684\u89D2\u8272\u5462\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}mother than what society had intended for him or her?{\\\
+        r}\r\nDialogue: 0,0:47:28.87,0:47:31.48,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u8981\u662F\u4ED6\u6E34\u671B\u66F4\u4F1F\u5927\u7684\
+        \u4E1C\u897F\u5462\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}What if a child aspired to something greater?{\\r}\r\nDialogue: 0,0:47:32.24,0:47:34.25,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5C31\u662F\u8FD9\u79CD\u4FE1\u5FF5\
+        \u7684\u4F53\u73B0 \u5361\u5C14{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You were the embodiment of that belief, Kal.{\\r}\r\nDialogue: 0,0:47:34.51,0:47:37.59,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u51E0\u4E16\u7EAA\u4EE5\u6765\u6C2A\u661F\
+        \u7684\u7B2C\u4E00\u4E2A\u81EA\u7136\u5206\u5A29\u7684\u5B69\u5B50{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Krypton's first natural\
+        \ birth in centuries.{\\r}\r\nDialogue: 0,0:47:38.08,0:47:40.76,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6240\u4EE5\u6211\u4EEC\u624D\u5192\u5982\
+        \u6B64\u5927\u7684\u98CE\u9669\u6551\u4F60{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}That's why we risked so much to save you.{\\r}\r\n\
+        Dialogue: 0,0:47:41.89,0:47:43.33,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4F60\u4EEC\u4E3A\u4EC0\u4E48\u4E0D\u8DDF\u6211\u4E00\u8D77\
+        \u6765\u5462\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Why\
+        \ didn't you come with me?{\\r}\r\nDialogue: 0,0:47:46.86,0:47:48.60,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u505A\u4E0D\u5230 \u5361\u5C14\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We couldn't, Kal.{\\\
+        r}\r\nDialogue: 0,0:47:49.66,0:47:52.50,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E0D\u8BBA\u6211\u4EEC\u591A\u4E48\u6E34\u671B{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}No matter how much we wanted\
+        \ to.{\\r}\r\nDialogue: 0,0:47:52.60,0:47:54.60,chs,,0000,0000,0000,,{\\fn\u534E\
+        \u6587\u6977\u4F53\\blur3}\u4E0D\u8BBA\u6211\u4EEC\u6709\u591A\u7231\u4F60\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}No matter how much\
+        \ we loved you.{\\r}\r\nDialogue: 0,0:47:55.37,0:47:56.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6BCD\u4EB2\u83B1\u62C9\u548C\u6211\
+        \ \u90FD\u8DDF\u4F50\u5FB7\u4E00\u6837{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Your mother, Lara, and I...{\\r}\r\nDialogue: 0,0:47:57.00,0:48:00.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u662F\u6211\u4EEC\u4E16\u754C\u751F\u4EA7\
+        \u51FA\u6765\u7684\u5931\u8D25\u4EA7\u7269{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...were a product of the failures of our world as\
+        \ much as Zod was...{\\r}\r\nDialogue: 0,0:48:00.37,0:48:02.05,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u4E0E\u5B83\u7684\u547D\u8FD0\
+        \u7D27\u7D27\u76F8\u8FDE{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...tied to its fate.{\\r}\r\nDialogue: 0,0:48:02.27,0:48:04.35,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u90A3\u6211\u662F\u5B64\u5355\u4E00\u4EBA\
+        \u4E86   - \u4E0D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}-\
+        \ So I'm alone.       - No.{\\r}\r\nDialogue: 0,0:48:06.08,0:48:09.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u65E2\u662F\u6C2A\u661F\u7684\u5B50\
+        \u55E3 \u4E5F\u662F\u5730\u7403\u7684\u5B69\u5B50{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}You're as much a child of Earth now as you are of\
+        \ Krypton.{\\r}\r\nDialogue: 0,0:48:10.02,0:48:13.19,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u80FD\u4F53\u73B0\u4E24\u4E2A\u4E16\
+        \u754C\u7684\u7CBE\u534E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You can embody the best of both worlds.{\\r}\r\nDialogue: 0,0:48:13.42,0:48:17.06,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6BCD\u4EB2\u548C\u6211\u81F4\u529B\
+        \u4FDD\u62A4\u7684\u68A6\u60F3{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}A dream your mother and I dedicated our lives to preserve.{\\r}\r\n\
+        Dialogue: 0,0:48:21.59,0:48:24.58,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u5730\u7403\u4EBA\u4E0E\u6211\u4EEC\u4E0D\u540C \u8FD9\u4E0D\
+        \u5047{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The people\
+        \ of Earth are different from us, it's true.{\\r}\r\nDialogue: 0,0:48:24.80,0:48:27.74,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u6700\u7EC8\u6211\u76F8\u4FE1\u8FD9\
+        \u662F\u4EF6\u597D\u4E8B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}But, ultimately, I believe that's a good thing.{\\r}\r\nDialogue: 0,0:48:27.97,0:48:30.41,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4EEC\u4E0D\u4E00\u5B9A\u4F1A\u72AF\
+        \u4E0E\u6211\u4EEC\u76F8\u540C\u7684\u9519\u8BEF{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}They won't necessarily make the same mistakes we\
+        \ did.{\\r}\r\nDialogue: 0,0:48:30.64,0:48:32.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53EA\u8981\u6709\u4F60\u7684\u5F15\u5BFC\
+        \ \u5361\u5C14{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Not\
+        \ if you guide them, Kal.{\\r}\r\nDialogue: 0,0:48:34.21,0:48:36.24,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53EA\u8981\u4F60\u5E26\u7ED9\u4ED6\u4EEC\
+        \u5E0C\u671B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Not\
+        \ if you give them hope.{\\r}\r\nDialogue: 0,0:48:39.65,0:48:41.82,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD9\u4E2A\u7B26\u53F7\u5C31\u662F\u8FD9\
+        \u4E2A\u610F\u601D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}That's\
+        \ what this symbol means.{\\r}\r\nDialogue: 0,0:48:42.55,0:48:44.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u827E\u5C14\u5BB6\u65CF\u7684\u6807\u5FD7\
+        \u4EE3\u8868\u5E0C\u671B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}The symbol of the house of El means hope.{\\r}\r\nDialogue: 0,0:48:45.12,0:48:47.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u79CD\u5E0C\u671B\u7684\u4F53\u73B0\
+        \u5728\u4E8E...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Embodied\
+        \ within that hope is the fundamental belief...{\\r}\r\nDialogue: 0,0:48:47.89,0:48:52.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8BA9\u6BCF\u4E2A\u4EBA\u7684\u6F5C\u529B\
+        \u6210\u4E3A\u5584\u7684\u529B\u91CF{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}...in the potential of every person to be a force for good.{\\\
+        r}\r\nDialogue: 0,0:48:52.93,0:48:54.96,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u53EF\u4EE5\u5C06\u8FD9\u4E00\u70B9\u5E26\u7ED9\
+        \u4ED6\u4EEC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}That's\
+        \ what you can bring them.{\\r}\r\nDialogue: 0,0:49:15.15,0:49:17.59,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E3A\u4EC0\u4E48\u6211\u8FD9\u4E48\u4E0E\
+        \u4F17\u4E0D\u540C\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Why am I so different from them?{\\r}\r\nDialogue: 0,0:49:18.25,0:49:21.45,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5730\u7403\u7684\u592A\u9633\u6BD4\u6C2A\
+        \u661F\u7684\u592A\u9633\u66F4\u5E74\u8F7B\u66F4\u660E\u4EAE{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Earth's sun is younger and brighter\
+        \ than Krypton's was.{\\r}\r\nDialogue: 0,0:49:22.66,0:49:25.03,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u7684\u7EC6\u80DE\u6C72\u53D6\u4E86\
+        \u5B83\u7684\u8F90\u5C04{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Your cells have drunken its radiation...{\\r}\r\nDialogue: 0,0:49:25.29,0:49:29.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u52A0\u5F3A\u4F60\u7684\u808C\u8089 \u76AE\
+        \u80A4\u4EE5\u53CA\u611F\u5B98{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...strengthening your muscles, your skin, your senses.{\\r}\r\nDialogue:\
+        \ 0,0:49:29.83,0:49:33.83,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5730\u7403\u7684\u5F15\u529B\u8F83\u5F31 \u4F46\u5927\u6C14\u66F4\
+        \u52A0\u6ECB\u6DA6{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Earth's\
+        \ gravity is weaker, yet its atmosphere is more nourishing.{\\r}\r\nDialogue:\
+        \ 0,0:49:35.13,0:49:38.14,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u5728\u8FD9\u91CC\u53D8\u5F97\u4F1A\u6BD4\u6211\u60F3\u8C61\
+        \u4E2D\u7684\u66F4\u5F3A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You've grown stronger here than I ever could have imagined.{\\r}\r\n\
+        Dialogue: 0,0:49:38.37,0:49:41.00,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u77E5\u9053\u591A\u5F3A\u7684\u552F\u4E00\u529E\u6CD5\u5C31\
+        \u662F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The only way\
+        \ to know how strong...{\\r}\r\nDialogue: 0,0:49:41.04,0:49:44.58,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u65AD\u6D4B\u8BD5\u4F60\u7684\u6781\
+        \u9650{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...is to keep\
+        \ testing your limits.{\\r}\r\nDialogue: 0,0:50:36.43,0:50:40.43,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4F1A\u5E26\u7ED9\u5730\u7403\u4EBA\
+        \u4E3A\u4E4B\u594B\u6597\u7684\u7406\u60F3{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}You will give the people of Earth an ideal lo strive\
+        \ towards.{\\r}\r\nDialogue: 0,0:50:42.10,0:50:43.91,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4EEC\u4F1A\u5728\u4F60\u8EAB\u540E\
+        \u52AA\u529B\u8FFD\u8D76{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}They'll race behind you.{\\r}\r\nDialogue: 0,0:50:44.17,0:50:45.55,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4EEC\u4F1A\u5931\u8DB3{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}They will stumble.{\\r}\r\n\
+        Dialogue: 0,0:50:45.77,0:50:46.91,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4F1A\u5012\u4E0B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}They will fall.{\\r}\r\nDialogue: 0,0:50:47.17,0:50:48.88,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u6700\u540E{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}But In time...{\\r}\r\nDialogue: 0,0:50:50.41,0:50:53.05,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4EEC\u4F1A\u5728\u592A\u9633\u4E0B\
+        \u4E0E\u4F60\u6BD4\u80A9 \u5361\u5C14{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}...they will join you in the sun, Kal.{\\r}\r\nDialogue:\
+        \ 0,0:50:54.55,0:50:56.25,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5230\u6700\u540E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}In time...{\\r}\r\nDialogue: 0,0:50:56.58,0:50:59.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4F1A\u5E2E\u52A9\u4ED6\u4EEC\u521B\
+        \u9020\u5947\u8FF9{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}you\
+        \ will help them accomplish wonders.{\\r}\r\nDialogue: 0,0:52:25.94,0:52:27.54,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5148\u4ECE\u8FFD\u8E2A\u6709\u4ED6\u51FA\
+        \u73B0\u7684\u90FD\u5E02\u4F20\u8BF4\u5F00\u59CB{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}You start with the urban legends...{\\r}\r\nDialogue:\
+        \ 0,0:52:27.81,0:52:30.15,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}- \u4ED6\u9192\u6765\u540E\u90FD\u6D8C\u73B0\u4E86\u51FA\u6765   -\
+        \ \u8FD9\u662F\u4E54{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}-\
+        \ ...that have sprung up in his wake.        - That's Joe.{\\r}\r\nDialogue:\
+        \ 0,0:52:30.38,0:52:32.85,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6240\u6709\u58F0\u79F0\u89C1\u8FC7\u4ED6\u7684\u670B\u53CB\u7684\
+        \u670B\u53CB{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The\
+        \ friends of a friend who have seen him.{\\r}\r\nDialogue: 0,0:52:32.85,0:52:34.01,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u8FC7\u53BB\u5728\u8FD9\u91CC\u5DE5\
+        \u4F5C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He worked\
+        \ here.{\\r}\r\nDialogue: 0,0:52:34.28,0:52:36.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5BF9\u67D0\u4E9B\u4EBA\u800C\u8A00 \u4ED6\
+        \u662F\u5B88\u62A4\u5929\u4F7F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}For some he was a guardian angel.{\\r}\r\nDialogue: 0,0:52:36.26,0:52:39.80,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5BF9\u5176\u4ED6\u4EBA\u6765\u8BB2 \u4ED6\
+        \u662F\u4E2A\u8C1C \u662F\u4E2A\u683C\u683C\u4E0D\u5165\u7684\u5E7D\u7075\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}For others, a cipher,\
+        \ a ghost who never quite fit in...{\\r}\r\nDialogue: 0,0:52:40.02,0:52:43.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u597D\u5427 \u6211\u662F\u8BF4\u6211\u4EEC\
+        \u5728\u9760\u8FD1\u77F3\u6CB9\u94BB\u673A{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Well, I was saying we were coming towards the oil\
+        \ rig.{\\r}\r\nDialogue: 0,0:52:43.19,0:52:47.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u968F\u7740\u4F60\u6392\u9664\u56F0\u96BE\
+        \u8FFD\u6EAF\u8FC7\u53BB \u6545\u4E8B\u5F00\u59CB\u6E10\u6E10\u6210\u578B\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}As you work your\
+        \ way back in time, the stories form a pattern.{\\r}\r\nDialogue: 0,0:52:47.06,0:52:49.13,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5728\u627E\u76AE\u7279\u2022\u7F57\
+        \u65AF \u4F60\u8BA4\u8BC6\u4ED6\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}I'm looking for a Pete Ross. Do you know him?{\\\
+        r}\r\nDialogue: 0,0:52:54.13,0:52:55.44,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u662F\u76AE\u7279\u2022\u7F57\u65AF\u5417\uFF1F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Pete Ross?{\\r}\r\nDialogue:\
+        \ 0,0:52:57.17,0:53:00.38,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u60F3\u8DDF\u60A8\u8C08\u8C08\u4F60\u5E74\u8F7B\u65F6\u5019\
+        \u7684\u4E00\u573A\u4E8B\u6545{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I'd like to talk to you about an accident when you were younger.{\\\
+        r}\r\nDialogue: 0,0:53:00.64,0:53:03.14,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E00\u8F86\u51B2\u8FDB\u6CB3\u91CC\u7684\u6821\u8F66\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}A school bus that\
+        \ went into the river.{\\r}\r\nDialogue: 0,0:53:08.65,0:53:10.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6770\u65AF{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Dusty.{\\r}\r\nDialogue: 0,0:53:10.92,0:53:11.99,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u80AF\u7279\u592B\u4EBA\u5417\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Mrs. Kent?{\\r}\r\n\
+        Dialogue: 0,0:53:12.92,0:53:15.36,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6211\u662F\u9732\u6613\u4E1D\u2022\u83B2\u6069 \u6765\u81EA\
+        \u300A\u661F\u7403\u65E5\u62A5\u300B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}I'm Lois Lane. I'm from the  Daily Planet.{\\r}\r\nDialogue:\
+        \ 0,0:53:15.92,0:53:16.66,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5B89\u9759{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Quiet.{\\\
+        r}\r\nDialogue: 0,0:53:18.26,0:53:21.73,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u6765\u81EA\u300A\u661F\u7403\u65E5\u62A5\u300B\
+        \ \u6211\u60F3\u8DDF\u60A8\u8C08\u8C08\u4F60\u7684\u513F\u5B50{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm from the Daily Planet and\
+        \ I'd like to talk to you about your son.{\\r}\r\nDialogue: 0,0:53:39.85,0:53:44.45,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u65E9\u5C31\u77E5\u9053\u8981\u662F\
+        \u6211\u67E5\u5F97\u591F\u4ED4\u7EC6 \u4F60\u6700\u540E\u4F1A\u627E\u5230\u6211\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I figured if I turned\
+        \ over enough stones you'd eventually find me.{\\r}\r\nDialogue: 0,0:53:49.42,0:53:52.46,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4ECE\u54EA\u6765\uFF1F\u5728\u8FD9\
+        \u91CC\u505A\u4EC0\u4E48\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Where are you from? What are you doing here?{\\r}\r\nDialogue: 0,0:53:52.73,0:53:54.07,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8BA9\u6211\u8BB2\u4F60\u7684\u6545\u4E8B\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Let me tell your\
+        \ story.{\\r}\r\nDialogue: 0,0:53:54.29,0:53:57.43,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8981\u662F\u6211\u4E0D\u60F3\u8BA9\u6211\
+        \u7684\u6545\u4E8B\u88AB\u8BB2\u51FA\u53BB\u5462\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What if I don't want my story told?{\\\
+        r}\r\nDialogue: 0,0:53:57.70,0:53:59.47,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6700\u540E\u5B83\u603B\u4F1A\u88AB\u4F20\u51FA\u53BB\
+        \u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's going\
+        \ to come out eventually.{\\r}\r\nDialogue: 0,0:53:59.73,0:54:02.77,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6709\u4EBA\u4F1A\u62FF\u5230\u76F8\u7247\
+        \u6216\u662F\u67E5\u5230\u4F60\u7684\u4F4F\u5904{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Somebody's going to get a photograph or figure out\
+        \ where you live.{\\r}\r\nDialogue: 0,0:54:03.04,0:54:05.98,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u90A3\u6211\u5C31\u518D\u6B21\u6D88\u5931\
+        \   - \u552F\u4E00\u7684\u529E\u6CD5\u5C31\u662F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}- Then I'll disappear again.       - The only way\
+        \ you could disappear...{\\r}\r\nDialogue: 0,0:54:06.24,0:54:10.24,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u518D\u5E2E\u52A9\u4EBA\u4EEC \u6211\
+        \u611F\u89C9\u4F60\u4E0D\u4F1A\u90A3\u6837\u7684{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...is to stop helping people altogether, and I sense\
+        \ that's not an option for you.{\\r}\r\nDialogue: 0,0:54:14.41,0:54:18.42,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u7236\u4EB2\u76F8\u4FE1\u8981\u662F\
+        \u4E16\u754C\u67E5\u51FA\u6211\u7684\u771F\u5B9E\u8EAB\u4EFD{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}My father believed that if the world\
+        \ found out who I really was...{\\r}\r\nDialogue: 0,0:54:20.42,0:54:21.92,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4EEC\u4F1A\u62D2\u7EDD\u6211{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...they'd reject me...{\\\
+        r}\r\nDialogue: 0,0:54:22.15,0:54:23.79,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u56E0\u4E3A\u6050\u60E7{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...out of fear.{\\r}\r\nDialogue: 0,0:54:25.82,0:54:27.90,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u538C\u5026\u4E86\u5B89\u5168{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm tired of safe.{\\\
+        r}\r\nDialogue: 0,0:54:28.13,0:54:30.23,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u53EA\u60F3\u6709\u751F\u4E4B\u5E74\u505A\u4E9B\
+        \u6709\u7528\u7684\u4E8B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I just wanna do something useful with my life.{\\r}\r\nDialogue: 0,0:54:30.46,0:54:33.07,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u4E48\u5F00\u519C\u573A \u517B\u6D3B\
+        \u5927\u5BB6 \u5C31\u6CA1\u6709\u7528\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}So farming, feeding people. That's not useful?{\\\
+        r}\r\nDialogue: 0,0:54:33.30,0:54:34.30,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u6CA1\u90A3\u4E48\u8BF4{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}I didn't say that.{\\r}\r\nDialogue: 0,0:54:34.40,0:54:36.64,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u7684\u5BB6\u65CF\u6574\u6574\
+        \u4E94\u4EE3\u90FD\u4EE5\u519C\u573A\u4E3A\u751F \u514B\u62C9\u514B{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Our family's been farming\
+        \ for five generations.{\\r}\r\nDialogue: 0,0:54:36.77,0:54:38.68,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u7684\u5BB6\u65CF \u4E0D\u662F\u6211\
+        \u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Your family,\
+        \ not mine.{\\r}\r\nDialogue: 0,0:54:38.94,0:54:42.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u90FD\u4E0D\u77E5\u9053\u81EA\u5DF1\
+        \u4E3A\u4EC0\u4E48\u8981\u542C\u4F60\u8BF4 \u4F60\u4E0D\u662F\u6211\u7238\u7238\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I don't even know\
+        \ why I'm listening to you. You're not my dad.{\\r}\r\nDialogue: 0,0:54:42.14,0:54:43.52,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u53EA\u662F\u67D0\u4E2A\u5728\u5730\
+        \u91CC\u6361\u5230\u6211\u7684\u4EBA{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}You're just some guy who found me in a field.{\\r}\r\n\
+        Dialogue: 0,0:54:43.78,0:54:44.95,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Clark.{\\r}\r\nDialogue: 0,0:54:47.31,0:54:48.99,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6CA1\u5173\u7CFB \u739B\u838E{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's all right, Martha.{\\\
+        r}\r\nDialogue: 0,0:54:50.82,0:54:52.92,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4ED6\u8BF4\u5F97\u5BF9 \u514B\u62C9\u514B\u8BF4\u5F97\
+        \u6709\u9053\u7406{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He's\
+        \ right. Clark has a point.{\\r}\r\nDialogue: 0,0:54:53.49,0:54:54.52,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u4E0D\u662F\u4F60\u7684\u7236\
+        \u6BCD{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We're not\
+        \ your parents.{\\r}\r\nDialogue: 0,0:54:56.62,0:54:58.33,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u6211\u4EEC\u529B\u6C42\u505A\u5230\
+        \u6700\u597D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}But\
+        \ we've been doing the best we can.{\\r}\r\nDialogue: 0,0:54:58.59,0:55:01.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u4E5F\u5728\u5C3D\u53EF\u80FD\
+        \u5730\u6539\u8FDB \u4E5F\u8BB8...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}And we've been making this up as we go along, so maybe...{\\\
+        r}\r\nDialogue: 0,0:55:02.19,0:55:05.11,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u4EEC\u6240\u8C13\u7684\u6700\u597D\u5DF2\u7ECF\
+        \u4E0D\u591F\u597D\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Maybe our best isn't good enough anymore.{\\r}\r\nDialogue: 0,0:55:09.64,0:55:11.67,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u542C\u7740 \u7238{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Look, Dad...{\\r}\r\nDialogue: 0,0:55:11.94,0:55:13.38,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7B49\u4E00\u4E0B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Hold on.{\\r}\r\nDialogue: 0,0:55:33.13,0:55:34.83,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5FEB\u53BB\u5929\u6865\u8EB2\u7740{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Go for the overpass.{\\\
+        r}\r\nDialogue: 0,0:55:36.63,0:55:37.73,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5FEB\u70B9\u53BB\u8EB2\u8D77\u6765{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Go for the overpass!{\\r}\r\nDialogue:\
+        \ 0,0:55:40.07,0:55:41.70,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u627E\u63A9\u62A4 \u5FEB\u627E\u63A9\u62A4{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Take cover! Take cover!{\\r}\r\nDialogue:\
+        \ 0,0:55:41.97,0:55:44.35,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}- \u5728\u90A3\u8FB9 \u8DDF\u4E0A\u4ED6\u4EEC   - \u627E\u63A9\u62A4\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Over there. Just\
+        \ follow them.       - Take cover.{\\r}\r\nDialogue: 0,0:55:48.07,0:55:49.25,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5979\u88AB\u56F0\u4F4F\u4E86{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}She's stuck.{\\r}\r\nDialogue:\
+        \ 0,0:55:53.81,0:55:55.69,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6C49\u514B\u5728\u8F66\u91CC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Hank's still in the car.{\\r}\r\nDialogue: 0,0:55:56.52,0:55:57.55,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6C49\u514B\u5728\u8F66\u91CC{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Hank's in the car.{\\r}\r\n\
+        Dialogue: 0,0:55:58.42,0:56:00.56,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}- \u6211\u53BB\u6551\u5B83 \u6211\u53BB\u6551   - \u4E0D{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- I'll get him, I'll\
+        \ get him.       - No, no.{\\r}\r\nDialogue: 0,0:56:01.09,0:56:03.33,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5E26\u4F60\u5988\u53BB\u5929\u6865{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Get your mom to the\
+        \ overpass.{\\r}\r\nDialogue: 0,0:56:21.71,0:56:23.52,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6C49\u514B \u5FEB\u6765{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Hank! Hank! Come!{\\r}\r\nDialogue:\
+        \ 0,0:56:54.64,0:56:56.09,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}- \u4E54\u7EB3\u68EE   - \u5988 \u5F85\u5728\u8FD9{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Jonathan!       - Mom, stay here.{\\\
+        r}\r\nDialogue: 0,0:57:21.90,0:57:24.40,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u7238{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Dad!{\\r}\r\nDialogue: 0,0:57:26.94,0:57:30.81,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u56E0\u4E3A\u6211\u7684\u4FE1\u4EFB \u7236\
+        \u4EB2\u53BB\u4E16\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I let my father die because I trusted him.{\\r}\r\nDialogue: 0,0:57:30.91,0:57:34.82,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u56E0\u4E3A\u4ED6\u76F8\u4FE1\u4E16\u754C\
+        \u8FD8\u6CA1\u6709\u51C6\u5907\u597D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Because he was convinced that I had to wait.{\\r}\r\nDialogue:\
+        \ 0,0:57:35.58,0:57:37.75,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u5FC5\u987B\u7B49\u5F85\u4E0B\u53BB{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}That the world was not ready.{\\r}\r\n\
+        Dialogue: 0,0:57:39.48,0:57:41.12,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4F60\u600E\u4E48\u60F3\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}What do you think?{\\r}\r\nDialogue: 0,0:57:46.02,0:57:47.66,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5F97\u5C0F\u5FC3\u4E86 \u9732\u6613\
+        \u4E1D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You better\
+        \ watch out, Lois.{\\r}\r\nDialogue: 0,0:57:48.16,0:57:50.47,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F69\u91CC\u8981\u51B2\u4F60\u53D1\u706B\
+        \u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Hey, Perry's\
+        \ gunning for you.{\\r}\r\nDialogue: 0,0:57:50.70,0:57:52.65,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u77E5\u9053\u4F60\u662F\u4F0D\u5FB7\
+        \u4F2F\u6069\u7684\u533F\u540D\u4FE1\u606F\u6E90{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}He knows you're Woodburn's anonymous source{\\r}\r\
+        \nDialogue: 0,0:57:52.65,0:57:54.97,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u90FD\u7B49\u4E0D\u53CA\u597D\u597D\u6559\u8BAD\u4F60\
+        \u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}and cannot\
+        \ wait to rip you a new one.{\\r}\r\nDialogue: 0,0:57:56.84,0:57:58.28,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u770B\u770B\u5979 \u54C8\u54C8{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Oh, look at her. Ha, ha, ha.{\\\
+        r}\r\nDialogue: 0,0:58:00.27,0:58:02.81,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u544A\u8BC9\u8FC7\u4F60\u4E0D\u8981\u8DDF\u8FD9\
+        \u6761\u7EBF \u7136\u540E\u5462\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}I told you not to run with this, and what do you do?{\\\
+        r}\r\nDialogue: 0,0:58:03.04,0:58:05.54,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u5374\u8BA9\u4F0D\u5FB7\u4F2F\u6069\u5C06\u4E4B\
+        \u4F20\u904D\u4E86\u7F51\u7EDC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You let Woodburn just shotgun it all over the Internet.{\\r}\r\nDialogue:\
+        \ 0,0:58:05.81,0:58:08.69,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u73B0\u5728\u51FA\u7248\u5546\u60F3\u8BA9\u6211\u8D77\u8BC9\u4F60\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Now the publishers\
+        \ want me to sue you.{\\r}\r\nDialogue: 0,0:58:08.95,0:58:12.19,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u597D\u5427 \u5982\u679C\u8FD8\u6709\u7528\
+        \u7684\u8BDD \u6211\u653E\u5F03{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Well, if it makes a difference, I'm dropping it.{\\r}\r\nDialogue: 0,0:58:12.45,0:58:13.45,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C31\u90A3\u6837\u5417\uFF1F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Whoa, just like that?{\\r}\r\
+        \nDialogue: 0,0:58:13.69,0:58:14.69,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6CA1\u9519{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Yep.{\\r}\r\nDialogue: 0,0:58:15.05,0:58:16.36,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u7684\u7EBF\u7D22\u600E\u4E48\u4E86\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What happened\
+        \ to your leads?{\\r}\r\nDialogue: 0,0:58:17.02,0:58:19.66,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6CA1\u4EC0\u4E48\u610F\u601D \u6574\u4E2A\
+        \u6545\u4E8B\u90FD\u662F\u8FC7\u773C\u4E91\u70DF{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}They didn't pan out. The story is smoke.{\\r}\r\n\
+        Dialogue: 0,0:58:19.89,0:58:22.44,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4E5F\u6709\u53EF\u80FD\u6CA1\u5F15\u8D77\u4F60\u671F\u76FC\
+        \u7684\u516C\u4F17\u6CE8\u610F\u7F62\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Or it didn't get the traction you hoped?{\\r}\r\n\
+        Dialogue: 0,0:58:24.20,0:58:25.04,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4E24\u5468\u7684\u65E0\u85AA\u4F11\u5047{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Two weeks leave...{\\r}\r\nDialogue:\
+        \ 0,0:58:25.30,0:58:26.90,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u7B97\u662F\u60E9\u7F5A\u4F60\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...no pay, that's your penance.{\\r}\r\nDialogue:\
+        \ 0,0:58:27.17,0:58:28.84,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u518D\u8FD9\u4E48\u5F04\u4E00\u6B21{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}You try something like this again...{\\\
+        r}\r\nDialogue: 0,0:58:29.07,0:58:30.74,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u6211\u5C31\u5F00\u9664\u4F60   - \u597D\u5427{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- ...you're done here.\
+        \       - Fine.{\\r}\r\nDialogue: 0,0:58:31.00,0:58:32.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u8FD9\u4E48\u8FEB\u4E0D\u53CA\u5F85\
+        \u5730\u9644\u548C\u6211{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Let's make it three weeks{\\r}\r\nDialogue: 0,0:58:32.11,0:58:33.71,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6539\u6210\u4E09\u5468\u4F11\u5047\u6BD4\
+        \u8F83\u5408\u9002{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}since\
+        \ you're so willing to agree.{\\r}\r\nDialogue: 0,0:58:37.14,0:58:38.82,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9732\u6613\u4E1D \u6211\u7EDD\u4E0D\u8BA4\
+        \u4E3A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I believe\
+        \ you saw something, Lois.{\\r}\r\nDialogue: 0,0:58:39.31,0:58:42.32,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u7684\u7EBF\u7D22\u6BEB\u65E0\u4EF7\
+        \u503C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}But not for\
+        \ a moment do I believe that your leads just went cold.{\\r}\r\nDialogue:\
+        \ 0,0:58:42.55,0:58:46.05,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u56E0\u6B64\u4E0D\u7BA1\u4F60\u653E\u5F03\u7684\u7406\u7531\u662F\
+        \u4EC0\u4E48{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}So whatever\
+        \ your reasons are for dropping it...{\\r}\r\nDialogue: 0,0:58:47.09,0:58:48.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u76F8\u4FE1\u4F60\u505A\u5F97\u6CA1\
+        \u9519{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...I think\
+        \ you're doing the right thing.{\\r}\r\nDialogue: 0,0:58:49.49,0:58:50.73,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E3A\u4EC0\u4E48\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Why?{\\r}\r\nDialogue: 0,0:58:52.09,0:58:55.73,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5982\u679C\u4EBA\u4EEC\u5F97\u77E5\u5730\
+        \u7403\u6709\u8FD9\u6837\u7684\u4EBA\u7684\u5B58\u5728{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Can you imagine how people on this\
+        \ planet would react...{\\r}\r\nDialogue: 0,0:58:58.00,0:59:01.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u80FD\u60F3\u8C61\u4EBA\u4EEC\u4F1A\
+        \u6709\u4F55\u79CD\u53CD\u5E94\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...if they knew there was someone like this out there?{\\\
+        r}\r\nDialogue: 0,0:59:19.58,0:59:20.99,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u53BB\u63A5\u63A5\u4ED6{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Go get him.{\\r}\r\nDialogue: 0,0:59:27.43,0:59:29.06,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u770B\u770B\u6211\u513F\u5B50{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Well, look at you.{\\r}\r\n\
+        Dialogue: 0,0:59:46.11,0:59:47.92,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4E00\u4E2A\u8BB0\u8005\u6765\u8FC7{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}A reporter came by here.{\\r}\r\nDialogue:\
+        \ 0,0:59:48.48,0:59:50.72,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u662F\u4E2A\u670B\u53CB \u522B\u62C5\u5FC3{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}She's a friend. Don't worry.{\\r}\r\n\
+        Dialogue: 0,0:59:53.72,0:59:54.59,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u5988\u5988{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Mom.{\\r}\r\nDialogue: 0,0:59:54.75,0:59:56.49,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u600E\u4E48\u4E86\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What?{\\r}\r\nDialogue: 0,0:59:57.96,1:00:00.49,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u6211\u627E\u5230\u4E86   - \u8C01\uFF1F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- I found them.\
+        \       - Who?{\\r}\r\nDialogue: 0,1:00:01.33,1:00:02.83,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u7684\u7236\u6BCD{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}My parents.{\\r}\r\nDialogue: 0,1:00:04.00,1:00:05.34,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u7684\u65CF\u4EBA{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}My People.{\\r}\r\nDialogue: 0,1:00:06.23,1:00:09.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u73B0\u5728\u77E5\u9053\u81EA\u5DF1\
+        \u7684\u8EAB\u4E16\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I know where I come from now.{\\r}\r\nDialogue: 0,1:00:10.84,1:00:12.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u54C7{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Wow.{\\r}\r\nDialogue: 0,1:00:13.17,1:00:14.95,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u771F\u662F\u592A\u597D\u4E86{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}That's wonderful.{\\\
+        r}\r\nDialogue: 0,1:00:16.81,1:00:19.25,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u592A\u4E3A\u4F60\u9AD8\u5174\u4E86 \u514B\u62C9\u514B\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm so happy for\
+        \ you, Clark.{\\r}\r\nDialogue: 0,1:00:28.09,1:00:30.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u600E\u4E48\u4E86\uFF1F - \u6CA1\u4E8B\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- What?       -\
+        \ It's nothing.{\\r}\r\nDialogue: 0,1:00:33.33,1:00:36.27,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5C1A\u5728\u8941\u8913\u4E2D\u65F6\
+        \ \u6211\u6574\u591C\u5728\u5A74\u513F\u5E8A\u8FB9\u966A\u4F60{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}When you were a baby I used\
+        \ to lay by your crib at night...{\\r}\r\nDialogue: 0,1:00:36.50,1:00:38.87,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u542C\u7740\u4F60\u7684\u547C\u5438{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...listening to you\
+        \ breathe.{\\r}\r\nDialogue: 0,1:00:39.93,1:00:41.54,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u5BF9\u4F60\u6765\u8BF4\u4E0D\u5BB9\
+        \u6613{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It was hard\
+        \ for you.{\\r}\r\nDialogue: 0,1:00:42.77,1:00:44.14,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u52AA\u529B\u7740{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You struggled.{\\r}\r\nDialogue: 0,1:00:44.37,1:00:46.21,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u65E0\u65F6\u4E0D\u523B\u4E0D\u62C5\
+        \u5FC3\u4F60{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And\
+        \ I worried all the time.{\\r}\r\nDialogue: 0,1:00:46.47,1:00:48.31,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6015\u771F\u76F8\u66B4\u9732\u5417\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You worried\
+        \ the truth would come out.{\\r}\r\nDialogue: 0,1:00:49.84,1:00:51.05,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}No.{\\r}\r\nDialogue: 0,1:00:52.01,1:00:54.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u7684\u771F\u76F8\u5417\uFF1F\u90A3\
+        \u5C31\u662F\u4F60\u592A\u53EF\u7231\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}The truth about you is beautiful.{\\r}\r\nDialogue:\
+        \ 0,1:00:55.05,1:00:58.49,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u7B2C\u4E00\u773C\u89C1\u5230\u4F60\u7684\u65F6\u5019\u6211\u4EEC\
+        \u5C31\u77E5\u9053{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We\
+        \ saw that the moment we laid eyes on you.{\\r}\r\nDialogue: 0,1:01:00.79,1:01:04.79,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u77E5\u9053\u6709\u4E00\u5929 \u4E16\u4EBA\
+        \u4E5F\u7EC8\u5F52\u4F1A\u53D1\u73B0{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}We knew that one day, the whole world would see that.{\\\
+        r}\r\nDialogue: 0,1:01:07.23,1:01:08.86,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u53EA\u662F...{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}I'm just...{\\r}\r\nDialogue: 0,1:01:09.49,1:01:11.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u62C5\u5FC3\u4ED6\u4EEC\u4F1A\u8BA9\u6211\
+        \u4EEC\u5206\u79BB{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm\
+        \ worried they'll take you away from me.{\\r}\r\nDialogue: 0,1:01:13.80,1:01:16.18,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u54EA\u4E5F\u4E0D\u53BB \u5988\u5988\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm not going anywhere,\
+        \ Mom.{\\r}\r\nDialogue: 0,1:01:18.00,1:01:19.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4FDD\u8BC1{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}I promise.{\\r}\r\nDialogue: 0,1:01:25.71,1:01:27.88,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u65AF\u65FA\u5A01\u514B\u5C06\u519B \u957F\
+        \u5B98{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}General Swanwick,\
+        \ sir.{\\r}\r\nDialogue: 0,1:01:28.15,1:01:31.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD9\u662F\u4EC0\u4E48 \u535A\u58EB\uFF1F\
+        \u5F57\u661F\u8FD8\u662F\u5C0F\u884C\u661F\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}What am I looking at, doc? Comet? Asteroid?{\\r}\r\
+        \nDialogue: 0,1:01:33.05,1:01:37.06,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5F57\u661F\u53EF\u4E0D\u4F1A\u4FEE\u6B63\u822A\u9053\
+        \ \u5C06\u519B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Comets\
+        \ don't make course corrections, general.{\\r}\r\nDialogue: 0,1:01:39.86,1:01:43.86,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5728\u67D0\u4E2A\u5929\u6587\u7231\u597D\
+        \u8005\u770B\u5230\u5E76\u5F15\u8D77\u6050\u614C\u524D \u6211\u60F3\u8BA9\u4F60\
+        \u597D\u597D\u770B\u4E00\u4E0B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Wanted you to see this before some amateur with a telescope creates\
+        \ a worldwide panic.{\\r}\r\nDialogue: 0,1:01:45.53,1:01:46.91,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD9\u8258\u8239\u4F3C\u4E4E{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The ship appears to have...{\\\
+        r}\r\nDialogue: 0,1:01:47.17,1:01:49.91,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5C06\u81EA\u5DF1\u9001\u5165\u4E86\u6708\u7403\u540C\
+        \u6B65\u8F68\u9053{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...inserted\
+        \ itself into a lunar synchronous orbit...{\\r}\r\nDialogue: 0,1:01:50.17,1:01:52.34,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E0D\u77E5\u9053\u4E3A\u4EC0\u4E48\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...though I have\
+        \ no idea why.{\\r}\r\nDialogue: 0,1:01:52.57,1:01:55.42,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6709\u8BD5\u8FC7\u548C\u5B83\u53D6\
+        \u5F97\u8054\u7CFB\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Have you tried... communicating with it?{\\r}\r\nDialogue: 0,1:01:55.67,1:01:59.68,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4EEC\u81F3\u4ECA\u6CA1\u6709\u56DE\
+        \u5E94{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Well, they\
+        \ haven't responded as of yet.{\\r}\r\nDialogue: 0,1:02:00.95,1:02:04.95,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E2A\u4EBA\u7684\u731C\u6D4B\u662F\
+        \ \u4E0D\u7BA1\u662F\u8C01\u5728\u64CD\u7EB5\u98DE\u8239...{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm just speculating, but I think\
+        \ whoever's at the helm of that thing...{\\r}\r\nDialogue: 0,1:02:05.22,1:02:07.72,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4E00\u5B9A\u60F3\u6765\u4E2A\u60CA\
+        \u4EBA\u7684\u7740\u9646{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...is looking to make a dramatic entrance.{\\r}\r\nDialogue: 0,1:02:14.59,1:02:16.07,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6709\u4EBA\u77E5\u9053\u58A8\u76D2\u653E\
+        \u5728\u54EA\u4E86\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Anybody know where we keep the toner?{\\r}\r\nDialogue: 0,1:02:17.03,1:02:18.94,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u600E\u4E48\u4E86\uFF1F - \u65B0\u95FB\
+        \u90FD\u5728\u62A5\u9053{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}- What's going on?       - It's all over the news.{\\r}\r\nDialogue:\
+        \ 0,1:02:19.20,1:02:21.14,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u5F97\u6765\u770B\u770B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}You gotta see this.{\\r}\r\nDialogue: 0,1:02:48.13,1:02:49.63,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark.{\\r}\r\nDialogue: 0,1:02:50.00,1:02:51.13,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u55EF\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Yeah?{\\r}\r\nDialogue: 0,1:02:51.40,1:02:52.74,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6765\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Coming.{\\r}\r\nDialogue: 0,1:02:53.06,1:02:55.27,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD9\u662F\u4E2A\u7A81\u53D1\u65B0\u95FB\
+        \ \u8EAB\u4EFD\u4E0D\u660E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}This is a breaking news. An unidentified...{\\r}\r\nDialogue: 0,1:03:36.98,1:03:39.05,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5E76\u4E0D\u662F\u4E00\u4E2A\u4EBA\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You are not alone.{\\\
+        r}\r\nDialogue: 0,1:03:40.71,1:03:43.06,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u5E76\u4E0D\u662F\u4E00\u4E2A\u4EBA{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You are not alone.{\\r}\r\n\
+        Dialogue: 0,1:03:44.98,1:03:47.22,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4F60\u5E76\u4E0D\u662F\u4E00\u4E2A\u4EBA{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You are not alone.{\\r}\r\nDialogue:\
+        \ 0,1:03:52.89,1:03:55.50,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60 \u5E76\u4E0D\u662F \u4E00\u4E2A\u4EBA{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}You are not alone.{\\r}\r\nDialogue: 0,1:04:20.92,1:04:22.48,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}RSS\u4E5F\u6709\u8FD9\u4FE1\u606F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's coming in on the RSS\
+        \ feeds.{\\r}\r\nDialogue: 0,1:04:22.69,1:04:24.56,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5E76\u4E0D\u662F\u4E00\u4E2A\u4EBA\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You are not alone.{\\\
+        r}\r\nDialogue: 0,1:04:25.19,1:04:27.23,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u624B\u673A\u4E0A\u4E5F\u6709{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's on my phone too.{\\r}\r\nDialogue:\
+        \ 0,1:04:29.39,1:04:31.84,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u662F\u4F50\u5FB7\u5C06\u519B{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}My name is General Zod.{\\r}\r\nDialogue: 0,1:04:33.67,1:04:36.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u6765\u81EA\u4E00\u4E2A\u9065\u8FDC\
+        \u7684\u661F\u7403{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I\
+        \ come from a world far from yours.{\\r}\r\nDialogue: 0,1:04:37.84,1:04:42.34,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u7A7F\u8D8A\u4E86\u832B\u832B\u661F\
+        \u6D77\u6765\u627E\u4F60\u4EEC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I have journeyed across an ocean of stars to reach you.{\\r}\r\nDialogue:\
+        \ 0,1:04:43.94,1:04:47.95,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u4EEC\u5E87\u62A4\u4E86\u6211\u7684\u4E00\u4E2A\u5B50\u6C11\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}For some time, your\
+        \ world has sheltered one of my citizens.{\\r}\r\nDialogue: 0,1:04:48.58,1:04:51.79,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u73B0\u5728\u6211\u8981\u6C42\u4F60\u4EEC\
+        \u628A\u4ED6\u4EA4\u51FA\u6765{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I request that you return this individual...{\\r}\r\nDialogue: 0,1:04:52.05,1:04:54.19,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7ED9\u6211\u5904\u7406{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...to my custody.{\\r}\r\nDialogue:\
+        \ 0,1:04:54.42,1:05:00.80,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u56E0\u4E3A\u67D0\u4E9B\u539F\u56E0 \u4ED6\u9009\u62E9\u5411\u4F60\
+        \u4EEC\u9690\u7792\u4ED6\u7684\u5B58\u5728{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}For reasons unknown, he has chosen to keep his existence\
+        \ a secret from you.{\\r}\r\nDialogue: 0,1:05:01.59,1:05:04.77,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u7AED\u5C3D\u5168\u529B\u878D\u5165\
+        \u4F60\u4EEC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He will\
+        \ have made efforts to blend in.{\\r}\r\nDialogue: 0,1:05:05.36,1:05:07.04,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u770B\u8D77\u6765\u548C\u4F60\u4EEC\
+        \u76F8\u4F3C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He will\
+        \ look like you.{\\r}\r\nDialogue: 0,1:05:07.77,1:05:10.37,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u4ED6\u4E0D\u662F\u540C\u65CF{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}But he is not one of\
+        \ you.{\\r}\r\nDialogue: 0,1:05:11.57,1:05:13.41,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5982\u679C\u6709\u8C01\u77E5\u9053{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}To those of you who\
+        \ may know...{\\r}\r\nDialogue: 0,1:05:13.64,1:05:15.64,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u7684\u4F4D\u7F6E{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...of his current location.{\\r}\r\
+        \nDialogue: 0,1:05:15.91,1:05:18.44,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u90A3\u4F60\u4EEC\u661F\u7403\u7684\u547D\u8FD0{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...the fate of your planet...{\\\
+        r}\r\nDialogue: 0,1:05:18.71,1:05:21.38,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5C31\u5728\u4F60\u624B\u4E2D\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...rests in your hands.{\\r}\r\nDialogue:\
+        \ 0,1:05:22.45,1:05:25.49,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5361\u5C14\u2022\u827E\u5C14 \u542C\u5230\u4E86\u5417\uFF1F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}To Kai-El, I say this:{\\\
+        r}\r\nDialogue: 0,1:05:27.55,1:05:30.23,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}24\u5C0F\u65F6\u5185\u51FA\u6765\u6295\u964D{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Surrender within 24 hours...{\\\
+        r}\r\nDialogue: 0,1:05:34.49,1:05:37.97,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6216\u8005\u8BA9\u6574\u4E2A\u4E16\u754C\u6765\u627F\
+        \u62C5\u540E\u679C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...or\
+        \ watch this world suffer the consequences...{\\r}\r\nDialogue: 0,1:05:53.24,1:05:55.09,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u5BF9\u4ED6\u4E00\u65E0\u6240\
+        \u77E5 \u5BF9\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}We hardly know anything about him, isn't that right?{\\r}\r\nDialogue:\
+        \ 0,1:05:55.25,1:05:57.25,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5982\u679C\u4ED6\u771F\u7684\u4E0D\u60F3\u5BB3\u6211\u4EEC{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}If he truly means us no\
+        \ harm...{\\r}\r\nDialogue: 0,1:05:57.48,1:05:59.98,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u4ED6\u5E94\u8BE5\u56DE\u5F52\u4ED6\
+        \u7684\u65CF\u4EBA \u53BB\u627F\u62C5\u540E\u679C{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...he'll turn himself in and face the consequences.{\\\
+        r}\r\nDialogue: 0,1:06:00.12,1:06:01.32,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5982\u679C\u4ED6\u4E0D\u80AF\u53BB{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And if he won't do that...{\\r}\r\n\
+        Dialogue: 0,1:06:01.59,1:06:03.59,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4E5F\u8BB8\u6211\u4EEC\u8BE5\u9001\u4ED6\u53BB{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...then maybe we should.{\\\
+        r}\r\nDialogue: 0,1:06:03.82,1:06:06.80,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u300A\u661F\u7403\u65E5\u62A5\u300B\u7684\u9732\u6613\
+        \u4E1D\u2022\u83B2\u6069\u77E5\u9053\u4ED6\u662F\u8C01{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The Daily Planet's Lois Lane knows\
+        \ who this guy is. She's...{\\r}\r\nDialogue: 0,1:06:07.03,1:06:08.43,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u8BA4\u4E3A\u5979\u662F\u6211\u4EEC\
+        \u8BE5\u8D28\u95EE\u7684\u4EBA{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...the one we should be questioning.{\\r}\r\nDialogue: 0,1:06:08.93,1:06:11.67,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u7B49\u7B49 \u4F60\u662F\u8BF4\u9732\u6613\
+        \u4E1D\u2022\u83B2\u6069   - \u4F60\u597D{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}- Hold on. You're saying Lois Lane...        - Hello?{\\\
+        r}\r\nDialogue: 0,1:06:11.93,1:06:14.43,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u5728\u770B\u65B0\u95FB\u5417\uFF1F\u64AD\u4E86\
+        \u4E00\u65E9\u4E0A\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Are you watching this crap? Been running all morning.{\\r}\r\nDialogue:\
+        \ 0,1:06:14.67,1:06:16.98,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u8FD9\u6B21\u6211\u7ADF\u7136\u5B8C\u5168\u540C\u610F\u4F0D\u5FB7\
+        \u4F2F\u6069\u7684\u89C2\u70B9 \u4F60\u89C1\u8FC7\u4ED6\u5417\uFF1F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}For once I agree with Woodburn.\
+        \ Have you seen him?{\\r}\r\nDialogue: 0,1:06:17.20,1:06:20.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u77E5\u9053\u4ED6\u5728\u54EA\u5417\uFF1F\
+        \ - \u4E0D\u77E5\u9053 \u5373\u4F7F\u77E5\u9053 \u6211\u4E5F\u4E0D\u4F1A\u8BF4\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Do you know where\
+        \ he is?        - No. Even if I did, I wouldn't say.{\\r}\r\nDialogue: 0,1:06:20.77,1:06:23.95,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6574\u4E2A\u4E16\u754C\u5C8C\u5C8C\u53EF\
+        \u5371{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The entire\
+        \ world is being threatened here.{\\r}\r\nDialogue: 0,1:06:24.18,1:06:28.60,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD9\u53EF\u4E0D\u662F\u4F60\u5C55\u73B0\
+        \u65B0\u95FB\u9053\u5FB7\u7684\u65F6\u5019{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}This is not time for you to fall back on journalistic\
+        \ integrity.{\\r}\r\nDialogue: 0,1:06:28.65,1:06:30.13,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E8B\u6001\u4E25\u91CD\u4E86 \u9732\u6613\
+        \u4E1D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}This is serious,\
+        \ Lois.{\\r}\r\nDialogue: 0,1:06:30.35,1:06:33.33,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}FBI\u90FD\u6765\u4E86 \u4ED6\u4EEC\u5728\
+        \u8BF4\u53DB\u56FD\u7F6A\u4EC0\u4E48\u7684{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}The FBI is here. They're throwing around words like\
+        \ \"treason.\"{\\r}\r\nDialogue: 0,1:06:33.55,1:06:35.22,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5F97\u8D70\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I gotta go.{\\r}\r\nDialogue: 0,1:06:51.37,1:06:52.71,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}FBI \u4E3E\u8D77\u624B\u6765{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}FBI. Hands up.{\\r}\r\nDialogue:\
+        \ 0,1:06:52.97,1:06:54.75,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6254\u4E86\u888B\u5B50 \u9A6C\u4E0A{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Drop the bag. Now.{\\r}\r\nDialogue: 0,1:07:01.65,1:07:04.01,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u636E\u6211\u91C7\u8BBF\u7684\u653F\u5E9C\
+        \u5B98\u5458\u8BF4{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Regarding\
+        \ the visitors themselves we know...{\\r}\r\nDialogue: 0,1:07:04.15,1:07:06.59,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u73B0\u5728\u6211\u4EEC\u6240\u77E5\u751A\
+        \u5C11{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...very little.\
+        \ According to government officials...{\\r}\r\nDialogue: 0,1:07:06.85,1:07:09.33,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C3D\u7BA1\u4ED6\u4EEC\u7684\u8BED\u8C03\
+        \u5E76\u4E0D\u53CB\u5584{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...the visitors do not represent a threat...{\\r}\r\nDialogue: 0,1:07:09.55,1:07:11.73,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u6765\u5BA2\u5E76\u4E0D\u4EE3\u8868\
+        \u7740\u5A01\u80C1{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...despite\
+        \ the ominous tone of their message.{\\r}\r\nDialogue: 0,1:07:11.99,1:07:14.49,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5F53\u7136\u4E86 \u5927\u5BB6\u5FC3\u4E2D\
+        \u90FD\u6709\u4E00\u4E2A\u7591\u95EE{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Then of course there's the question on everyone's mind:{\\\
+        r}\r\nDialogue: 0,1:07:14.73,1:07:18.54,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u8FD9\u4E2A\u5361\u5C14\u2022\u827E\u5C14\u662F\u8C01\
+        \uFF1F\u4ED6\u771F\u7684\u5B58\u5728\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}\"Who is this Kai-El person? Does he actually exist?\"\
+        {\\r}\r\nDialogue: 0,1:07:18.76,1:07:21.44,chs,,0000,0000,0000,,{\\fn\u534E\
+        \u6587\u6977\u4F53\\blur3}\u4ED6\u5982\u4F55\u5728\u6211\u4EEC\u4E4B\u4E2D\
+        \u9690\u85CF\u4E86\u8FD9\u4E48\u4E45\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}\"How could he have remained hidden from us for so\
+        \ long?\"{\\r}\r\nDialogue: 0,1:07:26.07,1:07:27.38,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6765\u554A \u80AF\u7279{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Come on, Kent.{\\r}\r\nDialogue: 0,1:07:34.45,1:07:35.55,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6765\u554A \u6253\u56DE\u6765\u554A{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Come on. Fight back.{\\\
+        r}\r\nDialogue: 0,1:07:35.78,1:07:37.38,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u7AD9\u8D77\u6765 \u80AF\u7279{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Get up, Kent.{\\r}\r\nDialogue: 0,1:07:40.69,1:07:42.06,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C31\u8FD9\u70B9\u6C34\u5E73{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}So is that it?{\\r}\r\nDialogue:\
+        \ 0,1:07:42.52,1:07:44.02,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u5C31\u8FD9\u70B9\u5B9E\u529B\u5417\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Is that all you've got?{\\r}\r\nDialogue:\
+        \ 0,1:07:45.69,1:07:47.19,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6765\u554A \u80AF\u7279{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Come on, Kent.{\\r}\r\nDialogue: 0,1:07:48.43,1:07:49.80,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FC7\u6765{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Come on!{\\r}\r\nDialogue: 0,1:08:18.42,1:08:19.56,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4EEC\u4F24\u5230\u4F60\u4E86\u5417\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Did they hurl\
+        \ you?{\\r}\r\nDialogue: 0,1:08:20.83,1:08:22.54,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u77E5\u9053\u90A3\u4E0D\u53EF\u80FD\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You know they can't.{\\\
+        r}\r\nDialogue: 0,1:08:22.59,1:08:25.47,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u4E0D\u662F\u90A3\u4E2A\u610F\u601D \u6211\u662F\
+        \u8BF4 \u4F60\u8FD8\u597D\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}That's not what I meant. I meant, are you all right?{\\\
+        r}\r\nDialogue: 0,1:08:27.47,1:08:29.78,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u60F3\u75DB\u6241\u90A3\u4E2A\u5C41\u5B69 \u6211\
+        \u60F3\u72E0\u72E0\u5730\u63CD\u4ED6{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}I wanted to hit that kid. I wanted to hit him bad.{\\r}\r\
+        \nDialogue: 0,1:08:30.00,1:08:31.48,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u77E5\u9053\u4F60\u60F3{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}I know you did. I mean...{\\r}\r\nDialogue:\
+        \ 0,1:08:31.74,1:08:34.44,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u751A\u81F3\u4E5F\u60F3\u8BA9\u4F60\u63CD\u4ED6 \u53EF\u662F\
+        \u7136\u540E\u5462\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...part of me even wanted you to, but then what?{\\r}\r\nDialogue: 0,1:08:35.14,1:08:36.91,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5C31\u4F1A\u9AD8\u5174\u4E86\u5417\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Make you feel\
+        \ any better?{\\r}\r\nDialogue: 0,1:08:39.68,1:08:43.68,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u53EA\u9700\u8981\u51B3\u5B9A\u4F60\
+        \u60F3\u6210\u957F\u4E3A\u4EC0\u4E48\u6837\u7684\u4EBA \u514B\u62C9\u514B\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You just have to\
+        \ decide what kind of man you want to grow up to be, Clark.{\\r}\r\nDialogue:\
+        \ 0,1:08:43.95,1:08:47.66,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u56E0\u4E3A\u65E0\u8BBA\u6210\u4E3A\u4EC0\u4E48\u6837 \u597D\u4EBA\
+        \u6216\u662F\u574F\u4EBA \u4F60\u90FD\u4F1A...{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Because whoever that man is, good character or bad,\
+        \ he's...{\\r}\r\nDialogue: 0,1:08:49.29,1:08:51.43,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6539\u53D8\u8FD9\u4E2A\u4E16\u754C{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He's gonna change the\
+        \ world.{\\r}\r\nDialogue: 0,1:08:56.66,1:08:58.02,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u8111\u4E2D\u6240\u8651\u4E3A\u4F55\
+        \u4E8B\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What's\
+        \ on your mind?{\\r}\r\nDialogue: 0,1:09:03.77,1:09:05.04,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E0D\u77E5\u4ECE\u4F55\u8BF4\u8D77\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I don't know where\
+        \ to start.{\\r}\r\nDialogue: 0,1:09:05.67,1:09:07.27,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6089\u542C\u5C0A\u4FBF{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Wherever you want.{\\r}\r\nDialogue:\
+        \ 0,1:09:09.44,1:09:11.55,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6628\u665A\u51FA\u73B0\u7684\u98DE\u8239{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}That ship that appeared last night.{\\\
+        r}\r\nDialogue: 0,1:09:12.88,1:09:14.69,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u5C31\u662F\u4ED6\u4EEC\u8981\u627E\u7684\u4EBA\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm the one they're\
+        \ looking for.{\\r}\r\nDialogue: 0,1:09:19.18,1:09:20.69,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u77E5\u9053{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Do you know...{\\r}\r\nDialogue: 0,1:09:21.49,1:09:22.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4EEC\u627E\u4F60\u7684\u539F\u56E0\
+        \u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...why\
+        \ they want you?{\\r}\r\nDialogue: 0,1:09:22.85,1:09:25.46,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D \u4F46\u8FD9\u4E2A\u4F50\u5FB7\u5C06\
+        \u519B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}No. But this\
+        \ General Zod...{\\r}\r\nDialogue: 0,1:09:25.69,1:09:29.70,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5373\u4F7F\u6211\u6295\u964D \u4ED6\u4E5F\
+        \u672A\u5FC5\u4F1A\u4FE1\u5B88\u8BFA\u8A00{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...even if I surrender, there's no guarantee he'll\
+        \ keep his word, but...{\\r}\r\nDialogue: 0,1:09:29.96,1:09:33.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u82E5\u6211\u6295\u964D\u5C31\u53EF\
+        \u4EE5\u62EF\u6551\u5730\u7403\u7684\u8BDD{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...if there's a chance I can save Earth by turning\
+        \ myself in...{\\r}\r\nDialogue: 0,1:09:35.57,1:09:37.40,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u96BE\u9053\u6211\u4E0D\u8BE5\u8FD9\u4E48\
+        \u505A\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...shouldn't\
+        \ I take it?{\\r}\r\nDialogue: 0,1:09:38.20,1:09:40.08,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u7684\u76F4\u89C9\u5462\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What does your gut\
+        \ tell you?{\\r}\r\nDialogue: 0,1:09:40.81,1:09:42.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F50\u5FB7\u4E0D\u53EF\u4FE1{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Zod can't be trusted.{\\r}\r\
+        \nDialogue: 0,1:09:45.14,1:09:46.71,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u95EE\u9898\u662F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}The problem is...{\\r}\r\nDialogue: 0,1:09:47.75,1:09:50.95,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E5F\u4E0D\u77E5\u9053\u5730\u7403\
+        \u7684\u4EBA\u6C11\u53EF\u4E0D\u53EF\u4FE1{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...I'm not sure the people of Earth can be either.{\\\
+        r}\r\nDialogue: 0,1:09:58.36,1:10:01.34,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6709\u65F6\u5019\u4F60\u5FC5\u987B\u575A\u4FE1\u4E0D\
+        \u7591{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Sometimes\
+        \ you have to take a leap of faith first.{\\r}\r\nDialogue: 0,1:10:02.73,1:10:04.76,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4FE1\u4EFB\u4F1A\u968F\u4E4B\u800C\u6765\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The trust part comes\
+        \ later.{\\r}\r\nDialogue: 0,1:10:28.92,1:10:32.03,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u597D\u4E86 \u6211\u4EEC\u6CE8\u610F\u5230\
+        \u4F60\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}All\
+        \ right. You've got our attention.{\\r}\r\nDialogue: 0,1:10:32.12,1:10:33.12,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u60F3\u600E\u4E48\u6837\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What is it you want?{\\\
+        r}\r\nDialogue: 0,1:10:33.39,1:10:35.20,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u8981\u548C\u9732\u6613\u4E1D\u2022\u83B2\u6069\
+        \u8C08\u8BDD{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I would\
+        \ like to speak to Lois Lane.{\\r}\r\nDialogue: 0,1:10:35.43,1:10:37.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u51ED\u4EC0\u4E48\u8BA4\u4E3A\u5979\
+        \u5728\u8FD9\u91CC\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}What makes you think she's here?{\\r}\r\nDialogue: 0,1:10:37.63,1:10:39.70,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u522B\u6D6A\u8D39\u65F6\u95F4 \u5C06\u519B\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Don't play games\
+        \ with me, general.{\\r}\r\nDialogue: 0,1:10:39.93,1:10:43.94,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53EA\u8981\u4F60\u4EEC\u80FD\u4FDD\u8BC1\
+        \u9732\u6613\u4E1D\u7684\u81EA\u7531 \u6211\u5C31\u6295\u964D{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'll surrender, but only if you guarantee\
+        \ Lois's freedom.{\\r}\r\nDialogue: 0,1:10:54.05,1:10:55.99,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4E3A\u4EC0\u4E48\u5411\u4F50\u5FB7\
+        \u6295\u964D\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Why\
+        \ are you surrendering to Zod?{\\r}\r\nDialogue: 0,1:10:57.22,1:11:00.82,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u662F\u5411\u4EBA\u7C7B\u5C48\u670D\
+        \ \u8FD9\u5E76\u4E0D\u4E00\u6837{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I'm surrendering to mankind. There's a difference.{\\r}\r\nDialogue:\
+        \ 0,1:11:01.95,1:11:03.90,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u8BA9\u4ED6\u4EEC\u628A\u4F60\u94D0\u8D77\u6765\u4E86\u5417\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You let them\
+        \ handcuff you?{\\r}\r\nDialogue: 0,1:11:04.62,1:11:07.07,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u8981\u662F\u62B5\u6297 \u5C31\u4E0D\
+        \u7B97\u662F\u6295\u964D\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Wouldn't be much of a surrender if I resisted.{\\r}\r\nDialogue: 0,1:11:08.56,1:11:10.60,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5982\u679C\u4ED6\u4EEC\u8FD9\u6837\u505A\
+        \u611F\u5230\u5B89\u5168{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}And if it makes them feel more secure...{\\r}\r\nDialogue: 0,1:11:11.66,1:11:13.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u4E48 \u5982\u4ED6\u4EEC\u6240\u613F\
+        \u5427{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...then all\
+        \ the better for it.{\\r}\r\nDialogue: 0,1:11:17.94,1:11:19.81,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}S\u8FD9\u4E2A\u5B57\u6BCD\u6709\u542B\u4E49\
+        \u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What's\
+        \ the S stand for?{\\r}\r\nDialogue: 0,1:11:22.74,1:11:24.31,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u4E0D\u662FS{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's not an S.{\\r}\r\nDialogue: 0,1:11:25.78,1:11:27.95,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5728\u6211\u7684\u661F\u7403 \u90A3\u4EE3\
+        \u8868\u5E0C\u671B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}On\
+        \ my world it means hope.{\\r}\r\nDialogue: 0,1:11:29.31,1:11:33.42,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u597D\u5427 \u5728\u5730\u7403\u8FD9\u5C31\
+        \u662F\u4E2AS{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Well,\
+        \ here, it's an S.{\\r}\r\nDialogue: 0,1:11:34.85,1:11:36.42,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u60F3\u60F3{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}How about...{\\r}\r\nDialogue: 0,1:11:41.99,1:11:43.03,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5148\u751F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Sir?{\\r}\r\nDialogue: 0,1:11:43.29,1:11:46.64,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u55E8 \u6211\u662F\u2026\u535A\u58EB\
+        \   - \u57C3\u7C73\u5C14\u2022\u6C49\u5BC6\u5C14\u987F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Hi, my name is Dr. E...       -\
+        \ Emil Hamilton.{\\r}\r\nDialogue: 0,1:11:46.86,1:11:49.85,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u77E5\u9053 \u6211\u53EF\u4EE5\u770B\
+        \u5230\u4F60\u4E0A\u8863\u53E3\u888B\u91CC\u7684\u8EAB\u4EFD\u5361{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I know, I can see your\
+        \ ID tag in your breast pocket.{\\r}\r\nDialogue: 0,1:11:50.10,1:11:52.74,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD8\u6709\u4E00\u888B\u5403\u4E86\u4E00\
+        \u534A\u7684\u7CD6{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Along\
+        \ with a half-eaten roll of Lifesavers.{\\r}\r\nDialogue: 0,1:11:53.30,1:11:55.65,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E5F\u80FD\u770B\u5230\u9694\u58C1\
+        \u623F\u95F4\u7684\u4E00\u961F\u58EB\u5175{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}I can also see the soldiers in the next room...{\\\
+        r}\r\nDialogue: 0,1:11:55.87,1:11:58.18,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u8FD8\u6709\u4F60\u7684\u9547\u538B\u7528\u7279\u5DE5\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...preparing that\
+        \ tranquilizing agent of yours.{\\r}\r\nDialogue: 0,1:11:58.44,1:11:59.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6CA1\u5FC5\u8981\u7684{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You won't need it.{\\r}\r\nDialogue:\
+        \ 0,1:12:00.14,1:12:03.18,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5148\u751F \u6211\u4EEC\u4E0D\u53EF\u80FD\u6BEB\u65E0\u51C6\u5907\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Sir, you can't expect\
+        \ us to not take precautions.{\\r}\r\nDialogue: 0,1:12:03.45,1:12:05.86,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5F88\u53EF\u80FD\u643A\u5E26\u4E86\
+        \u5916\u661F\u75C5\u539F\u4F53{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You could be carrying some kind of alien pathogen.{\\r}\r\nDialogue:\
+        \ 0,1:12:06.12,1:12:07.56,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u5DF2\u7ECF\u5728\u8FD9\u91CC\u751F\u6D3B\u4E8633\u5E74\u4E86\
+        \ \u535A\u58EB{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Been\
+        \ here for 33 years, doctor.{\\r}\r\nDialogue: 0,1:12:07.82,1:12:10.83,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u8FD8\u6CA1\u611F\u67D3\u4EFB\u4F55\u4EBA\
+        \   - \u4E00\u9762\u4E4B\u8F9E\u800C\u5DF2{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}- Haven't infected anyone yet.       - That you know\
+        \ of. {\\r}\r\nDialogue: 0,1:12:10.83,1:12:12.68,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u6709\u5B89\u5168\u65B9\u9762\
+        \u7684\u8003\u8651{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We\
+        \ have legitimate security concerns.{\\r}\r\nDialogue: 0,1:12:12.68,1:12:15.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u65E2\u7136\u4F60\u5411\u83B2\u6069\u5C0F\
+        \u59D0\u900F\u9732\u4E86\u8EAB\u4EFD{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}You revealed your identity to Miss Lane over there.{\\\
+        r}\r\nDialogue: 0,1:12:16.36,1:12:18.57,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E3A\u4EC0\u4E48\u6CA1\u544A\u8BC9\u6211\u4EEC\uFF1F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Why won't you do\
+        \ the same with us?{\\r}\r\nDialogue: 0,1:12:19.53,1:12:21.87,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u628A\u8BDD\u8BF4\u5F00\u4E86\
+        \u5427 \u5C06\u519B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Let's\
+        \ put our cards on the table here, general.{\\r}\r\nDialogue: 0,1:12:23.33,1:12:25.05,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4EEC\u6015\u6211\u662F\u56E0\u4E3A\
+        \u4F60\u4EEC\u65E0\u6CD5\u63A7\u5236\u6211{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}You're scared because you can't control me.{\\r}\r\
+        \nDialogue: 0,1:12:25.64,1:12:28.17,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u73B0\u5728\u4E0D\u80FD \u4EE5\u540E\u4E5F\u4E0D\u80FD\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You don't, and you\
+        \ never will.{\\r}\r\nDialogue: 0,1:12:29.01,1:12:30.99,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u90A3\u5E76\u4E0D\u610F\u5473\u7740\
+        \u6211\u662F\u654C\u4EBA{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}But that doesn't' mean I'm your enemy.{\\r}\r\nDialogue: 0,1:12:31.21,1:12:32.71,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u8C01\u662F\u654C\u4EBA\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Then who is?{\\r}\r\
+        \nDialogue: 0,1:12:32.98,1:12:34.39,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F50\u5FB7\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Zod?{\\r}\r\nDialogue: 0,1:12:35.01,1:12:36.92,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u6B63\u662F\u62C5\u5FC3\u8FD9\u4E00\
+        \u70B9{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}That's what\
+        \ I'm worried about.{\\r}\r\nDialogue: 0,1:12:37.01,1:12:38.72,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C31\u7B97\u662F\u8FD9\u6837{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Be that as it may...{\\r}\r\
+        \nDialogue: 0,1:12:38.98,1:12:42.36,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u4E5F\u6536\u5230\u4E86\u547D\u4EE4\u8981\u628A\
+        \u4F60\u4EA4\u7ED9\u4ED6{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...I've been given orders to hand you over to him.{\\r}\r\nDialogue:\
+        \ 0,1:12:42.99,1:12:44.86,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u505A\u4F60\u5FC5\u987B\u505A\u7684\u5427 \u5C06\u519B{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Do what you have to do, general.{\\\
+        r}\r\nDialogue: 0,1:12:49.66,1:12:50.43,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u8C22\u8C22{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Thank you.{\\r}\r\nDialogue: 0,1:12:51.56,1:12:52.54,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8C22\u4EC0\u4E48\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}For what?{\\r}\r\nDialogue: 0,1:12:53.70,1:12:55.27,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8C22\u8C22\u4F60\u4FE1\u4EFB\u6211{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}For believing in me.{\\\
+        r}\r\nDialogue: 0,1:12:58.34,1:13:00.37,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5230\u6700\u540E\u4E5F\u6CA1\u6539\u53D8\u4EC0\u4E48\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Didn't make much\
+        \ difference in the end.{\\r}\r\nDialogue: 0,1:13:01.21,1:13:02.74,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6539\u53D8\u4E86\u6211{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It did to me.{\\r}\r\nDialogue: 0,1:13:23.36,1:13:24.90,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4EEC\u6765\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}They're coming.{\\r}\r\nDialogue:\
+        \ 0,1:13:25.70,1:13:27.20,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u8BE5\u8D70\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You should leave now.{\\r}\r\nDialogue: 0,1:13:30.30,1:13:31.87,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5FEB\u8D70 \u9732\u6613\u4E1D{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Go, Lois.{\\r}\r\nDialogue:\
+        \ 0,1:14:42.77,1:14:44.15,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5361\u5C14\u2022\u827E\u5C14{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Kal-El.{\\r}\r\nDialogue: 0,1:14:44.68,1:14:46.71,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u662F\u526F\u6307\u6325\u5B98\u8299\
+        \u62C9\u2022\u5965{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm\
+        \ sub-commander Faora-UI.{\\r}\r\nDialogue: 0,1:14:47.38,1:14:51.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4EE3\u8868\u4F50\u5FB7\u5C06\u519B \u5411\
+        \u4F60\u95EE\u5019{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}On\
+        \ behalf of General Zod, I extend you his greetings.{\\r}\r\nDialogue: 0,1:14:56.69,1:14:59.79,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4F60\u662F\u6307\u6325\u5B98\u5417\uFF1F\
+        \ - \u6211\u662F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}-\
+        \ Are you the ranking officer here?       - I am.{\\r}\r\nDialogue: 0,1:15:00.02,1:15:04.20,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F50\u5FB7\u5C06\u519B\u5E0C\u671B\u8FD9\
+        \u4E2A\u5973\u4EBA\u966A\u6211\u8D70{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}General Zod would like this woman to accompany me.{\\r}\r\
+        \nDialogue: 0,1:15:04.83,1:15:06.67,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u8981\u7684\u53EA\u662F\u4F60\u7684\u65CF\u4EBA\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You asked for the\
+        \ alien.{\\r}\r\nDialogue: 0,1:15:07.40,1:15:10.35,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5E76\u6CA1\u6709\u8BF4\u8981\u5E26\
+        \u8D70\u6211\u4EEC\u7684\u4EBA{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You didn't say anything about one of our own.{\\r}\r\nDialogue: 0,1:15:10.57,1:15:13.71,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9700\u8981\u6211\u544A\u8BC9\u5C06\u519B\
+        \u4F60\u4E0D\u7B54\u5E94\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Shall I tell the general you're unwilling to comply?{\\\
+        r}\r\nDialogue: 0,1:15:13.97,1:15:15.85,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u4E0D\u5728\u4E4E\u4F60\u600E\u4E48\u544A\u8BC9\
+        \u4ED6{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I don't care\
+        \ what you tell him.{\\r}\r\nDialogue: 0,1:15:18.84,1:15:20.25,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6CA1\u5173\u7CFB{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's all right.{\\r}\r\nDialogue: 0,1:15:21.35,1:15:22.55,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u53BB{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}I'll go.{\\r}\r\nDialogue: 0,1:16:05.39,1:16:09.24,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4EBA\u7C7B\u65E0\u6CD5\u9002\u5E94\u6211\
+        \u4EEC\u98DE\u8239\u4E2D\u7684\u5927\u6C14\u6210\u5206{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The atmospheric composition on our\
+        \ ship is not compatible with humans.{\\r}\r\nDialogue: 0,1:16:09.46,1:16:10.87,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FC7\u53BB\u4EE5\u540E \u4F60\u5FC5\u987B\
+        \u5E26\u4E0A\u547C\u5438\u5668{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}You need to wear a breather...{\\r}\r\nDialogue: 0,1:16:11.10,1:16:12.77,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u8981\u9760\u8FD1{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...beyond this point.{\\r}\r\nDialogue:\
+        \ 0,1:16:37.92,1:16:38.83,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5361\u5C14\u2022\u827E\u5C14{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Kal-El.{\\r}\r\nDialogue: 0,1:16:40.79,1:16:42.43,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u90FD\u4E0D\u77E5\u9053{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You have no idea how long...{\\\
+        r}\r\nDialogue: 0,1:16:42.66,1:16:44.73,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u4EEC\u627E\u4E86\u4F60\u591A\u4E45{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...we've been searching for\
+        \ you.{\\r}\r\nDialogue: 0,1:16:45.16,1:16:46.16,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u60F3\u4F60\u5C31\u662F\u4F50\u5FB7\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I take it you're\
+        \ Zod?{\\r}\r\nDialogue: 0,1:16:46.43,1:16:47.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u662F\u4F50\u5FB7\u5C06\u519B{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}General Zod.{\\r}\r\nDialogue:\
+        \ 0,1:16:47.80,1:16:49.61,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}- \u6211\u4EEC\u7684\u7EDF\u9886   - \u6CA1\u5173\u7CFB \u8299\u62C9\
+        \u2022\u5965{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Our\
+        \ commander.       - It's all right, Faora.{\\r}\r\nDialogue: 0,1:16:49.83,1:16:52.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u539F\u8C05\u5361\u5C14\u7684\u65E0\u793C\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We can forgive Kal\
+        \ any lapses in decorum.{\\r}\r\nDialogue: 0,1:16:52.77,1:16:54.68,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u8FD8\u4E0D\u719F\u6089\u6211\u4EEC\
+        \u7684\u793C\u4EEA{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He's\
+        \ a stranger to our ways.{\\r}\r\nDialogue: 0,1:16:54.94,1:16:58.40,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u5E94\u8BE5\u597D\u597D\u5E86\
+        \u795D\u4E00\u4E0B \u800C\u4E0D\u8BE5\u4E89\u5435{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}This should be cause for celebration, not conflict.{\\\
+        r}\r\nDialogue: 0,1:16:59.51,1:17:01.68,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u522B\u51B2\u7A81{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Not conflict.{\\r}\r\nDialogue: 0,1:17:04.12,1:17:05.15,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211...{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}I...{\\r}\r\nDialogue: 0,1:17:05.42,1:17:06.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u611F\u89C9\u4E0D\u8212\u670D{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...feel strange.{\\r}\r\nDialogue:\
+        \ 0,1:17:09.35,1:17:10.66,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5F88\u865A\u5F31{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Weak.{\\r}\r\nDialogue: 0,1:17:12.86,1:17:14.06,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u600E\u4E48\u4E86\uFF1F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What's happening to him?{\\\
+        r}\r\nDialogue: 0,1:17:14.26,1:17:16.80,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4ED6\u7684\u8EAB\u4F53\u5BF9\u8239\u4E0A\u7684\u5927\
+        \u6C14\u6709\u6392\u65A5{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}He's rejecting our ship's atmospherics.{\\r}\r\nDialogue: 0,1:17:17.03,1:17:17.63,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark.{\\r}\r\nDialogue: 0,1:17:17.86,1:17:20.54,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u7528\u4E86\u4E00\u8F88\u5B50\u6765\
+        \u9002\u5E94\u5730\u7403\u7684\u73AF\u5883{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}You've spent a lifetime adapting to Earth's ecology...{\\\
+        r}\r\nDialogue: 0,1:17:20.70,1:17:21.64,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5374\u9002\u5E94\u4E0D\u4E86\u6211\u4EEC\u81EA\u5DF1\
+        \u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...but never\
+        \ adapted to ours.{\\r}\r\nDialogue: 0,1:17:21.80,1:17:22.83,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5FEB\u5E2E\u5E2E\u4ED6{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Help him.{\\r}\r\nDialogue: 0,1:17:24.87,1:17:27.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark.{\\r}\r\nDialogue: 0,1:17:28.47,1:17:29.78,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5E2E\u5E2E\u4ED6{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Help him.{\\r}\r\nDialogue: 0,1:17:31.54,1:17:32.71,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5FEB\u5E2E\u5E2E\u4ED6{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Help him.{\\r}\r\nDialogue: 0,1:17:44.36,1:17:45.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u597D \u5361\u5C14{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Hello, Kal.{\\r}\r\nDialogue: 0,1:17:47.56,1:17:49.63,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD8\u662F\u4F60\u66F4\u559C\u6B22\u6211\
+        \u53EB\u4F60\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Or do you prefer Clark?{\\r}\r\nDialogue: 0,1:17:50.36,1:17:51.74,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u662F\u4ED6\u4EEC\u7ED9\u4F60\u8D77\
+        \u7684\u540D\u5B57{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}That's\
+        \ the name they gave you.{\\r}\r\nDialogue: 0,1:17:52.00,1:17:53.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u662F\u5417\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Isn't it?{\\r}\r\nDialogue: 0,1:17:54.57,1:17:56.31,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u66FE\u662F\u6C2A\u661F\u7684\u519B\
+        \u4E8B\u7EDF\u9886{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I\
+        \ was Krypton's military leader...{\\r}\r\nDialogue: 0,1:17:56.53,1:17:58.98,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u800C\u4F60\u7236\u4EB2\u662F\u6211\u4EEC\
+        \u7684\u9996\u5E2D\u79D1\u5B66\u5BB6{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}...your father our foremost scientist.{\\r}\r\nDialogue:\
+        \ 0,1:17:59.20,1:18:00.65,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u4EEC\u552F\u4E00\u8FBE\u6210\u5171\u8BC6\u7684\u4E00\u70B9\
+        \u5C31\u662F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The\
+        \ only thing we agreed on...{\\r}\r\nDialogue: 0,1:18:00.87,1:18:02.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6C2A\u661F\u5C31\u8981\u6BC1\u706D\u4E86\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...was that Krypton\
+        \ was dying. {\\r}\r\nDialogue: 0,1:18:02.75,1:18:06.41,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u62FC\u547D\u4FDD\u62A4\u6211\u4EEC\
+        \u7684\u6587\u5316{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}In\
+        \ return for my efforts to protect our civilization...{\\r}\r\nDialogue: 0,1:18:06.68,1:18:08.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4FDD\u536B\u6211\u4EEC\u7684\u661F\u7403\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...and save our\
+        \ planet...{\\r}\r\nDialogue: 0,1:18:09.01,1:18:13.02,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5F97\u5230\u7684\u56DE\u62A5\u5374\u662F\
+        \u6211\u4EEC\u90FD\u88AB\u653E\u9010\u5230\u5E7D\u7075\u533A{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...I and my fellow officers were sentenced\
+        \ to the Phantom Zone.{\\r}\r\nDialogue: 0,1:18:15.99,1:18:21.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u800C\u6211\u4EEC\u661F\u7403\u7684\u6BC1\
+        \u706D\u5374\u8BA9\u6211\u4EEC\u91CD\u83B7\u81EA\u7531{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And then the destruction of our world\
+        \ freed us.{\\r}\r\nDialogue: 0,1:18:26.16,1:18:27.92,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u56DB\u5904\u6F02\u6CCA{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We were adrift, {\\\
+        r}\r\nDialogue: 0,1:18:27.92,1:18:31.85,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6CE8\u5B9A\u6F02\u6D41\u5728\u6211\u4EEC\u661F\u7403\
+        \u7684\u6B8B\u9AB8\u4E4B\u4E2D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}destined to float amongst the ruins of our planet...{\\r}\r\nDialogue:\
+        \ 0,1:18:32.07,1:18:33.95,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u76F4\u81F3\u6B7B\u4EA1{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...until we starved.{\\r}\r\nDialogue: 0,1:18:34.84,1:18:36.52,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4EEC\u662F\u600E\u4E48\u627E\u5230\
+        \u5730\u7403\u6765\u7684\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}How did you find your way to Earth?{\\r}\r\nDialogue: 0,1:18:37.21,1:18:41.21,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u628A\u5E7D\u7075\u63A8\u8FDB\
+        \u5668\u6539\u9020\u6210\u4E86\u9AD8\u901F\u98DE\u884C\u5668{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We managed to retrofit the phantom\
+        \ projector into a hyperdrive.{\\r}\r\nDialogue: 0,1:18:41.71,1:18:45.49,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u7236\u4EB2\u4E5F\u662F\u5BF9\u98DE\
+        \u8239\u505A\u4E86\u7C7B\u4F3C\u7684\u4FEE\u6539 \u628A\u4F60\u9001\u5230\u4E86\
+        \u8FD9\u91CC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Your\
+        \ father made a similar modification to the craft that brought you here.{\\\
+        r}\r\nDialogue: 0,1:18:46.92,1:18:50.02,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6240\u4EE5\u56DA\u7981\u6211\u4EEC\u7684\u5DE5\u5177\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And so the instrument\
+        \ of our damnation...{\\r}\r\nDialogue: 0,1:18:52.06,1:18:53.87,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u540C\u65F6\u4E5F\u62EF\u6551\u4E86\u6211\
+        \u4EEC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...became\
+        \ our salvation.{\\r}\r\nDialogue: 0,1:18:58.80,1:19:01.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u627E\u904D\u4E86\u65E7\u6B96\
+        \u6C11\u5730\u7684\u524D\u54E8\u7AD9{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}We sought out the old colonial outposts...{\\r}\r\nDialogue:\
+        \ 0,1:19:01.57,1:19:03.77,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u60F3\u8981\u5BFB\u627E\u751F\u547D\u7684\u8FF9\u8C61{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...looking for signs of life.{\\\
+        r}\r\nDialogue: 0,1:19:06.24,1:19:09.05,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F46\u627E\u5230\u7684\u53EA\u6709\u6B7B\u4EA1{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}But all we found was death.{\\\
+        r}\r\nDialogue: 0,1:19:10.04,1:19:12.61,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u8FD9\u4E9B\u524D\u54E8\u7AD9\u65E9\u548C\u6C2A\u661F\
+        \u5931\u53BB\u8054\u7EDC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Cut off from Krypton, these outposts...{\\r}\r\nDialogue: 0,1:19:12.88,1:19:15.08,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4EE5\u540E\u5C31\u5E9F\u5F03\u4E86{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...withered and died\
+        \ long ago.{\\r}\r\nDialogue: 0,1:19:15.58,1:19:17.56,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u628A\u80FD\u7528\u7684\u90FD\
+        \u5E26\u8D70\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We\
+        \ salvaged what we could...{\\r}\r\nDialogue: 0,1:19:17.78,1:19:19.49,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u76D4\u7532 \u6B66\u5668{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...armor, weapons...{\\r}\r\nDialogue:\
+        \ 0,1:19:19.75,1:19:21.66,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u8FD8\u6709\u4E00\u4E2A\u4E16\u754C\u5F15\u64CE{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...even a world engine.{\\r}\r\nDialogue:\
+        \ 0,1:19:23.42,1:19:25.30,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u4EEC\u51C6\u5907\u4E8633\u5E74{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}For 33 years we prepared...{\\r}\r\nDialogue: 0,1:19:26.79,1:19:29.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u76F4\u5230\u6211\u4EEC\u4FA6\u6D4B\u5230\
+        \u4E00\u4E2A\u6C42\u6551\u4FE1\u53F7{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}...until finally we detected a distress beacon...{\\r}\r\
+        \nDialogue: 0,1:19:29.79,1:19:34.50,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u662F\u4F60\u5728\u8001\u4FA6\u5BDF\u673A\u91CC\u53D1\
+        \u51FA\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...which\
+        \ you triggered when you accessed the ancient scout ship.{\\r}\r\nDialogue:\
+        \ 0,1:19:35.47,1:19:38.00,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u662F\u4F60\u628A\u6211\u4EEC\u5E26\u5230\u8FD9\u91CC\u7684 \u5361\
+        \u5C14{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You led us\
+        \ here, Kal.{\\r}\r\nDialogue: 0,1:19:39.14,1:19:44.70,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u73B0\u5728\u4F60\u6709\u80FD\u529B\u62EF\
+        \u6551\u6211\u4EEC\u7684\u79CD\u65CF{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Now it's within your power to save what remains of your\
+        \ race.{\\r}\r\nDialogue: 0,1:19:49.11,1:19:50.35,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5728\u6C2A\u661F\u4E0A{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}On Krypton...{\\r}\r\nDialogue: 0,1:19:50.61,1:19:53.25,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6240\u6709\u672A\u51FA\u751F\u5B69\u5B50\
+        \u7684\u9057\u4F20\u57FA\u56E0{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...the genetic template for every being yet to be born...{\\r}\r\nDialogue:\
+        \ 0,1:19:53.48,1:19:56.02,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u90FD\u88AB\u7F16\u5199\u5728\u516C\u6C11\u6863\u6848\u91CC{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...is encoded in the registry\
+        \ of citizens.{\\r}\r\nDialogue: 0,1:19:56.69,1:19:58.83,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u7236\u4EB2\u5077\u8D70\u4E86\u6863\
+        \u6848\u7684\u5BC6\u5178{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Your father stole the registry's Codex...{\\r}\r\nDialogue: 0,1:19:59.09,1:20:01.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u85CF\u5728\u4E86\u5E26\u4F60\u6765\u7684\
+        \u592A\u7A7A\u8231\u91CC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...and stored it in the capsule that brought you here.{\\r}\r\nDialogue:\
+        \ 0,1:20:02.63,1:20:03.47,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4E3A\u4EC0\u4E48\u5462\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}For what purpose?{\\r}\r\nDialogue: 0,1:20:04.53,1:20:09.90,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD9\u6837\u6C2A\u661F\u5C31\u80FD\u5728\
+        \u5730\u7403\u4E0A\u91CD\u751F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}So that Krypton can live again on Earth.{\\r}\r\nDialogue: 0,1:20:29.52,1:20:31.63,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5BC6\u5178\u5728\u54EA\u91CC \u5361\u5C14\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Where is the\
+        \ Codex, Kal?{\\r}\r\nDialogue: 0,1:20:33.29,1:20:35.13,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5982\u679C\u6C2A\u661F\u91CD\u751F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}If Krypton lives again...{\\\
+        r}\r\nDialogue: 0,1:20:36.29,1:20:37.67,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5730\u7403\u4F1A\u600E\u4E48\u6837\uFF1F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...what happens to Earth?{\\\
+        r}\r\nDialogue: 0,1:20:38.70,1:20:42.20,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u91CD\u751F\u603B\u9700\u8981\u5EFA\u7ACB\u5728\u6BC1\
+        \u706D\u4E4B\u4E0A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The\
+        \ foundation has to be built on something.{\\r}\r\nDialogue: 0,1:20:42.47,1:20:45.24,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FDE\u4F60\u7236\u4EB2\u90FD\u77E5\u9053\
+        \u8FD9\u4E00\u70B9{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Even\
+        \ your father recognized that.{\\r}\r\nDialogue: 0,1:20:51.71,1:20:54.02,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D \u4F50\u5FB7{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}No, Zod.{\\r}\r\nDialogue: 0,1:20:55.18,1:20:56.79,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E0D\u4F1A\u5E2E\u4F60\u7684{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I can't be a part of\
+        \ this.{\\r}\r\nDialogue: 0,1:20:57.21,1:20:58.92,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u4E48\u4F60\u4F1A\u5E2E\u8C01\u5462\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Then what\
+        \ can you be a part of?{\\r}\r\nDialogue: 0,1:20:59.52,1:21:00.72,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}No!{\\r}\r\nDialogue: 0,1:21:01.92,1:21:02.52,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F50\u5FB7{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Zod!{\\r}\r\nDialogue: 0,1:21:04.02,1:21:04.73,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}No!{\\r}\r\nDialogue: 0,1:21:05.89,1:21:07.53,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}No!{\\r}\r\nDialogue: 0,1:21:13.56,1:21:17.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u7684\u7236\u4EB2\u4E3A\u8363\u8A89\
+        \u732E\u51FA\u4E86\u81EA\u5DF1{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Your father acquitted himself with honor, Kal.{\\r}\r\nDialogue: 0,1:21:19.84,1:21:21.78,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u662F\u4F60\u6740\u4E86\u4ED6\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You killed him?{\\\
+        r}\r\nDialogue: 0,1:21:22.17,1:21:23.52,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u662F\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I did.{\\r}\r\nDialogue: 0,1:21:24.11,1:21:27.52,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u6C38\u8FDC\u90FD\u6446\u8131\u4E0D\
+        \u4E86\u8FD9\u4EF6\u4E8B\u7684\u9634\u5F71{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}And not a day goes by where it doesn't haunt me.{\\\
+        r}\r\nDialogue: 0,1:21:28.88,1:21:31.22,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F46\u5982\u679C\u91CD\u6765\u4E00\u6B21 \u6211\u8FD8\
+        \u662F\u4F1A\u8FD9\u4E48\u505A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}But if I had to do it again, I would.{\\r}\r\nDialogue: 0,1:21:31.45,1:21:34.92,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u8981\u5BF9\u6211\u7684\u4EBA\u6C11\
+        \u8D1F\u8D23{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I have\
+        \ a duty to my people...{\\r}\r\nDialogue: 0,1:21:35.19,1:21:39.59,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E0D\u4F1A\u8BA9\u4EFB\u4F55\u4EBA\
+        \u963B\u6B62\u6211{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...and\
+        \ I will not allow anyone to prevent me from carrying it out.{\\r}\r\nDialogue:\
+        \ 0,1:21:55.64,1:21:57.28,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u90A3\u662F\u4EC0\u4E48 \u5C11\u6821\uFF1F{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}What's the sit-rep, major?{\\r}\r\nDialogue:\
+        \ 0,1:21:57.91,1:22:00.29,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4FA6\u6D4B\u5230\u4E24\u67B6\u654C\u673A\u4ECE\u5916\u661F\u98DE\
+        \u8239\u4E2D\u53D1\u5C04{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}DSP pinged two bogeys launching from the alien ship.{\\r}\r\nDialogue:\
+        \ 0,1:22:00.54,1:22:02.65,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}- \u8367\u5E55\u663E\u793A   - \u597D\u7684 \u957F\u5B98{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Put it up.       - Yes, sir.{\\\
+        r}\r\nDialogue: 0,1:22:03.08,1:22:04.15,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5C31\u662F\u8FD9\u4E2A{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}There it is.{\\r}\r\nDialogue: 0,1:22:04.42,1:22:05.22,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u63A5\u65E0\u7EBF\u75354\u53F7{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Re-task IKon-4...{\\r}\r\n\
+        Dialogue: 0,1:22:05.45,1:22:07.90,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}-  \u518D\u62C9\u8FD1\u70B9   - \u597D\u7684{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- ...and get me a closer look.   \
+        \    - Yes, sir.{\\r}\r\nDialogue: 0,1:22:08.22,1:22:09.39,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6307\u6325\u90E8{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Command, the word...{\\r}\r\nDialogue:\
+        \ 0,1:22:09.39,1:22:10.56,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4ECA\u5929\u7684\u6697\u53F7\u662F\u4E09\u53C9\u621F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...of the day is trident.{\\\
+        r}\r\nDialogue: 0,1:22:10.79,1:22:12.89,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6709\u4E24\u67B6\u5916\u661F\u98DE\u8239\u6B63\u5728\
+        \u63A5\u8FD1{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We have\
+        \ two alien craft on aggressive approach.{\\r}\r\nDialogue: 0,1:22:13.12,1:22:14.76,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u65E0\u7EBF\u75354\u53F7\u5DF2\u63A5\u901A\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Ikon-4 coming online.{\\\
+        r}\r\nDialogue: 0,1:22:14.99,1:22:15.80,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u901F\u5EA6\u6709\u591A\u5FEB\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Air speed?{\\r}\r\nDialogue: 0,1:22:16.06,1:22:17.58,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}380\u6D77\u91CC \u6B63\u5728\u8FDB\u5165\
+        \u582A\u8428\u65AF\u5DDE\u4E0A\u7A7A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}380 knots, entering Kansas...{\\r}\r\nDialogue: 0,1:22:17.73,1:22:19.73,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4EEC\u4E0D\u56DE\u5E94\u6211\u4EEC\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...airspace. Not\
+        \ responding to our hails.{\\r}\r\nDialogue: 0,1:22:19.96,1:22:22.17,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4E0D\u8981\u6D6A\u8D39\u4F53\u529B\
+        \u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You're wasting\
+        \ your efforts.{\\r}\r\nDialogue: 0,1:22:23.10,1:22:25.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4ECE\u5730\u7403\u7684\u592A\u9633\
+        \u5F97\u5230\u7684\u529B\u91CF{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}The strength you derived from the Earth's sun...{\\r}\r\nDialogue: 0,1:22:25.67,1:22:27.77,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5728\u6211\u4EEC\u7684\u8239\u4E0A\u5B8C\
+        \u5168\u6CA1\u6709\u7528{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...has been neutralized aboard our ship.{\\r}\r\nDialogue: 0,1:22:28.44,1:22:29.58,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5728\u8FD9\u91CC{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Here...{\\r}\r\nDialogue: 0,1:22:29.81,1:22:31.41,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD9\u6837\u7684\u73AF\u5883\u4E0B{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...in this environment...{\\\
+        r}\r\nDialogue: 0,1:22:32.18,1:22:33.66,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u5C31\u8DDF\u4EBA\u7C7B\u4E00\u6837\u8106\u5F31\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...you are as weak\
+        \ as a human.{\\r}\r\nDialogue: 0,1:23:32.20,1:23:34.05,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4ECE\u54EA\u5192\u51FA\u6765\u7684\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Where did\
+        \ you come from?{\\r}\r\nDialogue: 0,1:23:34.57,1:23:36.02,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E3B\u63A7\u94A5\u5319\u91CC \u83B2\u6069\
+        \u5C0F\u59D0{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The\
+        \ command key, Miss Lane.{\\r}\r\nDialogue: 0,1:23:36.24,1:23:39.39,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u591A\u4E8F\u4E86\u4F60 \u6211\u6B63\u5728\
+        \u88AB\u4E0A\u4F20\u5230\u8FD9\u8258\u8239\u7684\u4E3B\u7A0B\u5E8F\u91CC{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Thanks to you, I'm\
+        \ uploading to the ship's mainframe.{\\r}\r\nDialogue: 0,1:23:39.91,1:23:40.89,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u662F\u8C01\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Who are you?{\\r}\r\nDialogue: 0,1:23:41.85,1:23:43.15,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u662F\u5361\u5C14\u7684\u7236\u4EB2\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I am Kai's father.{\\\
+        r}\r\nDialogue: 0,1:23:44.82,1:23:45.96,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u80FD\u5E2E\u6211\u4EEC\u5417\uFF1F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Can you help us?{\\r}\r\nDialogue:\
+        \ 0,1:23:47.52,1:23:49.36,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u8FD9\u8258\u8239\u662F\u6211\u8BBE\u8BA1\u7684{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I designed this ship.{\\r}\r\nDialogue:\
+        \ 0,1:23:49.59,1:23:51.76,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u80FD\u6539\u9020\u5B83\u7684\u5927\u6C14\u7ED3\u6784{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I can modify its atmospheric\
+        \ composition...{\\r}\r\nDialogue: 0,1:23:52.02,1:23:53.76,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F7F\u4EBA\u7C7B\u9002\u5E94{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...to human compatibility.{\\\
+        r}\r\nDialogue: 0,1:23:54.02,1:23:54.87,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u4EEC\u80FD\u963B\u6B62\u4ED6\u4EEC{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We can stop them.{\\r}\r\n\
+        Dialogue: 0,1:23:55.09,1:23:57.57,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6211\u4EEC\u80FD\u628A\u4ED6\u4EEC\u9001\u56DE\u5E7D\u7075\
+        \u533A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We can send\
+        \ them back to the Phantom Zone.{\\r}\r\nDialogue: 0,1:23:58.53,1:23:59.17,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u600E\u4E48\u505A\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}How?{\\r}\r\nDialogue: 0,1:23:59.40,1:24:00.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u6765\u6559\u4F60{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I can teach you.{\\r}\r\nDialogue:\
+        \ 0,1:24:01.20,1:24:03.01,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u7136\u540E\u4F60\u518D\u6559\u7ED9\u5361\u5C14{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And in turn, you can teach Kal.{\\\
+        r}\r\nDialogue: 0,1:24:03.23,1:24:04.94,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u4F1A\u5E2E\u6211\u5417\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Will you help me?{\\r}\r\nDialogue:\
+        \ 0,1:24:18.78,1:24:20.22,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u8239\u4E0A\u7684\u8B66\u62A5\u54CD\u4E86{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}The ship's crew are alerted.{\\r}\r\n\
+        Dialogue: 0,1:24:20.35,1:24:21.39,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6211\u4EEC\u5F97\u5FEB\u70B9{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}We need to move quickly.{\\r}\r\nDialogue: 0,1:24:21.62,1:24:23.29,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u628A\u4E3B\u63A7\u94A5\u5319\u62FF\u4E0A\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Retrieve the command\
+        \ key.{\\r}\r\nDialogue: 0,1:24:30.93,1:24:33.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u662F\u4F60\u505A\u7684\u5417\uFF1F -\
+        \ \u662F\u7684 \u628A\u5979\u7684\u6B66\u5668\u62FF\u4E0A{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Did you do that?       - Yes. Pick\
+        \ up her sidearm.{\\r}\r\nDialogue: 0,1:24:43.37,1:24:44.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53D1\u751F\u4E86\u4EC0\u4E48\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What's happening?{\\\
+        r}\r\nDialogue: 0,1:25:05.73,1:25:06.40,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u53F3\u8FB9{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}To your right.{\\r}\r\nDialogue: 0,1:25:06.63,1:25:07.27,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5F00\u706B{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Fire.{\\r}\r\nDialogue: 0,1:25:08.83,1:25:09.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u540E\u9762{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Behind you.{\\r}\r\nDialogue: 0,1:25:23.08,1:25:25.12,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5B89\u5168\u5F85\u5728\u6551\u751F\u8231\
+        \u91CC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Secure yourself\
+        \ inside the open pod.{\\r}\r\nDialogue: 0,1:25:26.15,1:25:28.43,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u65C5\u9014\u5E73\u5B89 \u83B2\u6069\u5C0F\
+        \u59D0{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Safe travels,\
+        \ Miss Lane. It's unlikely...{\\r}\r\nDialogue: 0,1:25:28.65,1:25:30.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u5E94\u8BE5\u4E0D\u53EF\u80FD\
+        \u518D\u89C1\u9762\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...we'll see each other again.{\\r}\r\nDialogue: 0,1:25:31.82,1:25:34.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8BB0\u4F4F \u5E7D\u7075\u5F15\u64CE\u662F\
+        \u963B\u6B62\u4ED6\u4EEC\u7684\u5173\u952E{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Remember, the phantom drives are essential in stopping\
+        \ them.{\\r}\r\nDialogue: 0,1:25:35.79,1:25:37.03,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u628A\u5934\u504F\u5411\u5DE6\u8FB9{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Move your head to the\
+        \ left.{\\r}\r\nDialogue: 0,1:26:04.62,1:26:07.23,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F50\u5FB7\u8BF4\u7684\u5173\u4E8E\u5BC6\
+        \u5178\u7684\u4E8B\u662F\u771F\u7684\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Is it true what Zod said about the Codex?{\\r}\r\n\
+        Dialogue: 0,1:26:07.66,1:26:09.04,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u628A\u8239\u58C1\u6253\u7834{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Strike that panel.{\\r}\r\nDialogue: 0,1:26:12.70,1:26:16.80,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u60F3\u8981\u4F60\u5B66\u4E60\
+        \u4EBA\u7C7B\u6700\u91CD\u8981\u7684\u662F\u4EC0\u4E48{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We wanted you to learn what it meant\
+        \ to be human first...{\\r}\r\nDialogue: 0,1:26:16.87,1:26:18.90,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6240\u4EE5\u5982\u679C\u6709\u4E00\u5929\
+        \ \u65F6\u673A\u6210\u719F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...so that one day, when the time was right, {\\r}\r\nDialogue: 0,1:26:18.90,1:26:22.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4F1A\u6210\u4E3A\u4E24\u4E2A\u79CD\
+        \u65CF\u6C9F\u901A\u7684\u6865\u6881{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}you could be the bridge between two peoples.{\\r}\r\nDialogue:\
+        \ 0,1:26:25.24,1:26:26.02,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u770B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Look.{\\\
+        r}\r\nDialogue: 0,1:26:29.18,1:26:30.42,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u9732\u6613\u4E1D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Lois.{\\r}\r\nDialogue: 0,1:26:31.01,1:26:32.05,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u80FD\u6551\u5979 \u5361\u5C14{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You can save her, Kal.{\\\
+        r}\r\nDialogue: 0,1:26:35.19,1:26:37.06,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u80FD\u62EF\u6551\u6240\u6709\u4EBA{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You can save all of them.{\\\
+        r}\r\nDialogue: 0,1:27:55.97,1:27:57.50,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u5B89\u5168\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}You'll be safe here.{\\r}\r\nDialogue: 0,1:27:59.84,1:28:02.41,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4F60\u6CA1\u4E8B\u5427\uFF1F - \u6CA1\
+        \u4E8B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Are you\
+        \ all right?       - Yeah.{\\r}\r\nDialogue: 0,1:28:05.64,1:28:07.12,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5BF9\u4E0D\u8D77{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm sorry.{\\r}\r\nDialogue: 0,1:28:07.84,1:28:10.83,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E0D\u662F\u6545\u610F\u544A\u8BC9\
+        \u4ED6\u4EEC\u4F60\u7684\u4E8B \u4ED6\u4EEC\u5BF9\u6211\u52A8\u4E86\u624B\u811A\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I didn't wanna tell\
+        \ them anything, but they did something to me.{\\r}\r\nDialogue: 0,1:28:11.08,1:28:13.25,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4ED6\u4EEC\u770B\u7A7F\u4E86\u6211\u7684\
+        \u5FC3\u601D   - \u6CA1\u5173\u7CFB \u9732\u6613\u4E1D{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- They looked inside my mind...  \
+        \     - It's okay, Lois.{\\r}\r\nDialogue: 0,1:28:13.48,1:28:15.26,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4EEC\u4E5F\u5BF9\u6211\u505A\u4E86\
+        \u540C\u6837\u7684\u4E8B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}They did the same thing to me.{\\r}\r\nDialogue: 0,1:28:28.33,1:28:29.67,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark!{\\r}\r\nDialogue: 0,1:28:38.68,1:28:40.45,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5E26\u4ED6\u6765\u7684\u90A3\u8258\u8239\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The craft he arrived\
+        \ in...{\\r}\r\nDialogue: 0,1:28:40.98,1:28:42.15,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5B83\u5728\u54EA\u91CC\uFF1F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...where is it?{\\r}\r\nDialogue:\
+        \ 0,1:28:44.05,1:28:45.22,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u53BB\u6B7B\u5427{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Go to hell.{\\r}\r\nDialogue: 0,1:28:56.53,1:28:57.50,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5728\u90A3\u8FB9{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}There.{\\r}\r\nDialogue: 0,1:29:20.52,1:29:22.66,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5BC6\u5178\u4E0D\u5728\u8FD9\u91CC{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The Codex is not here.{\\\
+        r}\r\nDialogue: 0,1:29:29.39,1:29:30.51,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4ED6\u85CF\u5728\u54EA\u4E86\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Where has he hidden it?{\\r}\r\nDialogue:\
+        \ 0,1:29:30.69,1:29:31.33,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u4E0D\u77E5\u9053{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I don't know.{\\r}\r\nDialogue: 0,1:29:31.56,1:29:32.67,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5BC6\u5178\u5728\u54EA\u91CC\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Where is the Codex?!{\\\
+        r}\r\nDialogue: 0,1:29:48.68,1:29:50.62,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u5C45\u7136\u6562\u5A01\u80C1\u6211\u5988\u5988\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You think you can\
+        \ threaten my mother?!{\\r}\r\nDialogue: 0,1:30:32.42,1:30:33.90,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5BF9\u6211\u505A\u4E86\u4EC0\u4E48\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What have\
+        \ you done to me?{\\r}\r\nDialogue: 0,1:30:34.12,1:30:38.50,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u7236\u6BCD\u6559\u6211\u8981\u78E8\
+        \u7EC3\u6211\u7684\u611F\u5B98 \u4F50\u5FB7{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}My parents taught me to hone my senses, Zod.{\\r}\r\
+        \nDialogue: 0,1:30:39.96,1:30:41.57,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4E13\u6CE8{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Focus...{\\r}\r\nDialogue: 0,1:30:42.13,1:30:43.84,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5728\u81EA\u5DF1\u60F3\u770B\u7684\u4E1C\
+        \u897F\u4E0A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...on\
+        \ just what I wanted to see.{\\r}\r\nDialogue: 0,1:30:44.10,1:30:45.14,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6CA1\u4E86\u5934\u76D4{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Without your helmet...{\\r}\r\
+        \nDialogue: 0,1:30:45.40,1:30:46.97,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u53EF\u4EE5\u611F\u53D7\u5230\u66F4\u591A\u4E1C\u897F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...you're getting\
+        \ everything.{\\r}\r\nDialogue: 0,1:30:48.24,1:30:49.65,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5F88\u96BE\u53D7{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}And it hurts...{\\r}\r\nDialogue: 0,1:30:50.24,1:30:51.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u662F\u5427\uFF1F{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}...doesn't it?{\\r}\r\nDialogue: 0,1:31:36.45,1:31:37.73,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u522B\u7AD9\u5728\u7A97\u6237\u8FB9\u4E0A\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Get away from the\
+        \ window.{\\r}\r\nDialogue: 0,1:31:40.69,1:31:42.90,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90FD\u8FDB\u53BB \u8FD9\u91CC\u4E0D\u5B89\
+        \u5168{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Get inside.\
+        \ It's not safe.{\\r}\r\nDialogue: 0,1:31:47.83,1:31:50.71,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5168\u4F53\u542C\u547D \u8FD9\u91CC\u662F\
+        \u5B88\u62A4\u8005 \u6211\u662F\u7A7A\u4E2D\u6307\u6325\u5B98{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}All players, this is Guardian. I am\
+        \ airborne mission commander.{\\r}\r\nDialogue: 0,1:31:50.97,1:31:53.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5DF2\u7ECF\u4E8B\u5148\u63A5\u89E6\
+        \u8FC7\u5E76\u89C2\u5BDF\u8FC7{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I have previously encountered and observed...{\\r}\r\nDialogue: 0,1:31:53.24,1:31:55.38,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u5C06\u8981\u63A5\u8FD1\u7684\
+        \u76EE\u6807{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...the\
+        \ beings we're about to engage.{\\r}\r\nDialogue: 0,1:31:55.64,1:31:58.35,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4EEC\u975E\u5E38\u5371\u9669 \u6211\
+        \u4EEC\u53EF\u4EE5...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}They are extremely dangerous and we have been authorized...{\\r}\r\n\
+        Dialogue: 0,1:31:58.58,1:32:00.08,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4F7F\u7528\u81F4\u547D\u6B66\u5668{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}...to use deadly force.{\\r}\r\nDialogue:\
+        \ 0,1:32:02.05,1:32:04.09,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6536\u5230 \u5B88\u62A4\u8005 \u6211\u4EEC\u6B63\u63A5\u8FD1\u76EE\
+        \u6807{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Roger, Guardian,\
+        \ we are inbound to target.{\\r}\r\nDialogue: 0,1:32:09.69,1:32:11.15,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5F00\u706B{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Cleared hot. Weapons free.{\\r}\r\nDialogue: 0,1:32:11.15,1:32:12.76,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}11\u53F7 \u5F00\u706B{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Copy, 11. Weapons free.{\\r}\r\nDialogue:\
+        \ 0,1:32:15.56,1:32:16.44,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u8FD9\u91CC\u662F\u96F7\u753511\u53F7{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Thunder 11...{\\r}\r\nDialogue: 0,1:32:16.56,1:32:17.59,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9501\u5B9A\u4E09\u4E2A\u76EE\u6807{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...tally three targets.{\\\
+        r}\r\nDialogue: 0,1:32:35.21,1:32:36.02,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u96F7\u753511\u53F7{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Thunder 11...{\\r}\r\nDialogue: 0,1:32:36.25,1:32:38.69,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5E72\u5F97\u6F02\u4EAE \u8BF7\u6C42\u7ACB\
+        \u5373\u518D\u6B21\u653B\u51FB{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...good hit. Request immediate re-attack.{\\r}\r\nDialogue: 0,1:32:38.92,1:32:41.12,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6536\u5230 \u5B88\u62A4\u8005 \u51C6\u5907\
+        \u4E8C\u6B21\u653B\u51FB{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Roger, Guardian. We'll make a second gun run...{\\r}\r\nDialogue: 0,1:32:41.28,1:32:43.39,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u822A\u5411212\u5EA6{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...on a heading of 212 degrees.{\\\
+        r}\r\nDialogue: 0,1:32:50.39,1:32:51.47,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u96F7\u753511\u53F7 \u5FEB\u5F39\u51FA\u9003\u751F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Thunder 11, eject!{\\\
+        r}\r\nDialogue: 0,1:32:51.59,1:32:52.97,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5FEB\u5F39\u51FA\u9003\u751F{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Eject!{\\r}\r\nDialogue: 0,1:32:53.30,1:32:54.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u96F7\u753511\u53F7 \u5FEB\u5F39\u51FA\u9003\
+        \u751F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Thunder 11,\
+        \ eject!{\\r}\r\nDialogue: 0,1:33:05.08,1:33:06.65,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6709\u654C\u4EBA\u5411\u6211\u51B2\u6765\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I have a bogey incoming!{\\\
+        r}\r\nDialogue: 0,1:33:07.48,1:33:08.92,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u8BE5\u6B7B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Oh, shit.{\\r}\r\nDialogue: 0,1:33:27.10,1:33:27.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u592A\u5F31\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You are weak...{\\r}\r\nDialogue:\
+        \ 0,1:33:28.23,1:33:29.34,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u827E\u5C14\u4E4B\u5B50{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...son of El.{\\r}\r\nDialogue: 0,1:33:29.60,1:33:30.74,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5BF9\u81EA\u5DF1\u6CA1\u4FE1\u5FC3{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Unsure of yourself.{\\\
+        r}\r\nDialogue: 0,1:33:35.97,1:33:38.95,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u4EEC\u5E76\u4E0D\u50CF\u4F60{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The fact that you possess a sense\
+        \ of morality...{\\r}\r\nDialogue: 0,1:33:39.18,1:33:40.95,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53D7\u9053\u5FB7\u51C6\u5219\u7684\u675F\
+        \u7F1A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...and we\
+        \ do not...{\\r}\r\nDialogue: 0,1:33:41.18,1:33:43.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u800C\u8FD9\u6B63\u662F\u6211\u4EEC\u8FDB\
+        \u5316\u7684\u4F18\u52BF{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...gives us an evolutionary advantage.{\\r}\r\nDialogue: 0,1:33:47.25,1:33:49.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5982\u679C\u8BF4\u5386\u53F2\u8BC1\u660E\
+        \u4E86\u4EC0\u4E48{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And\
+        \ if history has proven anything...{\\r}\r\nDialogue: 0,1:33:59.63,1:34:03.20,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u5C31\u662F\u8FDB\u5316\u8005\u6C38\
+        \u8FDC\u66F4\u5F3A\u5927{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...it is that evolution always wins.{\\r}\r\nDialogue: 0,1:34:24.52,1:34:26.02,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u6765\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}CCT, we're approaching...{\\r}\r\n\
+        Dialogue: 0,1:34:26.29,1:34:28.13,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u7740\u9646 \u5168\u529B\u4E0B\u964D{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}...LZ Jayhawk. Get down in five.{\\r}\r\
+        \nDialogue: 0,1:34:28.36,1:34:30.20,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u8D70\u5427 \u524D\u8FDB{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Let's go. Go to the LZ.{\\r}\r\nDialogue: 0,1:34:30.99,1:34:32.32,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6536\u5230 \u4E2D\u58EB \u51FA\u53D1{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Roger, sarge. let's\
+        \ go!{\\r}\r\nDialogue: 0,1:35:09.77,1:35:11.09,chs,,0000,0000,0000,,{\\fn\u534E\
+        \u6587\u6977\u4F53\\blur3}\u516C\u725B\u6D41\u6D6A\u8005\u53F7{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}All rangers, I need you...{\\\
+        r}\r\nDialogue: 0,1:35:11.33,1:35:12.51,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u7784\u51C6\u6240\u6709\u76EE\u6807{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...to engage the targets.{\\r}\r\n\
+        Dialogue: 0,1:35:13.00,1:35:14.12,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u5B88\u62A4\u8005 \u8FD9\u91CC\u662F\u4E00\u53F7\u6218\u573A\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Guardian, this is\
+        \ Badger 01.{\\r}\r\nDialogue: 0,1:35:14.34,1:35:15.61,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u4E2A\u7A7F\u84DD\u8863\u670D\u7684\
+        \u5BB6\u4F19\u600E\u4E48\u529E\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}What about the guy in blue?{\\r}\r\nDialogue: 0,1:35:15.87,1:35:16.91,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u8BF4\u4E86{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}I said engage...{\\r}\r\nDialogue: 0,1:35:17.17,1:35:18.35,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u653B\u51FB\u6240\u6709\u76EE\u6807{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...all targets.{\\\
+        r}\r\nDialogue: 0,1:35:29.52,1:35:30.56,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6218\u6597 \u6218\u6597{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Contact. Contact.{\\r}\r\nDialogue: 0,1:35:40.73,1:35:41.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6CA1\u4E8B\u5427\uFF1F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You okay?{\\r}\r\nDialogue:\
+        \ 0,1:35:47.30,1:35:49.41,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u4EEC\u88AB\u51FB\u4E2D\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}We're auto-rotating, going in hard.{\\r}\r\nDialogue:\
+        \ 0,1:35:50.14,1:35:51.31,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u4EEC\u53D7\u5230\u4E86\u649E\u51FB{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Brace for impact.{\\r}\r\nDialogue: 0,1:35:52.11,1:35:53.25,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u53D7\u649E\u51FB{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Brace for impact.{\\r}\r\n\
+        Dialogue: 0,1:35:53.48,1:35:54.45,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6B63\u5728\u5760\u843D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}We're going in hard!{\\r}\r\nDialogue: 0,1:35:59.55,1:36:03.55,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5B88\u62A4\u8005\u5DF2\u5760\u6BC1 \u91CD\
+        \u590D\u4E00\u6B21 \u5B88\u62A4\u8005\u5DF2\u5760\u6BC1{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Fallen angel. Fallen angel. Guardian\
+        \ is down. I repeat, Guardian is down.{\\r}\r\nDialogue: 0,1:36:25.48,1:36:26.98,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5B88\u62A4\u8005 \u542C\u5230\u8BF7\u56DE\
+        \u7B54{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Guardian,\
+        \ do you read?{\\r}\r\nDialogue: 0,1:36:27.24,1:36:28.59,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u96F7\u753512\u53F7\u547C\u53EB\u5B88\u62A4\
+        \u8005{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Thunder 12,\
+        \ calling Guardian.{\\r}\r\nDialogue: 0,1:36:28.81,1:36:30.15,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u80FD\u6536\u5230\u5417\uFF1F - \u96F7\
+        \u753512\u53F7{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}-\
+        \ Do you read?        - Thunder 12...{\\r}\r\nDialogue: 0,1:36:30.41,1:36:31.32,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD9\u91CC\u662F\u5B88\u62A4\u8005{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...this is Guardian.{\\\
+        r}\r\nDialogue: 0,1:36:31.58,1:36:33.96,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u706B\u529B\u5168\u90E8\u5BF9\u51C6\u8FD9\u91CC \u4E0D\
+        \u7528\u7BA1\u6211\u4EEC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Put down everything you've got north of my position.{\\r}\r\nDialogue:\
+        \ 0,1:36:34.18,1:36:36.36,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}- \u8FD9\u91CC\u662F\u5371\u9669\u533A\u57DF   - \u6536\u5230 \u5371\
+        \u9669\u533A\u57DF{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}-\
+        \ This will be danger-close.        - Copy, danger-close.{\\r}\r\nDialogue:\
+        \ 0,1:36:36.62,1:36:37.86,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u795D\u4F60\u597D\u8FD0 \u957F\u5B98{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Good luck, sir.{\\r}\r\nDialogue: 0,1:37:17.73,1:37:20.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6B7B\u5F97\u5149\u8363\u5C31\u662F\u6B7B\
+        \u5F97\u5176\u6240{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}A\
+        \ good death is its own reward.{\\r}\r\nDialogue: 0,1:37:34.18,1:37:35.55,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u8D62\u4E0D\u4E86\u7684{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You will not win.{\\r}\r\n\
+        Dialogue: 0,1:37:36.98,1:37:38.52,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u4F60\u6BCF\u6551\u4E00\u4E2A\u4EBA{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}For every human you save...{\\r}\r\nDialogue:\
+        \ 0,1:37:38.75,1:37:41.42,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u4EEC\u4F1A\u591A\u6740\u4E00\u767E\u4E07{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...we will kill a million more. Unh!{\\\
+        r}\r\nDialogue: 0,1:38:32.74,1:38:35.91,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u8FD8\u6709\u654C\u4EBA\u5417\uFF1F\u8FD8\u6709\u654C\
+        \u4EBA\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Do\
+        \ we have an all clear? Do we have an all clear?{\\r}\r\nDialogue: 0,1:38:36.14,1:38:38.42,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}A\u5C0F\u961F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Alpha team, sit-rep. Alpha team.{\\r}\r\nDialogue:\
+        \ 0,1:38:38.64,1:38:40.25,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6536\u5230\u8BF7\u56DE\u7B54{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Do you copy? Alpha team.{\\r}\r\nDialogue: 0,1:39:29.76,1:39:31.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD9\u4E2A\u4EBA\u4E0D\u662F\u6211\u4EEC\
+        \u7684\u654C\u4EBA{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}This\
+        \ man is not our enemy.{\\r}\r\nDialogue: 0,1:39:34.43,1:39:35.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8C22\u8C22\u4F60 \u4E0A\u6821{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Thank you, colonel.{\\r}\r\n\
+        Dialogue: 0,1:39:53.82,1:39:54.66,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u5988\u5988{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Mom?{\\r}\r\nDialogue: 0,1:39:55.95,1:39:57.63,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u6CA1\u4E8B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm all right.{\\r}\r\nDialogue: 0,1:40:09.67,1:40:11.65,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8863\u670D\u5F88\u6F02\u4EAE \u513F\u5B50\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Nice suit, son.{\\\
+        r}\r\nDialogue: 0,1:40:12.70,1:40:14.01,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5BF9\u4E0D\u8D77{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}I'm so sorry.{\\r}\r\nDialogue: 0,1:40:15.04,1:40:17.35,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD9\u4E9B\u53EA\u662F\u8EAB\u5916\u4E4B\
+        \u7269 \u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}It's only stuff, Clark.{\\r}\r\nDialogue: 0,1:40:18.51,1:40:20.92,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u603B\u662F\u4F1A\u88AB\u53D6\u4EE3\u7684\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It can always be\
+        \ replaced.{\\r}\r\nDialogue: 0,1:40:23.38,1:40:24.65,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u4F60\u4E0D\u80FD\u88AB\u53D6\u4EE3\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}But you can't be.{\\\
+        r}\r\nDialogue: 0,1:40:25.98,1:40:28.39,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5988\u5988 \u4F50\u5FB7\u8BF4\u4ED6\u8981\u627E\u7684\
+        \u5BC6\u5178{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Mom,\
+        \ Zod said this Codex...{\\r}\r\nDialogue: 0,1:40:28.65,1:40:30.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53EF\u4EE5\u8BA9\u6211\u7684\u79CD\u65CF\
+        \u91CD\u751F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...he's\
+        \ looking for can bring my people back.{\\r}\r\nDialogue: 0,1:40:31.25,1:40:32.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD9\u4E0D\u662F\u5F88\u597D\u5417\uFF1F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Isn't that a good\
+        \ thing?{\\r}\r\nDialogue: 0,1:40:37.16,1:40:39.66,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E0D\u8BA4\u4E3A\u4ED6\u4EEC\u60F3\
+        \u8981\u5206\u4EAB\u8FD9\u4E2A\u4E16\u754C{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}I don't think they're interested in sharing this\
+        \ world.{\\r}\r\nDialogue: 0,1:40:40.26,1:40:41.50,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark.{\\r}\r\nDialogue: 0,1:40:42.23,1:40:43.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u514B\u62C9\u514B{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Clark.{\\r}\r\nDialogue: 0,1:40:45.00,1:40:46.88,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u77E5\u9053\u600E\u4E48\u963B\u6B62\
+        \u4ED6\u4EEC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I know\
+        \ how to stop them.{\\r}\r\nDialogue: 0,1:40:48.94,1:40:50.38,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53D1\u751F\u4E86\u4EC0\u4E48\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What happened down\
+        \ there?{\\r}\r\nDialogue: 0,1:40:50.61,1:40:53.45,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u53D1\u73B0\u4E86\u6211\u4EEC\u4E00\
+        \u4E2A\u6682\u65F6\u7684\u5F31\u70B9{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}He exposed a temporary weakness.{\\r}\r\nDialogue: 0,1:40:54.34,1:40:56.19,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD9\u5DF2\u7ECF\u4E0D\u91CD\u8981\u4E86\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It is of little\
+        \ consequence...{\\r}\r\nDialogue: 0,1:40:57.55,1:41:00.46,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u56E0\u4E3A\u6211\u77E5\u9053\u5BC6\u5178\
+        \u5728\u54EA\u513F\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...because I have located the Codex.{\\r}\r\nDialogue: 0,1:41:01.25,1:41:03.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6839\u672C\u5C31\u4E0D\u5728\u592A\u7A7A\
+        \u8231\u91CC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It was\
+        \ never in the capsule.{\\r}\r\nDialogue: 0,1:41:04.12,1:41:05.79,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E54\u2022\u827E\u5C14\u62FF\u8D70\u4E86\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Jor-el took the\
+        \ Codex...{\\r}\r\nDialogue: 0,1:41:06.06,1:41:08.54,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8BB0\u5F55\u7740\u6570\u5341\u4EBF\u4EBA\
+        \u57FA\u56E0\u7684\u5BC6\u5178{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...the DNA of a billion people, then he bonded it...{\\r}\r\nDialogue:\
+        \ 0,1:41:08.76,1:41:11.90,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u628A\u5B83\u85CF\u5728\u4ED6\u513F\u5B50\u7684\u6BCF\u4E00\u4E2A\
+        \u7EC6\u80DE\u5F53\u4E2D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...within his son's individual cells.{\\r}\r\nDialogue: 0,1:41:11.96,1:41:13.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6240\u6709\u6C2A\u661F\u4EBA\u7684\u540E\
+        \u4EE3{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}All of Krypton's\
+        \ heirs...{\\r}\r\nDialogue: 0,1:41:13.80,1:41:17.24,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C31\u85CF\u5728\u4E00\u4E2A\u5916\u661F\
+        \u96BE\u6C11\u7684\u8EAB\u4F53\u91CC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}...living hidden in one refugee's body.{\\r}\r\nDialogue:\
+        \ 0,1:41:21.30,1:41:23.28,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u8981\u4ECE\u5361\u5C14\u2022\u827E\u5C14\u7684\u7EC6\u80DE\u91CC\
+        \u62FF\u5230\u5BC6\u5178{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Does Kal-El need to be alive...{\\r}\r\nDialogue: 0,1:41:23.54,1:41:26.71,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9700\u8981\u4ED6\u6D3B\u7740\u5417\uFF1F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...for us to extract\
+        \ the Codex from his cells?{\\r}\r\nDialogue: 0,1:41:28.08,1:41:29.25,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u7528{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}No.{\\r}\r\nDialogue: 0,1:41:35.15,1:41:37.43,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u542F\u52A8\u4E16\u754C\u5F15\u64CE{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Release the world engine.{\\\
+        r}\r\nDialogue: 0,1:42:09.65,1:42:10.60,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u53D1\u751F\u4E86\u4EC0\u4E48\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What just happened?{\\r}\r\nDialogue:\
+        \ 0,1:42:10.75,1:42:11.93,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u90A3\u8258\u8239\u4E00\u5206\u4E3A\u4E8C{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}The ship just split in two.{\\r}\r\nDialogue:\
+        \ 0,1:42:12.15,1:42:15.26,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4E00\u8258\u5F80\u4E1C\u98DE\u53BB\u4E86 \u53E6\u4E00\u8258\u5411\
+        \u5357\u534A\u7403\u53BB\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Track one is heading east, track two to the southern hemisphere.{\\\
+        r}\r\nDialogue: 0,1:42:15.49,1:42:18.16,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u901F\u5EA6\u6709\u591A\u5FEB\uFF1F - \u63A5\u8FD1\
+        ...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- How fast is\
+        \ that bogey moving?       - Approaching...{\\r}\r\nDialogue: 0,1:42:18.16,1:42:19.61,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}24\u9A6C\u8D6B \u5E76\u4E14\u8FD8\u5728\u52A0\
+        \u901F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...Mach 24\
+        \ and accelerating.{\\r}\r\nDialogue: 0,1:42:19.83,1:42:22.90,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u770B\u8D77\u6765\u50CF\u662F\u8981\u964D\
+        \u843D\u5728\u5357\u5370\u5EA6\u6D0B\u7684\u67D0\u4E2A\u5730\u65B9{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's gonna impact somewhere\
+        \ in the Indian Ocean.{\\r}\r\nDialogue: 0,1:42:41.22,1:42:42.86,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53E6\u4E00\u8258\u8239\u4E5F\u5728\u964D\
+        \u843D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The rest of\
+        \ the ship is descending.{\\r}\r\nDialogue: 0,1:42:43.85,1:42:45.22,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8367\u5E55\u663E\u793A{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Put it on the board now.{\\r}\r\n\
+        Dialogue: 0,1:42:45.22,1:42:46.29,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u9075\u547D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Yes, sir.{\\r}\r\nDialogue: 0,1:42:47.32,1:42:48.50,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5929\u554A{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Oh, my God.{\\r}\r\nDialogue: 0,1:43:29.00,1:43:31.77,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8BA9\u5E7D\u7075\u5F15\u64CE\u5F85\u547D\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Bring the phantom\
+        \ drive online.{\\r}\r\nDialogue: 0,1:43:53.39,1:43:55.83,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5DF2\u7ECF\u4E0E\u4E16\u754C\u5F15\u64CE\
+        \u5EFA\u7ACB\u8FDE\u63A5{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}We are now slave to the world engine.{\\r}\r\nDialogue: 0,1:43:56.96,1:43:58.37,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u542F\u52A8{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Initiate.{\\r}\r\nDialogue: 0,1:44:31.63,1:44:33.67,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4EEC\u53D1\u5C04\u8FC7\u6765\u7684\
+        \u662F\u4EC0\u4E48\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}What have they hit us with?{\\r}\r\nDialogue: 0,1:44:33.67,1:44:35.84,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3} \u770B\u4E0A\u53BB\u50CF\u662F\u67D0\u79CD\
+        \u91CD\u529B\u6B66\u5668{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Looks like some kind of gravity...{\\r}\r\nDialogue: 0,1:44:36.10,1:44:39.34,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u548C\u4ED6\u4EEC\u7684\u98DE\u8239\u540C\
+        \u6B65\u5DE5\u4F5C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...weapon.\
+        \ It's working in tandem with their ship.{\\r}\r\nDialogue: 0,1:44:40.07,1:44:43.14,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E00\u79CD\u53EF\u4EE5\u589E\u52A0\u5730\
+        \u7403\u8D28\u91CF\u7684\u4E1C\u897F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Somehow they're increasing the Earth's mass...{\\r}\r\n\
+        Dialogue: 0,1:44:43.41,1:44:45.51,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u5229\u7528\u5FAE\u5C18\u6C61\u6D4A\u5927\u6C14{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...clouding the atmosphere\
+        \ with particulates.{\\r}\r\nDialogue: 0,1:44:47.24,1:44:48.85,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5929\u54EA{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Oh, my God.{\\r}\r\nDialogue: 0,1:44:50.18,1:44:51.88,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4EEC\u5728\u8FDB\u884C\u73AF\u5883\
+        \u6539\u9020{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}They're\
+        \ terraforming.{\\r}\r\nDialogue: 0,1:44:51.95,1:44:52.76,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u662F\u4EC0\u4E48\uFF1F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What's that?{\\r}\r\nDialogue:\
+        \ 0,1:44:53.58,1:44:54.69,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u884C\u661F\u5DE5\u7A0B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Planetary engineering...{\\r}\r\nDialogue: 0,1:44:54.95,1:44:58.16,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4FEE\u6539\u5730\u7403\u4E0A\u7684\u5927\
+        \u6C14\u548C\u5730\u5F62{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...modifying the Earth's atmosphere and topography.{\\r}\r\nDialogue:\
+        \ 0,1:44:58.42,1:44:59.66,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4ED6\u4EEC\u8981\u628A\u5730\u7403\u8F6C\u5316\u6210\u6C2A\u661F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Turning Earth into\
+        \ Krypton.{\\r}\r\nDialogue: 0,1:45:00.36,1:45:03.50,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4F46\u662F\u6211\u4EEC\u4F1A\u600E\u4E48\
+        \u6837\uFF1F - \u7406\u8BBA\u4E0A\u8BF4...{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}- But what happens to us?       - Based on these\
+        \ readings...{\\r}\r\nDialogue: 0,1:45:03.76,1:45:06.76,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4E0D\u518D\u6709\"\u6211\u4EEC\"\u4E86\
+        \    - \u65AF\u65FA\u5A01\u514B\u5C06\u519B{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}- ...there won't be an \"us.\"       - General Swanwick,\
+        \ sir.{\\r}\r\nDialogue: 0,1:45:07.16,1:45:08.54,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u63A7\u5236\u5854\u6765\u7535{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm on with the control tower.{\\\
+        r}\r\nDialogue: 0,1:45:08.80,1:45:11.64,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u54C8\u8FEA\u4E0A\u6821\u6B63\u5728\u8DEF\u4E0A \u548C\
+        \u4ED6\u5728\u4E00\u8D77\u7684\u8FD8\u6709\u8D85\u4EBA{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Colonel Hardy's on his way and he's\
+        \ got Superman in tow.{\\r}\r\nDialogue: 0,1:45:11.77,1:45:12.84,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8D85\u4EBA\uFF1F{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Superman?{\\r}\r\nDialogue: 0,1:45:13.37,1:45:14.54,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u4E2A\u5916\u661F\u4EBA \u5148\u751F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The alien, sir.{\\\
+        r}\r\nDialogue: 0,1:45:14.80,1:45:17.18,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4ED6\u4EEC\u53EB\u4ED6\u8D85\u4EBA{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}That's what they're calling him. Superman.{\\\
+        r}\r\nDialogue: 0,1:45:22.68,1:45:23.88,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u4EEC\u6709\u4E2A\u8BA1\u5212 \u5C06\u519B{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We have a plan, general.{\\\
+        r}\r\nDialogue: 0,1:45:24.15,1:45:26.23,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u548C\u6211\u60F3\u7684\u4E00\u6837\u5417\uFF1F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Is that what I think it\
+        \ is?{\\r}\r\nDialogue: 0,1:45:26.78,1:45:28.56,chs,,0000,0000,0000,,{\\fn\u534E\
+        \u6587\u6977\u4F53\\blur3}\u8FD9\u662F\u4ED6\u5750\u7684\u98DE\u8239{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's the ship he arrived\
+        \ in.{\\r}\r\nDialogue: 0,1:45:30.22,1:45:32.86,chs,,0000,0000,0000,,{\\fn\u534E\
+        \u6587\u6977\u4F53\\blur3}\u8FD9\u8258\u98DE\u8239\u7531\u67D0\u79CD\u53EB\
+        \u5E7D\u7075\u5F15\u64CE\u7684\u7269\u8D28\u9A71\u52A8{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}This ship is powered by something\
+        \ called a phantom drive.{\\r}\r\nDialogue: 0,1:45:33.12,1:45:34.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5B83\u80FD\u591F\u626D\u66F2\u65F6\u7A7A\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It bends space.{\\\
+        r}\r\nDialogue: 0,1:45:34.82,1:45:38.80,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F50\u5FB7\u7684\u98DE\u8239\u8FD0\u7528\u4E86\u540C\
+        \u6837\u7684\u539F\u7406 \u5982\u679C\u6211\u4EEC\u80FD\u8BA9\u4E24\u8005\u5BF9\
+        \u649E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Zod's ship\
+        \ uses the same technology, and if we can make the two drives collide...{\\\
+        r}\r\nDialogue: 0,1:45:39.03,1:45:40.87,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5C31\u80FD\u521B\u9020\u51FA\u4E00\u4E2A\u5947\u5F02\
+        \u70B9{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}A singularity\
+        \ can be created.{\\r}\r\nDialogue: 0,1:45:41.13,1:45:42.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u5C31\u50CF\u9ED1\u6D1E   - \u5BF9{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Like a black hole.\
+        \       - Yes.{\\r}\r\nDialogue: 0,1:45:42.70,1:45:44.20,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6240\u4EE5\u5982\u679C\u6211\u4EEC\u6253\
+        \u5F00\u901A\u9053{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}So\
+        \ if we open up this doorway...{\\r}\r\nDialogue: 0,1:45:44.47,1:45:46.07,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7406\u8BBA\u4E0A\u6765\u8BF4\u4ED6\u4EEC\
+        \u5C31\u5E94\u8BE5\u88AB\u5438\u8FDB\u53BB{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...they should be pulled back in.{\\r}\r\nDialogue:\
+        \ 0,1:45:46.34,1:45:48.84,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6240\u4EE5\u4F60\u60F3\u6211\u4EEC\u7528\u90A3\u4E2A\u70B8\u6389\
+        \u4ED6\u4EEC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}So you\
+        \ want us to bomb them with that?{\\r}\r\nDialogue: 0,1:45:49.07,1:45:51.05,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C06\u519B \u5982\u679C\u592A\u7A7A\u8239\
+        \u8FBE\u5230{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}General,\
+        \ that craft maxes out...{\\r}\r\nDialogue: 0,1:45:51.31,1:45:54.69,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}17000\u78C5 \u53EF\u4EE5\u4ECEC-17\u6295\
+        \u63B7\u4E0B\u6765{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...17,000\
+        \ pounds, we can drop it from a C-17.{\\r}\r\nDialogue: 0,1:45:54.91,1:45:56.05,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD9\u662F\u53EF\u884C\u7684{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's a viable plan.{\\r}\r\n\
+        Dialogue: 0,1:45:56.31,1:45:58.42,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u5982\u679C\u6211\u4E0D\u963B\u6B62\u5370\u5EA6\u6D0B\u4E0A\
+        \u7684\u673A\u5668{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}If\
+        \ I don't stop that machine over the Indian Ocean...{\\r}\r\nDialogue: 0,1:45:58.68,1:46:02.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u91CD\u529B\u573A\u8FD8\u4F1A\u7EE7\u7EED\
+        \u6269\u5927{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...the\
+        \ gravity field will continue to expand.{\\r}\r\nDialogue: 0,1:46:07.76,1:46:10.53,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5982\u679C\u90A3\u4E2A\u4E1C\u897F\u662F\
+        \u4F7F\u5730\u7403\u6C2A\u661F\u5316{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}If that thing is making Earth more like Krypton...{\\r}\r\
+        \nDialogue: 0,1:46:10.89,1:46:12.93,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u5728\u5B83\u9644\u8FD1\u4E0D\u4F1A\u66F4\u8106\
+        \u5F31\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...won't\
+        \ you be weaker around it?{\\r}\r\nDialogue: 0,1:46:14.23,1:46:15.54,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6709\u53EF\u80FD{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Maybe.{\\r}\r\nDialogue: 0,1:46:16.40,1:46:18.88,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u6211\u4E0D\u4F1A\u8BA9\u5B83\u963B\
+        \u6B62\u6211\u8BD5\u4E00\u8BD5{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I'm not about to let that stop me from trying.{\\r}\r\nDialogue: 0,1:46:19.84,1:46:22.04,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u53EF\u80FD\u60F3\u540E\u9000\u4E00\
+        \u70B9{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You might\
+        \ want to step back a little bit.{\\r}\r\nDialogue: 0,1:46:24.11,1:46:25.94,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53EF\u80FD\u8981\u518D\u9000\u4E00\u70B9\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Maybe a little bit\
+        \ more.{\\r}\r\nDialogue: 0,1:46:57.71,1:46:58.31,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8299\u62C9{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Faora.{\\r}\r\nDialogue: 0,1:46:59.31,1:47:00.41,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6765\u6307\u6325{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Take command.{\\r}\r\nDialogue: 0,1:47:00.64,1:47:03.78,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u9075\u547D   - \u6211\u8981\u4FDD\u8BC1\
+        \u59CB\u6E90\u5BA4\u7684\u5B89\u5168{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}- Yes, sir.       - I need to secure the genesis chamber...{\\\
+        r}\r\nDialogue: 0,1:47:04.21,1:47:06.96,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u8FD8\u8981\u5411\u4E00\u4E2A\u8001\u670B\u53CB\u81F4\
+        \u610F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...and pay\
+        \ my respects to an old friend.{\\r}\r\nDialogue: 0,1:47:14.72,1:47:16.83,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5B88\u62A4\u8005\u524D\u5F80\u5927\u90FD\
+        \u4F1A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Guardian en\
+        \ route to Metropolis...{\\r}\r\nDialogue: 0,1:47:17.63,1:47:18.83,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u643A\u5E26\u5305\u88F9{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...package in tow.{\\r}\r\nDialogue:\
+        \ 0,1:47:24.10,1:47:27.01,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u88AB\u544A\u77E5\u4E86F-35\u6218\u673A\u5165\u5883\u7684\u4F1A\u5408\
+        \u70B9{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Be advised,\
+        \ F-35s inbound to rendezvous point.{\\r}\r\nDialogue: 0,1:47:27.27,1:47:29.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u73B0\u5728\u5E94\u8BE5\u5728\u89C6\
+        \u89C9\u63A5\u89E6{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You\
+        \ should have visual contact now.{\\r}\r\nDialogue: 0,1:48:14.45,1:48:18.13,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E3B\u63A7\u94A5\u5319\u8BC6\u522B\u6B63\
+        \u786E \u59CB\u6E90\u5BA4\u5F85\u547D \u5148\u751F{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Command key accepted. Genesis chamber\
+        \ coming online, sir.{\\r}\r\nDialogue: 0,1:48:18.52,1:48:19.52,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F4F\u624B \u4F50\u5FB7{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Stop this, Zod...{\\r}\r\nDialogue:\
+        \ 0,1:48:19.69,1:48:21.83,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u8D81\u8FD8\u6709\u65F6\u95F4{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}...while there's still time.{\\r}\r\nDialogue: 0,1:48:23.06,1:48:26.37,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD8\u6CA1\u653E\u5F03\u5BF9\u6211\u8BF4\
+        \u6559\u5462 \u662F\u5427 \u54EA\u6015\u662F\u6B7B\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Haven't given up lecturing me, have\
+        \ you, even in death?{\\r}\r\nDialogue: 0,1:48:26.73,1:48:28.73,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E0D\u4F1A\u8BA9\u4F60\u7528\u5BC6\
+        \u5178\u505A\u8FD9\u4E9B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I will not let you use the Codex like this.{\\r}\r\nDialogue: 0,1:48:29.00,1:48:30.71,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6CA1\u6743\u529B\u963B\u6B62\u6211\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You don't have the\
+        \ power to stop me.{\\r}\r\nDialogue: 0,1:48:30.97,1:48:34.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u63D2\u5165\u7684\u4E3B\u63A7\u94A5\
+        \u5319\u5DF2\u7ECF\u5E9F\u9664\u4E86\u4F60\u7684\u6743\u9650{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}The command key I have entered is\
+        \ revoking your authority.{\\r}\r\nDialogue: 0,1:48:34.24,1:48:37.15,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u98DE\u8239\u5728\u6211\u638C\u63A7\u4E4B\
+        \u4E0B\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}This\
+        \ ship is now under my control.{\\r}\r\nDialogue: 0,1:49:08.67,1:49:10.35,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5317\u65B9\u53F8\u4EE4\u90E8 \u8FD9\u91CC\
+        \u662F\u95EA\u75351\u53F7{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Northcom, Lightning 1, request...{\\r}\r\nDialogue: 0,1:49:10.51,1:49:12.03,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8BF7\u6C42\u91CA\u653E\u5BFC\u5F39{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...permission to unleash\
+        \ the hounds.{\\r}\r\nDialogue: 0,1:49:12.03,1:49:16.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5468\u56F4\u5B89\u5168 \u53EF\u4EE5\u88AD\
+        \u51FB \u53EF\u80FD\u7684\u8BDD\u53D1\u751F\u4F5C\u6218\u635F\u574F\u8BC4\u4F30\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Lightning 1, you\
+        \ are clear to engage. Send battle damage assessment when able. Out.{\\r}\r\
+        \nDialogue: 0,1:49:30.19,1:49:32.57,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u7535\u5B50\u8BBE\u5907\u9677\u5165\u6DF7\u4E71{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Avionics are going haywire.\
+        \ The gravity field...{\\r}\r\nDialogue: 0,1:49:32.80,1:49:35.14,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u91CD\u529B\u573A\u7275\u5F15\u6211\u4EEC\
+        \u7684\u5BFC\u5F39\u4E0B\u5760 \u6211\u4EEC\u9700\u8981\u66F4\u52A0\u63A5\u8FD1\
+        \u76EE\u6807{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...is\
+        \ pulling our missiles down. We gotta get closer.{\\r}\r\nDialogue: 0,1:49:40.24,1:49:41.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u597D\u4E86\u5404\u4F4D{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}All right, everybody...{\\r}\r\nDialogue:\
+        \ 0,1:49:41.54,1:49:44.42,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u4EEC\u79BB\u5F00\u4E86 \u73B0\u5728\u5C31\u79BB\u5F00\u5927\
+        \u697C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...we're leaving.\
+        \ We're leaving the building now.{\\r}\r\nDialogue: 0,1:50:07.56,1:50:09.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5931\u53BB\u4E86\u6211\u7684\u50DA\
+        \u673A\u9A7E\u9A76\u5458{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}I just lost my wingman.{\\r}\r\nDialogue: 0,1:50:11.80,1:50:12.94,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u98DE\u673A\u5931\u63A7 \u98DE\u673A\u5931\
+        \u63A7 \u98DE\u673A\u5931\u63A7{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Mayday! Mayday! Mayday!{\\r}\r\nDialogue: 0,1:50:24.51,1:50:26.49,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5404\u4F4D \u8FD9\u8FB9{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Everybody, this way! Come on!{\\r}\r\
+        \nDialogue: 0,1:50:26.75,1:50:29.82,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5404\u4F4D \u5FEB\u70B9 \u5FEB \u5FEB{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Everybody, come on! Keep moving, keep\
+        \ moving.{\\r}\r\nDialogue: 0,1:50:36.66,1:50:37.69,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8A79\u59AE{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Jenny!{\\r}\r\nDialogue: 0,1:50:41.66,1:50:42.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5929\u54EA{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Oh, my God.{\\r}\r\nDialogue: 0,1:50:42.76,1:50:43.77,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u739B\u4E3D{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Perry!{\\r}\r\nDialogue: 0,1:50:48.20,1:50:50.15,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8D70\u8FD9\u8FB9 \u5FEB{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Go! There! Go!{\\r}\r\nDialogue: 0,1:50:56.01,1:50:57.51,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u53EF\u4EE5\u5171\u5B58{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Our people can co-exist.{\\\
+        r}\r\nDialogue: 0,1:50:58.15,1:51:00.12,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u8FD9\u6837\u6211\u4EEC\u5C31\u50CF\u4F60\u513F\u5B50\
+        \u90A3\u6837{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}So we\
+        \ can suffer through years of pain{\\r}\r\nDialogue: 0,1:51:00.12,1:51:02.65,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6491\u8FC7\u6570\u5E74\u7684\u4F24\u75DB\
+        \u6765\u9002\u5E94\u73AF\u5883\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}trying to adapt like your son has?{\\r}\r\nDialogue: 0,1:51:02.99,1:51:04.66,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4F60\u8BF4\u7684\u662F\u79CD\u65CF\u5C60\
+        \u6740   - \u662F\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}- You're talking about genocide.       - Yes.{\\r}\r\nDialogue: 0,1:51:04.89,1:51:07.99,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u800C\u4E14\u6211\u6B63\u548C\u4E00\u4E2A\
+        \u9B3C\u9B42\u4E89\u8BBA\u5176\u529F\u8FC7{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}And I'm arguing its merits with a ghost.{\\r}\r\n\
+        Dialogue: 0,1:51:08.86,1:51:10.67,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6211\u4EEC\u90FD\u662F\u9B3C\u9B42 \u4F50\u5FB7{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We're both ghosts, Zod.{\\\
+        r}\r\nDialogue: 0,1:51:10.89,1:51:14.40,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u4E0D\u660E\u767D\u5417\uFF1F\u4F60\u4E0D\u613F\
+        \u653E\u5F03\u7684\u6C2A\u661F\u5DF2\u7ECF\u6CA1\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Can't you see that? The Krypton you're\
+        \ clinging onto is gone.{\\r}\r\nDialogue: 0,1:51:14.66,1:51:17.23,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u68C0\u67E5\u597D\u5165\u4FB5\u7684\
+        \u60C5\u62A5\u4E86\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Ship, have you managed to quarantine this invasive intelligence?{\\\
+        r}\r\nDialogue: 0,1:51:17.50,1:51:18.42,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u5931\u8D25\u4E86   - \u597D\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- You'll fail.        - I have.{\\\
+        r}\r\nDialogue: 0,1:51:18.63,1:51:20.05,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u51C6\u5907\u597D\u7EC8\u7ED3\u8FD9\u4E00\u5207{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Then prepare to terminate\
+        \ it.{\\r}\r\nDialogue: 0,1:51:20.30,1:51:22.08,chs,,0000,0000,0000,,{\\fn\u534E\
+        \u6587\u6977\u4F53\\blur3}\u6211\u4E0D\u60F3\u4E89\u5435\u4E86 \u8BA9\u6211\
+        \u95ED\u5634{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm\
+        \ tired of this debate. Silencing me...{\\r}\r\nDialogue: 0,1:51:22.34,1:51:23.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6539\u53D8\u4E0D\u4E86\u4EFB\u4F55\u4E8B\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...won't change\
+        \ anything.{\\r}\r\nDialogue: 0,1:51:26.01,1:51:27.32,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u513F\u5B50...{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}My son...{\\r}\r\nDialogue: 0,1:51:28.14,1:51:29.49,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6BD4\u4F60\u5F3A\u4E24\u500D{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...is twice the man you were.{\\\
+        r}\r\nDialogue: 0,1:51:32.48,1:51:34.15,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4ED6\u4F1A\u7ED3\u675F\u6211\u4EEC\u53D1\u8D77\u7684\
+        \u79CD\u79CD{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And\
+        \ he will finish what we started.{\\r}\r\nDialogue: 0,1:51:35.08,1:51:36.32,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4FDD\u8BC1{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}I can promise you that.{\\r}\r\nDialogue:\
+        \ 0,1:51:41.52,1:51:42.90,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u544A\u8BC9\u6211{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Tell me...{\\r}\r\nDialogue: 0,1:51:43.16,1:51:46.73,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6709\u4E54\u2022\u827E\u5C14\u7684\
+        \u8BB0\u5FC6\u548C\u826F\u77E5{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...you have Jor-El's memories, his conscience.{\\r}\r\nDialogue: 0,1:51:47.43,1:51:50.20,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53EF\u4F60\u7ECF\u5386\u8FC7\u4ED6\u7684\
+        \u75DB\u82E6\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Can you experience his pain?{\\r}\r\nDialogue: 0,1:51:51.87,1:51:55.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4F1A\u4ECE\u4F60\u513F\u5B50\u7684\
+        \u5C38\u4F53\u91CC\u63D0\u53D6\u5BC6\u5178{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}I will harvest the Codex from your son's corpse...{\\\
+        r}\r\nDialogue: 0,1:51:55.90,1:52:01.21,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5728\u4ED6\u7684\u5C38\u9AA8\u4E4B\u4E0A\u91CD\u5EFA\
+        \u6C2A\u661F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...and\
+        \ I will rebuild Krypton atop his bones.{\\r}\r\nDialogue: 0,1:52:58.63,1:52:59.34,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8A79\u59AE{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Jenny.{\\r}\r\nDialogue: 0,1:52:59.60,1:53:02.34,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u8A79\u59AE \u8A79\u59AE \u4F60\u5728\
+        \u54EA\uFF1F - \u6211\u5728\u8FD9\u91CC{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}- Jenny. Jenny, where are you?       - I'm here!{\\r}\r\
+        \nDialogue: 0,1:53:02.60,1:53:03.90,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u8FD9\u91CC \u8FD9\u91CC   - \u8A79\u59AE{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- I'm here. Here.       - Jenny.{\\\
+        r}\r\nDialogue: 0,1:53:03.91,1:53:05.41,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6491\u4F4F \u6491\u4F4F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Hold on, hold on.{\\r}\r\nDialogue: 0,1:53:05.64,1:53:06.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5361\u4F4F\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm stuck.{\\r}\r\nDialogue: 0,1:53:06.84,1:53:08.52,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u6211\u52A8\u4E0D\u4E86 \u5361\u4F4F\u4E86\
+        \   - \u597D\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}-\
+        \ I can't get free. I'm stuck.       - Okay.{\\r}\r\nDialogue: 0,1:53:08.78,1:53:11.31,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u4F1A\u628A\u4F60\u6551\u51FA\
+        \u53BB \u4F60\u522B\u52A8{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}We'll get you out of there, all right? Just sit tight.{\\r}\r\nDialogue:\
+        \ 0,1:53:11.58,1:53:12.15,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4E0D\u4E0D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}No,\
+        \ no, no!{\\r}\r\nDialogue: 0,1:53:12.41,1:53:14.22,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u522B\u79BB\u5F00\u6211   - \u6211\u4E0D\
+        \u4F1A\u79BB\u5F00\u4F60{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}- Don't leave me.       - We're not gonna leave you.{\\r}\r\nDialogue:\
+        \ 0,1:53:14.35,1:53:15.52,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}- \u597D   - \u4F26\u5DF4\u7B2C{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}- Okay.       - Lombard!{\\r}\r\nDialogue: 0,1:53:15.78,1:53:19.13,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4ED6\u5988\u7684\u5FEB\u8FC7\u6765\u5E2E\
+        \u5FD9   - \u8BE5\u6B7B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}- Get your ass over here and help me.       - Damn it.{\\r}\r\nDialogue:\
+        \ 0,1:53:21.12,1:53:23.10,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}- \u7528\u8FD9\u4E2A\u64AC   - \u7ED9\u4F60{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}- We just gotta move this.       - Here.{\\\
+        r}\r\nDialogue: 0,1:53:23.33,1:53:25.36,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u7528\u529B\u8BD5\u8BD5\u770B \u597D\u4E86\u5417\uFF1F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Slide that in. You\
+        \ push, I'll pull, okay?{\\r}\r\nDialogue: 0,1:53:25.63,1:53:26.66,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6765\u5427{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Go.{\\r}\r\nDialogue: 0,1:53:30.87,1:53:32.17,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u7528\u529B   - \u5929\u554A{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Push!       - Oh, my God.{\\\
+        r}\r\nDialogue: 0,1:53:32.43,1:53:34.27,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u8D8A\u6765\u8D8A\u8FD1\u4E86 \u7528\u529B{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's getting closer! Come on,\
+        \ push!{\\r}\r\nDialogue: 0,1:53:36.10,1:53:38.31,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5317\u65B9\u53F8\u4EE4\u90E8 \u8FD9\u91CC\
+        \u662F\u5B88\u62A4\u8005 \u53EF\u4EE5\u6295\u63B7\u5417\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Northcom, this is Guardian. Are we\
+        \ cleared?{\\r}\r\nDialogue: 0,1:53:38.84,1:53:39.84,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u884C \u5B88\u62A4\u8005{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Negative, Guardian.{\\r}\r\n\
+        Dialogue: 0,1:54:04.57,1:54:07.01,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u5FEB \u7528\u529B\u554A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Come on! Push!{\\r}\r\nDialogue: 0,1:54:59.02,1:55:00.36,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u505A\u5230\u4E86{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He did it.{\\r}\r\nDialogue: 0,1:55:02.56,1:55:03.80,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5317\u65B9\u53F8\u4EE4\u90E8 \u8FD9\u91CC\
+        \u662F\u5B88\u62A4\u8005{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Northcom, this is Guardian.{\\r}\r\nDialogue: 0,1:55:04.06,1:55:06.30,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u6B63\u7ECF\u8FC7\u8C03\u6574\
+        \u7EBF \u4E00\u5207\u826F\u597D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}We're passing through phase line red. Good to go.{\\r}\r\nDialogue:\
+        \ 0,1:55:06.56,1:55:07.73,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4E00\u8DEF\u5E73\u5B89 \u5B88\u62A4\u8005{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Godspeed, Guardian.{\\r}\r\nDialogue:\
+        \ 0,1:55:07.73,1:55:10.14,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6574\u7406\u5305\u88F9 \u51C6\u5907\u6295\u63B7{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Arm the package. You are cleared hot.{\\\
+        r}\r\nDialogue: 0,1:55:10.40,1:55:12.47,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u51C6\u5907\u53D1\u51FA\u6700\u540E\u4E00\u51FB{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We're lining up for the\
+        \ final run.{\\r}\r\nDialogue: 0,1:55:13.27,1:55:15.27,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u73B0\u5728\u770B\u4F60\u548C\u6C49\u5BC6\
+        \u5C14\u987F\u7684\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}It's up to you and Hamilton now.{\\r}\r\nDialogue: 0,1:55:55.44,1:55:56.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u641E\u4EC0\u4E48{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}You gotta be kidding me.{\\r}\r\nDialogue:\
+        \ 0,1:55:56.45,1:55:59.30,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u7406\u8D27\u5458 \u5305\u88F9\u662F\u5426\u6B66\u88C5\u5B8C\u6BD5\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Loadmaster,\
+        \ is the package ready to drop?{\\r}\r\nDialogue: 0,1:55:59.35,1:56:00.62,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u884C \u5B88\u62A4\u8005{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Negative, Guardian.{\\r}\r\n\
+        Dialogue: 0,1:56:00.85,1:56:02.42,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u51FA\u95EE\u9898\u4E86 \u4E0D\u8BE5\u8FD9\u6837\u7684{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}There's something wrong.\
+        \ It's not supposed to do this.{\\r}\r\nDialogue: 0,1:56:02.65,1:56:04.43,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u90A3\u5E94\u8BE5\u600E\u6837\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}What's it supposed\
+        \ to do?{\\r}\r\nDialogue: 0,1:56:04.65,1:56:07.69,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u5E94\u8BE5\u5B8C\u5168\u63D2\u8FDB\u53BB\
+        \   - \u6211\u770B\u770B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}- It's supposed to go in all the way.       - Let me take a look.{\\\
+        r}\r\nDialogue: 0,1:56:07.96,1:56:09.53,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u526F\u9A7E\u9A76\u63A5\u7BA1\u98DE\u673A{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Co-pilot's aircraft.{\\r}\r\
+        \nDialogue: 0,1:56:10.26,1:56:11.76,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u526F\u9A7E\u9A76\u63A5\u7BA1\u98DE\u673A{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Co-pilot's aircraft.{\\r}\r\
+        \nDialogue: 0,1:56:18.50,1:56:21.17,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u4EEC\u5DF2\u7ECF\u6392\u5217\u597D\u51C6\u5907\
+        \u6295\u63B7\u4E86 \u8FD8\u5728\u7B49\u4EC0\u4E48\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We are lined up for the drop. What's\
+        \ the hold up?{\\r}\r\nDialogue: 0,1:56:21.44,1:56:22.44,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u51FA\u73B0\u4E86\u70B9\u95EE\u9898{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We've had a setback.{\\\
+        r}\r\nDialogue: 0,1:56:38.19,1:56:39.69,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u7784\u51C6\u98DE\u673A{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Target that aircraft.{\\r}\r\nDialogue: 0,1:56:43.56,1:56:45.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u9501\u5B9A\u76EE\u6807{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Target locked.{\\r}\r\nDialogue: 0,1:56:54.80,1:56:55.68,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u8981{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Stop!{\\r}\r\nDialogue: 0,1:56:55.90,1:56:58.01,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5982\u679C\u4F60\u6BC1\u4E86\u8FD9\u8258\
+        \u98DE\u8239{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}If you\
+        \ destroy this ship...{\\r}\r\nDialogue: 0,1:56:58.24,1:57:00.91,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C31\u662F\u6BC1\u4E86\u6C2A\u661F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...you destroy Krypton!{\\\
+        r}\r\nDialogue: 0,1:57:03.71,1:57:05.89,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6C2A\u661F\u672C\u6765\u8FD8\u6709\u673A\u4F1A\u7684\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Krypton had its\
+        \ chance.{\\r}\r\nDialogue: 0,1:57:59.87,1:58:01.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u83B2\u6069\u5C0F\u59D0 \u8FD9\u513F\u4E0D\
+        \u5B89\u5168{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Miss\
+        \ Lane! It's not safe for you...{\\r}\r\nDialogue: 0,1:58:01.97,1:58:02.88,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u79BB\u5F00\u90A3\u513F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...over there!{\\r}\r\nDialogue: 0,1:58:03.10,1:58:03.71,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u83B2\u6069\u5C0F\u59D0{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Miss Lane!{\\r}\r\nDialogue: 0,1:58:33.60,1:58:35.34,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u79BB\u5F00 \u5FEB{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Move now! Go!{\\r}\r\nDialogue: 0,1:58:56.19,1:58:57.19,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6B7B\u5F97\u5149\u8363{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}A good death...{\\r}\r\nDialogue:\
+        \ 0,1:58:57.46,1:58:59.03,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5C31\u662F\u6B7B\u5F97\u5176\u6240{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...is its own reward.{\\r}\r\nDialogue: 0,2:00:01.49,2:00:02.93,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4EEC\u8D70\u4E86\u5417\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Are they gone?{\\r}\r\
+        \nDialogue: 0,2:00:04.09,2:00:05.50,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u60F3\u662F\u7684{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}I think so.{\\r}\r\nDialogue: 0,2:00:07.40,2:00:08.74,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u6551\u4E86\u6211\u4EEC{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He saved us.{\\r}\r\nDialogue:\
+        \ 0,2:00:34.22,2:00:37.43,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4ED6\u4EEC\u8BF4\u521D\u543B\u4E4B\u540E\u5C31\u6BCF\u51B5\u6108\
+        \u4E0B\u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You\
+        \ know, they say it's all downhill after the first kiss.{\\r}\r\nDialogue:\
+        \ 0,2:00:40.90,2:00:43.93,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u5F88\u786E\u5B9A \u4ED6\u4EEC\u53EA\u7EDF\u8BA1\u4E86\u4EB2\
+        \u543B\u4EBA\u7C7B\u7684\u6570\u636E{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}I'm pretty sure that only counts when you're kissing a\
+        \ human.{\\r}\r\nDialogue: 0,2:01:13.29,2:01:14.77,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u770B\u8FD9\u4E2A{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Look at this.{\\r}\r\nDialogue: 0,2:01:17.07,2:01:21.10,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4EEC\u672C\u53EF\u4EE5\u5728\u8FD9\
+        \u7247\u5E9F\u589F\u4E0A\u5EFA\u7ACB\u8D77\u4E00\u4E2A\u65B0\u7684\u6C2A\u661F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}We could have built\
+        \ a new Krypton in this squalor.{\\r}\r\nDialogue: 0,2:01:21.24,2:01:24.34,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F46\u662F\u5728\u6211\u4EEC\u548C\u4EBA\
+        \u7C7B\u4E4B\u95F4 \u4F60\u9009\u62E9\u4E86\u540E\u8005{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}But you chose the humans over us.{\\\
+        r}\r\nDialogue: 0,2:01:25.77,2:01:27.31,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u7684\u5B58\u5728{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}I exist...{\\r}\r\nDialogue: 0,2:01:27.58,2:01:29.99,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4EC5\u662F\u4E3A\u4E86\u5B88\u62A4\u6C2A\
+        \u661F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...only to\
+        \ protect Krypton.{\\r}\r\nDialogue: 0,2:01:31.75,2:01:35.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD9\u662F\u81EA\u6211\u51FA\u751F\u4EE5\
+        \u6765\u7684\u552F\u4E00\u76EE\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}That is the sole purpose for which I was born.{\\r}\r\n\
+        Dialogue: 0,2:01:36.99,2:01:39.12,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\
+        \u4F53\\blur3}\u6211\u6240\u505A\u7684\u4E00\u5207{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}And every action I take...{\\r}\r\nDialogue:\
+        \ 0,2:01:39.35,2:01:41.36,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u65E0\u8BBA\u591A\u66B4\u529B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}...no matter how violent...{\\r}\r\nDialogue: 0,2:01:41.62,2:01:43.33,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u591A\u4E48\u6B8B\u5FCD{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...or how cruel...{\\r}\r\nDialogue:\
+        \ 0,2:01:44.53,2:01:49.11,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u7686\u662F\u4E3A\u4E86\u6211\u7684\u4EBA\u6C11\u7684\u798F\u7949\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...is for the greater\
+        \ good of my people.{\\r}\r\nDialogue: 0,2:01:53.43,2:01:54.85,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u73B0\u5728{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}And now...{\\r}\r\nDialogue: 0,2:01:55.10,2:01:57.38,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u6CA1\u6709\u4EBA\u6C11\u4E86{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...I have no people.{\\\
+        r}\r\nDialogue: 0,2:02:00.81,2:02:10.00,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u662F\u4F60\u593A\u8D70\u4E86\u6211\u7684\u7075\u9B42\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}My soul that is\
+        \ what you have taken from me.{\\r}\r\nDialogue: 0,2:02:16.79,2:02:19.29,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u8981\u8BA9\u4ED6\u4EEC\u627F\u62C5\
+        \u75DB\u82E6{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm\
+        \ going to make them suffer, Kal.{\\r}\r\nDialogue: 0,2:02:19.53,2:02:22.97,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6551\u4E0B\u7684\u4EBA\u7C7B \u6211\
+        \u8981\u4ECE\u4F60\u624B\u91CC...{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}These humans you've adopted, I will take them all from you...{\\r}\r\
+        \nDialogue: 0,2:02:23.20,2:02:26.18,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u4E00\u4E2A\u4E00\u4E2A\u593A\u8D70   - \u4F60\u8FD9\
+        \u4E2A\u602A\u7269 \u4F50\u5FB7{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}- ...one by one.       - You're a monster, Zod...{\\r}\r\nDialogue:\
+        \ 0,2:02:28.80,2:02:30.61,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u4F1A\u963B\u6B62\u4F60\u7684{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...and I'm gonna stop you.{\\r}\r\nDialogue: 0,2:04:11.61,2:04:14.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u7ED3\u675F\u8FD9\u4E00\u5207\u53EA\u6709\
+        \u4E00\u4E2A\u529E\u6CD5{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}There's only one way this ends, Kal.{\\r}\r\nDialogue: 0,2:04:14.14,2:04:15.99,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u662F\u4F60\u6B7B{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Either you die...{\\r}\r\nDialogue:\
+        \ 0,2:04:16.24,2:04:17.52,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u5C31\u662F\u6211\u4EA1{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}...or I do.{\\r}\r\nDialogue: 0,2:04:48.68,2:04:50.82,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u88AB\u5F53\u505A\u4E00\u4E2A\u6218\
+        \u58EB\u8BAD\u7EC3{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I\
+        \ was bred to be a warrior, Kal.{\\r}\r\nDialogue: 0,2:04:51.68,2:04:55.70,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u7EC8\u751F\u90FD\u5728\u53D7\u8BAD\
+        \u63A7\u5236\u611F\u5B98{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Trained my entire life to master my senses.{\\r}\r\nDialogue: 0,2:04:55.88,2:04:59.49,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u5728\u54EA\u53D7\u8BAD\u7684\uFF1F\
+        \u519C\u573A\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\\
+        blur3}Where did you train? On a farm?{\\r}\r\nDialogue: 0,2:07:08.42,2:07:12.80,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5982\u679C\u4F60\u6DF1\u7231\u7740\u8FD9\
+        \u7FA4\u4EBA\u7C7B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}If\
+        \ you love these people so much...{\\r}\r\nDialogue: 0,2:07:13.19,2:07:15.46,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C31\u4E3A\u4ED6\u4EEC\u8FFD\u60BC\u5427\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...you can mourn\
+        \ for them.{\\r}\r\nDialogue: 0,2:07:19.93,2:07:21.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u8981{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Don't do this!{\\r}\r\nDialogue: 0,2:07:24.20,2:07:25.01,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F4F\u624B{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Stop!{\\r}\r\nDialogue: 0,2:07:31.37,2:07:32.35,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Stop!{\\r}\r\nDialogue: 0,2:07:34.71,2:07:35.85,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u53EF\u80FD{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}Never.{\\r}\r\nDialogue: 0,2:09:10.54,2:09:11.92,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4ED6\u5988\u662F\u8822\u86CB\u5417\
+        \uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Are you effing\
+        \ stupid?{\\r}\r\nDialogue: 0,2:09:12.14,2:09:14.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u6709\u90A3\u4E48\u591A\u7A7A\u4E2D\
+        \u4FA6\u5BDF\u673A{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}It's\
+        \ one of your surveillance drones.{\\r}\r\nDialogue: 0,2:09:14.11,2:09:16.61,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u8FD9\u73A9\u610F\u503C1200\u4E07{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}That's a $12,000,000 piece\
+        \ of hardware.{\\r}\r\nDialogue: 0,2:09:16.78,2:09:17.81,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u66FE\u7ECF\u503C{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}It was.{\\r}\r\nDialogue: 0,2:09:18.61,2:09:21.15,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u77E5\u9053\u4F60\u60F3\u8FFD\u8E2A\
+        \u6211{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I know you're\
+        \ trying to find out where I hang my cape.{\\r}\r\nDialogue: 0,2:09:21.75,2:09:25.00,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4F46\u662F\u6CA1\u95E8   - \u90A3\u6211\
+        \u660E\u786E\u95EE\u4F60\u4E00\u4E2A\u95EE\u9898{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}- You won't.       - Then I'll ask the obvious question:{\\\
+        r}\r\nDialogue: 0,2:09:25.22,2:09:28.82,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u4EEC\u600E\u4E48\u77E5\u9053\u6709\u4E00\u5929\
+        \ \u4F60\u4E0D\u4F1A\u635F\u5BB3\u7F8E\u56FD\u7684\u5229\u76CA\uFF1F{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}How do we know you won't\
+        \ one day act against America's interests?{\\r}\r\nDialogue: 0,2:09:28.92,2:09:30.77,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u5728\u582A\u8428\u65AF\u957F\u5927\
+        \ \u5C06\u519B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I\
+        \ grew up in Kansas, general.{\\r}\r\nDialogue: 0,2:09:31.23,2:09:33.40,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u4E5F\u7B97\u662F\u7F8E\u56FD\u4EBA\
+        \u4E86{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I'm about\
+        \ as American as it gets.{\\r}\r\nDialogue: 0,2:09:33.66,2:09:34.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u770B{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Look...{\\r}\r\nDialogue: 0,2:09:34.80,2:09:36.27,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u613F\u610F\u5E2E\u5FD9{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...I'm here to help...{\\r}\r\
+        \nDialogue: 0,2:09:36.50,2:09:38.74,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F46\u5FC5\u987B\u662F\u6211\u5FC3\u7518\u60C5\u613F\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...but it has to\
+        \ be on my own terms.{\\r}\r\nDialogue: 0,2:09:38.97,2:09:40.81,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u53EF\u4EE5\u8FD9\u6837\u8BF4\u670D\
+        \u534E\u76DB\u987F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You\
+        \ have to convince Washington of that.{\\r}\r\nDialogue: 0,2:09:41.07,2:09:45.57,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5C31\u7B97\u6211\u613F\u610F\u8BF4 \u4F60\
+        \u8BA4\u4E3A\u4ED6\u4EEC\u4F1A\u542C\u5417\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Even if I were willing to try, what makes you think\
+        \ they'd listen?{\\r}\r\nDialogue: 0,2:09:46.14,2:09:47.74,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4E0D\u77E5\u9053 \u5C06\u519B{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I don't know, general.{\\r}\r\
+        \nDialogue: 0,2:09:49.14,2:09:50.85,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F46\u662F\u6211\u53EA\u80FD\u76F8\u4FE1\u4F60{\\r}\\\
+        N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Guess I'll just have to\
+        \ trust you.{\\r}\r\nDialogue: 0,2:10:00.42,2:10:03.87,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u4F60\u7B11\u4EC0\u4E48 \u4E0A\u5C09\uFF1F\
+        \  - \u6CA1\u4EC0\u4E48 \u957F\u5B98{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}- What are you smiling about?       - Nothing, Sir.{\\\
+        r}\r\nDialogue: 0,2:10:07.13,2:10:09.71,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u89C9\u5F97\u4ED6\u5E05\u7206\u4E86{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}I just think he's kind of hot.{\\\
+        r}\r\nDialogue: 0,2:10:11.27,2:10:13.37,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}- \u4E0A\u8F66 \u4E0A\u5C09   - \u9075\u547D{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Get in the car, captain.\
+        \       - Mm-hm. Yes, sir.{\\r}\r\nDialogue: 0,2:10:23.34,2:10:26.55,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u4E00\u76F4\u575A\u4FE1\u4F60\u751F\
+        \u6765\u8981\u505A\u5927\u4E8B\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}He always believed you were meant for greater things.{\\\
+        r}\r\nDialogue: 0,2:10:26.81,2:10:28.32,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u5F53\u8FD9\u4E00\u5929\u6765\u4E34\u65F6{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}And that when the day came...{\\\
+        r}\r\nDialogue: 0,2:10:28.55,2:10:31.36,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u7684\u80A9\u8180\u8981\u80FD\u625B\u8D77\u5343\
+        \u65A4{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...your shoulders\
+        \ would be able to bear the weight.{\\r}\r\nDialogue: 0,2:10:31.62,2:10:35.47,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u662F\u554A \u6211\u5E0C\u671B\u4ED6\u80FD\
+        \u591F\u770B\u5230\u8FD9\u4E00\u5207{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Yeah, I just wish he could have been here to see it finally\
+        \ happen.{\\r}\r\nDialogue: 0,2:10:35.89,2:10:38.47,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ED6\u770B\u5230\u4E86 \u514B\u62C9\u514B\
+        \ \u76F8\u4FE1\u6211{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}He\
+        \ saw it, Clark, believe me.{\\r}\r\nDialogue: 0,2:11:25.37,2:11:28.22,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F60\u4E0D\u62EF\u6551\u5730\u7403\u7684\
+        \u65F6\u5019 \u60F3\u5E72\u70B9\u4EC0\u4E48\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}What are you going to do when you're not saving the\
+        \ world?{\\r}\r\nDialogue: 0,2:11:28.44,2:11:32.19,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u6709\u60F3\u8FC7\u5417\uFF1F - \u60F3\
+        \u8FC7 \u771F\u7684{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}-\
+        \ Have you given any thought to that?       - I have, actually. Heh, heh.{\\\
+        r}\r\nDialogue: 0,2:11:33.78,2:11:37.79,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6211\u4F1A\u627E\u4E00\u4EFD\u5DE5\u4F5C \u80FD\u591F\
+        \u4FDD\u6301\u9AD8\u5EA6\u8B66\u89C9{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}I gotta find a job where I can keep my ear to the ground.{\\\
+        r}\r\nDialogue: 0,2:11:43.02,2:11:45.09,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4EBA\u4EEC\u4E0D\u4F1A\u591A\u770B\u6211\u4E24\u773C\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Where people won't\
+        \ look twice...{\\r}\r\nDialogue: 0,2:11:45.36,2:11:49.14,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5F53\u6211\u8981\u53BB\u5371\u9669\u7684\
+        \u5730\u65B9 \u4E0D\u4F1A\u95EE\u6211\u95EE\u9898{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}...when I want to go somewhere dangerous and start\
+        \ asking questions...{\\r}\r\nDialogue: 0,2:12:03.24,2:12:06.28,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u884C\u884C\u597D \u9732\u6613\u4E1D \u4F60\
+        \u4EC0\u4E48\u65F6\u5019\u80FD\u53EF\u601C\u6211\u4E00\u4E0B\u5462\uFF1F{\\\
+        r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Come on, Lois. When\
+        \ are you gonna throw me a bone?{\\r}\r\nDialogue: 0,2:12:07.55,2:12:09.22,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4ECA\u665A\u6BD4\u8D5B\u7684\u7EDD\u4F73\
+        \u4F4D\u5B50 \u600E\u4E48\u6837\uFF1F{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Courtside seats to the game tonight.{\\r}\r\nDialogue:\
+        \ 0,2:12:09.65,2:12:11.22,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}- \u4EC0\u4E48\uFF1F - \u6211\u8BF4...{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}- What do you say?       - I say...{\\r}\r\nDialogue:\
+        \ 0,2:12:11.45,2:12:13.99,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u4F60\u5E94\u8BE5\u53BB\u9493\u9493\u5B9E\u4E60\u751F{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}...you should go back to trolling\
+        \ the intern pool.{\\r}\r\nDialogue: 0,2:12:14.26,2:12:17.63,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u53EF\u80FD\u4F1A\u6709\u597D\u8FD0 \u62B1\
+        \u6B49{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}You'll probably\
+        \ have more luck. Sorry.{\\r}\r\nDialogue: 0,2:12:19.43,2:12:20.10,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u770B\u6BD4\u8D5B\uFF1F{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Courtside?{\\r}\r\nDialogue: 0,2:12:20.33,2:12:22.07,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u522B\u53BB   - \u4E0D\u53BB{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Don't. Ha, ha, ha.      \
+        \ - No.{\\r}\r\nDialogue: 0,2:12:22.30,2:12:25.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u4F26\u5DF4\u7B2C \u83B2\u6069 \u6765\u89C1\
+        \u89C1\u65B0\u7684\u7279\u7EA6\u901A\u8BAF\u5458{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Lombard, Lane, I want you to meet our new stringer.{\\\
+        r}\r\nDialogue: 0,2:12:25.33,2:12:28.58,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u4F60\u7ED9\u4ED6\u4F20\u6388\u4F20\u6388\u7A8D\u95E8\
+        \ \u4ED6\u53EB\u5361\u62C9\u514B\u2022\u80AF\u7279{\\r}\\N{\\fnCronos Pro\
+        \ Subhead\\fs14\\1c&H3CF1F3&\\blur3}I want you to show him the ropes. This\
+        \ is Clark Kent.{\\r}\r\nDialogue: 0,2:12:28.80,2:12:30.11,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u597D\u8FD0 \u5B69\u5B50{\\r}\\N{\\fnCronos\
+        \ Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Good luck, kid.{\\r}\r\nDialogue:\
+        \ 0,2:12:31.64,2:12:32.91,chs,,0000,0000,0000,,{\\fn\u534E\u6587\u6977\u4F53\
+        \\blur3}\u6211\u53EB\u65AF\u8482\u592B{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\\
+        1c&H3CF1F3&\\blur3}Hey. Steve.{\\r}\r\nDialogue: 0,2:12:33.14,2:12:34.64,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}- \u5E78\u4F1A   - \u5E78\u4F1A{\\r}\\N{\\\
+        fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}- Nice to meet you.       -\
+        \ You too.{\\r}\r\nDialogue: 0,2:12:34.64,2:12:35.48,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u55E8{\\r}\\N{\\fnCronos Pro Subhead\\\
+        fs14\\1c&H3CF1F3&\\blur3}Hi.{\\r}\r\nDialogue: 0,2:12:36.41,2:12:37.75,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u6211\u53EB\u9732\u6613\u4E1D\u2022\u83B2\
+        \u6069{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Lois Lane.{\\\
+        r}\r\nDialogue: 0,2:12:38.58,2:12:40.12,chs,,0000,0000,0000,,{\\fn\u534E\u6587\
+        \u6977\u4F53\\blur3}\u6B22\u8FCE\u6765\u300A\u661F\u7403\u65E5\u62A5\u300B\
+        {\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Welcome to the \
+        \ Planet.{\\r}\r\nDialogue: 0,2:12:43.85,2:12:46.33,chs,,0000,0000,0000,,{\\\
+        fn\u534E\u6587\u6977\u4F53\\blur3}\u5F88\u9AD8\u5174\u6765\u8FD9 \u9732\u6613\
+        \u4E1D{\\r}\\N{\\fnCronos Pro Subhead\\fs14\\1c&H3CF1F3&\\blur3}Glad to be\
+        \ here, Lois.{\\r}\r\n"
+    headers:
+      cache-control:
+      - max-age=2678400
+      connection:
+      - keep-alive
+      # content-disposition:
+      # - !!python/str "subtitle; filename=\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7B80\
+        # \u4F53&\u82F1\u6587.ass\""
+      content-length:
+      - '239576'
+      content-type:
+      - application/octet-stream
+      date:
+      - Sat, 30 Nov 2019 14:08:00 GMT
+      expires:
+      - Tue, 31 Dec 2019 14:08:00 GMT
+      master:
+      - Windu
+      server:
+      - nginx
+      x-cache:
+      - HIT
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/assrt/test_query_episode.yaml
+++ b/tests/cassettes/assrt/test_query_episode.yaml
@@ -1,0 +1,83 @@
+interactions:
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - Sub-Zero/2
+    method: GET
+    uri: https://api.assrt.net/v1/sub/search?q=%5B%27The+Big+Bang+Theory+S07E05%27%5D&token=SECRET&is_file=%5B%271%27%5D
+  response:
+    body:
+      string: "{\"status\":0,\"sub\":{\"keyword\":\"The Big Bang Theory S07E05\",\"\
+        result\":\"succeed\",\"subs\":[{\"subtype\":\"Subrip(srt)\",\"id\":618200,\"\
+        lang\":{\"desc\":\"\u7B80\",\"langlist\":{\"langchs\":true}},\"vote_score\"\
+        :0,\"upload_time\":\"2018-01-26 19:23:52\",\"release_site\":\"\u4F0A\u7538\
+        \u56ED\",\"native_name\":\"\u5929\u624D\u7406\u8BBA\u4F20\u7B2C7\u5B63\u5168\
+        24\u96C6The.Big.Bang.Theory.S07.1080p.WEB-DL.DD5.1.H.264\",\"videoname\":\"\
+        The.Big.Bang.Theory.S07.1080p.WEB-DL.DD5.1.H.264\",\"revision\":0},{\"subtype\"\
+        :\"Subrip(srt)\",\"id\":316965,\"vote_score\":0,\"upload_time\":\"2014-12-06\
+        \ 04:13:43\",\"native_name\":\"\u751F\u6D3B\u5927\u7206\u70B8 \u7B2C\u4E03\
+        \u5B63 \u7B2C 5 \u96C6\",\"videoname\":\"The Big Bang Theory S07E05 720p HDTV\
+        \ X264-DIMENSION\",\"revision\":0},{\"subtype\":\"Subrip(srt)\",\"id\":316966,\"\
+        vote_score\":0,\"upload_time\":\"2014-12-06 04:13:43\",\"native_name\":\"\u751F\
+        \u6D3B\u5927\u7206\u70B8 \u7B2C\u4E03\u5B63 \u7B2C 5 \u96C6\",\"videoname\"\
+        :\"The Big Bang Theory S07E05 720p HDTV X264-DIMENSION\",\"revision\":0},{\"\
+        subtype\":\"SSA\",\"id\":264973,\"lang\":{\"desc\":\"\u53CC\u8BED\",\"langlist\"\
+        :{\"langdou\":true}},\"vote_score\":80,\"upload_time\":\"2014-11-02 10:41:05\"\
+        ,\"native_name\":\"The Big Bang Theory S07\\/\u751F\u6D3B\u5927\u7206\u70B8\
+        \ \u7B2C\u4E03\u5B63\\/The Big Bang Theory Season 07\",\"videoname\":\"The.Big.Bang.Theory.S07E05.720p.BluRay.x264-DEMAND\"\
+        ,\"revision\":0},{\"subtype\":\"Subrip(srt)\",\"id\":261680,\"lang\":{\"desc\"\
+        :\"\u7B80\",\"langlist\":{\"langchs\":true}},\"vote_score\":0,\"upload_time\"\
+        :\"2014-08-30 05:11:21\",\"native_name\":\"\u751F\u6D3B\u5927\u7206\u70B8\
+        \ \u7B2C\u4E03\u5B63\\/\u5929\u624D\u7406\u8BBA\u4F20\",\"videoname\":\"The.Big.Bang.Theory.S07.720p.BluRay.x264-DEMAND\"\
+        ,\"revision\":0},{\"subtype\":\"Subrip(srt)\",\"id\":244659,\"lang\":{\"desc\"\
+        :\"\u82F1 \u7B80 \u7E41\",\"langlist\":{\"langeng\":true,\"langcht\":true,\"\
+        langchs\":true}},\"vote_score\":0,\"upload_time\":\"2013-10-19 03:34:04\"\
+        ,\"native_name\":\"\u5929\u624D\u7406\u8BBA\u4F20\\/\u751F\u6D3B\u5927\u7206\
+        \u70B8 \u7B2C\u4E03\u5B63\u7B2C\u4E94\u96C6\",\"videoname\":\"The Big Bang\
+        \ Theory S07E05 the.big.bang.theory.705.hdtv-lol\",\"revision\":0},{\"subtype\"\
+        :\"Subrip(srt)\",\"id\":244640,\"lang\":{\"desc\":\"\u82F1 \u7B80 \u7E41 \u53CC\
+        \u8BED\",\"langlist\":{\"langchs\":true,\"langeng\":true,\"langdou\":true,\"\
+        langcht\":true}},\"vote_score\":0,\"upload_time\":\"2013-10-18 23:33:24\"\
+        ,\"native_name\":\"\",\"videoname\":\"\u751F\u6D3B\u5927\u7206\u70B8\\/The\
+        \ Big Bang Theory S07E05\\/\u7B2C\u4E03\u5B63\u7B2C5\u96C6\\/\u5723\u57CE\u5BB6\
+        \u56ED\u53CC\u8BED\u5B57\u5E55 the.big.bang.theory.705.hdtv-lol\",\"revision\"\
+        :0},{\"subtype\":\"SSA\",\"id\":244632,\"lang\":{\"desc\":\"\u82F1 \u7B80\"\
+        ,\"langlist\":{\"langeng\":true,\"langchs\":true}},\"vote_score\":0,\"upload_time\"\
+        :\"2013-10-18 22:15:16\",\"native_name\":\"\u5929\u624D\u7406\u8BBA\u4F20\\\
+        /The Big Bang Theory S07E05\u751F\u6D3B\u5927\u7206\u70B8 \u7B2C\u4E03\u5B63\
+        \u7B2C\u4E94\u96C6\u3010\u8C22\u8033\u6735\u5B57\u5E55\u7EC4\u3011\",\"videoname\"\
+        :\"The.Big.Bang.Theory.S07E05.720p.HDTV.X264-DIMENSION\",\"revision\":0},{\"\
+        subtype\":\"\u5176\u4ED6\",\"id\":244630,\"lang\":{\"desc\":\"\",\"langlist\"\
+        :{}},\"vote_score\":0,\"upload_time\":\"2013-10-18 21:31:21\",\"native_name\"\
+        :\"\",\"videoname\":\"\u751F\u6D3B\u5927\u7206\u70B8 \u7B2C7\u96C6\u7B2C5\u96C6\
+        \ 720P\",\"revision\":0},{\"subtype\":\"\u5176\u4ED6\",\"id\":244624,\"lang\"\
+        :{\"desc\":\"\u82F1 \u7B80 \u7E41\",\"langlist\":{\"langeng\":true,\"langcht\"\
+        :true,\"langchs\":true}},\"vote_score\":0,\"upload_time\":\"2013-10-18 20:46:57\"\
+        ,\"native_name\":\"The Big Bang Theory S07E05\",\"videoname\":\"\u751F\u6D3B\
+        \u5927\u7206\u70B8\u7B2C\u4E03\u5B63\u7B2C5\u96C6\",\"revision\":0},{\"subtype\"\
+        :\"Subrip(srt)\",\"id\":585062,\"lang\":{\"desc\":\"\u82F1 \u7B80 \u7E41 \u53CC\
+        \u8BED\",\"langlist\":{\"langchs\":true,\"langeng\":true,\"langdou\":true,\"\
+        langcht\":true}},\"vote_score\":0,\"upload_time\":\"2013-10-17 17:31:00\"\
+        ,\"release_site\":\"\u4EBA\u4EBA\u5F71\u89C6YYeTs\",\"native_name\":\"\u751F\
+        \u6D3B\u5927\u7206\u70B8   \u7B2C7\u96C6\u7B2C5\u96C6\",\"videoname\":\"The\
+        \ Big Bang Theory   S07E05\",\"revision\":0}],\"action\":\"search\"}}\n"
+    headers:
+      access-control-allow-origin:
+      - '*'
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Sat, 30 Nov 2019 07:14:39 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/assrt/test_query_list_subtitles.yaml
+++ b/tests/cassettes/assrt/test_query_list_subtitles.yaml
@@ -1,0 +1,98 @@
+interactions:
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - Sub-Zero/2
+    method: GET
+    uri: https://api.assrt.net/v1/sub/search?q=%5B%27Man+of+Steel+2013%27%5D&token=SECRET&is_file=%5B%271%27%5D
+  response:
+    body:
+      string: "{\"status\":0,\"sub\":{\"keyword\":\"Man of Steel 2013\",\"result\"\
+        :\"succeed\",\"subs\":[{\"subtype\":\"SSA\",\"id\":618185,\"lang\":{\"desc\"\
+        :\"\u82F1 \u7B80 \u7E41 \u53CC\u8BED\",\"langlist\":{\"langchs\":true,\"langeng\"\
+        :true,\"langdou\":true,\"langcht\":true}},\"vote_score\":0,\"upload_time\"\
+        :\"2018-01-26 12:19:27\",\"release_site\":\"CMCT\",\"native_name\":\"\u8D85\
+        \u4EBA\uFF1A\u94A2\u94C1\u4E4B\u8EAF.Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7B80\
+        \u7E41\u82F1\u53CC\u8BED\u5B57\u5E55\",\"videoname\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT\"\
+        ,\"revision\":0},{\"subtype\":\"SSA\",\"id\":316973,\"vote_score\":0,\"upload_time\"\
+        :\"2014-12-06 04:13:44\",\"native_name\":\"\u8D85\u4EBA\uFF1A\u94A2\u94C1\u4E4B\
+        \u8EAF\\/\u8D85\u4EBA\uFF1A\u94A2\u94C1\u82F1\u96C4\",\"videoname\":\"Man\
+        \ of Steel 2013 720p BluRay x264 DTS-WiKi\",\"revision\":0},{\"subtype\":\"\
+        Subrip(srt)\",\"id\":253629,\"lang\":{\"desc\":\"\u7E41\",\"langlist\":{\"\
+        langcht\":true}},\"vote_score\":0,\"upload_time\":\"2014-03-17 15:30:19\"\
+        ,\"native_name\":\"\",\"videoname\":\"[\u8D85\u4EBA \u92FC\u9435\u82F1\u96C4\
+        ]Man.of.Steel.(2013).BDRip.720p.DTS.X264-Felony\",\"revision\":0},{\"subtype\"\
+        :\"SSA\",\"id\":252930,\"lang\":{\"desc\":\"\u82F1 \u7E41 \u53CC\u8BED\",\"\
+        langlist\":{\"langeng\":true,\"langdou\":true,\"langcht\":true}},\"vote_score\"\
+        :45,\"upload_time\":\"2014-03-05 18:10:39\",\"native_name\":\"\u8D85\u4EBA\
+        \uFF1A\u92FC\u9435\u82F1\u96C4\",\"videoname\":\"Man of Steel\",\"revision\"\
+        :0},{\"subtype\":\"Subrip(srt)\",\"id\":246016,\"lang\":{\"desc\":\"\u82F1\
+        \ \u7B80 \u7E41\",\"langlist\":{\"langeng\":true,\"langcht\":true,\"langchs\"\
+        :true}},\"vote_score\":0,\"upload_time\":\"2013-11-09 10:43:13\",\"native_name\"\
+        :\"\u8D85\u4EBA\uFF1A\u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA\uFF1A\u94A2\u94C1\
+        \u82F1\u96C4\\/\u3010TLF\u5B57\u5E55\u7EC4\u3011Man of Steel\",\"videoname\"\
+        :\"Man.of.Steel.2013.720p.BluRay.x264.YIFY\",\"revision\":0},{\"subtype\"\
+        :\"SSA\",\"id\":245602,\"lang\":{\"desc\":\"\u7B80 \u7E41 \u53CC\u8BED\",\"\
+        langlist\":{\"langchs\":true,\"langdou\":true,\"langcht\":true}},\"vote_score\"\
+        :0,\"upload_time\":\"2013-11-02 05:56:40\",\"native_name\":\"\u8D85\u4EBA\uFF1A\
+        \u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA\uFF1A\u94A2\u94C1\u82F1\u96C4\\/\u7279\
+        \u6548\u53CC\u8BED\\/\u84DD\u5149\u5B57\u5E55\",\"videoname\":\"Man of Steel\
+        \ 1080p.bluray.x264-sector7\",\"revision\":0},{\"subtype\":\"\u5176\u4ED6\"\
+        ,\"id\":245568,\"lang\":{\"desc\":\"\u7B80\",\"langlist\":{\"langchs\":true}},\"\
+        vote_score\":0,\"upload_time\":\"2013-10-31 23:41:07\",\"native_name\":\"\u8D85\
+        \u4EBA: \u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA: \u94A2\u94C1\u82F1\u96C4\"\
+        ,\"videoname\":\"Man.of.Steel.2013\",\"revision\":0},{\"subtype\":\"VobSub\"\
+        ,\"id\":245259,\"vote_score\":100,\"upload_time\":\"2013-10-27 07:04:18\"\
+        ,\"native_name\":\"\",\"videoname\":\"Man.Of.Steel.3D.2013.1080p.BluRay.Half-SBS.DTS.x264-PublicHD\"\
+        ,\"revision\":0},{\"subtype\":\"Subrip(srt)\",\"id\":245131,\"lang\":{\"desc\"\
+        :\"\u7B80\",\"langlist\":{\"langchs\":true}},\"vote_score\":80,\"upload_time\"\
+        :\"2013-10-25 04:50:37\",\"native_name\":\"\u8D85\u4EBA-\u94A2\u94C1\u4E4B\
+        \u8EAF\",\"videoname\":\"Man.Of.Steel\",\"revision\":0},{\"subtype\":\"SSA\"\
+        ,\"id\":245056,\"lang\":{\"desc\":\"\u7E41\",\"langlist\":{\"langcht\":true}},\"\
+        vote_score\":0,\"upload_time\":\"2013-10-24 07:52:31\",\"native_name\":\"\"\
+        ,\"videoname\":\"\u8D85\u4EBA \u92FC\u9435\u82F1\u96C4 Man of Steel (2013)\
+        \ 1080p.cht\",\"revision\":0},{\"subtype\":\"Subrip(srt)\",\"id\":244971,\"\
+        lang\":{\"desc\":\"\u7B80 \u7E41\",\"langlist\":{\"langchs\":true,\"langcht\"\
+        :true}},\"vote_score\":10,\"upload_time\":\"2013-10-23 00:46:40\",\"native_name\"\
+        :\"\u84DD\u5149\u539F\u76D8\u5B57\u5E55\",\"videoname\":\"\u8D85\u4EBA: \u94A2\
+        \u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA: \u94A2\u94C1\u82F1\u96C4(\u6E2F\\/\u53F0\
+        ).Man.of.Steel.2013.BluRay CEE\u7248\u84DD\u5149\u539F\u76D8\",\"revision\"\
+        :0},{\"subtype\":\"Subrip(srt)\",\"id\":244969,\"lang\":{\"desc\":\"\",\"\
+        langlist\":{}},\"vote_score\":0,\"upload_time\":\"2013-10-22 23:39:00\",\"\
+        native_name\":\"\u8D85\u4EBA\uFF1A\u94A2\u94C1\u4E4B\u8EAF 3D\\/\u8D85\u4EBA\
+        \uFF1A\u94A2\u94C1\u82F1\u96C4\\/Man of Steel 3D\",\"videoname\":\"Man.Of.Steel.3D.2013.1080p.BluRay.Half-SBS.DTS.x264-PublicHD\"\
+        ,\"revision\":0},{\"subtype\":\"SSA\",\"id\":244960,\"lang\":{\"desc\":\"\u82F1\
+        \ \u7B80\",\"langlist\":{\"langeng\":true,\"langchs\":true}},\"vote_score\"\
+        :0,\"upload_time\":\"2013-10-22 22:06:42\",\"native_name\":\"\u8D85\u4EBA\
+        :\u94A2\u94C1\u4E4B\u8EAF\",\"videoname\":\"Superman: Man of Steel BD\",\"\
+        revision\":0},{\"subtype\":\"\u5176\u4ED6\",\"id\":244939,\"lang\":{\"desc\"\
+        :\"\",\"langlist\":{}},\"vote_score\":0,\"upload_time\":\"2013-10-22 17:42:45\"\
+        ,\"native_name\":\"\",\"videoname\":\"\u8D85\u4EBA\uFF1A\u94A2\u94C1\u4E4B\
+        \u8EAF.Man.of.Steel.2013.1080p-PublicHD 2D.1080p\u62163D.1080p.HSBS-PublicHD\"\
+        ,\"revision\":0},{\"subtype\":\"Subrip(srt)\",\"id\":244863,\"lang\":{\"desc\"\
+        :\"\u82F1 \u7B80 \u7E41\",\"langlist\":{\"langeng\":true,\"langcht\":true,\"\
+        langchs\":true}},\"vote_score\":0,\"upload_time\":\"2013-10-21 16:52:23\"\
+        ,\"native_name\":\"\\/Man of Steel \\/\u8D85\u4EBA:\u94A2\u94C1\u4E4B\u8EAF\
+        \\/\u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA:\u94A2\u94C1\u82F1\u96C4\",\"videoname\"\
+        :\"man.of.steel.2013.720p.bluray.x264-felony.mkv\",\"revision\":0}],\"action\"\
+        :\"search\"}}\n"
+    headers:
+      access-control-allow-origin:
+      - '*'
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Sat, 30 Nov 2019 08:28:00 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/assrt/test_query_movie_zh.yaml
+++ b/tests/cassettes/assrt/test_query_movie_zh.yaml
@@ -1,0 +1,97 @@
+interactions:
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - Sub-Zero/2
+    method: GET
+    uri: https://api.assrt.net/v1/sub/search?q=%5B%27Man+of+Steel+2013%27%5D&token=SECRET&is_file=%5B%271%27%5D
+  response:
+    body:
+      string: "{\"status\":0,\"sub\":{\"keyword\":\"Man of Steel 2013\",\"result\"\
+        :\"succeed\",\"subs\":[{\"subtype\":\"SSA\",\"id\":618185,\"lang\":{\"desc\"\
+        :\"\u82F1 \u7B80 \u7E41 \u53CC\u8BED\",\"langlist\":{\"langcht\":true,\"langeng\"\
+        :true,\"langdou\":true,\"langchs\":true}},\"vote_score\":0,\"upload_time\"\
+        :\"2018-01-26 12:19:27\",\"native_name\":\"\u8D85\u4EBA\uFF1A\u94A2\u94C1\u4E4B\
+        \u8EAF.Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7B80\u7E41\u82F1\
+        \u53CC\u8BED\u5B57\u5E55\",\"videoname\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT\"\
+        ,\"release_site\":\"CMCT\",\"revision\":0},{\"upload_time\":\"2014-12-06 04:13:44\"\
+        ,\"subtype\":\"SSA\",\"id\":316973,\"native_name\":\"\u8D85\u4EBA\uFF1A\u94A2\
+        \u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA\uFF1A\u94A2\u94C1\u82F1\u96C4\",\"videoname\"\
+        :\"Man of Steel 2013 720p BluRay x264 DTS-WiKi\",\"revision\":0,\"vote_score\"\
+        :0},{\"upload_time\":\"2014-03-17 15:30:19\",\"subtype\":\"Subrip(srt)\",\"\
+        revision\":0,\"id\":253629,\"lang\":{\"desc\":\"\u7E41\",\"langlist\":{\"\
+        langcht\":true}},\"videoname\":\"[\u8D85\u4EBA \u92FC\u9435\u82F1\u96C4]Man.of.Steel.(2013).BDRip.720p.DTS.X264-Felony\"\
+        ,\"native_name\":\"\",\"vote_score\":0},{\"upload_time\":\"2014-03-05 18:10:39\"\
+        ,\"subtype\":\"SSA\",\"revision\":0,\"id\":252930,\"lang\":{\"desc\":\"\u82F1\
+        \ \u7E41 \u53CC\u8BED\",\"langlist\":{\"langeng\":true,\"langcht\":true,\"\
+        langdou\":true}},\"videoname\":\"Man of Steel\",\"native_name\":\"\u8D85\u4EBA\
+        \uFF1A\u92FC\u9435\u82F1\u96C4\",\"vote_score\":45},{\"upload_time\":\"2013-11-09\
+        \ 10:43:13\",\"subtype\":\"Subrip(srt)\",\"revision\":0,\"id\":246016,\"lang\"\
+        :{\"desc\":\"\u82F1 \u7B80 \u7E41\",\"langlist\":{\"langeng\":true,\"langchs\"\
+        :true,\"langcht\":true}},\"videoname\":\"Man.of.Steel.2013.720p.BluRay.x264.YIFY\"\
+        ,\"native_name\":\"\u8D85\u4EBA\uFF1A\u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA\
+        \uFF1A\u94A2\u94C1\u82F1\u96C4\\/\u3010TLF\u5B57\u5E55\u7EC4\u3011Man of Steel\"\
+        ,\"vote_score\":0},{\"upload_time\":\"2013-11-02 05:56:40\",\"subtype\":\"\
+        SSA\",\"revision\":0,\"id\":245602,\"lang\":{\"desc\":\"\u7B80 \u7E41 \u53CC\
+        \u8BED\",\"langlist\":{\"langcht\":true,\"langchs\":true,\"langdou\":true}},\"\
+        videoname\":\"Man of Steel 1080p.bluray.x264-sector7\",\"native_name\":\"\u8D85\
+        \u4EBA\uFF1A\u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA\uFF1A\u94A2\u94C1\u82F1\
+        \u96C4\\/\u7279\u6548\u53CC\u8BED\\/\u84DD\u5149\u5B57\u5E55\",\"vote_score\"\
+        :0},{\"upload_time\":\"2013-10-31 23:41:07\",\"subtype\":\"\u5176\u4ED6\"\
+        ,\"revision\":0,\"id\":245568,\"lang\":{\"desc\":\"\u7B80\",\"langlist\":{\"\
+        langchs\":true}},\"videoname\":\"Man.of.Steel.2013\",\"native_name\":\"\u8D85\
+        \u4EBA: \u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA: \u94A2\u94C1\u82F1\u96C4\"\
+        ,\"vote_score\":0},{\"upload_time\":\"2013-10-27 07:04:18\",\"subtype\":\"\
+        VobSub\",\"id\":245259,\"native_name\":\"\",\"videoname\":\"Man.Of.Steel.3D.2013.1080p.BluRay.Half-SBS.DTS.x264-PublicHD\"\
+        ,\"revision\":0,\"vote_score\":100},{\"upload_time\":\"2013-10-25 04:50:37\"\
+        ,\"subtype\":\"Subrip(srt)\",\"revision\":0,\"id\":245131,\"lang\":{\"desc\"\
+        :\"\u7B80\",\"langlist\":{\"langchs\":true}},\"videoname\":\"Man.Of.Steel\"\
+        ,\"native_name\":\"\u8D85\u4EBA-\u94A2\u94C1\u4E4B\u8EAF\",\"vote_score\"\
+        :80},{\"upload_time\":\"2013-10-24 07:52:31\",\"subtype\":\"SSA\",\"revision\"\
+        :0,\"id\":245056,\"lang\":{\"desc\":\"\u7E41\",\"langlist\":{\"langcht\":true}},\"\
+        videoname\":\"\u8D85\u4EBA \u92FC\u9435\u82F1\u96C4 Man of Steel (2013) 1080p.cht\"\
+        ,\"native_name\":\"\",\"vote_score\":0},{\"upload_time\":\"2013-10-23 00:46:40\"\
+        ,\"subtype\":\"Subrip(srt)\",\"revision\":0,\"id\":244971,\"lang\":{\"desc\"\
+        :\"\u7B80 \u7E41\",\"langlist\":{\"langcht\":true,\"langchs\":true}},\"videoname\"\
+        :\"\u8D85\u4EBA: \u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA: \u94A2\u94C1\u82F1\
+        \u96C4(\u6E2F\\/\u53F0).Man.of.Steel.2013.BluRay CEE\u7248\u84DD\u5149\u539F\
+        \u76D8\",\"native_name\":\"\u84DD\u5149\u539F\u76D8\u5B57\u5E55\",\"vote_score\"\
+        :10},{\"upload_time\":\"2013-10-22 23:39:00\",\"subtype\":\"Subrip(srt)\"\
+        ,\"revision\":0,\"id\":244969,\"lang\":{\"desc\":\"\",\"langlist\":{}},\"\
+        videoname\":\"Man.Of.Steel.3D.2013.1080p.BluRay.Half-SBS.DTS.x264-PublicHD\"\
+        ,\"native_name\":\"\u8D85\u4EBA\uFF1A\u94A2\u94C1\u4E4B\u8EAF 3D\\/\u8D85\u4EBA\
+        \uFF1A\u94A2\u94C1\u82F1\u96C4\\/Man of Steel 3D\",\"vote_score\":0},{\"upload_time\"\
+        :\"2013-10-22 22:06:42\",\"subtype\":\"SSA\",\"revision\":0,\"id\":244960,\"\
+        lang\":{\"desc\":\"\u82F1 \u7B80\",\"langlist\":{\"langchs\":true,\"langeng\"\
+        :true}},\"videoname\":\"Superman: Man of Steel BD\",\"native_name\":\"\u8D85\
+        \u4EBA:\u94A2\u94C1\u4E4B\u8EAF\",\"vote_score\":0},{\"upload_time\":\"2013-10-22\
+        \ 17:42:45\",\"subtype\":\"\u5176\u4ED6\",\"revision\":0,\"id\":244939,\"\
+        lang\":{\"desc\":\"\",\"langlist\":{}},\"videoname\":\"\u8D85\u4EBA\uFF1A\u94A2\
+        \u94C1\u4E4B\u8EAF.Man.of.Steel.2013.1080p-PublicHD 2D.1080p\u62163D.1080p.HSBS-PublicHD\"\
+        ,\"native_name\":\"\",\"vote_score\":0},{\"upload_time\":\"2013-10-21 16:52:23\"\
+        ,\"subtype\":\"Subrip(srt)\",\"revision\":0,\"id\":244863,\"lang\":{\"desc\"\
+        :\"\u82F1 \u7B80 \u7E41\",\"langlist\":{\"langeng\":true,\"langchs\":true,\"\
+        langcht\":true}},\"videoname\":\"man.of.steel.2013.720p.bluray.x264-felony.mkv\"\
+        ,\"native_name\":\"\\/Man of Steel \\/\u8D85\u4EBA:\u94A2\u94C1\u4E4B\u8EAF\
+        \\/\u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA:\u94A2\u94C1\u82F1\u96C4\",\"vote_score\"\
+        :0}],\"action\":\"search\"}}\n"
+    headers:
+      access-control-allow-origin:
+      - '*'
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Sat, 30 Nov 2019 07:14:39 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/assrt/test_query_movie_zh_Hans.yaml
+++ b/tests/cassettes/assrt/test_query_movie_zh_Hans.yaml
@@ -1,0 +1,97 @@
+interactions:
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - Sub-Zero/2
+    method: GET
+    uri: https://api.assrt.net/v1/sub/search?q=%5B%27Man+of+Steel+2013%27%5D&token=SECRET&is_file=%5B%271%27%5D
+  response:
+    body:
+      string: "{\"status\":0,\"sub\":{\"keyword\":\"Man of Steel 2013\",\"result\"\
+        :\"succeed\",\"subs\":[{\"subtype\":\"SSA\",\"id\":618185,\"lang\":{\"desc\"\
+        :\"\u82F1 \u7B80 \u7E41 \u53CC\u8BED\",\"langlist\":{\"langcht\":true,\"langeng\"\
+        :true,\"langdou\":true,\"langchs\":true}},\"vote_score\":0,\"upload_time\"\
+        :\"2018-01-26 12:19:27\",\"native_name\":\"\u8D85\u4EBA\uFF1A\u94A2\u94C1\u4E4B\
+        \u8EAF.Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7B80\u7E41\u82F1\
+        \u53CC\u8BED\u5B57\u5E55\",\"videoname\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT\"\
+        ,\"release_site\":\"CMCT\",\"revision\":0},{\"upload_time\":\"2014-12-06 04:13:44\"\
+        ,\"subtype\":\"SSA\",\"id\":316973,\"native_name\":\"\u8D85\u4EBA\uFF1A\u94A2\
+        \u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA\uFF1A\u94A2\u94C1\u82F1\u96C4\",\"videoname\"\
+        :\"Man of Steel 2013 720p BluRay x264 DTS-WiKi\",\"revision\":0,\"vote_score\"\
+        :0},{\"upload_time\":\"2014-03-17 15:30:19\",\"subtype\":\"Subrip(srt)\",\"\
+        revision\":0,\"id\":253629,\"lang\":{\"desc\":\"\u7E41\",\"langlist\":{\"\
+        langcht\":true}},\"videoname\":\"[\u8D85\u4EBA \u92FC\u9435\u82F1\u96C4]Man.of.Steel.(2013).BDRip.720p.DTS.X264-Felony\"\
+        ,\"native_name\":\"\",\"vote_score\":0},{\"upload_time\":\"2014-03-05 18:10:39\"\
+        ,\"subtype\":\"SSA\",\"revision\":0,\"id\":252930,\"lang\":{\"desc\":\"\u82F1\
+        \ \u7E41 \u53CC\u8BED\",\"langlist\":{\"langeng\":true,\"langcht\":true,\"\
+        langdou\":true}},\"videoname\":\"Man of Steel\",\"native_name\":\"\u8D85\u4EBA\
+        \uFF1A\u92FC\u9435\u82F1\u96C4\",\"vote_score\":45},{\"upload_time\":\"2013-11-09\
+        \ 10:43:13\",\"subtype\":\"Subrip(srt)\",\"revision\":0,\"id\":246016,\"lang\"\
+        :{\"desc\":\"\u82F1 \u7B80 \u7E41\",\"langlist\":{\"langeng\":true,\"langchs\"\
+        :true,\"langcht\":true}},\"videoname\":\"Man.of.Steel.2013.720p.BluRay.x264.YIFY\"\
+        ,\"native_name\":\"\u8D85\u4EBA\uFF1A\u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA\
+        \uFF1A\u94A2\u94C1\u82F1\u96C4\\/\u3010TLF\u5B57\u5E55\u7EC4\u3011Man of Steel\"\
+        ,\"vote_score\":0},{\"upload_time\":\"2013-11-02 05:56:40\",\"subtype\":\"\
+        SSA\",\"revision\":0,\"id\":245602,\"lang\":{\"desc\":\"\u7B80 \u7E41 \u53CC\
+        \u8BED\",\"langlist\":{\"langcht\":true,\"langchs\":true,\"langdou\":true}},\"\
+        videoname\":\"Man of Steel 1080p.bluray.x264-sector7\",\"native_name\":\"\u8D85\
+        \u4EBA\uFF1A\u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA\uFF1A\u94A2\u94C1\u82F1\
+        \u96C4\\/\u7279\u6548\u53CC\u8BED\\/\u84DD\u5149\u5B57\u5E55\",\"vote_score\"\
+        :0},{\"upload_time\":\"2013-10-31 23:41:07\",\"subtype\":\"\u5176\u4ED6\"\
+        ,\"revision\":0,\"id\":245568,\"lang\":{\"desc\":\"\u7B80\",\"langlist\":{\"\
+        langchs\":true}},\"videoname\":\"Man.of.Steel.2013\",\"native_name\":\"\u8D85\
+        \u4EBA: \u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA: \u94A2\u94C1\u82F1\u96C4\"\
+        ,\"vote_score\":0},{\"upload_time\":\"2013-10-27 07:04:18\",\"subtype\":\"\
+        VobSub\",\"id\":245259,\"native_name\":\"\",\"videoname\":\"Man.Of.Steel.3D.2013.1080p.BluRay.Half-SBS.DTS.x264-PublicHD\"\
+        ,\"revision\":0,\"vote_score\":100},{\"upload_time\":\"2013-10-25 04:50:37\"\
+        ,\"subtype\":\"Subrip(srt)\",\"revision\":0,\"id\":245131,\"lang\":{\"desc\"\
+        :\"\u7B80\",\"langlist\":{\"langchs\":true}},\"videoname\":\"Man.Of.Steel\"\
+        ,\"native_name\":\"\u8D85\u4EBA-\u94A2\u94C1\u4E4B\u8EAF\",\"vote_score\"\
+        :80},{\"upload_time\":\"2013-10-24 07:52:31\",\"subtype\":\"SSA\",\"revision\"\
+        :0,\"id\":245056,\"lang\":{\"desc\":\"\u7E41\",\"langlist\":{\"langcht\":true}},\"\
+        videoname\":\"\u8D85\u4EBA \u92FC\u9435\u82F1\u96C4 Man of Steel (2013) 1080p.cht\"\
+        ,\"native_name\":\"\",\"vote_score\":0},{\"upload_time\":\"2013-10-23 00:46:40\"\
+        ,\"subtype\":\"Subrip(srt)\",\"revision\":0,\"id\":244971,\"lang\":{\"desc\"\
+        :\"\u7B80 \u7E41\",\"langlist\":{\"langcht\":true,\"langchs\":true}},\"videoname\"\
+        :\"\u8D85\u4EBA: \u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA: \u94A2\u94C1\u82F1\
+        \u96C4(\u6E2F\\/\u53F0).Man.of.Steel.2013.BluRay CEE\u7248\u84DD\u5149\u539F\
+        \u76D8\",\"native_name\":\"\u84DD\u5149\u539F\u76D8\u5B57\u5E55\",\"vote_score\"\
+        :10},{\"upload_time\":\"2013-10-22 23:39:00\",\"subtype\":\"Subrip(srt)\"\
+        ,\"revision\":0,\"id\":244969,\"lang\":{\"desc\":\"\",\"langlist\":{}},\"\
+        videoname\":\"Man.Of.Steel.3D.2013.1080p.BluRay.Half-SBS.DTS.x264-PublicHD\"\
+        ,\"native_name\":\"\u8D85\u4EBA\uFF1A\u94A2\u94C1\u4E4B\u8EAF 3D\\/\u8D85\u4EBA\
+        \uFF1A\u94A2\u94C1\u82F1\u96C4\\/Man of Steel 3D\",\"vote_score\":0},{\"upload_time\"\
+        :\"2013-10-22 22:06:42\",\"subtype\":\"SSA\",\"revision\":0,\"id\":244960,\"\
+        lang\":{\"desc\":\"\u82F1 \u7B80\",\"langlist\":{\"langchs\":true,\"langeng\"\
+        :true}},\"videoname\":\"Superman: Man of Steel BD\",\"native_name\":\"\u8D85\
+        \u4EBA:\u94A2\u94C1\u4E4B\u8EAF\",\"vote_score\":0},{\"upload_time\":\"2013-10-22\
+        \ 17:42:45\",\"subtype\":\"\u5176\u4ED6\",\"revision\":0,\"id\":244939,\"\
+        lang\":{\"desc\":\"\",\"langlist\":{}},\"videoname\":\"\u8D85\u4EBA\uFF1A\u94A2\
+        \u94C1\u4E4B\u8EAF.Man.of.Steel.2013.1080p-PublicHD 2D.1080p\u62163D.1080p.HSBS-PublicHD\"\
+        ,\"native_name\":\"\",\"vote_score\":0},{\"upload_time\":\"2013-10-21 16:52:23\"\
+        ,\"subtype\":\"Subrip(srt)\",\"revision\":0,\"id\":244863,\"lang\":{\"desc\"\
+        :\"\u82F1 \u7B80 \u7E41\",\"langlist\":{\"langeng\":true,\"langchs\":true,\"\
+        langcht\":true}},\"videoname\":\"man.of.steel.2013.720p.bluray.x264-felony.mkv\"\
+        ,\"native_name\":\"\\/Man of Steel \\/\u8D85\u4EBA:\u94A2\u94C1\u4E4B\u8EAF\
+        \\/\u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA:\u94A2\u94C1\u82F1\u96C4\",\"vote_score\"\
+        :0}],\"action\":\"search\"}}\n"
+    headers:
+      access-control-allow-origin:
+      - '*'
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Sat, 30 Nov 2019 07:14:39 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/assrt/test_query_movie_zh_Hant.yaml
+++ b/tests/cassettes/assrt/test_query_movie_zh_Hant.yaml
@@ -1,0 +1,97 @@
+interactions:
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - Sub-Zero/2
+    method: GET
+    uri: https://api.assrt.net/v1/sub/search?q=%5B%27Man+of+Steel+2013%27%5D&token=SECRET&is_file=%5B%271%27%5D
+  response:
+    body:
+      string: "{\"status\":0,\"sub\":{\"keyword\":\"Man of Steel 2013\",\"result\"\
+        :\"succeed\",\"subs\":[{\"subtype\":\"SSA\",\"id\":618185,\"lang\":{\"desc\"\
+        :\"\u82F1 \u7B80 \u7E41 \u53CC\u8BED\",\"langlist\":{\"langcht\":true,\"langeng\"\
+        :true,\"langdou\":true,\"langchs\":true}},\"vote_score\":0,\"upload_time\"\
+        :\"2018-01-26 12:19:27\",\"native_name\":\"\u8D85\u4EBA\uFF1A\u94A2\u94C1\u4E4B\
+        \u8EAF.Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT.\u7B80\u7E41\u82F1\
+        \u53CC\u8BED\u5B57\u5E55\",\"videoname\":\"Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT\"\
+        ,\"release_site\":\"CMCT\",\"revision\":0},{\"upload_time\":\"2014-12-06 04:13:44\"\
+        ,\"subtype\":\"SSA\",\"id\":316973,\"native_name\":\"\u8D85\u4EBA\uFF1A\u94A2\
+        \u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA\uFF1A\u94A2\u94C1\u82F1\u96C4\",\"videoname\"\
+        :\"Man of Steel 2013 720p BluRay x264 DTS-WiKi\",\"revision\":0,\"vote_score\"\
+        :0},{\"upload_time\":\"2014-03-17 15:30:19\",\"subtype\":\"Subrip(srt)\",\"\
+        revision\":0,\"id\":253629,\"lang\":{\"desc\":\"\u7E41\",\"langlist\":{\"\
+        langcht\":true}},\"videoname\":\"[\u8D85\u4EBA \u92FC\u9435\u82F1\u96C4]Man.of.Steel.(2013).BDRip.720p.DTS.X264-Felony\"\
+        ,\"native_name\":\"\",\"vote_score\":0},{\"upload_time\":\"2014-03-05 18:10:39\"\
+        ,\"subtype\":\"SSA\",\"revision\":0,\"id\":252930,\"lang\":{\"desc\":\"\u82F1\
+        \ \u7E41 \u53CC\u8BED\",\"langlist\":{\"langeng\":true,\"langcht\":true,\"\
+        langdou\":true}},\"videoname\":\"Man of Steel\",\"native_name\":\"\u8D85\u4EBA\
+        \uFF1A\u92FC\u9435\u82F1\u96C4\",\"vote_score\":45},{\"upload_time\":\"2013-11-09\
+        \ 10:43:13\",\"subtype\":\"Subrip(srt)\",\"revision\":0,\"id\":246016,\"lang\"\
+        :{\"desc\":\"\u82F1 \u7B80 \u7E41\",\"langlist\":{\"langeng\":true,\"langchs\"\
+        :true,\"langcht\":true}},\"videoname\":\"Man.of.Steel.2013.720p.BluRay.x264.YIFY\"\
+        ,\"native_name\":\"\u8D85\u4EBA\uFF1A\u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA\
+        \uFF1A\u94A2\u94C1\u82F1\u96C4\\/\u3010TLF\u5B57\u5E55\u7EC4\u3011Man of Steel\"\
+        ,\"vote_score\":0},{\"upload_time\":\"2013-11-02 05:56:40\",\"subtype\":\"\
+        SSA\",\"revision\":0,\"id\":245602,\"lang\":{\"desc\":\"\u7B80 \u7E41 \u53CC\
+        \u8BED\",\"langlist\":{\"langcht\":true,\"langchs\":true,\"langdou\":true}},\"\
+        videoname\":\"Man of Steel 1080p.bluray.x264-sector7\",\"native_name\":\"\u8D85\
+        \u4EBA\uFF1A\u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA\uFF1A\u94A2\u94C1\u82F1\
+        \u96C4\\/\u7279\u6548\u53CC\u8BED\\/\u84DD\u5149\u5B57\u5E55\",\"vote_score\"\
+        :0},{\"upload_time\":\"2013-10-31 23:41:07\",\"subtype\":\"\u5176\u4ED6\"\
+        ,\"revision\":0,\"id\":245568,\"lang\":{\"desc\":\"\u7B80\",\"langlist\":{\"\
+        langchs\":true}},\"videoname\":\"Man.of.Steel.2013\",\"native_name\":\"\u8D85\
+        \u4EBA: \u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA: \u94A2\u94C1\u82F1\u96C4\"\
+        ,\"vote_score\":0},{\"upload_time\":\"2013-10-27 07:04:18\",\"subtype\":\"\
+        VobSub\",\"id\":245259,\"native_name\":\"\",\"videoname\":\"Man.Of.Steel.3D.2013.1080p.BluRay.Half-SBS.DTS.x264-PublicHD\"\
+        ,\"revision\":0,\"vote_score\":100},{\"upload_time\":\"2013-10-25 04:50:37\"\
+        ,\"subtype\":\"Subrip(srt)\",\"revision\":0,\"id\":245131,\"lang\":{\"desc\"\
+        :\"\u7B80\",\"langlist\":{\"langchs\":true}},\"videoname\":\"Man.Of.Steel\"\
+        ,\"native_name\":\"\u8D85\u4EBA-\u94A2\u94C1\u4E4B\u8EAF\",\"vote_score\"\
+        :80},{\"upload_time\":\"2013-10-24 07:52:31\",\"subtype\":\"SSA\",\"revision\"\
+        :0,\"id\":245056,\"lang\":{\"desc\":\"\u7E41\",\"langlist\":{\"langcht\":true}},\"\
+        videoname\":\"\u8D85\u4EBA \u92FC\u9435\u82F1\u96C4 Man of Steel (2013) 1080p.cht\"\
+        ,\"native_name\":\"\",\"vote_score\":0},{\"upload_time\":\"2013-10-23 00:46:40\"\
+        ,\"subtype\":\"Subrip(srt)\",\"revision\":0,\"id\":244971,\"lang\":{\"desc\"\
+        :\"\u7B80 \u7E41\",\"langlist\":{\"langcht\":true,\"langchs\":true}},\"videoname\"\
+        :\"\u8D85\u4EBA: \u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA: \u94A2\u94C1\u82F1\
+        \u96C4(\u6E2F\\/\u53F0).Man.of.Steel.2013.BluRay CEE\u7248\u84DD\u5149\u539F\
+        \u76D8\",\"native_name\":\"\u84DD\u5149\u539F\u76D8\u5B57\u5E55\",\"vote_score\"\
+        :10},{\"upload_time\":\"2013-10-22 23:39:00\",\"subtype\":\"Subrip(srt)\"\
+        ,\"revision\":0,\"id\":244969,\"lang\":{\"desc\":\"\",\"langlist\":{}},\"\
+        videoname\":\"Man.Of.Steel.3D.2013.1080p.BluRay.Half-SBS.DTS.x264-PublicHD\"\
+        ,\"native_name\":\"\u8D85\u4EBA\uFF1A\u94A2\u94C1\u4E4B\u8EAF 3D\\/\u8D85\u4EBA\
+        \uFF1A\u94A2\u94C1\u82F1\u96C4\\/Man of Steel 3D\",\"vote_score\":0},{\"upload_time\"\
+        :\"2013-10-22 22:06:42\",\"subtype\":\"SSA\",\"revision\":0,\"id\":244960,\"\
+        lang\":{\"desc\":\"\u82F1 \u7B80\",\"langlist\":{\"langchs\":true,\"langeng\"\
+        :true}},\"videoname\":\"Superman: Man of Steel BD\",\"native_name\":\"\u8D85\
+        \u4EBA:\u94A2\u94C1\u4E4B\u8EAF\",\"vote_score\":0},{\"upload_time\":\"2013-10-22\
+        \ 17:42:45\",\"subtype\":\"\u5176\u4ED6\",\"revision\":0,\"id\":244939,\"\
+        lang\":{\"desc\":\"\",\"langlist\":{}},\"videoname\":\"\u8D85\u4EBA\uFF1A\u94A2\
+        \u94C1\u4E4B\u8EAF.Man.of.Steel.2013.1080p-PublicHD 2D.1080p\u62163D.1080p.HSBS-PublicHD\"\
+        ,\"native_name\":\"\",\"vote_score\":0},{\"upload_time\":\"2013-10-21 16:52:23\"\
+        ,\"subtype\":\"Subrip(srt)\",\"revision\":0,\"id\":244863,\"lang\":{\"desc\"\
+        :\"\u82F1 \u7B80 \u7E41\",\"langlist\":{\"langeng\":true,\"langchs\":true,\"\
+        langcht\":true}},\"videoname\":\"man.of.steel.2013.720p.bluray.x264-felony.mkv\"\
+        ,\"native_name\":\"\\/Man of Steel \\/\u8D85\u4EBA:\u94A2\u94C1\u4E4B\u8EAF\
+        \\/\u94A2\u94C1\u4E4B\u8EAF\\/\u8D85\u4EBA:\u94A2\u94C1\u82F1\u96C4\",\"vote_score\"\
+        :0}],\"action\":\"search\"}}\n"
+    headers:
+      access-control-allow-origin:
+      - '*'
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Sat, 30 Nov 2019 07:27:41 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+import libs
+from io import BytesIO
+import os
+from zipfile import ZipFile
+
+import pytest
+import requests
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
+
+from subliminal import Episode, Movie
+from subliminal.cache import region
+
+@pytest.fixture(autouse=True, scope='session')
+def configure_region():
+    region.configure('dogpile.cache.null')
+    region.configure = Mock()
+
+
+@pytest.fixture
+def movies():
+    return {'man_of_steel':
+            Movie(os.path.join('Man of Steel (2013)', 'man.of.steel.2013.720p.bluray.x264-felony.mkv'), 'Man of Steel',
+                  format='BluRay', release_group='felony', resolution='720p', video_codec='h264', audio_codec='DTS',
+                  imdb_id='tt0770828', size=7033732714, year=2013,
+                  hashes={'napiprojekt': '6303e7ee6a835e9fcede9fb2fb00cb36',
+                          'opensubtitles': '5b8f8f4e41ccb21e',
+                          'shooter': '314f454ab464775498ae6f1f5ad813a9;fdaa8b702d8936feba2122e93ba5c44f;'
+                                     '0a6935e3436aa7db5597ef67a2c494e3;4d269733f36ddd49f71e92732a462fe5',
+                          'thesubdb': 'ad32876133355929d814457537e12dc2'}),
+            'enders_game':
+            Movie('enders.game.2013.720p.bluray.x264-sparks.mkv', 'Ender\'s Game',
+                  format='BluRay', release_group='sparks', resolution='720p', video_codec='h264', year=2013),
+            'interstellar':
+            Movie('Interstellar.2014.2014.1080p.BluRay.x264.YIFY.rar', 'Interstellar',
+                  format='BluRay', release_group='YIFY', resolution='1080p', video_codec='h264', year=2014)}
+
+
+@pytest.fixture
+def episodes():
+    return {'bbt_s07e05':
+            Episode(os.path.join('The Big Bang Theory', 'Season 07',
+                                 'The.Big.Bang.Theory.S07E05.720p.HDTV.X264-DIMENSION.mkv'),
+                    'The Big Bang Theory', 7, 5, title='The Workplace Proximity', year=2007, tvdb_id=4668379,
+                    series_tvdb_id=80379, series_imdb_id='tt0898266', format='HDTV', release_group='DIMENSION',
+                    resolution='720p', video_codec='h264', audio_codec='AC3', imdb_id='tt3229392', size=501910737,
+                    hashes={'napiprojekt': '6303e7ee6a835e9fcede9fb2fb00cb36',
+                            'opensubtitles': '6878b3ef7c1bd19e',
+                            'shooter': 'c13e0e5243c56d280064d344676fff94;cd4184d1c0c623735f6db90841ce15fc;'
+                                       '3faefd72f92b63f2504269b4f484a377;8c68d1ef873afb8ba0cc9f97cbac41c1',
+                            'thesubdb': '9dbbfb7ba81c9a6237237dae8589fccc'}),
+            'got_s03e10':
+            Episode(os.path.join('Game of Thrones', 'Season 03',
+                                 'Game.of.Thrones.S03E10.Mhysa.720p.WEB-DL.DD5.1.H.264-NTb.mkv'),
+                    'Game of Thrones', 3, 10, title='Mhysa', tvdb_id=4517466, series_tvdb_id=121361,
+                    series_imdb_id='tt0944947', format='WEB-DL', release_group='NTb', resolution='720p',
+                    video_codec='h264', audio_codec='AC3', imdb_id='tt2178796', size=2142810931,
+                    hashes={'napiprojekt': '6303e7ee6a835e9fcede9fb2fb00cb36',
+                            'opensubtitles': 'b850baa096976c22',
+                            'shooter': 'b02d992c04ad74b31c252bd5a097a036;ef1b32f873b2acf8f166fc266bdf011a;'
+                                       '82ce34a3bcee0c66ed3b26d900d31cca;78113770551f3efd1e2d4ec45898c59c',
+                            'thesubdb': 'b1f899c77f4c960b84b8dbf840d4e42d'}),
+            'dallas_s01e03':
+            Episode('Dallas.S01E03.mkv', 'Dallas', 1, 3, title='Spy in the House', year=1978, tvdb_id=228224,
+                    series_tvdb_id=77092, series_imdb_id='tt0077000'),
+            'dallas_2012_s01e03':
+            Episode('Dallas.2012.S01E03.mkv', 'Dallas', 1, 3, title='The Price You Pay', year=2012,
+                    original_series=False, tvdb_id=4199511, series_tvdb_id=242521, series_imdb_id='tt1723760',
+                    imdb_id='tt2205526'),
+            'marvels_agents_of_shield_s02e06':
+            Episode('Marvels.Agents.of.S.H.I.E.L.D.S02E06.720p.HDTV.x264-KILLERS.mkv',
+                    'Marvel\'s Agents of S.H.I.E.L.D.', 2, 6, year=2013, format='HDTV', release_group='KILLERS',
+                    resolution='720p', video_codec='h264'),
+            'csi_cyber_s02e03':
+            Episode('CSI.Cyber.S02E03.hdtv-lol.mp4', 'CSI: Cyber', 2, 3, format='HDTV', release_group='lol'),
+            'the_x_files_s10e02':
+            Episode('The.X-Files.S10E02.HDTV.x264-KILLERS.mp4', 'The X-Files', 10, 2, format='HDTV',
+                    release_group='KILLERS', video_codec='h264'),
+            'colony_s01e09':
+            Episode('Colony.S01E09.720p.HDTV.x264-KILLERS.mkv', 'Colony', 1, 9, title='Zero Day', year=2016,
+                    tvdb_id=5463229, series_tvdb_id=284210, series_imdb_id='tt4209256', format='HDTV',
+                    release_group='KILLERS', resolution='720p', video_codec='h264', imdb_id='tt4926022'),
+            'the_jinx_e05':
+            Episode('The.Jinx-The.Life.and.Deaths.of.Robert.Durst.E05.BDRip.x264-ROVERS.mkv',
+                    'The Jinx: The Life and Deaths of Robert Durst', 1, 5, year=2015, original_series=True,
+                    format='BluRay', release_group='ROVERS', video_codec='h264'),
+            'the_100_s03e09':
+            Episode('The.100.S03E09.720p.HDTV.x264-AVS.mkv', 'The 100', 3, 9, title='Stealing Fire', year=2014,
+                    tvdb_id=5544536, series_tvdb_id=268592, series_imdb_id='tt2661044', format='HDTV',
+                    release_group='AVS', resolution='720p', video_codec='h264', imdb_id='tt4799896'),
+            'csi_s15e18':
+            Episode('CSI.S15E18.720p.HDTV.X264.DIMENSION.mkv', 'CSI: Crime Scene Investigation', 15, 18,
+                    title='The End Game', year=2000, tvdb_id=5104359, series_tvdb_id=72546, series_imdb_id='tt0247082',
+                    format='HDTV', release_group='DIMENSION', resolution='720p', video_codec='h264',
+                    imdb_id='tt4145952')}
+
+
+@pytest.fixture(scope='session')
+def mkv():
+    data_path = os.path.join('tests', 'data', 'mkv')
+
+    # download matroska test suite
+    if not os.path.exists(data_path) or len(os.listdir(data_path)) != 8:
+        r = requests.get('http://downloads.sourceforge.net/project/matroska/test_files/matroska_test_w1_1.zip')
+        with ZipFile(BytesIO(r.content), 'r') as f:
+            f.extractall(data_path, [m for m in f.namelist() if os.path.splitext(m)[1] == '.mkv'])
+
+    # populate a dict with mkv files
+    files = {}
+    for path in os.listdir(data_path):
+        name, _ = os.path.splitext(path)
+        files[name] = os.path.join(data_path, path)
+
+    return files

--- a/tests/libs.py
+++ b/tests/libs.py
@@ -1,0 +1,11 @@
+# coding=utf-8
+
+import os
+import sys
+
+
+def set_libs():
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../libs/'))
+
+
+set_libs()

--- a/tests/test_assrt.py
+++ b/tests/test_assrt.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+import os
+
+from babelfish import language_converters
+from subzero.language import Language
+import pytest
+from vcr import VCR
+from urlparse import urlparse, parse_qs
+from urllib import urlencode
+
+from subliminal_patch.providers.assrt import AssrtSubtitle, AssrtProvider, \
+language_contains, search_language_in_list, supported_languages
+
+def remove_auth_token(request):
+    parsed_uri = urlparse(request.uri)
+    parsed_query = parse_qs(parsed_uri.query)
+    if 'token' in parsed_query:
+        parsed_query['token'] = 'SECRET'
+    parsed_uri = parsed_uri._replace(query=urlencode(parsed_query))
+    request.uri = parsed_uri.geturl()
+    return request
+
+vcr = VCR(path_transformer=lambda path: path + '.yaml',
+          before_record_request=remove_auth_token,
+          record_mode=os.environ.get('VCR_RECORD_MODE', 'once'),
+          match_on=['method', 'scheme', 'host', 'port', 'path', 'body'],
+          cassette_library_dir=os.path.realpath(os.path.join('cassettes', 'assrt')))
+
+TOKEN=os.environ.get('ASSRT_TOKEN', 'NO_TOKEN_PROVIDED')
+
+def test_supported_languages():
+    assert set(supported_languages) == set([('zho', None, None),
+                                            ('eng', None, None),
+                                            ('zho', None, 'Hans'),
+                                            ('zho', None, 'Hant')])
+
+def test_language_contains():
+    assert language_contains(Language('zho'), Language('zho'))
+    assert language_contains(Language('zho', 'TW', None), Language('zho'))
+    assert language_contains(Language('zho', 'CN', None), Language('zho'))
+    assert language_contains(Language('zho', None, 'Hant'), Language('zho'))
+    assert language_contains(Language('zho', None, 'Hans'), Language('zho'))
+    assert language_contains(Language('zho', 'TW', 'Hant'), Language('zho'))
+    assert language_contains(Language('zho', 'CN', 'Hans'), Language('zho'))
+    assert language_contains(Language('zho', None, 'Hant'), Language('zho', None, 'Hant'))
+    assert language_contains(Language('zho', None, 'Hans'), Language('zho', None, 'Hans'))
+
+
+def test_search_language_in_list():
+    assert search_language_in_list(Language('zho', None, 'Hant'), [Language('zho', None, 'Hant')])
+    assert search_language_in_list(Language('zho', None, 'Hans'), [Language('zho', None, 'Hans')])
+    assert search_language_in_list(Language('zho', None, 'Hant'), [Language('zho')])
+    assert search_language_in_list(Language('zho', None, 'Hans'), [Language('zho')])
+    assert search_language_in_list(Language('zho', None, 'Hant'), [Language('eng'), Language('zho')])
+    assert not search_language_in_list(Language('zho', None, 'Hans'), [Language('zho', None, 'Hant')])
+    assert search_language_in_list(Language('zho', None, 'Hans'), [Language('zho', None, 'Hant'), Language('zho')])
+
+
+def test_get_matches_exact_movie_name(movies):
+    subtitle = AssrtSubtitle(Language('zho'), 253629,
+                             'man.of.steel.2013.720p.bluray.x264-felony.mkv',
+                             None, None)
+    matches = subtitle.get_matches(movies['man_of_steel'])
+    assert matches == {'title', 'format', 'release_group', 'year',
+                       'video_codec', 'resolution'}
+
+
+def test_get_matches_movie_name(movies):
+    subtitle = AssrtSubtitle(Language('zho'), 618185,
+                             'Man.Of.Steel.2013.BluRay.720p.x264.AC3.2Audios-CMCT',
+                             None, None)
+    matches = subtitle.get_matches(movies['man_of_steel'])
+    assert matches == {'title', 'format', 'year', 'video_codec', 'resolution'}
+
+
+@pytest.mark.converter
+def test_converter_convert_alpha3():
+    assert language_converters['assrt'].convert('zho', None, 'Hans') == 'chs'
+    assert language_converters['assrt'].convert('zho', None, 'Hant') == 'cht'
+    assert language_converters['assrt'].convert('eng') == 'eng'
+
+
+@pytest.mark.converter
+def test_converter_reverse():
+    assert language_converters['assrt'].reverse('chs') == ('zho', None, 'Hans')
+    assert language_converters['assrt'].reverse('cht') == ('zho', None, 'Hant')
+    assert language_converters['assrt'].reverse(u'簡體') == ('zho', None, 'Hans')
+    assert language_converters['assrt'].reverse(u'繁體') == ('zho', None, 'Hant')
+    assert language_converters['assrt'].reverse(u'简体') == ('zho', None, 'Hans')
+    assert language_converters['assrt'].reverse(u'繁体') == ('zho', None, 'Hant')
+
+@pytest.mark.integration
+@vcr.use_cassette
+def test_query_movie_zh_Hans(movies):
+    languages = [Language('zho', None, 'Hant')]
+    video = movies['man_of_steel']
+    with AssrtProvider(TOKEN) as provider:
+        subtitles = provider.query(languages, video)
+        assert len(subtitles) == 8
+
+@pytest.mark.integration
+@vcr.use_cassette
+def test_query_movie_zh_Hant(movies):
+    languages = [Language('zho', None, 'Hans')]
+    video = movies['man_of_steel']
+    with AssrtProvider(TOKEN) as provider:
+        subtitles = provider.query(languages, video)
+        assert len(subtitles) == 8
+
+@pytest.mark.integration
+@vcr.use_cassette
+def test_query_movie_zh(movies):
+    languages = [Language('zho')]
+    video = movies['man_of_steel']
+    with AssrtProvider(TOKEN) as provider:
+        subtitles = provider.query(languages, video)
+        assert len(subtitles) == 16
+
+@pytest.mark.integration
+@vcr.use_cassette
+def test_query_episode(episodes):
+    video = episodes['bbt_s07e05']
+    languages = [Language('zho', None, 'Hant'), Language('zho', None, 'Hans')]
+    with AssrtProvider(TOKEN) as provider:
+        subtitles = provider.query(languages, video)
+        assert len(subtitles) == 11
+
+
+@pytest.mark.integration
+@vcr.use_cassette
+def test_query_list_subtitles(movies):
+    languages = [Language('zho', None, 'Hant'), Language('zho', None, 'Hans')]
+    video = movies['man_of_steel']
+    with AssrtProvider(TOKEN) as provider:
+        subtitles = provider.list_subtitles(video, languages)
+        assert len(subtitles) == 16
+
+
+@pytest.mark.integration
+@vcr.use_cassette
+def test_download_subtitle(movies):
+    languages = [Language('zho', None, 'Hant')]
+    video = movies['man_of_steel']
+    with AssrtProvider(TOKEN) as provider:
+        subtitles = provider.list_subtitles(video, languages)
+        provider.download_subtitle(subtitles[0])
+        assert subtitles[0].content is not None
+        assert subtitles[0].language == Language('zho', None, 'Hant')
+
+
+@pytest.mark.integration
+@vcr.use_cassette
+def test_download_subtitle_zh(movies):
+    languages = [Language('zho')]
+    video = movies['man_of_steel']
+    with AssrtProvider(TOKEN) as provider:
+        subtitles = provider.list_subtitles(video, languages)
+        provider.download_subtitle(subtitles[0])
+        assert subtitles[0].content is not None
+        assert subtitles[0].language == Language('zho')
+
+
+@pytest.mark.integration
+@vcr.use_cassette
+def test_download_episode_subtitle(episodes):
+    languages = [Language('zho', None, 'Hant'), Language('zho', None, 'Hans')]
+    video = episodes['bbt_s07e05']
+    with AssrtProvider(TOKEN) as provider:
+        subtitles = provider.list_subtitles(video, languages)
+        provider.download_subtitle(subtitles[0])
+        assert subtitles[0].content is not None
+        assert subtitles[0].language == Language('zho', None, 'Hans')


### PR DESCRIPTION
This commit should fix issue #460 
Assrt will now treat `zh-Hans` and `zh-Hant` as `zh`, if `zh` is the selected language. 
I also added some tests for the assrt provider.