### PR TITLE
Fix apiKey not used in API test endpoint

### DIFF
--- a/bazarr/main.py
+++ b/bazarr/main.py
@@ -2122,7 +2122,7 @@ def test_url(protocol, url):
     authorize()
     url = six.moves.urllib.parse.unquote(url)
     try:
-        result = requests.get(protocol + "://" + url, allow_redirects=False, verify=False).json()['version']
+        result = requests.get(protocol + "://" + url + "?apiKey=" + request.query.apikey, allow_redirects=False, verify=False).json()['version']
     except:
         return dict(status=False)
     else:


### PR DESCRIPTION
Disclaimer: I'm not originally a Python developer, I don't know the framework that much and there's certainly a better way to fix what I fixed. I opened the pull request to show you the issue, and how I resolved it. I'm open to any suggestion. 🙂 

Recently I tried using Bazarr using docker and the [linuxserver's image](https://github.com/linuxserver/docker-bazarr). I couldn't pass the Sonarr and Radarr tests. After adding some logs in the endpoint method, it appeared that the query string was not part of the `url` parameter.

The fix: manually adding the `apiKey` at the end of the request URL, using `request.query.apikey`. 

I know this change probably break other environments. I assume that you will know better than me how to ensure that the URL is well-formed. 🙂 