### PR TITLE
Fixed: upon SIGTERM reception, send an interruption signal to children process

### DIFF
--- a/bazarr.py
+++ b/bazarr.py
@@ -11,6 +11,7 @@ import os
 import sys
 import platform
 import re
+import signal
 
 from bazarr.get_args import args
 
@@ -39,15 +40,97 @@ check_python_version()
 dir_name = os.path.dirname(__file__)
 
 
-def start_bazarr():
+class ProcessRegistry:
+
+    def register(self, process):
+        pass
+
+    def unregister(self, process):
+        pass
+
+
+class DaemonStatus(ProcessRegistry):
+
+    def __init__(self):
+        self.__should_stop = False
+        self.__processes = set()
+
+    def register(self, process):
+        self.__processes.add(process)
+
+    def unregister(self, process):
+        self.__processes.remove(process)
+
+    '''
+    Waits all the provided processes for the specified amount of time in seconds.
+    '''
+    @staticmethod
+    def __wait_for_processes(processes, timeout):
+        reference_ts = time.time()
+        elapsed = 0
+        remaining_processes = list(processes)
+        while elapsed < timeout and len(remaining_processes) > 0:
+            remaining_time = timeout - elapsed
+            for ep in list(remaining_processes):
+                if ep.poll() is not None:
+                    remaining_processes.remove(ep)
+                else:
+                    if remaining_time > 0:
+                        if PY3:
+                            try:
+                                ep.wait(remaining_time)
+                                remaining_processes.remove(ep)
+                            except sp.TimeoutExpired:
+                                pass
+                        else:
+                            '''
+                            In python 2 there is no such thing as some mechanism to wait with a timeout.
+                            '''
+                            time.sleep(1)
+                        elapsed = time.time() - reference_ts
+                        remaining_time = timeout - elapsed
+        return remaining_processes
+
+    '''
+    Sends to every single of the specified processes the given signal and (if live_processes is not None) append to it processes which are still alive.
+    '''
+    @staticmethod
+    def __send_signal(processes, signal_no, live_processes=None):
+        for ep in processes:
+            if ep.poll() is None:
+                if live_processes is not None:
+                    live_processes.append(ep)
+                try:
+                    ep.send_signal(signal_no)
+                except Exception as e:
+                    print('Failed sending signal %s to process %s because of an unexpected error: %s' % (signal_no, ep.pid, e))
+        return live_processes
+
+    '''
+    Flags this instance as should stop and terminates as smoothly as possible children processes.
+    '''
+    def stop(self):
+        self.__should_stop = True
+        live_processes = DaemonStatus.__send_signal(self.__processes, signal.SIGINT, list())
+        live_processes = DaemonStatus.__wait_for_processes(live_processes, 120)
+        DaemonStatus.__send_signal(live_processes, signal.SIGTERM)
+
+    def should_stop(self):
+        return self.__should_stop
+    
+    
+def start_bazarr(process_registry=ProcessRegistry()):
     script = [sys.executable, "-u", os.path.normcase(os.path.join(dir_name, 'bazarr', 'main.py'))] + sys.argv[1:]
     
     ep = sp.Popen(script, stdout=sp.PIPE, stderr=sp.STDOUT, stdin=sp.PIPE)
+    process_registry.register(ep)
     print("Bazarr starting...")
     try:
         while True:
             line = ep.stdout.readline()
             if line == '' or not line:
+                # Process ended so let's unregister it
+                process_registry.unregister(ep)
                 break
             if PY3:
                 sys.stdout.buffer.write(line)
@@ -73,7 +156,7 @@ if __name__ == '__main__':
         pass
     
     
-    def daemon():
+    def daemon(daemonStatus):
         if os.path.exists(stopfile):
             try:
                 os.remove(stopfile)
@@ -89,12 +172,21 @@ if __name__ == '__main__':
             except:
                 print('Unable to delete restart file.')
             else:
-                start_bazarr()
+                start_bazarr(daemonStatus)
     
     
-    start_bazarr()
+    daemonStatus = DaemonStatus()
     
-    # Keep the script running forever.
-    while True:
-        daemon()
+    def shutdown():
+        # indicates that everything should stop
+        daemonStatus.stop()
+        # emulate a Ctrl C command on itself (bypasses the signal thing but, then, emulates the "Ctrl+C break")
+        os.kill(os.getpid(), signal.SIGINT)
+    
+    signal.signal(signal.SIGTERM, lambda signal_no, frame: shutdown())
+    start_bazarr(daemonStatus)
+    
+    # Keep the script running forever until stop is requested through term or keyboard interrupt
+    while not daemonStatus.should_stop():
+        daemon(daemonStatus)
         time.sleep(1)


### PR DESCRIPTION

This partially fixes issue #746 (at least on my mac).

Test cases being performed:
- The classic `Ctrl-C` thing
- The `kill -SIGTERM <pid>` scenario