### PR TITLE
Some fixes on providers subdvix, legendasdivx and bsplayer.

### DIFF
--- a/libs/subliminal_patch/providers/bsplayer.py
+++ b/libs/subliminal_patch/providers/bsplayer.py
@@ -1,30 +1,21 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 import logging
-import re
 import io
 import os
-import sys
 
 from requests import Session
 from guessit import guessit
-from babelfish import language_converters
 from subliminal_patch.providers import Provider
 from subliminal_patch.subtitle import Subtitle
-from subliminal_patch.utils import sanitize
-from subliminal.exceptions import ProviderError
 from subliminal.utils import sanitize_release_group
 from subliminal.subtitle import guess_matches
-from subliminal.video import Episode, Movie
-from subliminal.subtitle import fix_line_ending
 from subzero.language import Language
-from .utils import FIRST_THOUSAND_OR_SO_USER_AGENTS as AGENT_LIST
 
 import gzip
 import random
 from time import sleep
 from xml.etree import ElementTree
-import struct
 
 logger = logging.getLogger(__name__)
 

--- a/libs/subliminal_patch/providers/bsplayer.py
+++ b/libs/subliminal_patch/providers/bsplayer.py
@@ -44,6 +44,10 @@ class BSPlayerSubtitle(Subtitle):
     def id(self):
         return self.page_link
 
+    @property
+    def release_info(self):
+        return self.filename
+
     def get_matches(self, video):
         matches = set()
 

--- a/libs/subliminal_patch/providers/legendasdivx.py
+++ b/libs/subliminal_patch/providers/legendasdivx.py
@@ -9,6 +9,7 @@ import zipfile
 
 from requests import Session
 from guessit import guessit
+from subliminal_patch.exceptions import ParseResponseError
 from subliminal_patch.providers import Provider
 from subliminal.providers import ParserBeautifulSoup
 from subliminal_patch.subtitle import Subtitle

--- a/libs/subliminal_patch/providers/legendasdivx.py
+++ b/libs/subliminal_patch/providers/legendasdivx.py
@@ -287,15 +287,21 @@ class LegendasdivxProvider(Provider):
         return archive
 
     def _get_subtitle_from_archive(self, archive):
+        # some files have a non subtitle with .txt extension
+        _tmp = list(SUBTITLE_EXTENSIONS)
+        _tmp.remove('.txt')
+        _subtitle_extensions = tuple(_tmp)
+
         for name in archive.namelist():
             # discard hidden files
             if os.path.split(name)[-1].startswith('.'):
                 continue
 
             # discard non-subtitle files
-            if not name.lower().endswith(SUBTITLE_EXTENSIONS):
+            if not name.lower().endswith(_subtitle_extensions):
                 continue
 
+            logger.debug("returning from archive: %s" % name)
             return archive.read(name)
 
         raise ParseResponseError('Can not find the subtitle in the compressed file')

--- a/libs/subliminal_patch/providers/legendasdivx.py
+++ b/libs/subliminal_patch/providers/legendasdivx.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 import logging
 import io
 import os
-import sys
 import rarfile
 import zipfile
 
@@ -13,15 +12,9 @@ from subliminal_patch.exceptions import ParseResponseError
 from subliminal_patch.providers import Provider
 from subliminal.providers import ParserBeautifulSoup
 from subliminal_patch.subtitle import Subtitle
-from subliminal_patch.utils import sanitize
-from subliminal.exceptions import ProviderError
-from subliminal.utils import sanitize_release_group
-from subliminal.subtitle import guess_matches
-from subliminal.video import Episode, Movie
+from subliminal.video import Episode
 from subliminal.subtitle import SUBTITLE_EXTENSIONS, fix_line_ending,guess_matches
 from subzero.language import Language
-
-import gzip
 
 logger = logging.getLogger(__name__)
 

--- a/libs/subliminal_patch/providers/subdivx.py
+++ b/libs/subliminal_patch/providers/subdivx.py
@@ -35,6 +35,10 @@ class SubdivxSubtitle(Subtitle):
     def id(self):
         return self.page_link
 
+    @property
+    def release_info(self):
+        return self.description
+
     def get_matches(self, video):
         matches = set()
 


### PR DESCRIPTION
Hello!
This merge requests has:
- 2 fixes for LegendasDivxs  
- Adding release_info for bsplayer and subdivx (I used the "Filename" from bsplayer and the description from subdivx) I don't know if this is the proper place to put that info, but from my own usage I wanted to know that information when downloading manually.
- Removing unused imports from bsplayer and legendasdivx (tested both again)

Let me know if you prefer making many merge requests instead of one (for small fixes)