### PR TITLE
Create rc.d_FreeBSDJail

### DIFF
--- a/scripts/rc.d_FreeBSDJail
+++ b/scripts/rc.d_FreeBSDJail
@@ -1,0 +1,46 @@
+!/bin/sh
+# PROVIDE: bazarr
+# REQUIRE: LOGIN
+# KEYWORD: shutdown
+
+# Add the following lines to /etc/rc.conf to enable bazarr:
+# bazarr_enable="YES"
+# Optionally add:
+# Note: The bazarr_user must be unique as the stop_postcmd kills the other running process
+# bazarr_user="bazarr"
+
+. /etc/rc.subr
+
+name="bazarr"
+rcvar=bazarr_enable
+
+load_rc_config $name
+
+: ${bazarr_enable="NO"}
+: ${bazarr_user:="bazarr"}
+: ${bazarr_data_dir:="/usr/local/bazarr"}
+
+pidfile="/usr/local/bazarr/bazarr.pid"
+procname="/usr/local/bin/python3"
+command="/usr/sbin/daemon"
+command_args="-f -p ${pidfile} ${procname} /usr/local/bazarr/bazarr.py"
+
+start_precmd=bazarr_precmd
+stop_postcmd=bazarr_postcmd
+
+bazarr_precmd()
+{
+        export XDG_CONFIG_HOME=${bazarr_data_dir}
+        export GIT_PYTHON_REFRESH=quiet
+
+        if [ ! -d ${bazarr_data_dir} ]; then
+                install -d -o ${bazarr_user} ${bazarr_data_dir}
+        fi
+}
+
+bazarr_postcmd()
+{
+        killall -u ${bazarr_user}
+}
+
+run_rc_command "$1"


### PR DESCRIPTION
Hi,
How about adding a folder with startup scripts? Or if you rather want it in the wiki just copy the code :)

I had some problems with the rc.d script in the Wiki, so I did some changes. I corrected a missing quotation marker and added the following line:
`export GIT_PYTHON_REFRESH=quiet` 

I am running bazarr in a FreeBSD 12.1 jail and it was not able to find git without adding the command above. Even though this was only tested in a jail it should work on the host system as well (using no jails).