### PR TITLE
webui: fix infinite loop in browser when bazarr stops

### DIFF
--- a/views/menu.tpl
+++ b/views/menu.tpl
@@ -423,18 +423,14 @@
                             ratio: '{value} / {total}'
                         }
 					});
-				}
-            },
-            complete: function (data) {
-                // Schedule the next
-				if (data.responseText !== "") {
-                	notificationTimeout = setTimeout(doNotificationsAjax, 100);
+
+					notificationTimeout = setTimeout(doNotificationsAjax, 100);
 				} else {
-                	notificationTimeout = setTimeout(doNotificationsAjax, 5000);
+					notificationTimeout = setTimeout(doNotificationsAjax, 5000);
 				}
             },
 			error: function () {
-                    notificationTimeout = setTimeout(doNotificationsAjax, 5000);
+				notificationTimeout = setTimeout(doNotificationsAjax, 5000);
 			}
         });
     }


### PR DESCRIPTION
Steps to replicate:
1. Open Bazarr webui in the browser
2. Kill Bazarr
3. The browser becomes unresponsive after few seconds. You can see thousand of requests in DevTools pannel.

When the notifications request fails, the error and complete code is executed (both). That calls `setTimeout` function 2 times, then 4 times, then 8 ...