### PR TITLE
change: log redirection mechanism

### DIFF
--- a/bazarr.py
+++ b/bazarr.py
@@ -116,21 +116,12 @@ class DaemonStatus(ProcessRegistry):
 def start_bazarr(process_registry=ProcessRegistry()):
     script = [sys.executable, "-u", os.path.normcase(os.path.join(dir_name, 'bazarr', 'main.py'))] + sys.argv[1:]
 
-    ep = subprocess.Popen(script, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.PIPE)
-    process_registry.register(ep)
     print("Bazarr starting...")
+    ep = subprocess.Popen(script, stdout=None, stderr=None, stdin=subprocess.DEVNULL)
+    process_registry.register(ep)
     try:
-        while True:
-            line = ep.stdout.readline()
-            if line == '' or not line:
-                # Process ended so let's unregister it
-                process_registry.unregister(ep)
-                break
-            if PY3:
-                sys.stdout.buffer.write(line)
-            else:
-                sys.stdout.write(line)
-            sys.stdout.flush()
+        ep.wait()
+        process_registry.unregister(ep)
     except KeyboardInterrupt:
         pass
 


### PR DESCRIPTION
Rely on native output and error stream printing.
Blocked input reading

Here I was facing the issue where the parent process has received an interrupt signal and had exited the reading loop and therefore child process output was no longer being printed out.
With this PR the idea is to ensure that the output / error stream contents would inherit the current process characteristics.

At the same time I took the liberty of disabling the console input (since we're not operating with it as far as I can see)