### PR TITLE
subliminal_patch: hearing impaired fix

### DIFF
--- a/libs/subliminal_patch/score.py
+++ b/libs/subliminal_patch/score.py
@@ -113,7 +113,7 @@ def compute_score(matches, subtitle, video, hearing_impaired=None):
             matches |= {'title', 'year'}
 
     # handle hearing impaired
-    if hearing_impaired is not None and subtitle.hearing_impaired == hearing_impaired:
+    if hearing_impaired is not None and subtitle.hearing_impaired == hearing_impaired and subtitle.hearing_impaired:
         logger.debug('Matched hearing_impaired')
         matches.add('hearing_impaired')
 


### PR DESCRIPTION
While debugging bsplayer provider, I've found out that the subtitle matched hearing_impaired, it turns out that both hearing_impaired and subtitle.hearing_impaired were set to False, making true the expression:
```
subtitle.hearing_impaired == hearing_impaired
```

