### PR TITLE
opensubtitles - show uploader as anonymous when UserNickName is empty

### DIFF
--- a/libs/subliminal_patch/providers/opensubtitles.py
+++ b/libs/subliminal_patch/providers/opensubtitles.py
@@ -327,7 +327,7 @@ class OpenSubtitlesProvider(ProviderRetryMixin, _OpenSubtitlesProvider):
                                            hash, movie_name, movie_release_name, movie_year, movie_imdb_id,
                                            series_season, series_episode, query_parameters, filename, encoding,
                                            movie_fps, skip_wrong_fps=self.skip_wrong_fps)
-            subtitle.uploader = _subtitle_item['UserNickName']
+            subtitle.uploader = _subtitle_item['UserNickName'] if _subtitle_item['UserNickName'] else 'anonymous'
             logger.debug('Found subtitle %r by %s', subtitle, matched_by)
             subtitles.append(subtitle)
 


### PR DESCRIPTION
Show uploader as anonymous when UserNickName is empty as this is how the username is shown on opensubtitles.com