### PR TITLE
Use tmdbId as a key when updating table_movies

### DIFF
--- a/bazarr/get_movies.py
+++ b/bazarr/get_movies.py
@@ -231,8 +231,8 @@ def update_movies():
 
             for updated_movie in movies_to_update_list:
                 query = dict_converter.convert(updated_movie)
-                database.execute('''UPDATE table_movies SET ''' + query.keys_update + ''' WHERE radarrId = ?''',
-                                 query.values + (updated_movie['radarrId'],))
+                database.execute('''UPDATE table_movies SET ''' + query.keys_update + ''' WHERE tmdbId = ?''',
+                                 query.values + (updated_movie['tmdbId'],))
                 altered_movies.append([updated_movie['tmdbId'],
                                        updated_movie['path'],
                                        updated_movie['radarrId'],


### PR DESCRIPTION
if you delete a movie from radarr and then add it again, it will have the same tmdbId, but new radarrId. If this happens between two scans, bazarr won't be able to update the movie again. This fix should prevent this.