### PR TITLE
Subtitles FPS support for Bulgarian subtitle providers

### DIFF
--- a/libs/subliminal_patch/providers/subsunacs.py
+++ b/libs/subliminal_patch/providers/subsunacs.py
@@ -13,6 +13,7 @@ from guessit import guessit
 from subliminal_patch.providers import Provider
 from subliminal_patch.subtitle import Subtitle
 from subliminal_patch.utils import sanitize, fix_inconsistent_naming
+from subliminal_patch.score import framerate_equal
 from subliminal.exceptions import ProviderError
 from subliminal.utils import sanitize_release_group
 from subliminal.subtitle import guess_matches
@@ -41,13 +42,14 @@ class SubsUnacsSubtitle(Subtitle):
     """SubsUnacs Subtitle."""
     provider_name = 'subsunacs'
 
-    def __init__(self, langauge, filename, type, video, link):
+    def __init__(self, langauge, filename, type, video, link, fps):
         super(SubsUnacsSubtitle, self).__init__(langauge)
         self.langauge = langauge
         self.filename = filename
         self.page_link = link
         self.type = type
         self.video = video
+        self.fps = fps
         self.release_info = os.path.splitext(filename)[0]
 
     @property
@@ -75,6 +77,14 @@ class SubsUnacsSubtitle(Subtitle):
              matches.add('hash')
 
         matches |= guess_matches(video, guessit(self.filename, {'type': self.type}))
+
+        if self.fps and video.fps and float(self.fps) != float(video.fps):
+            logger.info('FPS do not match for %r, %s vs %s. Reducing score.', self.page_link, self.fps, video.fps)
+            return set([x for x in matches if x in ['series', 'season', 'episode']])
+        else:
+            matches.add('fps')
+            matches.add('format')
+
         return matches
 
 
@@ -147,8 +157,17 @@ class SubsUnacsProvider(Provider):
                     link = element.get('href')
                     element = row.find('a', href = re.compile(r'.*/search\.php\?t=1\&(memid|u)=.*'))
                     uploader = element.get_text() if element else None
-                    logger.info('Found subtitle link %r', link)
-                    sub = self.download_archive_and_add_subtitle_files('https://subsunacs.net' + link, language, video)
+                    cells = row.findChildren('td')
+
+                    sub_disks = int(cells[1].getText()) if cells else 1
+                    if sub_disks != 1:
+                        logger.info('Multi-disk subtitles (unsupported). Skipping %r', link)
+                        continue
+
+                    sub_fps = float(cells[2].getText()) if cells else 0
+                    logger.info('Found subtitle link %r, fps %s, video %s', link, sub_fps, video.fps)
+
+                    sub = self.download_archive_and_add_subtitle_files('https://subsunacs.net' + link, language, video, sub_fps)
                     for s in sub: 
                         s.uploader = uploader
                     subtitles = subtitles + sub
@@ -162,12 +181,12 @@ class SubsUnacsProvider(Provider):
             pass
         else:
             seeking_subtitle_file = subtitle.filename
-            arch = self.download_archive_and_add_subtitle_files(subtitle.page_link, subtitle.language, subtitle.video)
+            arch = self.download_archive_and_add_subtitle_files(subtitle.page_link, subtitle.language, subtitle.video, subtitle.fps)
             for s in arch:
                 if s.filename == seeking_subtitle_file:
                     subtitle.content = s.content
 
-    def process_archive_subtitle_files(self, archiveStream, language, video, link):
+    def process_archive_subtitle_files(self, archiveStream, language, video, link, fps):
         subtitles = []
         type = 'episode' if isinstance(video, Episode) else 'movie'
         for file_name in archiveStream.namelist():
@@ -177,13 +196,13 @@ class SubsUnacsProvider(Provider):
                     logger.info('Ignore readme txt file %r', file_name)
                     continue
                 logger.info('Found subtitle file %r', file_name)
-                subtitle = SubsUnacsSubtitle(language, file_name, type, video, link)
+                subtitle = SubsUnacsSubtitle(language, file_name, type, video, link, fps)
                 subtitle.content = archiveStream.read(file_name)
                 if file_is_txt == False or subtitle.is_valid():
                     subtitles.append(subtitle)
         return subtitles
 
-    def download_archive_and_add_subtitle_files(self, link, language, video ):
+    def download_archive_and_add_subtitle_files(self, link, language, video, fps ):
         logger.info('Downloading subtitle %r', link)
         request = self.session.get(link, headers={
             'Referer': 'https://subsunacs.net/search.php'
@@ -192,8 +211,8 @@ class SubsUnacsProvider(Provider):
 
         archive_stream = io.BytesIO(request.content)
         if is_rarfile(archive_stream):
-            return self.process_archive_subtitle_files( RarFile(archive_stream), language, video, link )
+            return self.process_archive_subtitle_files( RarFile(archive_stream), language, video, link, fps )
         elif is_zipfile(archive_stream):
-            return self.process_archive_subtitle_files( ZipFile(archive_stream), language, video, link )
+            return self.process_archive_subtitle_files( ZipFile(archive_stream), language, video, link, fps )
         else:
             raise ValueError('Not a valid archive')

--- a/libs/subliminal_patch/providers/yavkanet.py
+++ b/libs/subliminal_patch/providers/yavkanet.py
@@ -13,6 +13,7 @@ from guessit import guessit
 from subliminal_patch.providers import Provider
 from subliminal_patch.subtitle import Subtitle
 from subliminal_patch.utils import sanitize
+from subliminal_patch.score import framerate_equal
 from subliminal.exceptions import ProviderError
 from subliminal.utils import sanitize_release_group
 from subliminal.subtitle import guess_matches
@@ -27,13 +28,14 @@ class YavkaNetSubtitle(Subtitle):
     """YavkaNet Subtitle."""
     provider_name = 'yavkanet'
 
-    def __init__(self, langauge, filename, type, video, link):
+    def __init__(self, langauge, filename, type, video, link, fps):
         super(YavkaNetSubtitle, self).__init__(langauge)
         self.langauge = langauge
         self.filename = filename
         self.page_link = link
         self.type = type
         self.video = video
+        self.fps = fps
         self.release_info = os.path.splitext(filename)[0]
 
     @property
@@ -61,6 +63,14 @@ class YavkaNetSubtitle(Subtitle):
              matches.add('hash')
 
         matches |= guess_matches(video, guessit(self.filename, {'type': self.type}))
+
+        if self.fps and video.fps and float(self.fps) != float(video.fps):
+            logger.info('FPS do not match for %r, %s vs %s. Reducing score.', self.page_link, self.fps, video.fps)
+            return set([x for x in matches if x in ['series', 'season', 'episode']])
+        else:
+            matches.add('fps')
+            matches.add('format')
+
         return matches
 
 
@@ -131,8 +141,12 @@ class YavkaNetProvider(Provider):
                 link = element.get('href')
                 element = row.find('a', {'class': 'click'})
                 uploader = element.get_text() if element else None
-                logger.info('Found subtitle link %r', link)
-                sub = self.download_archive_and_add_subtitle_files('http://yavka.net/' + link, language, video)
+
+                fps_box = row.find('span', {'title': 'Кадри в секунда'})
+                sub_fps = float(fps_box.find('font').getText()) if fps_box and fps_box.find('font') else 0
+                logger.info('Found subtitle link %r, fps %s, video %s', link, sub_fps, video.fps)
+
+                sub = self.download_archive_and_add_subtitle_files('http://yavka.net/' + link, language, video, sub_fps)
                 for s in sub: 
                     s.uploader = uploader
                 subtitles = subtitles + sub
@@ -146,23 +160,23 @@ class YavkaNetProvider(Provider):
             pass
         else:
             seeking_subtitle_file = subtitle.filename
-            arch = self.download_archive_and_add_subtitle_files(subtitle.page_link, subtitle.language, subtitle.video)
+            arch = self.download_archive_and_add_subtitle_files(subtitle.page_link, subtitle.language, subtitle.video, subtitle.fps)
             for s in arch:
                 if s.filename == seeking_subtitle_file:
                     subtitle.content = s.content
 
-    def process_archive_subtitle_files(self, archiveStream, language, video, link):
+    def process_archive_subtitle_files(self, archiveStream, language, video, link, fps):
         subtitles = []
         type = 'episode' if isinstance(video, Episode) else 'movie'
         for file_name in archiveStream.namelist():
             if file_name.lower().endswith(('.srt', '.sub')):
                 logger.info('Found subtitle file %r', file_name)
-                subtitle = YavkaNetSubtitle(language, file_name, type, video, link)
+                subtitle = YavkaNetSubtitle(language, file_name, type, video, link, fps)
                 subtitle.content = archiveStream.read(file_name)
                 subtitles.append(subtitle)
         return subtitles
 
-    def download_archive_and_add_subtitle_files(self, link, language, video ):
+    def download_archive_and_add_subtitle_files(self, link, language, video, fps):
         logger.info('Downloading subtitle %r', link)
         request = self.session.get(link, headers={
             'Referer': 'http://yavka.net/subtitles.php'
@@ -171,9 +185,9 @@ class YavkaNetProvider(Provider):
 
         archive_stream = io.BytesIO(request.content)
         if is_rarfile(archive_stream):
-            return self.process_archive_subtitle_files( RarFile(archive_stream), language, video, link )
+            return self.process_archive_subtitle_files(RarFile(archive_stream), language, video, link, fps)
         elif is_zipfile(archive_stream):
-            return self.process_archive_subtitle_files( ZipFile(archive_stream), language, video, link )
+            return self.process_archive_subtitle_files(ZipFile(archive_stream), language, video, link, fps)
         else:
             raise ValueError('Not a valid archive')
         


### PR DESCRIPTION
This changeset adds 2 related improvements:
* Subtitles FPS for the 3 Bulgarian subtitle providers - SubsSabBz, SubsUnacs and YavkaNet - all of which list the video FPS the subtitles are intended for. The code compares the subtitle FPS value with the video file FPS and either boosts or reduces the subtitle score.
* Specifically for SubsSabBz and SubsUnacs, ignore subtitle matches for multi-disk/multi-file releases (e.g. CD1, CD2, CD3). Without this patch, the user ends up having only partial subtitles for their movie or episode.

cc @josdion