### PR TITLE
added new IPAddressBlocked exception and cache Legendasdivx login

### DIFF
--- a/bazarr/get_providers.py
+++ b/bazarr/get_providers.py
@@ -8,9 +8,21 @@ import time
 
 from get_args import args
 from config import settings
-from subliminal_patch.exceptions import TooManyRequests, APIThrottled, ParseResponseError
+from subliminal_patch.exceptions import TooManyRequests, APIThrottled, ParseResponseError, IPAddressBlocked
 from subliminal.exceptions import DownloadLimitExceeded, ServiceUnavailable
 from subliminal import region as subliminal_cache_region
+
+def time_until_end_of_day(dt=None):
+    # type: (datetime.datetime) -> datetime.timedelta
+    """
+    Get timedelta until end of day on the datetime passed, or current time.
+    """
+    if dt is None:
+        dt = datetime.datetime.now()
+    tomorrow = dt + datetime.timedelta(days=1)
+    return datetime.datetime.combine(tomorrow, datetime.time.min) - dt
+
+hours_until_end_of_day = time_until_end_of_day().seconds // 3600 + 1
 
 VALID_THROTTLE_EXCEPTIONS = (TooManyRequests, DownloadLimitExceeded, ServiceUnavailable, APIThrottled,
                              ParseResponseError)
@@ -39,7 +51,7 @@ PROVIDER_THROTTLE_MAP = {
     "legendasdivx": {
         TooManyRequests: (datetime.timedelta(hours=3), "3 hours"),
         DownloadLimitExceeded: (datetime.timedelta(hours=6), "6 hours"),
-        ParseResponseError: (datetime.timedelta(hours=1), "1 hours"),
+        IPAddressBlocked: (datetime.timedelta(hours=hours_until_end_of_day), "{} hours".format(str(hours_until_end_of_day))),
     }
 }
 

--- a/libs/subliminal_patch/exceptions.py
+++ b/libs/subliminal_patch/exceptions.py
@@ -7,11 +7,13 @@ class TooManyRequests(ProviderError):
     """Exception raised by providers when too many requests are made."""
     pass
 
-
 class APIThrottled(ProviderError):
     pass
-
 
 class ParseResponseError(ProviderError):
     """Exception raised by providers when they are not able to parse the response."""
     pass
+
+class IPAddressBlocked(ProviderError):
+	"""Exception raised when providers block requests from IP Address."""
+	pass


### PR DESCRIPTION
- added new exception IPAddressBlocked to subliminal_patch exceptions list. It's purpose is to throttle hits on the provider if our IP address got blocked for too many requests.

- Cache LegendasDivx cookies to stop login in every time we want to download subtitles. Got banned for too many login attempts :)

- bazarr/get_providers.py can now be confired to specify how many hours to throttle provider based on IPAddressBlocked excepetion. For example, LegendasDivx blocks your IP until 00am of next day. I've implemented a method to get number of seconds until end of day and set throttle hours wait.