### PR TITLE
Throttle connections to Addic7ed provider throwing IPAddressBlocked

### DIFF
--- a/bazarr/get_providers.py
+++ b/bazarr/get_providers.py
@@ -44,6 +44,8 @@ PROVIDER_THROTTLE_MAP = {
     "addic7ed": {
         DownloadLimitExceeded: (datetime.timedelta(hours=3), "3 hours"),
         TooManyRequests: (datetime.timedelta(minutes=5), "5 minutes"),
+        IPAddressBlocked: (datetime.timedelta(hours=1), "1 hours"),
+
     },
     "titulky": {
         DownloadLimitExceeded: (datetime.timedelta(hours=3), "3 hours")

--- a/libs/subliminal_patch/providers/addic7ed.py
+++ b/libs/subliminal_patch/providers/addic7ed.py
@@ -9,13 +9,14 @@ from random import randint
 
 from dogpile.cache.api import NO_VALUE
 from requests import Session
+from requests.exceptions import ConnectionError
 from subliminal.cache import region
 from subliminal.exceptions import DownloadLimitExceeded, AuthenticationError, ConfigurationError
 from subliminal.providers.addic7ed import Addic7edProvider as _Addic7edProvider, \
     Addic7edSubtitle as _Addic7edSubtitle, ParserBeautifulSoup
 from subliminal.subtitle import fix_line_ending
 from subliminal_patch.utils import sanitize
-from subliminal_patch.exceptions import TooManyRequests
+from subliminal_patch.exceptions import TooManyRequests, IPAddressBlocked
 from subliminal_patch.pitcher import pitchers, load_verification, store_verification
 from subzero.language import Language
 
@@ -91,15 +92,19 @@ class Addic7edProvider(_Addic7edProvider):
         # login
         if self.username and self.password:
             def check_verification(cache_region):
-                rr = self.session.get(self.server_url + 'panel.php', allow_redirects=False, timeout=10,
-                                      headers={"Referer": self.server_url})
-                if rr.status_code == 302:
-                    logger.info('Addic7ed: Login expired')
-                    cache_region.delete("addic7ed_data")
-                else:
-                    logger.info('Addic7ed: Re-using old login')
-                    self.logged_in = True
-                    return True
+                try:
+                    rr = self.session.get(self.server_url + 'panel.php', allow_redirects=False, timeout=10,
+                                          headers={"Referer": self.server_url})
+                    if rr.status_code == 302:
+                        logger.info('Addic7ed: Login expired')
+                        cache_region.delete("addic7ed_data")
+                    else:
+                        logger.info('Addic7ed: Re-using old login')
+                        self.logged_in = True
+                        return True
+                except ConnectionError as e:
+                    logger.debug("Addic7ed: There was a problem reaching the server: %s." % e)
+                    raise IPAddressBlocked("Addic7ed: Your IP is temporarily blocked.")
 
             if load_verification("addic7ed", self.session, callback=check_verification):
                 return


### PR DESCRIPTION
I've put request to login.php inside a try: except: block to catch ConnectionError (most likely based on IP being blocked). This throws IPAddressBlocked exception and throttles for 1 hour (I don't know the servers request intervals...).

Tries to avoid behaviour described on #861