### PR TITLE
don't raise an exception if compressed format is not supported

### DIFF
--- a/libs/subliminal_patch/providers/legendasdivx.py
+++ b/libs/subliminal_patch/providers/legendasdivx.py
@@ -400,7 +400,7 @@ class LegendasdivxProvider(Provider):
             logger.debug('Identified zip archive')
             archive = zipfile.ZipFile(archive_stream)
         else:
-            raise Exception('Unsupported compressed format')
+            raise ValueError('Unsupported compressed format')
 
         return archive
 


### PR DESCRIPTION
Was throwing an exception and throttling for 10 minutes because some archive had an unsupported compress format.