### PR TITLE
Propagate TERM signal to latest forked child process

### DIFF
--- a/bazarr.py
+++ b/bazarr.py
@@ -2,6 +2,7 @@
 
 import os
 import platform
+import signal
 import subprocess
 import sys
 import time
@@ -37,11 +38,18 @@ def end_child_process(ep):
     except:
         pass
 
+def terminate_child_process(ep):
+    try:
+        ep.terminate()
+    except:
+        pass
+
 
 def start_bazarr():
     script = [sys.executable, "-u", os.path.normcase(os.path.join(dir_name, 'bazarr', 'main.py'))] + sys.argv[1:]
     ep = subprocess.Popen(script, stdout=None, stderr=None, stdin=subprocess.DEVNULL)
     atexit.register(end_child_process, ep=ep)
+    signal.signal(signal.SIGTERM, lambda signal_no, frame: terminate_child_process(ep))
 
 
 def check_status():
@@ -92,6 +100,6 @@ if __name__ == '__main__':
             else:
                 os.wait()
                 time.sleep(1)
-        except (KeyboardInterrupt, SystemExit):
+        except (KeyboardInterrupt, SystemExit, ChildProcessError):
             print('Bazarr exited.')
             sys.exit(0)


### PR DESCRIPTION
The idea was, first of all, to be able to send the `TERM` signal to the parent process and ensure that all child processes are terminate.

As a personal preference, I switched to sending TERM signal over KILL signal (in windows it seems to be the same but in Linux the former allows for resource cleanups while the latter *in theory* doesn't). 

Catch ChildProcessError (occurs when child process is terminated by the current python script on mac os x)