### PR TITLE
Add setting to ignore embedded VobSub subtitles

### DIFF
--- a/bazarr/config.py
+++ b/bazarr/config.py
@@ -42,6 +42,7 @@ defaults = {
         'embedded_subs_show_desired': 'True',
         'utf8_encode': 'True',
         'ignore_pgs_subs': 'False',
+        'ignore_vobsub_subs': 'False',
         'adaptive_searching': 'False',
         'enabled_providers': '',
         'throtteled_providers': '{}',

--- a/bazarr/list_subtitles.py
+++ b/bazarr/list_subtitles.py
@@ -30,8 +30,8 @@ def store_subtitles(original_path, reversed_path):
                 subtitle_languages = embedded_subs_reader.list_languages(reversed_path)
                 for subtitle_language, subtitle_forced, subtitle_codec in subtitle_languages:
                     try:
-                        if settings.general.getboolean("ignore_pgs_subs") and subtitle_codec == "PGS":
-                            logging.debug("BAZARR skipping pgs sub for language: " + str(alpha2_from_alpha3(subtitle_language)))
+                        if (settings.general.getboolean("ignore_pgs_subs") and subtitle_codec == "PGS") or (settings.general.getboolean("ignore_vobsub_subs") and subtitle_codec == "VOBSUB"):
+                            logging.debug("BAZARR skipping %s sub for language: %s" % (subtitle_codec, alpha2_from_alpha3(subtitle_language)))
                             continue
 
                         if alpha2_from_alpha3(subtitle_language) is not None:
@@ -106,8 +106,8 @@ def store_subtitles_movie(original_path, reversed_path):
                 subtitle_languages = embedded_subs_reader.list_languages(reversed_path)
                 for subtitle_language, subtitle_forced, subtitle_codec in subtitle_languages:
                     try:
-                        if settings.general.getboolean("ignore_pgs_subs") and subtitle_codec == "PGS":
-                            logging.debug("BAZARR skipping pgs sub for language: " + str(alpha2_from_alpha3(subtitle_language)))
+                        if (settings.general.getboolean("ignore_pgs_subs") and subtitle_codec == "PGS") or (settings.general.getboolean("ignore_vobsub_subs") and subtitle_codec == "VOBSUB"):
+                            logging.debug("BAZARR skipping %s sub for language: %s" % (subtitle_codec, alpha2_from_alpha3(subtitle_language)))
                             continue
 
                         if alpha2_from_alpha3(subtitle_language) is not None:

--- a/views/settingssubtitles.html
+++ b/views/settingssubtitles.html
@@ -229,6 +229,20 @@
                 </div>
                 <div class="row">
                     <div class="col-sm-4 text-right">
+                        <b>Ignore Embedded VobSub Subtitles</b>
+                    </div>
+                    <div class="form-group col-sm-8">
+                        <label class="custom-control custom-checkbox">
+                            <input type="checkbox" class="custom-control-input" id="settings-general-ignore_vobsub_subs"
+                                name="settings-general-ignore_vobsub_subs">
+                            <span class="custom-control-label" for="settings-general-ignore_vobsub_subs"></span>
+                        </label>
+                        <label>Ignores VobSub Subtitles in Embedded Subtitles detection. Only relevant if 'Use embedded
+                            Subtitles' is enabled.</label>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-sm-4 text-right">
                         <b>Show Only Desired Languages</b>
                     </div>
                     <div class="form-group col-sm-8">
@@ -541,6 +555,7 @@
             $('#settings-general-multithreading').prop('checked', {{'true' if settings.general.getboolean('multithreading') else 'false'}}).trigger('change');
             $('#settings-general-use_embedded_subs').prop('checked', {{'true' if settings.general.getboolean('use_embedded_subs') else 'false'}}).trigger('change');
             $('#settings-general-ignore_pgs_subs').prop('checked', {{'true' if settings.general.getboolean('ignore_pgs_subs') else 'false'}}).trigger('change');
+            $('#settings-general-ignore_vobsub_subs').prop('checked', {{ 'true' if settings.general.getboolean('ignore_vobsub_subs') else 'false' }}).trigger('change');
             $('#settings-general-embedded_subs_show_desired').prop('checked', {{'true' if settings.general.getboolean('embedded_subs_show_desired') else 'false'}}).trigger('change');
             $('#settings-general-utf8_encode').prop('checked', {{'true' if settings.general.getboolean('utf8_encode') else 'false'}}).trigger('change');
             $('#settings-general-chmod_enabled').prop('checked', {{'true' if settings.general.getboolean('chmod_enabled') else 'false'}}).trigger('change');


### PR DESCRIPTION
This can be seen as an addition to ignoring embedded PGS subtitles which already exists as a setting. VobSub is another image format which might be undesired as support for it varies. Therefore it's often a good idea to replace it with SRT subs as we do. This PR aims to address that.