### PR TITLE
Fix loop with alternative titles in Argenteam provider

### DIFF
--- a/libs/subliminal_patch/providers/argenteam.py
+++ b/libs/subliminal_patch/providers/argenteam.py
@@ -266,18 +266,14 @@ class ArgenteamProvider(Provider, ProviderSubtitleArchiveMixin):
 
     def list_subtitles(self, video, languages):
         if isinstance(video, Episode):
-            titles = [video.series] + video.alternative_series
+            titles = [video.series] + video.alternative_series[:2]
         else:
-            titles = [video.title] + video.alternative_titles
+            titles = [video.title] + video.alternative_titles[:2]
 
-        inc = 0
         for title in titles:
             subs = self.query(title, video, titles=titles)
             if subs:
                 return subs
-            inc += 1
-            if inc > 2:
-                break
             time.sleep(self.multi_result_throttle)
 
         return []

--- a/libs/subliminal_patch/providers/argenteam.py
+++ b/libs/subliminal_patch/providers/argenteam.py
@@ -270,11 +270,14 @@ class ArgenteamProvider(Provider, ProviderSubtitleArchiveMixin):
         else:
             titles = [video.title] + video.alternative_titles
 
+        inc = 0
         for title in titles:
             subs = self.query(title, video, titles=titles)
             if subs:
                 return subs
-
+            inc += 1
+            if inc > 2:
+                break
             time.sleep(self.multi_result_throttle)
 
         return []


### PR DESCRIPTION
Movies with a lot of alternative titles (https://www.themoviedb.org/movie/25237/titles) break the manual search with Argenteam. It always returns `DataTables warning: table id=search_result - Ajax error. For more information about this error, please see http://datatables.net/tn/7 `. Here's the log:
[bazarr.log](https://github.com/morpheus65535/bazarr/files/5394038/bazarr.log)

This little change solves that problem