### PR TITLE
titulky provider: fix search for movie w/o year

### DIFF
--- a/libs/subliminal_patch/providers/titulky.py
+++ b/libs/subliminal_patch/providers/titulky.py
@@ -212,7 +212,7 @@ class TitulkyProvider(Provider):
         subtitles = []
         if season and episode:
             search_link = self.server_url + text_type(self.search_url_series).format(params)
-        elif year:
+        else:
             search_link = self.server_url + text_type(self.search_url_movies).format(params)
         
         


### PR DESCRIPTION
This fixes `UnboundLocalError. Exception info: "local variable 'search_link' referenced before assignment"` error occurring when a movie is queried without a year. Apparently, this happens in practice and results in failure and subsequent throttling of the provider.