### PR TITLE
Fix source score matching in subtitle.py

### DIFF
--- a/libs/subliminal_patch/subtitle.py
+++ b/libs/subliminal_patch/subtitle.py
@@ -104,7 +104,7 @@ class Subtitle(Subtitle_):
 
     def make_picklable(self):
         """
-        some subtitle instances might have unpicklable objects stored; clean them up here 
+        some subtitle instances might have unpicklable objects stored; clean them up here
         :return: self
         """
         return self
@@ -377,7 +377,7 @@ class Subtitle(Subtitle_):
 
     def get_modified_content(self, format="srt", debug=False):
         """
-        :return: string 
+        :return: string
         """
         if not self.mods:
             return fix_text(self.content.decode(encoding=self.get_encoding()), **ftfy_defaults).encode(
@@ -404,7 +404,9 @@ class ModifiedSubtitle(Subtitle):
 MERGED_FORMATS = {
     "TV": ("HDTV", "SDTV", "AHDTV", "UHDTV"),
     "Air": ("SATRip", "DVB", "PPV"),
-    "Disk": ("DVD", "HD-DVD", "BluRay")
+    "Disk-HD": ("HD-DVD", "Blu-ray"),
+    "Disk-SD": ("DVD", "VHS"),
+    "Web": ("Web"),
 }
 
 MERGED_FORMATS_REV = dict((v.lower(), k.lower()) for k in MERGED_FORMATS for v in MERGED_FORMATS[k])

--- a/libs/subliminal_patch/subtitle.py
+++ b/libs/subliminal_patch/subtitle.py
@@ -406,7 +406,6 @@ MERGED_FORMATS = {
     "Air": ("SATRip", "DVB", "PPV"),
     "Disk-HD": ("HD-DVD", "Blu-ray"),
     "Disk-SD": ("DVD", "VHS"),
-    "Web": ("Web"),
 }
 
 MERGED_FORMATS_REV = dict((v.lower(), k.lower()) for k in MERGED_FORMATS for v in MERGED_FORMATS[k])


### PR DESCRIPTION
`libs/subliminal_patch/subtitle.py` source matching is broken with Blu-ray and Web sources:

![2020-10-27_19-25](https://user-images.githubusercontent.com/59455966/97372499-2a599700-188a-11eb-9fa0-acd428f97f2a.png)


The problem lies in: 
``` python
MERGED_FORMATS = {
    "TV": ("HDTV", "SDTV", "AHDTV", "UHDTV"),
    "Air": ("SATRip", "DVB", "PPV"),
    "Disk": ("DVD", "HD-DVD", "BluRay")
}
```
Guessit doesn't return "Bluray" but "Blu-ray". This caused `MERGED_FORMATS_REV.get` to always return None with Blu-ray sources. Web is being matched with Blu-ray as Web is also always returning None with `MERGED_FORMATS_REV.get`:
```python3
        if video.source:
            video_format = video.source.lower()
            _video_gen_format = MERGED_FORMATS_REV.get(video_format)
            if _video_gen_format:
                logger.debug("Treating %s as %s the same", video_format, _video_gen_format)

            for frmt in formats:
                _guess_gen_frmt = MERGED_FORMATS_REV.get(frmt.lower())

                if _guess_gen_frmt == _video_gen_format: # None == None
                    matches.add('source')
                    break
```

To fix this, I modified the dictionary. I added Web and divided disk sources in Disk-HD and Disk-SD as DVD sources tend to be considerably different to Blu-ray ones due to remasters, restorations, etc. The latter is arguable and I'm not sure if Web was not added to the dict on purpose, so please let me know if these changes are acceptable.

Another minor change: sucha's matching logic