### PR TITLE
supersubtitles handle when title cannot be parsed

### DIFF
--- a/libs/subliminal_patch/providers/supersubtitles.py
+++ b/libs/subliminal_patch/providers/supersubtitles.py
@@ -229,6 +229,8 @@ class SuperSubtitlesProvider(Provider, ProviderSubtitleArchiveMixin):
                 continue
 
             result_title = result_title.strip().replace("�", "").replace(" ", ".")
+            if not result_title:
+                continue
 
             guessable = result_title.strip() + ".s01e01." + result_year
             guess = guessit(guessable, {'type': "episode"})


### PR DESCRIPTION
For example https://www.feliratok.info/index.php?term=American%20Chopper&nyelv=0&action=autoname returns a result which causes https://github.com/morpheus65535/bazarr/issues/1179#issuecomment-721068203