### PR TITLE
Update backend API to only send requirement info

### DIFF
--- a/bazarr/api.py
+++ b/bazarr/api.py
@@ -559,12 +559,12 @@ class SubtitleNameInfo(Resource):
             result = guessit(name, options=opts)
 
             res = dict()
-            if result['episode'] is not None:
+            if 'episode' in result:
                 res['episode'] = result['episode']
             else:
                 res['episode'] = 0
 
-            if result['season'] is not None:
+            if 'season' in result:
                 res['season'] = result['season']
             else:
                 res['season'] = 0

--- a/bazarr/api.py
+++ b/bazarr/api.py
@@ -557,9 +557,22 @@ class SubtitleNameInfo(Resource):
             opts = dict()
             opts['type'] = 'episode'
             result = guessit(name, options=opts)
+
+            res = dict()
+            if result['episode'] is not None:
+                res['episode'] = result['episode']
+            else:
+                res['episode'] = 0
+
+            if result['season'] is not None:
+                res['season'] = result['season']
+            else:
+                res['season'] = 0
+            
             if 'subtitle_language' in result:
-                result['subtitle_language'] = str(result['subtitle_language'])
-            return jsonify(data=result)
+                res['subtitle_language'] = str(result['subtitle_language'])
+            
+            return jsonify(data=res)
         else:
             return '', 400
 


### PR DESCRIPTION
This Pull Request will fix #1182 by only sending the requirement infos to the frontend instead of sending them all

Data after this pull request
```json
{
  "data": {
    "episode": 3, 
    "season": 1
  }
}
```