### PR TITLE
Brazilian subs are sometimes marked with the word "brazil" instead of…

### DIFF
--- a/bazarr/embedded_subs_reader.py
+++ b/bazarr/embedded_subs_reader.py
@@ -21,7 +21,7 @@ class EmbeddedSubsReader:
             data = api.know(file)
 
             traditional_chinese = ["cht", "tc", "traditional", "zht", "hant", "big5", u"繁", u"雙語"]
-            brazilian_portuguese = ["pt-br", "pob", "pb", "brazilian", "brasil"]
+            brazilian_portuguese = ["pt-br", "pob", "pb", "brazilian", "brasil", "brazil"]
 
             if 'subtitle' in data:
                 for detected_language in data['subtitle']:


### PR DESCRIPTION
… "brasil"