### PR TITLE
Fix TypeError for subliminal_patch

### DIFF
--- a/libs/subliminal_patch/utils.py
+++ b/libs/subliminal_patch/utils.py
@@ -14,7 +14,7 @@ def sanitize(string, ignore_characters=None, default_characters={'-', ':', '(', 
 
     """
     # only deal with strings
-    if string is None:
+    if not isinstance(string, str):
         return
 
     ignore_characters = ignore_characters or set()


### PR DESCRIPTION
``` 
matches = s.get_matches(video)
  File "/home/victor/programs/bazarr/bazarr/../libs/subliminal_patch/providers/subdivx.py", line 63, in get_matches
    matches |= guess_matches(
  File "/home/victor/programs/bazarr/bazarr/../libs/subliminal_patch/subtitle.py", line 474, in guess_matches
    if video.title and 'title' in guess and sanitize(guess['title']) in (
  File "/home/victor/programs/bazarr/bazarr/../libs/subliminal_patch/utils.py", line 25, in sanitize
    string = re.sub(r'[%s]' % re.escape(''.join(characters)), ' ', string)
  File "/usr/lib/python3.8/re.py", line 210, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: expected string or bytes-like object
```

There was a `TypeError` exception (apparently an unexpected type from guessit) breaking the "Search Wanted" tasks. This small change fixes it.