### PR TITLE
Use sha1 digest as cache key

### DIFF
--- a/libs/subliminal/cache.py
+++ b/libs/subliminal/cache.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 import datetime
+from hashlib import sha1
 
 from dogpile.cache import make_region
 
@@ -14,4 +15,13 @@ EPISODE_EXPIRATION_TIME = datetime.timedelta(days=3).total_seconds()
 REFINER_EXPIRATION_TIME = datetime.timedelta(weeks=1).total_seconds()
 
 
-region = make_region()
+def sha1_key_mangler(key):
+    """Return sha1 hex for cache keys"""
+    if isinstance(key, str):
+        key = key.encode("utf-8")
+
+    return sha1(key).hexdigest()
+
+
+# Use key mangler to limit cache key names to 40 characters
+region = make_region(key_mangler=sha1_key_mangler)


### PR DESCRIPTION
Subliminal uses dogpile.cache to save state of subtitle availability.
Some methods that dogpile.cache caches can have big argument lists,
resulting in a default cache key that is longer than 255 characters.
The dogpile.cache backend used, saves cache items to the filesystem,
using the cache key as filename. This can result in errors about
Filename too long.
SHA1 generates a 160bit hash of the key, and we use the hexadecimal
digest of that hash, resulting in key names of 80 characters.

Related to #1313 