### PR TITLE
Ignore embedded commentary subtitles and reorganize EmbeddedSubsReade…

### DIFF
--- a/bazarr/embedded_subs_reader.py
+++ b/bazarr/embedded_subs_reader.py
@@ -10,6 +10,17 @@ from subliminal.cache import region
 
 FFPROBE_CACHE_EXPIRATION_TIME = datetime.timedelta(weeks=2).total_seconds()
 
+_FFPROBE_SPECIAL_LANGS = {
+    "zho": {
+        "list": ["cht", "tc", "traditional", "zht", "hant", "big5", u"繁", u"雙語"],
+        "alpha3": "zht",
+    },
+    "por": {
+        "list": ["pt-br", "pob", "pb", "brazilian", "brasil", "brazil"],
+        "alpha3": "pob",
+    },
+}
+
 
 class EmbeddedSubsReader:
     def __init__(self):
@@ -19,50 +30,75 @@ class EmbeddedSubsReader:
     # file_size, episode_file_id and movie_file_id are used for cache identification. DO NOT REMOVE!
     def list_languages(self, file, file_size, episode_file_id=None, movie_file_id=None):
         from utils import get_binary
-        self.ffprobe = get_binary("ffprobe")
+
+        if self.ffprobe is None:  # Don't call get_binary if already set
+            self.ffprobe = get_binary("ffprobe")
 
         subtitles_list = []
         if self.ffprobe:
-            api.initialize({'provider': 'ffmpeg', 'ffmpeg': self.ffprobe})
-            data = api.know(file)
-
-            traditional_chinese = ["cht", "tc", "traditional", "zht", "hant", "big5", u"繁", u"雙語"]
-            brazilian_portuguese = ["pt-br", "pob", "pb", "brazilian", "brasil", "brazil"]
-
-            if 'subtitle' in data:
-                for detected_language in data['subtitle']:
-                    if 'language' in detected_language:
-                        language = detected_language['language'].alpha3
-                        if language == 'zho' and 'name' in detected_language:
-                            if any (ext in (detected_language['name'].lower()) for ext in traditional_chinese):
-                                language = 'zht'
-                        if language == 'por' and 'name' in detected_language:
-                            if any (ext in (detected_language['name'].lower()) for ext in brazilian_portuguese):
-                                language = 'pob'
-                        forced = detected_language['forced'] if 'forced' in detected_language else False
-                        hearing_impaired = detected_language['hearing_impaired'] if 'hearing_impaired' in \
-                                                                                    detected_language else False
-                        codec = detected_language['format'] if 'format' in detected_language else None
-                        subtitles_list.append([language, forced, hearing_impaired, codec])
-                    else:
-                        continue
-        else:
-            if os.path.splitext(file)[1] == '.mkv':
-                with open(file, 'rb') as f:
-                    try:
-                        mkv = enzyme.MKV(f)
-                    except MalformedMKVError:
-                        logging.error('BAZARR cannot analyze this MKV with our built-in MKV parser, you should install ffmpeg: ' + file)
-                    else:
-                        for subtitle_track in mkv.subtitle_tracks:
-                            hearing_impaired = False
-                            if subtitle_track.name:
-                                if 'sdh' in subtitle_track.name.lower():
-                                    hearing_impaired = True
-                            subtitles_list.append([subtitle_track.language, subtitle_track.forced, hearing_impaired,
-                                                   subtitle_track.codec_id])
+            subtitles_list += self._ffprobe_scan(file)
+        elif file.endswith(".mkv"):
+            subtitles_list += self._mkv_fallback(file)
 
         return subtitles_list
+
+    def _ffprobe_scan(self, file):
+        api.initialize({"provider": "ffmpeg", "ffmpeg": self.ffprobe})
+        data = api.know(file)
+
+        if "subtitle" in data:
+            for detected_language in data["subtitle"]:
+                if not "language" in detected_language:
+                    continue
+
+                # Avoid commentary subtitles
+                name = detected_language.get("name", "").lower()
+                if "commentary" in name:
+                    logging.debug("Ignoring commentary subtitle: %s", name)
+                    continue
+
+                language = self._handle_alpha3(detected_language)
+
+                forced = detected_language.get("forced", False)
+                hearing_impaired = detected_language.get("hearing_impaired", False)
+                codec = detected_language.get("format")  # or None
+                yield [language, forced, hearing_impaired, codec]
+
+    @staticmethod
+    def _handle_alpha3(detected_language: dict):
+        alpha3 = detected_language["language"].alpha3
+        name = detected_language.get("name")
+
+        lang_dict = _FFPROBE_SPECIAL_LANGS.get(alpha3)
+        if lang_dict is None or name is None:
+            return alpha3  # The original alpha3
+
+        if any(ext in name for ext in lang_dict["list"]):
+            return lang_dict["alpha3"]  # Guessed alpha from _FFPROBE_OTHER_LANGS
+
+        return alpha3  # In any case
+
+    @staticmethod
+    def _mkv_fallback(file):
+        with open(file, "rb") as f:
+            try:
+                mkv = enzyme.MKV(f)
+            except MalformedMKVError:
+                logging.error(
+                    "BAZARR cannot analyze this MKV with our built-in "
+                    "MKV parser, you should install ffmpeg: " + file
+                )
+            else:
+                for subtitle_track in mkv.subtitle_tracks:
+                    hearing_impaired = False
+                    if subtitle_track.name:
+                        hearing_impaired = "sdh" in subtitle_track.name.lower()
+                    yield [
+                        subtitle_track.language,
+                        subtitle_track.forced,
+                        hearing_impaired,
+                        subtitle_track.codec_id,
+                    ]
 
 
 embedded_subs_reader = EmbeddedSubsReader()

--- a/bazarr/embedded_subs_reader.py
+++ b/bazarr/embedded_subs_reader.py
@@ -1,14 +1,13 @@
 # coding=utf-8
 
-import enzyme
-from enzyme.exceptions import MalformedMKVError
 import logging
 import os
-import datetime
+import pickle
 from knowit import api
-from subliminal.cache import region
-
-FFPROBE_CACHE_EXPIRATION_TIME = datetime.timedelta(weeks=2).total_seconds()
+import enzyme
+from enzyme.exceptions import MalformedMKVError
+from enzyme.exceptions import MalformedMKVError
+from database import database
 
 _FFPROBE_SPECIAL_LANGS = {
     "zho": {
@@ -21,84 +20,111 @@ _FFPROBE_SPECIAL_LANGS = {
     },
 }
 
+def _handle_alpha3(detected_language: dict):
+    alpha3 = detected_language["language"].alpha3
 
-class EmbeddedSubsReader:
-    def __init__(self):
-        self.ffprobe = None
+    name = detected_language.get("name", "").lower()
+    special_lang = _FFPROBE_SPECIAL_LANGS.get(alpha3)
 
-    @region.cache_on_arguments(expiration_time=FFPROBE_CACHE_EXPIRATION_TIME)
-    # file_size, episode_file_id and movie_file_id are used for cache identification. DO NOT REMOVE!
-    def list_languages(self, file, file_size, episode_file_id=None, movie_file_id=None):
-        from utils import get_binary
+    if special_lang is None or not name:
+        return alpha3  # The original alpha3
 
-        if self.ffprobe is None:  # Don't call get_binary if already set
-            self.ffprobe = get_binary("ffprobe")
+    if any(ext in name for ext in special_lang["list"]):
+        return special_lang["alpha3"]  # Guessed alpha from _FFPROBE_OTHER_LANGS
 
-        subtitles_list = []
-        if self.ffprobe:
-            subtitles_list += self._ffprobe_scan(file)
-        elif file.endswith(".mkv"):
-            subtitles_list += self._mkv_fallback(file)
+    return alpha3  # In any case
 
-        return subtitles_list
+def embedded_subs_reader(file, file_size, episode_file_id=None, movie_file_id=None):
+    data = parse_video_metadata(file, file_size, episode_file_id, movie_file_id)
 
-    def _ffprobe_scan(self, file):
-        api.initialize({"provider": "ffmpeg", "ffmpeg": self.ffprobe})
-        data = api.know(file)
+    subtitles_list = []
+    if data['ffprobe'] and 'subtitle' in data['ffprobe']:
+        for detected_language in data['ffprobe']['subtitle']:
+            if not "language" in detected_language:
+                continue
 
-        if "subtitle" in data:
-            for detected_language in data["subtitle"]:
-                if not "language" in detected_language:
-                    continue
+            # Avoid commentary subtitles
+            name = detected_language.get("name", "").lower()
+            if "commentary" in name:
+                logging.debug("Ignoring commentary subtitle: %s", name)
+                continue
 
-                # Avoid commentary subtitles
-                name = detected_language.get("name", "").lower()
-                if "commentary" in name:
-                    logging.debug("Ignoring commentary subtitle: %s", name)
-                    continue
+            language = _handle_alpha3(detected_language)
 
-                language = self._handle_alpha3(detected_language)
+            forced = detected_language.get("forced", False)
+            hearing_impaired = detected_language.get("hearing_impaired", False)
+            codec = detected_language.get("format") # or None
+            subtitles_list.append([language, forced, hearing_impaired, codec])
 
-                forced = detected_language.get("forced", False)
-                hearing_impaired = detected_language.get("hearing_impaired", False)
-                codec = detected_language.get("format")  # or None
-                yield [language, forced, hearing_impaired, codec]
+    elif data['enzyme']:
+        for subtitle_track in data['enzyme'].subtitle_tracks:
+            hearing_impaired = subtitle_track.name and "sdh" in subtitle_track.name.lower()
 
-    @staticmethod
-    def _handle_alpha3(detected_language: dict):
-        alpha3 = detected_language["language"].alpha3
-        name = detected_language.get("name")
+            subtitles_list.append([subtitle_track.language, subtitle_track.forced, hearing_impaired,
+                                   subtitle_track.codec_id])
 
-        lang_dict = _FFPROBE_SPECIAL_LANGS.get(alpha3)
-        if lang_dict is None or name is None:
-            return alpha3  # The original alpha3
-
-        if any(ext in name for ext in lang_dict["list"]):
-            return lang_dict["alpha3"]  # Guessed alpha from _FFPROBE_OTHER_LANGS
-
-        return alpha3  # In any case
-
-    @staticmethod
-    def _mkv_fallback(file):
-        with open(file, "rb") as f:
-            try:
-                mkv = enzyme.MKV(f)
-            except MalformedMKVError:
-                logging.error(
-                    "BAZARR cannot analyze this MKV with our built-in "
-                    "MKV parser, you should install ffmpeg: " + file
-                )
-            else:
-                for subtitle_track in mkv.subtitle_tracks:
-                    hearing_impaired = False
-                    if subtitle_track.name:
-                        hearing_impaired = "sdh" in subtitle_track.name.lower()
-                    yield [
-                        subtitle_track.language,
-                        subtitle_track.forced,
-                        hearing_impaired,
-                        subtitle_track.codec_id,
-                    ]
+    return subtitles_list
 
 
-embedded_subs_reader = EmbeddedSubsReader()
+def parse_video_metadata(file, file_size, episode_file_id=None, movie_file_id=None):
+    # Define default data keys value
+    data = {
+        'ffprobe': {},
+        'enzyme': {},
+        'file_id': episode_file_id or movie_file_id,
+        'file_size': file_size
+    }
+
+    # Get the actual cache value form database
+    if episode_file_id:
+        cache_key = database.execute('SELECT ffprobe_cache FROM table_episodes WHERE episode_file_id=? AND file_size=?',
+                                     (episode_file_id, file_size), only_one=True)
+    elif movie_file_id:
+        cache_key = database.execute('SELECT ffprobe_cache FROM table_movies WHERE movie_file_id=? AND file_size=?',
+                                     (movie_file_id, file_size), only_one=True)
+    else:
+        cache_key = None
+
+    # check if we have a value for that cache key
+    if not isinstance(cache_key, dict):
+        return data
+    else:
+        try:
+            # Unpickle ffprobe cache
+            cached_value = pickle.loads(cache_key['ffprobe_cache'])
+        except:
+            pass
+        else:
+            # Check if file size and file id matches and if so, we return the cached value
+            if cached_value['file_size'] == file_size and cached_value['file_id'] in [episode_file_id, movie_file_id]:
+                return cached_value
+
+    # if not, we retrieve the metadata from the file
+    from utils import get_binary
+    ffprobe_path = get_binary("ffprobe")
+
+    # if we have ffprobe available
+    if ffprobe_path:
+        api.initialize({'provider': 'ffmpeg', 'ffmpeg': ffprobe_path})
+        data['ffprobe'] = api.know(file)
+    # if nto, we use enzyme for mkv files
+    else:
+        if os.path.splitext(file)[1] == '.mkv':
+            with open(file, 'rb') as f:
+                try:
+                    mkv = enzyme.MKV(f)
+                except MalformedMKVError:
+                    logging.error(
+                        'BAZARR cannot analyze this MKV with our built-in MKV parser, you should install '
+                        'ffmpeg/ffprobe: ' + file)
+                else:
+                    data['enzyme'] = mkv
+
+    # we write to db the result and return the newly cached ffprobe dict
+    if episode_file_id:
+        database.execute('UPDATE table_episodes SET ffprobe_cache=? WHERE episode_file_id=?',
+                         (pickle.dumps(data, pickle.HIGHEST_PROTOCOL), episode_file_id))
+    elif movie_file_id:
+        database.execute('UPDATE table_movies SET ffprobe_cache=? WHERE movie_file_id=?',
+                         (pickle.dumps(data, pickle.HIGHEST_PROTOCOL), movie_file_id))
+    return data


### PR DESCRIPTION
Sometimes Bazarr detects audio commentary subtitles as main subtitles, which is a common case with movies. I made a workaround for this.

I also tried to improve the class readability to make the maintainability easier. No functionality was lost, already tested.