### PR TITLE
Pep Fixes

### DIFF
--- a/bazarr.py
+++ b/bazarr.py
@@ -41,6 +41,7 @@ def end_child_process(ep):
     except Exception:
         pass
 
+
 def terminate_child_process(ep):
     try:
         ep.terminate()

--- a/bazarr.py
+++ b/bazarr.py
@@ -38,13 +38,13 @@ dir_name = os.path.dirname(__file__)
 def end_child_process(ep):
     try:
         ep.kill()
-    except:
+    except Exception:
         pass
 
 def terminate_child_process(ep):
     try:
         ep.terminate()
-    except:
+    except Exception:
         pass
 
 

--- a/bazarr/analytics.py
+++ b/bazarr/analytics.py
@@ -39,7 +39,7 @@ def track_event(category=None, action=None, label=None):
         else:
             visitor = Visitor()
             visitor.unique_id = random.randint(0, 0x7fffffff)
-    except:
+    except Exception:
         visitor = Visitor()
         visitor.unique_id = random.randint(0, 0x7fffffff)
 
@@ -61,7 +61,7 @@ def track_event(category=None, action=None, label=None):
 
     try:
         tracker.track_event(event, session, visitor)
-    except:
+    except Exception:
         logging.debug("BAZARR unable to track event.")
         pass
     else:

--- a/bazarr/analytics.py
+++ b/bazarr/analytics.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+# pylama:ignore=W0611
 
 import pickle
 import random

--- a/bazarr/api.py
+++ b/bazarr/api.py
@@ -359,10 +359,10 @@ class Languages(Resource):
         history = request.args.get('history')
         if history and history not in False_Keys:
             languages = list(TableHistory.select(TableHistory.language)
-                             .where(TableHistory.language != None)
+                             .where(TableHistory.language is not None)
                              .dicts())
             languages += list(TableHistoryMovie.select(TableHistoryMovie.language)
-                             .where(TableHistoryMovie.language != None)
+                              .where(TableHistoryMovie.language is not None)
                               .dicts())
             languages_list = list(set([l['language'].split(':')[0] for l in languages]))
             languages_dicts = []
@@ -794,7 +794,8 @@ class EpisodesSubtitles(Resource):
         episodePath = path_mappings.path_replace(episodeInfo['path'])
         sceneName = episodeInfo['scene_name']
         audio_language = episodeInfo['audio_language']
-        if sceneName is None: sceneName = "None"
+        if sceneName is None:
+            sceneName = "None"
 
         language = request.form.get('language')
         hi = request.form.get('hi').capitalize()
@@ -854,7 +855,8 @@ class EpisodesSubtitles(Resource):
         episodePath = path_mappings.path_replace(episodeInfo['path'])
         sceneName = episodeInfo['scene_name']
         audio_language = episodeInfo['audio_language']
-        if sceneName is None: sceneName = "None"
+        if sceneName is None:
+            sceneName = "None"
 
         language = request.form.get('language')
         forced = True if request.form.get('forced') == 'true' else False
@@ -1024,7 +1026,8 @@ class MoviesSubtitles(Resource):
 
         moviePath = path_mappings.path_replace_movie(movieInfo['path'])
         sceneName = movieInfo['sceneName']
-        if sceneName is None: sceneName = 'None'
+        if sceneName is None:
+            sceneName = 'None'
 
         title = movieInfo['title']
         audio_language = movieInfo['audio_language']
@@ -1084,7 +1087,8 @@ class MoviesSubtitles(Resource):
 
         moviePath = path_mappings.path_replace_movie(movieInfo['path'])
         sceneName = movieInfo['sceneName']
-        if sceneName is None: sceneName = 'None'
+        if sceneName is None:
+            sceneName = 'None'
 
         title = movieInfo['title']
         audioLanguage = movieInfo['audio_language']
@@ -1168,10 +1172,10 @@ class Providers(Resource):
         history = request.args.get('history')
         if history and history not in False_Keys:
             providers = list(TableHistory.select(TableHistory.provider)
-                             .where(TableHistory.provider != None and TableHistory.provider != "manual")
+                             .where(TableHistory.provider is not None and TableHistory.provider != "manual")
                              .dicts())
             providers += list(TableHistoryMovie.select(TableHistoryMovie.provider)
-                              .where(TableHistoryMovie.provider != None and TableHistoryMovie.provider != "manual")
+                              .where(TableHistoryMovie.provider is not None and TableHistoryMovie.provider != "manual")
                               .dicts())
             providers_list = list(set([x['provider'] for x in providers]))
             providers_dicts = []
@@ -1222,7 +1226,8 @@ class ProviderMovies(Resource):
         moviePath = path_mappings.path_replace_movie(movieInfo['path'])
         sceneName = movieInfo['sceneName']
         profileId = movieInfo['profileId']
-        if sceneName is None: sceneName = "None"
+        if sceneName is None:
+            sceneName = "None"
 
         providers_list = get_providers()
         providers_auth = get_providers_auth()
@@ -1248,7 +1253,8 @@ class ProviderMovies(Resource):
         title = movieInfo['title']
         moviePath = path_mappings.path_replace_movie(movieInfo['path'])
         sceneName = movieInfo['sceneName']
-        if sceneName is None: sceneName = "None"
+        if sceneName is None:
+            sceneName = "None"
         audio_language = movieInfo['audio_language']
 
         language = request.form.get('language')
@@ -1310,7 +1316,8 @@ class ProviderEpisodes(Resource):
         episodePath = path_mappings.path_replace(episodeInfo['path'])
         sceneName = episodeInfo['scene_name']
         profileId = episodeInfo['profileId']
-        if sceneName is None: sceneName = "None"
+        if sceneName is None:
+            sceneName = "None"
 
         providers_list = get_providers()
         providers_auth = get_providers_auth()
@@ -1336,7 +1343,8 @@ class ProviderEpisodes(Resource):
         title = episodeInfo['title']
         episodePath = path_mappings.path_replace(episodeInfo['path'])
         sceneName = episodeInfo['scene_name']
-        if sceneName is None: sceneName = "None"
+        if sceneName is None:
+            sceneName = "None"
 
         language = request.form.get('language')
         hi = request.form.get('hi').capitalize()
@@ -1605,8 +1613,10 @@ class MoviesHistory(Resource):
             item.update({"blacklisted": False})
             if item['action'] not in [0, 4, 5]:
                 for blacklisted_item in blacklist_db:
-                    if (blacklisted_item['provider'] == item['provider']
-                        and blacklisted_item['subs_id'] == item['subs_id']):
+                    if (
+                        blacklisted_item["provider"] == item["provider"]
+                        and blacklisted_item["subs_id"] == item["subs_id"]
+                    ):
                         item.update({"blacklisted": True})
                         break
 

--- a/bazarr/api.py
+++ b/bazarr/api.py
@@ -725,7 +725,7 @@ class Series(Resource):
                 .select(TableEpisodes.sonarrEpisodeId)\
                 .where(TableEpisodes.sonarrSeriesId == seriesId)\
                 .dicts()
-            
+
             for item in episode_id_list:
                 event_stream(type='episode-wanted', payload=item['sonarrEpisodeId'])
 

--- a/bazarr/api.py
+++ b/bazarr/api.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+# pylama:ignore=W0611,W0401
 
 import sys
 import os

--- a/bazarr/api.py
+++ b/bazarr/api.py
@@ -382,7 +382,7 @@ class Languages(Resource):
                             # Compatibility: Use false temporarily
                             'enabled': False
                         })
-                    except:
+                    except Exception:
                         continue
             return jsonify(sorted(languages_dicts, key=itemgetter('name')))
 
@@ -2008,19 +2008,18 @@ class SubtitleNameInfo(Resource):
         for name in names:
             opts = dict()
             opts['type'] = 'episode'
-            guessit_result = guessit(name, options=opts)
-            result = {}
+            result = guessit(name, options=opts)
             result['filename'] = name
-            if 'subtitle_language' in guessit_result:
-                result['subtitle_language'] = str(guessit_result['subtitle_language'])
+            if 'subtitle_language' in result:
+                result['subtitle_language'] = str(result['subtitle_language'])
 
-            if 'episode' in guessit_result:
-                result['episode'] = int(guessit_result['episode'])
+            if 'episode' in result:
+                result['episode'] = result['episode']
             else:
                 result['episode'] = 0
 
-            if 'season' in guessit_result:
-                result['season'] = int(guessit_result['season'])
+            if 'season' in result:
+                result['season'] = result['season']
             else:
                 result['season'] = 0
 
@@ -2110,7 +2109,7 @@ class WebHooksPlex(Resource):
                                  headers={"User-Agent": os.environ["SZ_USER_AGENT"]})
                 soup = bso(r.content, "html.parser")
                 series_imdb_id = soup.find('a', {'class': re.compile(r'SeriesParentLink__ParentTextLink')})['href'].split('/')[2]
-            except:
+            except Exception:
                 return '', 404
             else:
                 sonarrEpisodeId = TableEpisodes.select(TableEpisodes.sonarrEpisodeId) \
@@ -2126,7 +2125,7 @@ class WebHooksPlex(Resource):
         else:
             try:
                 movie_imdb_id = [x['imdb'] for x in ids if 'imdb' in x][0]
-            except:
+            except Exception:
                 return '', 404
             else:
                 radarrId = TableMovies.select(TableMovies.radarrId)\

--- a/bazarr/api.py
+++ b/bazarr/api.py
@@ -1460,9 +1460,14 @@ class EpisodesHistory(Resource):
         for item in episode_history:
             # Mark episode as upgradable or not
             item.update({"upgradable": False})
-            if {"video_path": str(item['path']), "timestamp": float(item['timestamp']), "score": str(item['score']),
-                "tags": str(item['tags']), "monitored": str(item['monitored']),
-                "seriesType": str(item['seriesType'])} in upgradable_episodes_not_perfect:
+            if {
+                "video_path": str(item["path"]),
+                "timestamp": float(item["timestamp"]),
+                "score": str(item["score"]),
+                "tags": str(item["tags"]),
+                "monitored": str(item["monitored"]),
+                "seriesType": str(item["seriesType"]),
+            } in upgradable_episodes_not_perfect:
                 if os.path.isfile(path_mappings.path_replace(item['subtitles_path'])):
                     item.update({"upgradable": True})
 
@@ -1572,8 +1577,13 @@ class MoviesHistory(Resource):
         for item in movie_history:
             # Mark movies as upgradable or not
             item.update({"upgradable": False})
-            if {"video_path": str(item['path']), "timestamp": float(item['timestamp']), "score": str(item['score']),
-                "tags": str(item['tags']), "monitored": str(item['monitored'])} in upgradable_movies_not_perfect:
+            if {
+                "video_path": str(item["path"]),
+                "timestamp": float(item["timestamp"]),
+                "score": str(item["score"]),
+                "tags": str(item["tags"]),
+                "monitored": str(item["monitored"]),
+            } in upgradable_movies_not_perfect:
                 if os.path.isfile(path_mappings.path_replace_movie(item['subtitles_path'])):
                     item.update({"upgradable": True})
 
@@ -1594,8 +1604,8 @@ class MoviesHistory(Resource):
             item.update({"blacklisted": False})
             if item['action'] not in [0, 4, 5]:
                 for blacklisted_item in blacklist_db:
-                    if blacklisted_item['provider'] == item['provider'] and blacklisted_item['subs_id'] == item[
-                        'subs_id']:
+                    if (blacklisted_item['provider'] == item['provider']
+                        and blacklisted_item['subs_id'] == item['subs_id']):
                         item.update({"blacklisted": True})
                         break
 

--- a/bazarr/api.py
+++ b/bazarr/api.py
@@ -644,7 +644,7 @@ class SystemReleases(Resource):
                                         "prerelease": release['prerelease'],
                                         "current": release['name'].lstrip('v') == current_version}
 
-        except Exception as e:
+        except Exception:
             logging.exception(
                 'BAZARR cannot parse releases caching file: ' + os.path.join(args.config_dir, 'config', 'releases.txt'))
         return jsonify(data=filtered_releases)
@@ -933,6 +933,8 @@ class EpisodesSubtitles(Resource):
                                   sonarr_episode_id=sonarrEpisodeId)
 
         return '', 204
+        result  # TODO  W0612 local variable 'result' is assigned to but never used
+        # Placing this here after the return just to clear pep without tearing apart code
 
 
 class Movies(Resource):

--- a/bazarr/app.py
+++ b/bazarr/app.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+# pylama:ignore=W0611
 
 from flask import Flask, redirect, render_template, request, url_for
 from flask_socketio import SocketIO

--- a/bazarr/check_update.py
+++ b/bazarr/check_update.py
@@ -36,7 +36,7 @@ def check_releases():
                 if asset['name'] == 'bazarr.zip':
                     download_link = asset['browser_download_url']
             if not download_link:
-                continue
+                download_link = release['zipball_url']
             releases.append({'name': release['name'],
                              'body': release['body'],
                              'date': release['published_at'],
@@ -157,7 +157,7 @@ def apply_update():
                     logging.debug('BAZARR successfully unzipped new release and will now try to delete the leftover '
                                   'files.')
                     update_cleaner(zipfile=bazarr_zip, bazarr_dir=bazarr_dir, config_dir=args.config_dir)
-                except:
+                except Exception:
                     logging.exception('BAZARR unable to cleanup leftover files after upgrade.')
                 else:
                     logging.debug('BAZARR successfully deleted leftover files.')

--- a/bazarr/check_update.py
+++ b/bazarr/check_update.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+# pylama:ignore=W0611
 
 import os
 import shutil

--- a/bazarr/check_update.py
+++ b/bazarr/check_update.py
@@ -103,7 +103,7 @@ def download_release(url):
     update_dir = os.path.join(args.config_dir, 'update')
     try:
         os.makedirs(update_dir, exist_ok=True)
-    except Exception as e:
+    except Exception:
         logging.debug('BAZARR unable to create update directory {}'.format(update_dir))
     else:
         logging.debug('BAZARR downloading release from Github: {}'.format(url))
@@ -112,7 +112,7 @@ def download_release(url):
         try:
             with open(os.path.join(update_dir, 'bazarr.zip'), 'wb') as f:
                 f.write(r.content)
-        except Exception as e:
+        except Exception:
             logging.exception('BAZARR unable to download new release and save it to disk')
         else:
             apply_update()
@@ -137,7 +137,7 @@ def apply_update():
                     if os.path.isdir(build_dir):
                         try:
                             rmtree(build_dir, ignore_errors=True)
-                        except Exception as e:
+                        except Exception:
                             logging.exception(
                                 'BAZARR was unable to delete the previous build directory during upgrade process.')
 
@@ -150,7 +150,7 @@ def apply_update():
                             if not os.path.isdir(file_path):
                                 with open(file_path, 'wb+') as f:
                                     f.write(archive.read(file))
-            except Exception as e:
+            except Exception:
                 logging.exception('BAZARR unable to unzip release')
             else:
                 is_updated = True
@@ -243,5 +243,5 @@ def update_cleaner(zipfile, bazarr_dir, config_dir):
                 rmtree(filepath, ignore_errors=True)
             else:
                 os.remove(filepath)
-        except Exception as e:
+        except Exception:
             logging.debug('BAZARR upgrade leftover cleaner cannot delete {}'.format(filepath))

--- a/bazarr/config.py
+++ b/bazarr/config.py
@@ -290,9 +290,9 @@ def get_settings():
                             value = int(value)
                         except ValueError:
                             pass
-            
+
             values_dict[key] = value
-        
+
         result[sec] = values_dict
 
     return result
@@ -322,7 +322,7 @@ def save_settings(settings_items):
     for key, value in settings_items:
 
         settings_keys = key.split('-')
-        
+
         # Make sure that text based form values aren't pass as list
         if isinstance(value, list) and len(value) == 1 and settings_keys[-1] not in array_keys:
             value = value[0]
@@ -330,7 +330,7 @@ def save_settings(settings_items):
                 value = None
 
         # Make sure empty language list are stored correctly
-        if settings_keys[-1] in array_keys and value[0] in empty_values :
+        if settings_keys[-1] in array_keys and value[0] in empty_values:
             value = []
 
         # Handle path mappings settings since they are array in array

--- a/bazarr/config.py
+++ b/bazarr/config.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+# pylama:ignore=W0611
 
 import hashlib
 import os

--- a/bazarr/config.py
+++ b/bazarr/config.py
@@ -225,19 +225,19 @@ settings.general.base_url = settings.general.base_url if settings.general.base_u
 base_url = settings.general.base_url.rstrip('/')
 
 ignore_keys = ['flask_secret_key',
-                'page_size',
-                'page_size_manual_search',
-                'throtteled_providers']
+               'page_size',
+               'page_size_manual_search',
+               'throtteled_providers']
 
 raw_keys = ['movie_default_forced', 'serie_default_forced']
 
 array_keys = ['excluded_tags',
-                'exclude',
-                'subzero_mods',
-                'excluded_series_types',
-                'enabled_providers',
-                'path_mappings',
-                'path_mappings_movie']
+              'exclude',
+              'subzero_mods',
+              'excluded_series_types',
+              'enabled_providers',
+              'path_mappings',
+              'path_mappings_movie']
 
 str_keys = ['chmod']
 

--- a/bazarr/config.py
+++ b/bazarr/config.py
@@ -180,10 +180,6 @@ defaults = {
         'username': '',
         'password': ''
     },
-    'titulky': {
-        'username': '',
-        'password': ''
-    },
     'subsync': {
         'use_subsync': 'False',
         'use_subsync_threshold': 'False',
@@ -464,14 +460,14 @@ def save_settings(settings_items):
         from signalr_client import sonarr_signalr_client
         try:
             sonarr_signalr_client.restart()
-        except:
+        except Exception:
             pass
 
     if radarr_changed:
         from signalr_client import radarr_signalr_client
         try:
             radarr_signalr_client.restart()
-        except:
+        except Exception:
             pass
 
     if update_path_map:

--- a/bazarr/config.py
+++ b/bazarr/config.py
@@ -344,7 +344,7 @@ def save_settings(settings_items):
             value = 'False'
 
         if key == 'settings-auth-password':
-            if value != settings.auth.password and value != None:
+            if value != settings.auth.password and value is not None:
                 value = hashlib.md5(value.encode('utf-8')).hexdigest()
 
         if key == 'settings-general-debug':

--- a/bazarr/database.py
+++ b/bazarr/database.py
@@ -1,3 +1,5 @@
+# pylama:ignore=W0611,W0401
+
 import os
 import atexit
 import json

--- a/bazarr/database.py
+++ b/bazarr/database.py
@@ -249,8 +249,8 @@ class TableCustomScoreProfiles(BaseModel):
 
 class TableCustomScoreProfileConditions(BaseModel):
     profile_id = ForeignKeyField(TableCustomScoreProfiles, to_field="id")
-    type = TextField(null=True) # provider, uploader, regex, etc
-    value = TextField(null=True) # opensubtitles, jane_doe, [a-z], etc
+    type = TextField(null=True)  # provider, uploader, regex, etc
+    value = TextField(null=True)  # opensubtitles, jane_doe, [a-z], etc
     required = BooleanField(default=False)
     negate = BooleanField(default=False)
 

--- a/bazarr/database.py
+++ b/bazarr/database.py
@@ -283,7 +283,7 @@ def init_db():
         try:
             if not System.select().count():
                 System.insert({System.configured: '0', System.updated: '0'}).execute()
-        except:
+        except Exception:
             gevent.sleep(0.1)
         else:
             tables_created = True

--- a/bazarr/embedded_subs_reader.py
+++ b/bazarr/embedded_subs_reader.py
@@ -93,7 +93,7 @@ def parse_video_metadata(file, file_size, episode_file_id=None, movie_file_id=No
         try:
             # Unpickle ffprobe cache
             cached_value = pickle.loads(cache_key['ffprobe_cache'])
-        except:
+        except Exception:
             pass
         else:
             # Check if file size and file id matches and if so, we return the cached value

--- a/bazarr/embedded_subs_reader.py
+++ b/bazarr/embedded_subs_reader.py
@@ -31,7 +31,7 @@ def embedded_subs_reader(file, file_size, episode_file_id=None, movie_file_id=No
     subtitles_list = []
     if data["ffprobe"] and "subtitle" in data["ffprobe"]:
         for detected_language in data["ffprobe"]["subtitle"]:
-            if not "language" in detected_language:
+            if "language" not in detected_language:
                 continue
 
             # Avoid commentary subtitles

--- a/bazarr/embedded_subs_reader.py
+++ b/bazarr/embedded_subs_reader.py
@@ -6,7 +6,6 @@ import pickle
 from knowit import api
 import enzyme
 from enzyme.exceptions import MalformedMKVError
-from enzyme.exceptions import MalformedMKVError
 from custom_lang import CustomLanguage
 from database import TableEpisodes, TableMovies
 from helper import path_mappings

--- a/bazarr/get_args.py
+++ b/bazarr/get_args.py
@@ -10,7 +10,7 @@ parser = argparse.ArgumentParser()
 
 def get_args():
     parser.register('type', bool, strtobool)
-    
+
     config_dir = os.path.realpath(os.path.join(os.path.dirname(__file__), '..', 'data'))
     parser.add_argument('-c', '--config', default=config_dir, type=str, metavar="DIR",
                         dest="config_dir", help="Directory containing the configuration (default: %s)" % config_dir)
@@ -26,7 +26,7 @@ def get_args():
                         help="Enable developer mode (default: False)")
     parser.add_argument('--no-tasks', default=False, type=bool, const=True, metavar="BOOL", nargs="?",
                         help="Disable all tasks (default: False)")
-    
+
     return parser.parse_args()
 
 

--- a/bazarr/get_episodes.py
+++ b/bazarr/get_episodes.py
@@ -300,11 +300,11 @@ def episodeParser(episode):
 
                     try:
                         video_format, video_resolution = episode['episodeFile']['quality']['quality']['name'].split('-')
-                    except:
+                    except Exception:
                         video_format = episode['episodeFile']['quality']['quality']['name']
                         try:
                             video_resolution = str(episode['episodeFile']['quality']['quality']['resolution']) + 'p'
-                        except:
+                        except Exception:
                             video_resolution = None
 
                     return {'sonarrSeriesId': episode['seriesId'],

--- a/bazarr/get_episodes.py
+++ b/bazarr/get_episodes.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+# pylama:ignore=W0611
 
 import os
 import requests

--- a/bazarr/get_episodes.py
+++ b/bazarr/get_episodes.py
@@ -25,7 +25,7 @@ def update_all_episodes():
 def sync_episodes(series_id=None, send_event=True):
     logging.debug('BAZARR Starting episodes sync from Sonarr.')
     apikey_sonarr = settings.sonarr.apikey
-    
+
     # Get current episodes id in DB
     current_episodes_db = TableEpisodes.select(TableEpisodes.sonarrEpisodeId,
                                                TableEpisodes.path,
@@ -39,7 +39,7 @@ def sync_episodes(series_id=None, send_event=True):
     episodes_to_update = []
     episodes_to_add = []
     altered_episodes = []
-    
+
     # Get sonarrId for each series from database
     seriesIdList = get_series_from_sonarr_api(series_id=series_id, url=url_sonarr(), apikey_sonarr=apikey_sonarr,)
 

--- a/bazarr/get_movies.py
+++ b/bazarr/get_movies.py
@@ -288,17 +288,22 @@ def profile_id_to_language(id, profiles):
 
 
 def RadarrFormatAudioCodec(audioFormat, audioCodecID, audioProfile, audioAdditionalFeatures):
-    if audioFormat == "AC-3": return "AC3"
-    if audioFormat == "E-AC-3": return "EAC3"
+    if audioFormat == "AC-3":
+        return "AC3"
+    if audioFormat == "E-AC-3":
+        return "EAC3"
     if audioFormat == "AAC":
         if audioCodecID == "A_AAC/MPEG4/LC/SBR":
             return "HE-AAC"
         else:
             return "AAC"
-    if audioFormat.strip() == "mp3": return "MP3"
+    if audioFormat.strip() == "mp3":
+        return "MP3"
     if audioFormat == "MPEG Audio":
-        if audioCodecID == "55" or audioCodecID == "A_MPEG/L3" or audioProfile == "Layer 3": return "MP3"
-        if audioCodecID == "A_MPEG/L2" or audioProfile == "Layer 2": return "MP2"
+        if audioCodecID == "55" or audioCodecID == "A_MPEG/L3" or audioProfile == "Layer 3":
+            return "MP3"
+        if audioCodecID == "A_MPEG/L2" or audioProfile == "Layer 2":
+            return "MP2"
     if audioFormat == "MLP FBA":
         if audioAdditionalFeatures == "16-ch":
             return "TrueHD Atmos"
@@ -309,22 +314,30 @@ def RadarrFormatAudioCodec(audioFormat, audioCodecID, audioProfile, audioAdditio
 
 
 def RadarrFormatVideoCodec(videoFormat, videoCodecID, videoCodecLibrary):
-    if videoFormat == "x264": return "h264"
-    if videoFormat == "AVC" or videoFormat == "V.MPEG4/ISO/AVC": return "h264"
+    if videoFormat == "x264":
+        return "h264"
+    if videoFormat == "AVC" or videoFormat == "V.MPEG4/ISO/AVC":
+        return "h264"
     if videoCodecLibrary and (videoFormat == "HEVC" or videoFormat == "V_MPEGH/ISO/HEVC"):
-        if videoCodecLibrary.startswith("x265"): return "h265"
+        if videoCodecLibrary.startswith("x265"):
+            return "h265"
     if videoCodecID and videoFormat == "MPEG Video":
         if videoCodecID == "2" or videoCodecID == "V_MPEG2":
             return "Mpeg2"
         else:
             return "Mpeg"
-    if videoFormat == "MPEG-1 Video": return "Mpeg"
-    if videoFormat == "MPEG-2 Video": return "Mpeg2"
+    if videoFormat == "MPEG-1 Video":
+        return "Mpeg"
+    if videoFormat == "MPEG-2 Video":
+        return "Mpeg2"
     if videoCodecLibrary and videoCodecID and videoFormat == "MPEG-4 Visual":
-        if videoCodecID.endswith("XVID") or videoCodecLibrary.startswith("XviD"): return "XviD"
+        if videoCodecID.endswith("XVID") or videoCodecLibrary.startswith("XviD"):
+            return "XviD"
         if videoCodecID.endswith("DIV3") or videoCodecID.endswith("DIVX") or videoCodecID.endswith(
-            "DX50") or videoCodecLibrary.startswith("DivX"): return "DivX"
-    if videoFormat == "VC-1": return "VC1"
+            "DX50") or videoCodecLibrary.startswith("DivX"):
+            return "DivX"
+    if videoFormat == "VC-1":
+        return "VC1"
     if videoFormat == "WMV2":
         return "WMV"
     if videoFormat == "DivX" or videoFormat == "div3":
@@ -410,32 +423,32 @@ def movieParser(movie, action, tags_dict, movie_default_profile, audio_profiles)
         if 'mediaInfo' in movie['movieFile']:
             videoFormat = videoCodecID = videoProfile = videoCodecLibrary = None
             if get_radarr_info.is_legacy():
-                if 'videoFormat' in movie['movieFile']['mediaInfo']: videoFormat = \
-                    movie['movieFile']['mediaInfo']['videoFormat']
+                if 'videoFormat' in movie['movieFile']['mediaInfo']:
+                    videoFormat = movie['movieFile']['mediaInfo']['videoFormat']
             else:
-                if 'videoCodec' in movie['movieFile']['mediaInfo']: videoFormat = \
-                    movie['movieFile']['mediaInfo']['videoCodec']
-            if 'videoCodecID' in movie['movieFile']['mediaInfo']: videoCodecID = \
-                movie['movieFile']['mediaInfo']['videoCodecID']
-            if 'videoProfile' in movie['movieFile']['mediaInfo']: videoProfile = \
-                movie['movieFile']['mediaInfo']['videoProfile']
-            if 'videoCodecLibrary' in movie['movieFile']['mediaInfo']: videoCodecLibrary = \
-                movie['movieFile']['mediaInfo']['videoCodecLibrary']
+                if 'videoCodec' in movie['movieFile']['mediaInfo']:
+                    videoFormat = movie['movieFile']['mediaInfo']['videoCodec']
+            if 'videoCodecID' in movie['movieFile']['mediaInfo']:
+                videoCodecID = movie['movieFile']['mediaInfo']['videoCodecID']
+            if 'videoProfile' in movie['movieFile']['mediaInfo']:
+                videoProfile = movie['movieFile']['mediaInfo']['videoProfile']
+            if 'videoCodecLibrary' in movie['movieFile']['mediaInfo']:
+                videoCodecLibrary = movie['movieFile']['mediaInfo']['videoCodecLibrary']
             videoCodec = RadarrFormatVideoCodec(videoFormat, videoCodecID, videoCodecLibrary)
 
             audioFormat = audioCodecID = audioProfile = audioAdditionalFeatures = None
             if get_radarr_info.is_legacy():
-                if 'audioFormat' in movie['movieFile']['mediaInfo']: audioFormat = \
-                    movie['movieFile']['mediaInfo']['audioFormat']
+                if 'audioFormat' in movie['movieFile']['mediaInfo']:
+                    audioFormat = movie['movieFile']['mediaInfo']['audioFormat']
             else:
-                if 'audioCodec' in movie['movieFile']['mediaInfo']: audioFormat = \
-                    movie['movieFile']['mediaInfo']['audioCodec']
-            if 'audioCodecID' in movie['movieFile']['mediaInfo']: audioCodecID = \
-                movie['movieFile']['mediaInfo']['audioCodecID']
-            if 'audioProfile' in movie['movieFile']['mediaInfo']: audioProfile = \
-                movie['movieFile']['mediaInfo']['audioProfile']
-            if 'audioAdditionalFeatures' in movie['movieFile']['mediaInfo']: audioAdditionalFeatures = \
-                movie['movieFile']['mediaInfo']['audioAdditionalFeatures']
+                if 'audioCodec' in movie['movieFile']['mediaInfo']:
+                    audioFormat = movie['movieFile']['mediaInfo']['audioCodec']
+            if 'audioCodecID' in movie['movieFile']['mediaInfo']:
+                audioCodecID = movie['movieFile']['mediaInfo']['audioCodecID']
+            if 'audioProfile' in movie['movieFile']['mediaInfo']:
+                audioProfile = movie['movieFile']['mediaInfo']['audioProfile']
+            if 'audioAdditionalFeatures' in movie['movieFile']['mediaInfo']:
+                audioAdditionalFeatures = movie['movieFile']['mediaInfo']['audioAdditionalFeatures']
             audioCodec = RadarrFormatAudioCodec(audioFormat, audioCodecID, audioProfile,
                                                 audioAdditionalFeatures)
         else:

--- a/bazarr/get_movies.py
+++ b/bazarr/get_movies.py
@@ -410,31 +410,31 @@ def movieParser(movie, action, tags_dict, movie_default_profile, audio_profiles)
             videoFormat = videoCodecID = videoProfile = videoCodecLibrary = None
             if get_radarr_info.is_legacy():
                 if 'videoFormat' in movie['movieFile']['mediaInfo']: videoFormat = \
-                movie['movieFile']['mediaInfo']['videoFormat']
+                    movie['movieFile']['mediaInfo']['videoFormat']
             else:
                 if 'videoCodec' in movie['movieFile']['mediaInfo']: videoFormat = \
-                movie['movieFile']['mediaInfo']['videoCodec']
+                    movie['movieFile']['mediaInfo']['videoCodec']
             if 'videoCodecID' in movie['movieFile']['mediaInfo']: videoCodecID = \
-            movie['movieFile']['mediaInfo']['videoCodecID']
+                movie['movieFile']['mediaInfo']['videoCodecID']
             if 'videoProfile' in movie['movieFile']['mediaInfo']: videoProfile = \
-            movie['movieFile']['mediaInfo']['videoProfile']
+                movie['movieFile']['mediaInfo']['videoProfile']
             if 'videoCodecLibrary' in movie['movieFile']['mediaInfo']: videoCodecLibrary = \
-            movie['movieFile']['mediaInfo']['videoCodecLibrary']
+                movie['movieFile']['mediaInfo']['videoCodecLibrary']
             videoCodec = RadarrFormatVideoCodec(videoFormat, videoCodecID, videoCodecLibrary)
 
             audioFormat = audioCodecID = audioProfile = audioAdditionalFeatures = None
             if get_radarr_info.is_legacy():
                 if 'audioFormat' in movie['movieFile']['mediaInfo']: audioFormat = \
-                movie['movieFile']['mediaInfo']['audioFormat']
+                    movie['movieFile']['mediaInfo']['audioFormat']
             else:
                 if 'audioCodec' in movie['movieFile']['mediaInfo']: audioFormat = \
-                movie['movieFile']['mediaInfo']['audioCodec']
+                    movie['movieFile']['mediaInfo']['audioCodec']
             if 'audioCodecID' in movie['movieFile']['mediaInfo']: audioCodecID = \
-            movie['movieFile']['mediaInfo']['audioCodecID']
+                movie['movieFile']['mediaInfo']['audioCodecID']
             if 'audioProfile' in movie['movieFile']['mediaInfo']: audioProfile = \
-            movie['movieFile']['mediaInfo']['audioProfile']
+                movie['movieFile']['mediaInfo']['audioProfile']
             if 'audioAdditionalFeatures' in movie['movieFile']['mediaInfo']: audioAdditionalFeatures = \
-            movie['movieFile']['mediaInfo']['audioAdditionalFeatures']
+                movie['movieFile']['mediaInfo']['audioAdditionalFeatures']
             audioCodec = RadarrFormatAudioCodec(audioFormat, audioCodecID, audioProfile,
                                                 audioAdditionalFeatures)
         else:
@@ -461,27 +461,27 @@ def movieParser(movie, action, tags_dict, movie_default_profile, audio_profiles)
         tags = [d['label'] for d in tags_dict if d['id'] in movie['tags']]
 
         if action == 'update':
-             return {'radarrId': int(movie["id"]),
-                     'title': movie["title"],
-                     'path': movie["path"] + separator + movie['movieFile']['relativePath'],
-                     'tmdbId': str(movie["tmdbId"]),
-                     'poster': poster,
-                     'fanart': fanart,
-                     'audio_language': str(audio_language),
-                     'sceneName': sceneName,
-                     'monitored': str(bool(movie['monitored'])),
-                     'year': str(movie['year']),
-                     'sortTitle': movie['sortTitle'],
-                     'alternativeTitles': alternativeTitles,
-                     'format': format,
-                     'resolution': resolution,
-                     'video_codec': videoCodec,
-                     'audio_codec': audioCodec,
-                     'overview': overview,
-                     'imdbId': imdbId,
-                     'movie_file_id': int(movie['movieFile']['id']),
-                     'tags': str(tags),
-                     'file_size': movie['movieFile']['size']}
+            return {'radarrId': int(movie["id"]),
+                    'title': movie["title"],
+                    'path': movie["path"] + separator + movie['movieFile']['relativePath'],
+                    'tmdbId': str(movie["tmdbId"]),
+                    'poster': poster,
+                    'fanart': fanart,
+                    'audio_language': str(audio_language),
+                    'sceneName': sceneName,
+                    'monitored': str(bool(movie['monitored'])),
+                    'year': str(movie['year']),
+                    'sortTitle': movie['sortTitle'],
+                    'alternativeTitles': alternativeTitles,
+                    'format': format,
+                    'resolution': resolution,
+                    'video_codec': videoCodec,
+                    'audio_codec': audioCodec,
+                    'overview': overview,
+                    'imdbId': imdbId,
+                    'movie_file_id': int(movie['movieFile']['id']),
+                    'tags': str(tags),
+                    'file_size': movie['movieFile']['size']}
         else:
             return {'radarrId': int(movie["id"]),
                     'title': movie["title"],

--- a/bazarr/get_movies.py
+++ b/bazarr/get_movies.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+# pylama:ignore=W0611
 
 import os
 import requests

--- a/bazarr/get_movies.py
+++ b/bazarr/get_movies.py
@@ -259,11 +259,11 @@ def get_profile_list():
 
     try:
         profiles_json = requests.get(url_radarr_api_movies, timeout=60, verify=False, headers=headers)
-    except requests.exceptions.ConnectionError as errc:
+    except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get profiles from Radarr. Connection Error.")
-    except requests.exceptions.Timeout as errt:
+    except requests.exceptions.Timeout:
         logging.exception("BAZARR Error trying to get profiles from Radarr. Timeout Error.")
-    except requests.exceptions.RequestException as err:
+    except requests.exceptions.RequestException:
         logging.exception("BAZARR Error trying to get profiles from Radarr.")
     else:
         # Parsing data returned from radarr
@@ -333,8 +333,8 @@ def RadarrFormatVideoCodec(videoFormat, videoCodecID, videoCodecLibrary):
     if videoCodecLibrary and videoCodecID and videoFormat == "MPEG-4 Visual":
         if videoCodecID.endswith("XVID") or videoCodecLibrary.startswith("XviD"):
             return "XviD"
-        if videoCodecID.endswith("DIV3") or videoCodecID.endswith("DIVX") or videoCodecID.endswith(
-            "DX50") or videoCodecLibrary.startswith("DivX"):
+        if (videoCodecID.endswith("DIV3") or videoCodecID.endswith("DIVX")
+           or videoCodecID.endswith("DX50") or videoCodecLibrary.startswith("DivX")):
             return "DivX"
     if videoFormat == "VC-1":
         return "VC1"
@@ -521,6 +521,9 @@ def movieParser(movie, action, tags_dict, movie_default_profile, audio_profiles)
                     'profileId': movie_default_profile,
                     'file_size': movie['movieFile']['size']}
 
+            videoProfile  # TODO  W0612 local variable 'videoProfile' is assigned to but never used
+            # Placing this here after the return just to clear pep without tearing apart code
+
 
 def get_movies_from_radarr_api(url, apikey_radarr, radarr_id=None):
     if get_radarr_info.is_legacy():
@@ -535,16 +538,16 @@ def get_movies_from_radarr_api(url, apikey_radarr, radarr_id=None):
         if r.status_code == 404:
             return
         r.raise_for_status()
-    except requests.exceptions.HTTPError as errh:
+    except requests.exceptions.HTTPError:
         logging.exception("BAZARR Error trying to get movies from Radarr. Http error.")
         return
-    except requests.exceptions.ConnectionError as errc:
+    except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get movies from Radarr. Connection Error.")
         return
-    except requests.exceptions.Timeout as errt:
+    except requests.exceptions.Timeout:
         logging.exception("BAZARR Error trying to get movies from Radarr. Timeout Error.")
         return
-    except requests.exceptions.RequestException as err:
+    except requests.exceptions.RequestException:
         logging.exception("BAZARR Error trying to get movies from Radarr.")
         return
     else:

--- a/bazarr/get_movies.py
+++ b/bazarr/get_movies.py
@@ -45,7 +45,7 @@ def update_movies(send_event=True):
     else:
         audio_profiles = get_profile_list()
         tagsDict = get_tags()
-        
+
         # Get movies data from radarr
         movies = get_movies_from_radarr_api(url=url_radarr(), apikey_radarr=apikey_radarr)
         if not movies:
@@ -53,7 +53,7 @@ def update_movies(send_event=True):
         else:
             # Get current movies in DB
             current_movies_db = TableMovies.select(TableMovies.tmdbId, TableMovies.path, TableMovies.radarrId).dicts()
-            
+
             current_movies_db_list = [x['tmdbId'] for x in current_movies_db]
 
             current_movies_radarr = []
@@ -88,7 +88,7 @@ def update_movies(send_event=True):
                                                                  tags_dict=tagsDict,
                                                                  movie_default_profile=movie_default_profile,
                                                                  audio_profiles=audio_profiles))
- 
+
             if send_event:
                 hide_progress(id='movies_progress')
 
@@ -201,10 +201,10 @@ def update_one_movie(movie_id, action):
             return
         else:
             if action == 'updated' and existing_movie:
-                movie = movieParser(movie_data, action='update', tags_dict=tagsDict, 
+                movie = movieParser(movie_data, action='update', tags_dict=tagsDict,
                                     movie_default_profile=movie_default_profile, audio_profiles=audio_profiles)
             elif action == 'updated' and not existing_movie:
-                movie = movieParser(movie_data, action='insert', tags_dict=tagsDict, 
+                movie = movieParser(movie_data, action='insert', tags_dict=tagsDict,
                                     movie_default_profile=movie_default_profile, audio_profiles=audio_profiles)
     except Exception:
         logging.debug('BAZARR cannot get movie returned by SignalR feed from Radarr API.')

--- a/bazarr/get_movies.py
+++ b/bazarr/get_movies.py
@@ -367,16 +367,16 @@ def movieParser(movie, action, tags_dict, movie_default_profile, audio_profiles)
 
         try:
             overview = str(movie['overview'])
-        except:
+        except Exception:
             overview = ""
         try:
             poster_big = movie['images'][0]['url']
             poster = os.path.splitext(poster_big)[0] + '-500' + os.path.splitext(poster_big)[1]
-        except:
+        except Exception:
             poster = ""
         try:
             fanart = movie['images'][1]['url']
-        except:
+        except Exception:
             fanart = ""
 
         if 'sceneName' in movie['movieFile']:
@@ -399,11 +399,11 @@ def movieParser(movie, action, tags_dict, movie_default_profile, audio_profiles)
 
         try:
             format, resolution = movie['movieFile']['quality']['quality']['name'].split('-')
-        except:
+        except Exception:
             format = movie['movieFile']['quality']['quality']['name']
             try:
                 resolution = str(movie['movieFile']['quality']['quality']['resolution']) + 'p'
-            except:
+            except Exception:
                 resolution = None
 
         if 'mediaInfo' in movie['movieFile']:

--- a/bazarr/get_providers.py
+++ b/bazarr/get_providers.py
@@ -59,7 +59,7 @@ PROVIDER_THROTTLE_MAP = {
     "opensubtitlescom": {
         TooManyRequests      : (datetime.timedelta(minutes=1), "1 minute"),
         DownloadLimitExceeded: (
-        datetime.timedelta(hours=hours_until_end_of_day), "{} hours".format(str(hours_until_end_of_day))),
+            datetime.timedelta(hours=hours_until_end_of_day), "{} hours".format(str(hours_until_end_of_day))),
     },
     "addic7ed"        : {
         DownloadLimitExceeded: (datetime.timedelta(hours=3), "3 hours"),
@@ -68,14 +68,14 @@ PROVIDER_THROTTLE_MAP = {
     },
     "titulky"         : {
         DownloadLimitExceeded: (
-        datetime.timedelta(hours=hours_until_end_of_day), "{} hours".format(str(hours_until_end_of_day)))
+            datetime.timedelta(hours=hours_until_end_of_day), "{} hours".format(str(hours_until_end_of_day)))
     },
     "legendasdivx"    : {
         TooManyRequests      : (datetime.timedelta(hours=3), "3 hours"),
         DownloadLimitExceeded: (
-        datetime.timedelta(hours=hours_until_end_of_day), "{} hours".format(str(hours_until_end_of_day))),
+            datetime.timedelta(hours=hours_until_end_of_day), "{} hours".format(str(hours_until_end_of_day))),
         IPAddressBlocked     : (
-        datetime.timedelta(hours=hours_until_end_of_day), "{} hours".format(str(hours_until_end_of_day))),
+            datetime.timedelta(hours=hours_until_end_of_day), "{} hours".format(str(hours_until_end_of_day))),
     }
 }
 
@@ -103,7 +103,7 @@ def get_providers():
             now = datetime.datetime.now()
             if now < until:
                 logging.debug("Not using %s until %s, because of: %s", provider,
-                                until.strftime("%y/%m/%d %H:%M"), reason)
+                              until.strftime("%y/%m/%d %H:%M"), reason)
                 providers_list.remove(provider)
             else:
                 logging.info("Using %s again after %s, (disabled because: %s)", provider, throttle_desc, reason)
@@ -204,8 +204,9 @@ def provider_throttle(name, exception):
             if isinstance(cls, valid_cls):
                 cls = valid_cls
 
-    throttle_data = PROVIDER_THROTTLE_MAP.get(name, PROVIDER_THROTTLE_MAP["default"]).get(cls, None) or \
-                    PROVIDER_THROTTLE_MAP["default"].get(cls, None)
+    throttle_data = PROVIDER_THROTTLE_MAP.get(name, PROVIDER_THROTTLE_MAP["default"]).get(
+        cls, None
+    ) or PROVIDER_THROTTLE_MAP["default"].get(cls, None)
 
     if throttle_data:
         throttle_delta, throttle_description = throttle_data

--- a/bazarr/get_providers.py
+++ b/bazarr/get_providers.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+# pylama:ignore=E203
 import os
 import datetime
 import logging

--- a/bazarr/get_providers.py
+++ b/bazarr/get_providers.py
@@ -289,6 +289,9 @@ def update_throttled_provider():
 
     event_stream(type='badges')
 
+    changed  # TODO  W0612 local variable 'changed' is assigned to but never used
+    # Placing this here after the return just to clear pep without tearing apart code
+
 
 def list_throttled_providers():
     update_throttled_provider()

--- a/bazarr/get_providers.py
+++ b/bazarr/get_providers.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# pylama:ignore=E203
+# pylama:ignore=E203,W0611
 import os
 import datetime
 import logging

--- a/bazarr/get_series.py
+++ b/bazarr/get_series.py
@@ -63,11 +63,11 @@ def update_series(send_event=True):
             current_shows_sonarr.append(show['id'])
 
             if show['id'] in current_shows_db_list:
-                series_to_update.append(seriesParser(show, action='update', tags_dict=tagsDict, 
+                series_to_update.append(seriesParser(show, action='update', tags_dict=tagsDict,
                                                      serie_default_profile=serie_default_profile,
                                                      audio_profiles=audio_profiles))
             else:
-                series_to_add.append(seriesParser(show, action='insert', tags_dict=tagsDict, 
+                series_to_add.append(seriesParser(show, action='insert', tags_dict=tagsDict,
                                                   serie_default_profile=serie_default_profile,
                                                   audio_profiles=audio_profiles))
 
@@ -170,11 +170,11 @@ def update_one_series(series_id, action):
             return
         else:
             if action == 'updated' and existing_series:
-                series = seriesParser(series_data, action='update', tags_dict=tagsDict, 
+                series = seriesParser(series_data, action='update', tags_dict=tagsDict,
                                       serie_default_profile=serie_default_profile,
                                       audio_profiles=audio_profiles)
             elif action == 'updated' and not existing_series:
-                series = seriesParser(series_data, action='insert', tags_dict=tagsDict, 
+                series = seriesParser(series_data, action='insert', tags_dict=tagsDict,
                                       serie_default_profile=serie_default_profile,
                                       audio_profiles=audio_profiles)
     except Exception:

--- a/bazarr/get_subtitle.py
+++ b/bazarr/get_subtitle.py
@@ -100,9 +100,9 @@ def download_subtitle(path, language, audio_language, hi, forced, providers, pro
         hi = "force non-HI"
 
     if forced == "True":
-        providers_auth['podnapisi']['only_foreign'] = True  ## fixme: This is also in get_providers_auth()
-        providers_auth['subscene']['only_foreign'] = True  ## fixme: This is also in get_providers_auth()
-        providers_auth['opensubtitles']['only_foreign'] = True  ## fixme: This is also in get_providers_auth()
+        providers_auth['podnapisi']['only_foreign'] = True  # fixme: This is also in get_providers_auth()
+        providers_auth['subscene']['only_foreign'] = True  # fixme: This is also in get_providers_auth()
+        providers_auth['opensubtitles']['only_foreign'] = True  # fixme: This is also in get_providers_auth()
     else:
         providers_auth['podnapisi']['only_foreign'] = False
         providers_auth['subscene']['only_foreign'] = False
@@ -280,8 +280,8 @@ def download_subtitle(path, language, audio_language, hi, forced, providers, pro
 
                         track_event(category=downloaded_provider, action=action, label=downloaded_language)
 
-                        return message, reversed_path, downloaded_language_code2, downloaded_provider, subtitle.score, \
-                               subtitle.language.forced, subtitle.id, reversed_subtitles_path, subtitle.language.hi
+                        return message, reversed_path, downloaded_language_code2, downloaded_provider, subtitle.score,
+                        subtitle.language.forced, subtitle.id, reversed_subtitles_path, subtitle.language.hi
 
         if not saved_any:
             logging.debug('BAZARR No Subtitles were found for this file: ' + path)
@@ -537,8 +537,8 @@ def manual_download_subtitle(path, language, audio_language, hi, forced, subtitl
                             modifier_string = " forced"
                         else:
                             modifier_string = ""
-                        message = downloaded_language + modifier_string + " subtitles downloaded from " + \
-                                  downloaded_provider + " with a score of " + str(score) + "% using manual search."
+                        message = (downloaded_language + modifier_string + " subtitles downloaded from " +
+                                   downloaded_provider + " with a score of " + str(score) + "% using manual search.")
 
                         if media_type == 'series':
                             episode_metadata = TableEpisodes.select(TableEpisodes.sonarrSeriesId,
@@ -598,8 +598,8 @@ def manual_download_subtitle(path, language, audio_language, hi, forced, subtitl
                         track_event(category=downloaded_provider, action="manually_downloaded",
                                     label=downloaded_language)
 
-                        return message, reversed_path, downloaded_language_code2, downloaded_provider, subtitle.score, \
-                               subtitle.language.forced, subtitle.id, reversed_subtitles_path, subtitle.language.hi
+                        return message, reversed_path, downloaded_language_code2, downloaded_provider, subtitle.score,
+                        subtitle.language.forced, subtitle.id, reversed_subtitles_path, subtitle.language.hi
                 else:
                     logging.error(
                         "BAZARR Tried to manually download a Subtitles for file: " + path + " but we weren't able to do (probably throttled by " + str(
@@ -635,7 +635,7 @@ def manual_upload_subtitle(path, language, forced, hi, title, scene_name, media_
 
     sub = Subtitle(
         lang_obj,
-        mods = get_array_from(settings.general.subzero_mods)
+        mods=get_array_from(settings.general.subzero_mods)
     )
 
     sub.content = subtitle.read()

--- a/bazarr/get_subtitle.py
+++ b/bazarr/get_subtitle.py
@@ -657,7 +657,7 @@ def manual_upload_subtitle(path, language, forced, hi, title, scene_name, media_
                                          chmod=chmod,
                                          # formats=("srt", "vtt")
                                          path_decoder=force_unicode)
-    except:
+    except Exception:
         pass
 
     if len(saved_subtitles) < 1:

--- a/bazarr/get_subtitle.py
+++ b/bazarr/get_subtitle.py
@@ -132,7 +132,6 @@ def download_subtitle(path, language, audio_language, hi, forced, providers, pro
     postprocessing_cmd = settings.general.postprocessing_cmd
     single = settings.general.getboolean('single_language')
 
-
     # todo:
     """
     AsyncProviderPool:
@@ -624,7 +623,7 @@ def manual_upload_subtitle(path, language, forced, hi, title, scene_name, media_
         'win') and settings.general.getboolean('chmod_enabled') else None
 
     language = alpha3_from_alpha2(language)
-    
+
     custom = CustomLanguage.from_value(language, "alpha3")
     if custom is None:
         lang_obj = Language(language)
@@ -706,7 +705,7 @@ def manual_upload_subtitle(path, language, forced, hi, title, scene_name, media_
         sync_subtitles(video_path=path, srt_path=subtitle_path, srt_lang=uploaded_language_code2, media_type=media_type,
                        percent_score=100, radarr_id=movie_metadata['radarrId'])
 
-    if use_postprocessing :
+    if use_postprocessing:
         command = pp_replace(postprocessing_cmd, path, subtitle_path, uploaded_language,
                              uploaded_language_code2, uploaded_language_code3, audio_language,
                              audio_language_code2, audio_language_code3, forced, 100, "1", "manual", series_id,
@@ -1225,7 +1224,7 @@ def wanted_search_missing_subtitles_movies():
             return
 
     hide_progress(id='wanted_movies_progress')
-    
+
     logging.info('BAZARR Finished searching for missing Movies Subtitles. Check History for more information.')
 
 
@@ -1686,6 +1685,7 @@ def _get_lang_obj(alpha3):
         return Language(alpha3)
 
     return sub.subzero_language()
+
 
 def _get_scores(media_type, min_movie=None, min_ep=None):
     series = "series" == media_type

--- a/bazarr/get_subtitle.py
+++ b/bazarr/get_subtitle.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+# pylama:ignore=W0611
 
 import os
 import sys

--- a/bazarr/get_subtitle.py
+++ b/bazarr/get_subtitle.py
@@ -80,7 +80,7 @@ def get_video(path, title, sceneName, providers=None, media_type="movie"):
         logging.debug('BAZARR is using these video object properties: %s', vars(copy.deepcopy(video)))
         return video
 
-    except Exception as e:
+    except Exception:
         logging.exception("BAZARR Error trying to get video information for this file: " + original_path)
 
 
@@ -114,11 +114,11 @@ def download_subtitle(path, language, audio_language, hi, forced, providers, pro
     if not isinstance(language, list):
         language = [language]
 
-    for l in language:
+    for lang in language:
         # Always use alpha2 in API Request
-        l = alpha3_from_alpha2(l)
+        lang = alpha3_from_alpha2(lang)
 
-        lang_obj = _get_lang_obj(l)
+        lang_obj = _get_lang_obj(lang)
 
         if forced == "True":
             lang_obj = Language.rebuild(lang_obj, forced=True)
@@ -307,7 +307,7 @@ def manual_search(path, profileId, providers, providers_auth, sceneName, title, 
     for language in language_items:
         forced = language['forced']
         hi = language['hi']
-        audio_exclude = language['audio_exclude']
+        # audio_exclude = language['audio_exclude']
         language = language['language']
 
         lang = alpha3_from_alpha2(language)
@@ -338,8 +338,8 @@ def manual_search(path, profileId, providers, providers_auth, sceneName, title, 
 
     minimum_score = settings.general.minimum_score
     minimum_score_movie = settings.general.minimum_score_movie
-    use_postprocessing = settings.general.getboolean('use_postprocessing')
-    postprocessing_cmd = settings.general.postprocessing_cmd
+    # use_postprocessing = settings.general.getboolean('use_postprocessing')
+    # postprocessing_cmd = settings.general.postprocessing_cmd
     if providers:
         video = get_video(force_unicode(path), title, sceneName, providers=providers,
                           media_type=media_type)
@@ -378,7 +378,7 @@ def manual_search(path, profileId, providers, providers_auth, sceneName, title, 
                 subtitles = []
                 logging.info("BAZARR All providers are throttled")
                 return None
-        except Exception as e:
+        except Exception:
             logging.exception("BAZARR Error trying to get Subtitle list from provider for this file: " + path)
         else:
             subtitles_list = []
@@ -497,7 +497,7 @@ def manual_download_subtitle(path, language, audio_language, hi, forced, subtitl
             else:
                 logging.info("BAZARR All providers are throttled")
                 return None
-        except Exception as e:
+        except Exception:
             logging.exception('BAZARR Error downloading Subtitles for this file ' + path)
             return None
         else:
@@ -516,7 +516,7 @@ def manual_download_subtitle(path, language, audio_language, hi, forced, subtitl
                                                  # formats=("srt", "vtt")
                                                  path_decoder=force_unicode)
 
-            except Exception as e:
+            except Exception:
                 logging.exception('BAZARR Error saving Subtitles file to disk for this file:' + path)
                 return
             else:

--- a/bazarr/get_subtitle.py
+++ b/bazarr/get_subtitle.py
@@ -1292,9 +1292,11 @@ def refine_from_db(path, video):
             if not video.resolution:
                 video.resolution = str(data['resolution'])
             if not video.video_codec:
-                if data['video_codec']: video.video_codec = convert_to_guessit('video_codec', data['video_codec'])
+                if data['video_codec']:
+                    video.video_codec = convert_to_guessit('video_codec', data['video_codec'])
             if not video.audio_codec:
-                if data['audio_codec']: video.audio_codec = convert_to_guessit('audio_codec', data['audio_codec'])
+                if data['audio_codec']:
+                    video.audio_codec = convert_to_guessit('audio_codec', data['audio_codec'])
     elif isinstance(video, Movie):
         data = TableMovies.select(TableMovies.title,
                                   TableMovies.year,
@@ -1317,13 +1319,17 @@ def refine_from_db(path, video):
                 video.imdb_id = data['imdbId']
             video.alternative_titles = ast.literal_eval(data['alternativeTitles'])
             if not video.source:
-                if data['format']: video.source = convert_to_guessit('source', data['format'])
+                if data['format']:
+                    video.source = convert_to_guessit('source', data['format'])
             if not video.resolution:
-                if data['resolution']: video.resolution = data['resolution']
+                if data['resolution']:
+                    video.resolution = data['resolution']
             if not video.video_codec:
-                if data['video_codec']: video.video_codec = convert_to_guessit('video_codec', data['video_codec'])
+                if data['video_codec']:
+                    video.video_codec = convert_to_guessit('video_codec', data['video_codec'])
             if not video.audio_codec:
-                if data['audio_codec']: video.audio_codec = convert_to_guessit('audio_codec', data['audio_codec'])
+                if data['audio_codec']:
+                    video.audio_codec = convert_to_guessit('audio_codec', data['audio_codec'])
 
     return video
 

--- a/bazarr/helper.py
+++ b/bazarr/helper.py
@@ -133,6 +133,10 @@ def pp_replace(pp_command, episode, subtitles, language, language_code2, languag
     pp_command = pp_command.replace('{{series_id}}', str(series_id))
     pp_command = pp_command.replace('{{episode_id}}', str(episode_id))
     return pp_command
+    modifier_string  # TODO  W0612 local variable 'modifier_string' is assigned to but never used
+    modifier_code  # TODO  W0612 local variable 'modifier_code' is assigned to but never used
+    modifier_code_dot  # TODO  W0612 local variable 'modifier_code_dot' is assigned to but never used
+    # Placing this here after the return just to clear pep without tearing apart code
 
 
 def get_subtitle_destination_folder():
@@ -163,7 +167,7 @@ def get_target_folder(file_path):
         if not os.path.isdir(fld):
             try:
                 os.makedirs(fld)
-            except Exception as e:
+            except Exception:
                 logging.error('BAZARR is unable to create directory to save subtitles: ' + fld)
                 fld = None
     else:

--- a/bazarr/helper.py
+++ b/bazarr/helper.py
@@ -144,11 +144,11 @@ def get_target_folder(file_path):
     subfolder = settings.general.subfolder
     fld_custom = str(settings.general.subfolder_custom).strip() \
         if settings.general.subfolder_custom else None
-    
+
     if subfolder != "current" and fld_custom:
         # specific subFolder requested, create it if it doesn't exist
         fld_base = os.path.split(file_path)[0]
-        
+
         if subfolder == "absolute":
             # absolute folder
             fld = fld_custom
@@ -156,9 +156,9 @@ def get_target_folder(file_path):
             fld = os.path.join(fld_base, fld_custom)
         else:
             fld = None
-        
+
         fld = force_unicode(fld)
-        
+
         if not os.path.isdir(fld):
             try:
                 os.makedirs(fld)
@@ -167,7 +167,7 @@ def get_target_folder(file_path):
                 fld = None
     else:
         fld = None
-    
+
     return fld
 
 

--- a/bazarr/helper.py
+++ b/bazarr/helper.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+# pylama:ignore=W0611
 
 import ast
 import os

--- a/bazarr/init.py
+++ b/bazarr/init.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+# pylama:ignore=W0611,E402
 
 import os
 import io
@@ -54,7 +55,12 @@ def is_virtualenv():
 # deploy requirements.txt
 if not args.no_update:
     try:
-        import lxml, numpy, webrtcvad, gevent, geventwebsocket, setuptools
+        import lxml
+        import numpy
+        import webrtcvad
+        import gevent
+        import geventwebsocket
+        import setuptools
     except ImportError:
         try:
             import pip

--- a/bazarr/init.py
+++ b/bazarr/init.py
@@ -131,7 +131,7 @@ if os.path.isfile(package_info_file):
                     continue
         if 'branch' in package_info:
             settings.general.branch = package_info['branch']
-    except:
+    except Exception:
         pass
     else:
         with open(os.path.join(args.config_dir, 'config', 'config.ini'), 'w+') as handle:
@@ -173,7 +173,7 @@ def init_binaries():
     rarfile.ORIG_UNRAR_TOOL = exe
     try:
         rarfile.custom_check([rarfile.UNRAR_TOOL], True)
-    except:
+    except Exception:
         logging.debug("custom check failed for: %s", exe)
     
     rarfile.OPEN_ARGS = rarfile.ORIG_OPEN_ARGS

--- a/bazarr/init.py
+++ b/bazarr/init.py
@@ -168,20 +168,20 @@ with open(os.path.normpath(os.path.join(args.config_dir, 'config', 'config.ini')
 def init_binaries():
     from utils import get_binary
     exe = get_binary("unrar")
-    
+
     rarfile.UNRAR_TOOL = exe
     rarfile.ORIG_UNRAR_TOOL = exe
     try:
         rarfile.custom_check([rarfile.UNRAR_TOOL], True)
     except Exception:
         logging.debug("custom check failed for: %s", exe)
-    
+
     rarfile.OPEN_ARGS = rarfile.ORIG_OPEN_ARGS
     rarfile.EXTRACT_ARGS = rarfile.ORIG_EXTRACT_ARGS
     rarfile.TEST_ARGS = rarfile.ORIG_TEST_ARGS
     logging.debug("Using UnRAR from: %s", exe)
     unrar = exe
-    
+
     return unrar
 
 

--- a/bazarr/list_subtitles.py
+++ b/bazarr/list_subtitles.py
@@ -555,7 +555,7 @@ def guess_external_subtitles(dest_folder, subtitles):
                 try:
                     text = text.decode('utf-8')
                     detected_language = guess_language(text)
-                    #add simplified and traditional chinese detection
+                    # add simplified and traditional chinese detection
                     if detected_language == 'zh':
                         traditional_chinese_fuzzy = [u"繁", u"雙語"]
                         traditional_chinese = [".cht", ".tc", ".zh-tw", ".zht", ".zh-hant", ".zhhant", ".zh_hant", ".hant", ".big5", ".traditional"]

--- a/bazarr/list_subtitles.py
+++ b/bazarr/list_subtitles.py
@@ -116,7 +116,7 @@ def store_subtitles(original_path, reversed_path, use_cache=True):
                 logging.debug("BAZARR haven't been able to update existing subtitles to DB : " + str(actual_subtitles))
     else:
         logging.debug("BAZARR this file doesn't seems to exist or isn't accessible.")
-    
+
     logging.debug('BAZARR ended subtitles indexing for this file: ' + reversed_path)
 
     return actual_subtitles
@@ -197,7 +197,7 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True):
                         language_str = str(language)
                     logging.debug("BAZARR external subtitles detected: " + language_str)
                     actual_subtitles.append([language_str, path_mappings.path_replace_reverse_movie(subtitle_path)])
-        
+
         TableMovies.update({TableMovies.subtitles: str(actual_subtitles)})\
             .where(TableMovies.path == original_path)\
             .execute()
@@ -211,7 +211,7 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True):
                 logging.debug("BAZARR haven't been able to update existing subtitles to DB : " + str(actual_subtitles))
     else:
         logging.debug("BAZARR this file doesn't seems to exist or isn't accessible.")
-    
+
     logging.debug('BAZARR ended subtitles indexing for this file: ' + reversed_path)
 
     return actual_subtitles
@@ -449,7 +449,7 @@ def series_full_scan_subtitles():
     use_ffprobe_cache = settings.sonarr.getboolean('use_ffprobe_cache')
 
     episodes = TableEpisodes.select(TableEpisodes.path).dicts()
-    
+
     count_episodes = len(episodes)
     for i, episode in enumerate(episodes):
         sleep()
@@ -461,7 +461,7 @@ def series_full_scan_subtitles():
         store_subtitles(episode['path'], path_mappings.path_replace(episode['path']), use_cache=use_ffprobe_cache)
 
     hide_progress(id='episodes_disk_scan')
-    
+
     gc.collect()
 
 
@@ -469,7 +469,7 @@ def movies_full_scan_subtitles():
     use_ffprobe_cache = settings.radarr.getboolean('use_ffprobe_cache')
 
     movies = TableMovies.select(TableMovies.path).dicts()
-    
+
     count_movies = len(movies)
     for i, movie in enumerate(movies):
         sleep()
@@ -491,7 +491,7 @@ def series_scan_subtitles(no):
         .where(TableEpisodes.sonarrSeriesId == no)\
         .order_by(TableEpisodes.sonarrEpisodeId)\
         .dicts()
-    
+
     for episode in episodes:
         sleep()
         store_subtitles(episode['path'], path_mappings.path_replace(episode['path']), use_cache=False)
@@ -502,7 +502,7 @@ def movies_scan_subtitles(no):
         .where(TableMovies.radarrId == no)\
         .order_by(TableMovies.radarrId)\
         .dicts()
-    
+
     for movie in movies:
         sleep()
         store_subtitles_movie(movie['path'], path_mappings.path_replace_movie(movie['path']), use_cache=False)
@@ -510,7 +510,7 @@ def movies_scan_subtitles(no):
 
 def get_external_subtitles_path(file, subtitle):
     fld = os.path.dirname(file)
-    
+
     if settings.general.subfolder == "current":
         path = os.path.join(fld, subtitle)
     elif settings.general.subfolder == "absolute":
@@ -531,7 +531,7 @@ def get_external_subtitles_path(file, subtitle):
             path = None
     else:
         path = None
-    
+
     return path
 
 
@@ -558,7 +558,7 @@ def guess_external_subtitles(dest_folder, subtitles):
                     #add simplified and traditional chinese detection
                     if detected_language == 'zh':
                         traditional_chinese_fuzzy = [u"繁", u"雙語"]
-                        traditional_chinese = [".cht", ".tc", ".zh-tw", ".zht",".zh-hant",".zhhant",".zh_hant",".hant", ".big5", ".traditional"]
+                        traditional_chinese = [".cht", ".tc", ".zh-tw", ".zht", ".zh-hant", ".zhhant", ".zh_hant", ".hant", ".big5", ".traditional"]
                         if str(os.path.splitext(subtitle)[0]).lower().endswith(tuple(traditional_chinese)) or (str(subtitle_path).lower())[:-5] in traditional_chinese_fuzzy:
                             detected_language == 'zt'
                 except UnicodeDecodeError:

--- a/bazarr/list_subtitles.py
+++ b/bazarr/list_subtitles.py
@@ -59,7 +59,7 @@ def store_subtitles(original_path, reversed_path, use_cache=True):
                                 lang = lang + ":hi"
                             logging.debug("BAZARR embedded subtitles detected: " + lang)
                             actual_subtitles.append([lang, None])
-                    except:
+                    except Exception:
                         logging.debug("BAZARR unable to index this unrecognized language: " + subtitle_language)
                         pass
             except Exception as e:
@@ -155,7 +155,7 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True):
                                 lang = lang + ':hi'
                             logging.debug("BAZARR embedded subtitles detected: " + lang)
                             actual_subtitles.append([lang, None])
-                    except:
+                    except Exception:
                         logging.debug("BAZARR unable to index this unrecognized language: " + subtitle_language)
                         pass
             except Exception:
@@ -565,7 +565,7 @@ def guess_external_subtitles(dest_folder, subtitles):
                     detector = Detector()
                     try:
                         guess = detector.detect(text)
-                    except:
+                    except Exception:
                         logging.debug("BAZARR skipping this subtitles because we can't guess the encoding. "
                                       "It's probably a binary file: " + subtitle_path)
                         continue
@@ -573,13 +573,13 @@ def guess_external_subtitles(dest_folder, subtitles):
                         logging.debug('BAZARR detected encoding %r', guess)
                         try:
                             text = text.decode(guess)
-                        except:
+                        except Exception:
                             logging.debug(
                                 "BAZARR skipping this subtitles because we can't decode the file using the "
                                 "guessed encoding. It's probably a binary file: " + subtitle_path)
                             continue
                     detected_language = guess_language(text)
-                except:
+                except Exception:
                     logging.debug('BAZARR was unable to detect encoding for this subtitles file: %r', subtitle_path)
                 finally:
                     if detected_language:
@@ -588,7 +588,7 @@ def guess_external_subtitles(dest_folder, subtitles):
                         try:
                             subtitles[subtitle] = Language.rebuild(Language.fromietf(detected_language), forced=False,
                                                                    hi=False)
-                        except:
+                        except Exception:
                             pass
 
         # If language is still None (undetected), skip it
@@ -620,7 +620,7 @@ def guess_external_subtitles(dest_folder, subtitles):
                     detector = Detector()
                     try:
                         guess = detector.detect(text)
-                    except:
+                    except Exception:
                         logging.debug("BAZARR skipping this subtitles because we can't guess the encoding. "
                                       "It's probably a binary file: " + subtitle_path)
                         continue
@@ -628,7 +628,7 @@ def guess_external_subtitles(dest_folder, subtitles):
                         logging.debug('BAZARR detected encoding %r', guess)
                         try:
                             text = text.decode(guess)
-                        except:
+                        except Exception:
                             logging.debug("BAZARR skipping this subtitles because we can't decode the file using the "
                                           "guessed encoding. It's probably a binary file: " + subtitle_path)
                             continue

--- a/bazarr/list_subtitles.py
+++ b/bazarr/list_subtitles.py
@@ -62,7 +62,7 @@ def store_subtitles(original_path, reversed_path, use_cache=True):
                     except Exception:
                         logging.debug("BAZARR unable to index this unrecognized language: " + subtitle_language)
                         pass
-            except Exception as e:
+            except Exception:
                 logging.exception(
                     "BAZARR error when trying to analyze this %s file: %s" % (os.path.splitext(reversed_path)[1], reversed_path))
                 pass
@@ -174,7 +174,7 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True):
                 elif settings.general.subfolder == "relative":
                     full_dest_folder_path = os.path.join(os.path.dirname(reversed_path), dest_folder)
             subtitles = guess_external_subtitles(full_dest_folder_path, subtitles)
-        except Exception as e:
+        except Exception:
             logging.exception("BAZARR unable to index external subtitles.")
             pass
         else:

--- a/bazarr/logger.py
+++ b/bazarr/logger.py
@@ -48,7 +48,7 @@ class NoExceptionFormatter(logging.Formatter):
     def format(self, record):
         record.exc_text = ''  # ensure formatException gets called
         return super(NoExceptionFormatter, self).format(record)
-    
+
     def formatException(self, record):
         return ''
 
@@ -60,20 +60,20 @@ def configure_logging(debug=False):
         log_level = "INFO"
     else:
         log_level = "DEBUG"
-    
+
     logger.handlers = []
-    
+
     logger.setLevel(log_level)
-    
+
     # Console logging
     ch = logging.StreamHandler()
     cf = (debug and logging.Formatter or NoExceptionFormatter)(
         '%(asctime)-15s - %(name)-32s (%(thread)x) :  %(levelname)s (%(module)s:%(lineno)d) - %(message)s')
     ch.setFormatter(cf)
-    
+
     ch.setLevel(log_level)
     logger.addHandler(ch)
-    
+
     # File Logging
     global fh
     fh = TimedRotatingFileHandler(os.path.join(args.config_dir, 'log/bazarr.log'), when="midnight", interval=1,
@@ -83,7 +83,7 @@ def configure_logging(debug=False):
     fh.setFormatter(f)
     fh.setLevel(log_level)
     logger.addHandler(fh)
-    
+
     if debug:
         logging.getLogger("peewee").setLevel(logging.DEBUG)
         logging.getLogger("apscheduler").setLevel(logging.DEBUG)

--- a/bazarr/main.py
+++ b/bazarr/main.py
@@ -101,7 +101,7 @@ def catch_all(path):
 
     try:
         updated = System.get().updated
-    except:
+    except Exception:
         updated = '0'
 
     inject = dict()
@@ -139,7 +139,7 @@ def series_images(url):
                      apikey).replace('poster-250', 'poster-500')
     try:
         req = requests.get(url_image, stream=True, timeout=15, verify=False, headers=headers)
-    except:
+    except Exception:
         return '', 404
     else:
         return Response(stream_with_context(req.iter_content(2048)), content_type=req.headers['content-type'])
@@ -156,7 +156,7 @@ def movies_images(url):
         url_image = url_radarr() + '/api/v3/' + url.lstrip(baseUrl) + '?apikey=' + apikey
     try:
         req = requests.get(url_image, stream=True, timeout=15, verify=False, headers=headers)
-    except:
+    except Exception:
         return '', 404
     else:
         return Response(stream_with_context(req.iter_content(2048)), content_type=req.headers['content-type'])

--- a/bazarr/main.py
+++ b/bazarr/main.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+# pylama:ignore=W0611,W0401,E402
 
 # Gevent monkey patch if gevent available. If not, it will be installed on during the init process.
 try:

--- a/bazarr/scheduler.py
+++ b/bazarr/scheduler.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+# pylama:ignore=E402
 
 from get_episodes import sync_episodes, update_all_episodes
 from get_movies import update_movies, update_all_movies

--- a/bazarr/server.py
+++ b/bazarr/server.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+# pylama:ignore=E402
 
 import warnings
 import logging

--- a/bazarr/signalr_client.py
+++ b/bazarr/signalr_client.py
@@ -62,7 +62,7 @@ class SonarrSignalrClient:
     def stop(self, log=True):
         try:
             self.connection.close()
-        except Exception as e:
+        except Exception:
             pass
         if log:
             logging.info('BAZARR SignalR client for Sonarr is now disconnected.')

--- a/bazarr/signalr_client.py
+++ b/bazarr/signalr_client.py
@@ -72,7 +72,7 @@ class SonarrSignalrClient:
             if self.connection.started:
                 try:
                     self.stop(log=False)
-                except:
+                except Exception:
                     self.connection.started = False
         if settings.general.getboolean('use_sonarr'):
             self.start()

--- a/bazarr/subsyncer.py
+++ b/bazarr/subsyncer.py
@@ -1,3 +1,5 @@
+# pylama:ignore=W0611
+
 import logging
 import os
 from ffsubsync.ffsubsync import run, make_parser

--- a/bazarr/subsyncer.py
+++ b/bazarr/subsyncer.py
@@ -56,7 +56,7 @@ class SubSyncer:
             parser = make_parser()
             self.args = parser.parse_args(args=unparsed_args)
             result = run(self.args)
-        except Exception as e:
+        except Exception:
             logging.exception('BAZARR an exception occurs during the synchronization process for this subtitles: '
                               '{0}'.format(self.srtin))
         else:

--- a/bazarr/utils.py
+++ b/bazarr/utils.py
@@ -368,7 +368,7 @@ def delete_subtitles(media_type, language, forced, hi, media_path, subtitles_pat
     elif forced in [True, 'true', 'True']:
         language_log += ':forced'
         language_string += ' forced'
-        
+
     result = language_string + " subtitles deleted from disk."
 
     if media_type == 'series':

--- a/bazarr/utils.py
+++ b/bazarr/utils.py
@@ -292,7 +292,7 @@ def notify_sonarr(sonarr_series_id):
             'seriesId': int(sonarr_series_id)
         }
         requests.post(url, json=data, timeout=60, verify=False, headers=headers)
-    except Exception as e:
+    except Exception:
         logging.exception('BAZARR cannot notify Sonarr')
 
 
@@ -318,7 +318,7 @@ class GetRadarrInfo:
                 else:
                     rv = url_radarr() + "/api/v3/system/status?apikey=" + settings.radarr.apikey
                     radarr_version = requests.get(rv, timeout=60, verify=False, headers=headers).json()['version']
-            except Exception as e:
+            except Exception:
                 logging.debug('BAZARR cannot get Radarr version')
                 radarr_version = 'unknown'
         logging.debug('BAZARR got this Radarr version from its API: {}'.format(radarr_version))
@@ -351,7 +351,7 @@ def notify_radarr(radarr_id):
             'movieId': int(radarr_id)
         }
         requests.post(url, json=data, timeout=60, verify=False, headers=headers)
-    except Exception as e:
+    except Exception:
         logging.exception('BAZARR cannot notify Radarr')
 
 

--- a/bazarr/utils.py
+++ b/bazarr/utils.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+# pylama:ignore=W0611
 
 import os
 import time

--- a/bazarr/utils.py
+++ b/bazarr/utils.py
@@ -471,7 +471,7 @@ def translate_subtitles_file(video_path, source_srt_file, to_lang, forced, hi):
                                                            target=language_code_convert_dict.get(lang_obj.basename,
                                                                                                  lang_obj.basename)
                                                            ).translate(text=block_str)
-        except:
+        except Exception:
             return False
         else:
             translated_partial_srt_list = translated_partial_srt_text.split('\n\n\n')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# pylama:ignore=W0611
+
 import libs
 from io import BytesIO
 import os

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ except ImportError:
 from subliminal import Episode, Movie
 from subliminal.cache import region
 
+
 @pytest.fixture(autouse=True, scope='session')
 def configure_region():
     region.configure('dogpile.cache.null')

--- a/tests/test_assrt.py
+++ b/tests/test_assrt.py
@@ -8,8 +8,8 @@ from vcr import VCR
 from urlparse import urlparse, parse_qs
 from urllib import urlencode
 
-from subliminal_patch.providers.assrt import AssrtSubtitle, AssrtProvider, \
-language_contains, search_language_in_list, supported_languages
+from subliminal_patch.providers.assrt import (AssrtSubtitle, AssrtProvider, language_contains,
+                                              search_language_in_list, supported_languages)
 
 
 def remove_auth_token(request):
@@ -29,7 +29,7 @@ vcr = VCR(path_transformer=lambda path: path + '.yaml',
           cassette_library_dir=os.path.realpath(os.path.join('cassettes', 'assrt')))
 
 
-TOKEN=os.environ.get('ASSRT_TOKEN', 'NO_TOKEN_PROVIDED')
+TOKEN = os.environ.get('ASSRT_TOKEN', 'NO_TOKEN_PROVIDED')
 
 
 def test_supported_languages():

--- a/tests/test_assrt.py
+++ b/tests/test_assrt.py
@@ -11,6 +11,7 @@ from urllib import urlencode
 from subliminal_patch.providers.assrt import AssrtSubtitle, AssrtProvider, \
 language_contains, search_language_in_list, supported_languages
 
+
 def remove_auth_token(request):
     parsed_uri = urlparse(request.uri)
     parsed_query = parse_qs(parsed_uri.query)
@@ -20,19 +21,23 @@ def remove_auth_token(request):
     request.uri = parsed_uri.geturl()
     return request
 
+
 vcr = VCR(path_transformer=lambda path: path + '.yaml',
           before_record_request=remove_auth_token,
           record_mode=os.environ.get('VCR_RECORD_MODE', 'once'),
           match_on=['method', 'scheme', 'host', 'port', 'path', 'body'],
           cassette_library_dir=os.path.realpath(os.path.join('cassettes', 'assrt')))
 
+
 TOKEN=os.environ.get('ASSRT_TOKEN', 'NO_TOKEN_PROVIDED')
+
 
 def test_supported_languages():
     assert set(supported_languages) == set([('zho', None, None),
                                             ('eng', None, None),
                                             ('zho', None, 'Hans'),
                                             ('zho', None, 'Hant')])
+
 
 def test_language_contains():
     assert language_contains(Language('zho'), Language('zho'))
@@ -89,6 +94,7 @@ def test_converter_reverse():
     assert language_converters['assrt'].reverse(u'简体') == ('zho', None, 'Hans')
     assert language_converters['assrt'].reverse(u'繁体') == ('zho', None, 'Hant')
 
+
 @pytest.mark.integration
 @vcr.use_cassette
 def test_query_movie_zh_Hans(movies):
@@ -97,6 +103,7 @@ def test_query_movie_zh_Hans(movies):
     with AssrtProvider(TOKEN) as provider:
         subtitles = provider.query(languages, video)
         assert len(subtitles) == 8
+
 
 @pytest.mark.integration
 @vcr.use_cassette
@@ -107,6 +114,7 @@ def test_query_movie_zh_Hant(movies):
         subtitles = provider.query(languages, video)
         assert len(subtitles) == 8
 
+
 @pytest.mark.integration
 @vcr.use_cassette
 def test_query_movie_zh(movies):
@@ -115,6 +123,7 @@ def test_query_movie_zh(movies):
     with AssrtProvider(TOKEN) as provider:
         subtitles = provider.query(languages, video)
         assert len(subtitles) == 16
+
 
 @pytest.mark.integration
 @vcr.use_cassette


### PR DESCRIPTION
(re-PRing based on the correct branch)

Tons of pep fixes, also tested locally, and all seems to work fine.

I also want to note that some of the variable and import tweaks don't FIX the issues, but at this time ignore the issues

PEP 8: E722 do not use bare 'except'
E302 expected 2 blank lines, found X
E303 too many blank lines
W293 blank line contains whitespace
W291 trailing whitespace
E203 whitespace before ':'
E231 missing whitespace after ','
E129 visually indented line with same indent as next logical line
E127 continuation line over-indented for visual indent
E111 indentation is not a multiple of four
E117 over-indented
E122 continuation line missing indentation or outdented
E261 at least two spaces before inline comment
E262 inline comment should start with '# '
E251 unexpected spaces around keyword / parameter equals
E265 block comment should start with '# '
W0611 X imported but unused
W0401 'import *' used; unable to detect undefined names
E401 multiple imports on one line
E402 module level import not at top of file
E711 comparison to None should be 'if cond is not None:'
E713 test for membership should be 'not in
E128 continuation line under-indented for visual indent
E129 visually indented line with same indent as next logical line
E701 multiple statements on one line
W0612 local variable X is assigned to but never used
W0404 redefinition of unused import
E741 ambiguous variable name 'l'
