### PR TITLE
Fixed titrari provider

### DIFF
--- a/libs/subliminal_patch/providers/titrari.py
+++ b/libs/subliminal_patch/providers/titrari.py
@@ -104,7 +104,9 @@ class TitrariProvider(Provider, ProviderSubtitleArchiveMixin):
 
     def initialize(self):
         self.session = Session()
-        self.session.headers['User-Agent'] = AGENT_LIST[randint(0, len(AGENT_LIST) - 1)]
+        # Hardcoding the UA to bypass the 30s throttle that titrari.ro uses for IP/UA pair
+        self.session.headers['User-Agent'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4535.2 Safari/537.36'
+        # self.session.headers['User-Agent'] = AGENT_LIST[randint(0, len(AGENT_LIST) - 1)]
 
     def terminate(self):
         self.session.close()
@@ -184,11 +186,28 @@ class TitrariProvider(Provider, ProviderSubtitleArchiveMixin):
         else:
             return None
 
-
+    # titrari.ro seems to require all parameters now
+    #  z2 = comment (empty)
+    #  z3 = fps (-1: any, 0: N/A, 1: 23.97 FPS etc.)
+    #  z4 = CD count (-1: any)
+    #  z5 = imdb_id (empty or integer)
+    #  z6 = sort order (0: unsorted, 1: by date, 2: by name)
+    #  z7 = title (empty or string)
+    #  z8 = language (-1: all, 1: ron, 2: eng)
+    #  z9 = genre (All: all, Action: action etc.)
+    # z11 = type (0: any, 1: movie, 2: series)
     def getQueryParams(self, imdb_id, title):
         queryParams = {
             'page': self.query_advanced_search,
-            'z8': '1'
+            'z7': '',
+            'z2': '',
+            'z5': '',
+            'z3': '-1',
+            'z4': '-1',
+            'z8': '-1',
+            'z9': 'All',
+            'z11': '0',
+            'z6': '0'
         }
         if imdb_id is not None:
             queryParams["z5"] = imdb_id


### PR DESCRIPTION
- Titrari.ro is using some sort of IP/UA pairing; repeat requests from the same IP address **but** with a different User-Agent get throttled. The pair validity seems to about 30s.  Going back to hardcoding a popular User-Agent to bypass this limit
- I've also added all the search parameters that a search coming from the website might have, just to appear more legit
- Also documented all the parameters for the search