### PR TITLE
Fix Ktuvit problem with default empty return values

### DIFF
--- a/libs/subliminal_patch/providers/ktuvit.py
+++ b/libs/subliminal_patch/providers/ktuvit.py
@@ -480,8 +480,8 @@ class KtuvitProvider(Provider):
                 "Unable to parse JSON returned while getting " + message, ex.doc, ex.pos
             )
         else:
-            logger.debug("Parsing d response: " + str(response.content))
-            logger.debug("Parsing d response_content: " + str(response_content))
+            # kept for manual debugging when needed:
+            # logger.debug("Parsing d response_content: " + str(response_content))
 
             if "d" in response_content:
                 response_content = json.loads(response_content["d"])


### PR DESCRIPTION
Fix another issue in #1541  - 
This time, it's caused by bad error handling:

```
-                if not value:
+               if not value and value != default_value:
```

Turns out that `not [] == true` and other default return values which may have caused this. 
Also - added extra printouts.