### PR TITLE
Added More Equivalent release groups

### DIFF
--- a/libs/subliminal/score.py
+++ b/libs/subliminal/score.py
@@ -45,7 +45,7 @@ movie_scores = {'hash': 119, 'title': 60, 'year': 30, 'release_group': 15,
                 'source': 7, 'audio_codec': 3, 'resolution': 2, 'video_codec': 2, 'hearing_impaired': 1}
 
 #: Equivalent release groups
-equivalent_release_groups = ({'LOL', 'DIMENSION'}, {'ASAP', 'IMMERSE', 'FLEET'}, {'AVS', 'SVA'})
+equivalent_release_groups = ({'FraMeSToR', 'W4NK3R', 'BHDStudio'}, {'LOL', 'DIMENSION'}, {'ASAP', 'IMMERSE', 'FLEET'}, {'AVS', 'SVA'})
 
 
 def get_equivalent_release_groups(release_group):


### PR DESCRIPTION
Added: `FraMeSToR`, `W4NK3R`, `BHDStudio` to the Equivalent release groups, being that `W4NK3R` and `BHDStudio` use the `Framestor` (Remux) release as source for their bluray encodes.