### PR TITLE
Set query for exact match and make sure keys exist on _guess dict bef…

### DIFF
--- a/libs/subliminal_patch/providers/legendasdivx.py
+++ b/libs/subliminal_patch/providers/legendasdivx.py
@@ -272,7 +272,7 @@ class LegendasdivxProvider(Provider):
             querytext = video.imdb_id if video.imdb_id else video.title
 
         if isinstance(video, Episode):
-            querytext = '{} S{:02d}E{:02d}'.format(video.series, video.season, video.episode)
+            querytext = '%22{}%20S{:02d}E{:02d}%22'.format(video.series, video.season, video.episode)
             querytext = quote(querytext.lower())
 
         # language query filter
@@ -430,12 +430,13 @@ class LegendasdivxProvider(Provider):
 
             _guess = guessit(name)
             if isinstance(subtitle.video, Episode):
-                logger.debug("Legendasdivx.pt :: guessing %s", name)
-                logger.debug("Legendasdivx.pt :: subtitle S%sE%s video S%sE%s", _guess['season'], _guess['episode'], subtitle.video.season, subtitle.video.episode)
+                if all(key in _guess for key in ('season', 'episode')):
+                    logger.debug("Legendasdivx.pt :: guessing %s", name)
+                    logger.debug("Legendasdivx.pt :: subtitle S%sE%s video S%sE%s", _guess['season'], _guess['episode'], subtitle.video.season, subtitle.video.episode)
 
-                if subtitle.video.episode != _guess['episode'] or subtitle.video.season != _guess['season']:
-                    logger.debug('Legendasdivx.pt :: subtitle does not match video, skipping')
-                    continue
+                    if subtitle.video.episode != _guess['episode'] or subtitle.video.season != _guess['season']:
+                        logger.debug('Legendasdivx.pt :: subtitle does not match video, skipping')
+                        continue
 
             matches = set()
             matches |= guess_matches(subtitle.video, _guess)


### PR DESCRIPTION
…ore getting value to avoid KeyError

LegendasDivx query gets wrong results especially when searching for series because we don't query terms between quotes:
'"Lost S06E02"' is much more accurate than Lost 'S06E02' because it search for full sequence.
When referencing _guess['season'] and _guess['episode'] sometimes they aren't set previously which caused KeyError on this provider and throttled it for 10 minutes unnecessarily.