### PR TITLE
Sanitize apostrophe and backticks

### DIFF
--- a/libs/subliminal_patch/utils.py
+++ b/libs/subliminal_patch/utils.py
@@ -25,7 +25,7 @@ def sanitize(string, ignore_characters=None, default_characters={'-', ':', '(', 
         string = re.sub(r'[%s]' % re.escape(''.join(characters)), ' ', string)
 
     # remove some characters
-    characters = {'\''} - ignore_characters
+    characters = {'\'', '´', '`', '’'} - ignore_characters
     if characters:
         string = re.sub(r'[%s]' % re.escape(''.join(characters)), '', string)
 


### PR DESCRIPTION
Adds <code>’</code>, <code>`</code> and <code>´</code> to the list of chars to remove in the <code>sanitize</code> function.

I found this while trying to fetch subtitles for https://www.thetvdb.com/series/its-always-sunny-in-philadelphia using opensubtitles. More specifically, fetching the subtitles for s03e01 was resulting 0 results but in the debug logs we were discarding 3 subtitles:

```
28/11/2021 11:00:57|DEBUG   |subliminal_patch.providers.opensubtitles|Using timeout: 15|
28/11/2021 11:00:57|DEBUG   |subliminal_patch.providers.opensubtitles|Using previous login token: 'QBLbIgJD91XXXXXXXXXXXXXXXXX'|
28/11/2021 11:00:57|INFO    |subliminal_patch.providers.opensubtitles|Searching subtitles [{'moviehash': 'de3d8831fa7f6780', 'moviebytesize': '267677395', 'sublanguageid': 'eng,eng'}, {'imdbid': '0472954', 'season': 3, 'ep
isode': 1, 'sublanguageid': 'eng,eng'}]|
28/11/2021 11:00:57|DEBUG   |urllib3.connectionpool          |Starting new HTTP connection (1): api.opensubtitles.org:80|
28/11/2021 11:00:57|DEBUG   |urllib3.connectionpool          |http://api.opensubtitles.org:80 "POST /xml-rpc HTTP/1.1" 200 1819|
28/11/2021 11:00:57|DEBUG   |subliminal_patch.providers.opensubtitles|Found subtitle <OpenSubtitlesSubtitle 'http://www.opensubtitles.org/en/subtitles/3295037/sid-QBLbIgJD91AxceUj,WKSFgSmrbc/it-s-always-sunny-in-philadelph
ia-the-gang-finds-a-dumpster-baby-en' [en:None]> by moviehash|
28/11/2021 11:00:57|DEBUG   |subliminal_patch.providers.opensubtitles|Found subtitle <OpenSubtitlesSubtitle 'http://www.opensubtitles.org/en/subtitles/4336349/sid-QBLbIgJD91AxceUj,WKSFgSmrbc/it-s-always-sunny-in-philadelph
ia-the-gang-finds-a-dumpster-baby-en' [en:None]> by imdbid|
28/11/2021 11:00:57|DEBUG   |subliminal_patch.providers.opensubtitles|Found subtitle <OpenSubtitlesSubtitle 'http://www.opensubtitles.org/en/subtitles/3689613/sid-QBLbIgJD91AxceUj,WKSFgSmrbc/it-s-always-sunny-in-philadelph
ia-the-gang-finds-a-dumpster-baby-en' [en:None]> by imdbid|
28/11/2021 11:00:57|DEBUG   |subliminal_patch.providers.opensubtitles|Found subtitle <OpenSubtitlesSubtitle 'http://www.opensubtitles.org/en/subtitles/3295037/sid-QBLbIgJD91AxceUj,WKSFgSmrbc/it-s-always-sunny-in-philadelph
ia-the-gang-finds-a-dumpster-baby-en' [en:None]> by imdbid|
28/11/2021 11:00:57|INFO    |subliminal_patch.core           |Found 3 subtitle(s)|
28/11/2021 11:00:57|DEBUG   |subliminal.core                 |Terminating initialized providers|
28/11/2021 11:00:57|INFO    |subliminal_patch.core           |Terminating provider opensubtitles|
28/11/2021 11:00:57|DEBUG   |subliminal.providers.opensubtitles|Match on hash discarded|
28/11/2021 11:00:57|DEBUG   |root                            |BAZARR Skipping <OpenSubtitlesSubtitle 'http://www.opensubtitles.org/en/subtitles/3295037/sid-QBLbIgJD91AxceUj,WKSFgSmrbc/it-s-always-sunny-in-philadelphia-the-
gang-finds-a-dumpster-baby-en' [en:None]>, because it doesn't match our series/episode|
28/11/2021 11:00:58|DEBUG   |subliminal_patch.subtitle       |Source match found? False: Web -> ['DVD']|
28/11/2021 11:00:58|DEBUG   |subliminal_patch.subtitle       |video_codec matched? False (H.264 -> Xvid)|
28/11/2021 11:00:58|DEBUG   |subliminal_patch.subtitle       |Source match found? False: Web -> ['DVD']|
28/11/2021 11:00:58|DEBUG   |subliminal_patch.subtitle       |video_codec matched? False (H.264 -> Xvid)|
28/11/2021 11:00:58|DEBUG   |root                            |BAZARR Skipping <OpenSubtitlesSubtitle 'http://www.opensubtitles.org/en/subtitles/4336349/sid-QBLbIgJD91AxceUj,WKSFgSmrbc/it-s-always-sunny-in-philadelphia-the-
gang-finds-a-dumpster-baby-en' [en:None]>, because it doesn't match our series/episode|
28/11/2021 11:00:58|DEBUG   |peewee                          |('SELECT "t1"."configured", "t1"."updated" FROM "system" AS "t1" LIMIT ? OFFSET ?', [1, 0])|
28/11/2021 11:00:59|DEBUG   |subliminal_patch.providers.opensubtitles|Wrong FPS (expected: 23.976, got: 30.000, continuing)|
28/11/2021 11:00:59|DEBUG   |root                            |BAZARR Skipping <OpenSubtitlesSubtitle 'http://www.opensubtitles.org/en/subtitles/3689613/sid-QBLbIgJD91AxceUj,WKSFgSmrbc/it-s-always-sunny-in-philadelphia-the-
gang-finds-a-dumpster-baby-en' [en:None]>, because it doesn't match our series/episode|
28/11/2021 11:00:59|DEBUG   |root                            |BAZARR 0 Subtitles have been found for this file: /data/media/tv/It’s Always Sunny in Philadelphia/Season 3/Its.Always.Sunny.in.Philadelphia.S03E01.The.Gang.Fin
ds.A.Dumpster.Baby.480p.WEB-DL.AAC2.0.H.264.mkv|
28/11/2021 11:00:59|DEBUG   |root                            |BAZARR Ended searching Subtitles for this file: /data/media/tv/It’s Always Sunny in Philadelphia/Season 3/Its.Always.Sunny.in.Philadelphia.S03E01.The.Gang.Finds
.A.Dumpster.Baby.480p.WEB-DL.AAC2.0.H.264.mkv|
```

After some debug logging, this was the `series` name being extracted: `It’s Always Sunny in Philadelphia`.

I also added the backticks to the set of characters to remove but they aren't needed for this situation, just more of a prevention. Let me know if you prefer to only have the apostrophe removed.