### PR TITLE
add cookies option for addic7ed to avoid captcha

### DIFF
--- a/bazarr/config.py
+++ b/bazarr/config.py
@@ -136,6 +136,8 @@ defaults = {
     'addic7ed': {
         'username': '',
         'password': '',
+        'cookies': '',
+        'user_agent': '',
         'vip': 'False'
     },
     'podnapisi': {

--- a/bazarr/get_providers.py
+++ b/bazarr/get_providers.py
@@ -128,6 +128,8 @@ def get_providers_auth():
         'addic7ed': {
             'username': settings.addic7ed.username,
             'password': settings.addic7ed.password,
+            'cookies': settings.addic7ed.cookies,
+            'user_agent': settings.addic7ed.user_agent,
             'is_vip': settings.addic7ed.getboolean('vip'),
         },
         'opensubtitles': {

--- a/frontend/src/Settings/Providers/list.ts
+++ b/frontend/src/Settings/Providers/list.ts
@@ -17,14 +17,20 @@ export interface ProviderInfo {
 export const ProviderList: Readonly<ProviderInfo[]> = [
   {
     key: "addic7ed",
-    description: "Requires Anti-Captcha Provider",
+    description: "Requires Anti-Captcha Provider or cookies",
     defaultKey: {
       username: "",
       password: "",
+      cookies: "",
+      user_agent: "",
       vip: false,
     },
     keyNameOverride: {
       vip: "VIP",
+      cookies:
+        "Cookies, e.g., PHPSESSID=abc; wikisubtitlesuser=xyz; wikisubtitlespass=efg",
+      user_agent:
+        "User-Agent, e.g., Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:95.0) Gecko/20100101 Firefox/95.0",
     },
   },
   { key: "argenteam", description: "LATAM Spanish Subtitles Provider" },

--- a/libs/subliminal/providers/addic7ed.py
+++ b/libs/subliminal/providers/addic7ed.py
@@ -98,12 +98,14 @@ class Addic7edProvider(Provider):
     server_url = 'http://www.addic7ed.com/'
     subtitle_class = Addic7edSubtitle
 
-    def __init__(self, username=None, password=None):
+    def __init__(self, username=None, password=None, cookies=None, user_agent=None):
         if any((username, password)) and not all((username, password)):
             raise ConfigurationError('Username and password must be specified')
 
         self.username = username
         self.password = password
+        self.cookies = cookies
+        self.user_agent = user_agent
         self.logged_in = False
         self.session = None
 

--- a/libs/subliminal_patch/providers/addic7ed.py
+++ b/libs/subliminal_patch/providers/addic7ed.py
@@ -83,13 +83,15 @@ class Addic7edProvider(_Addic7edProvider):
     sanitize_characters = {'-', ':', '(', ')', '.', '/'}
     last_show_ids_fetch_key = "addic7ed_last_id_fetch"
 
-    def __init__(self, username=None, password=None, use_random_agents=False, is_vip=False):
-        super(Addic7edProvider, self).__init__(username=username, password=password)
+    def __init__(self, username=None, password=None, cookies=None, user_agent=None, use_random_agents=False,
+                 is_vip=False):
+        super(Addic7edProvider, self).__init__(username=username, password=password, cookies=cookies,
+                                               user_agent=user_agent)
         self.USE_ADDICTED_RANDOM_AGENTS = use_random_agents
         self.vip = is_vip
 
-        if not all((username, password)):
-            raise ConfigurationError('Username and password must be specified')
+        if not all((username, password)) and not cookies:
+            raise ConfigurationError('Username and password or cookies must be specified')
 
     def initialize(self):
         self.session = Session()
@@ -99,6 +101,28 @@ class Addic7edProvider(_Addic7edProvider):
         logger.debug("Addic7ed: using random user agents")
         self.session.headers['User-Agent'] = AGENT_LIST[randint(0, len(AGENT_LIST) - 1)]
         self.session.headers['Referer'] = self.server_url
+
+        if self.user_agent:
+            self.session.headers['User-Agent'] = self.user_agent
+        if self.cookies:
+            cookies_string = self.cookies.split(";")
+            from requests.cookies import RequestsCookieJar
+            self.session.cookies = RequestsCookieJar()
+            for c in cookies_string:
+                k, v = c.split("=")
+                self.session.cookies.set(k,v)
+
+            rr = self.session.get(self.server_url + 'panel.php', allow_redirects=False, timeout=10,
+                                  headers={"Referer": self.server_url})
+            if rr.status_code == 302:
+                logger.info('Addic7ed: Login expired')
+                raise AuthenticationError("cookies not valid anymore")
+
+            store_verification("addic7ed", self.session)
+            logger.debug('Addic7ed: Logged in')
+            self.logged_in = True
+            time.sleep(2)
+            return True
 
         # login
         if self.username and self.password:


### PR DESCRIPTION
Support authentication by using cookie obtain in browser after manually login and resolved recaptcha
![Screenshot from 2022-01-04 20-40-16](https://user-images.githubusercontent.com/4802105/148278812-263af64d-2b41-43c1-a3fe-af28e5b815ed.png)

