### PR TITLE
Small grammar fix

### DIFF
--- a/frontend/src/Settings/Subtitles/index.tsx
+++ b/frontend/src/Settings/Subtitles/index.tsx
@@ -151,8 +151,7 @@ const SettingsSubtitlesView: FunctionComponent = () => {
                 options={adaptiveSearchingDelayOption}
               ></Selector>
               <Message>
-                How much weeks must Bazarr wait after initial search to reduce
-                search frequency.
+                In order to reduce search frequency, how many weeks must Bazarr wait after initial search.
               </Message>
             </Input>
             <Input>


### PR DESCRIPTION
Small change in the wording under `Settings > Subtitles > Adaptive Searching`