### PR TITLE
Allow package maintainers to store information about the package.

### DIFF
--- a/bazarr/api/system/status.py
+++ b/bazarr/api/system/status.py
@@ -24,4 +24,6 @@ class SystemStatus(Resource):
         system_status.update({'bazarr_directory': os.path.dirname(os.path.dirname(__file__))})
         system_status.update({'bazarr_config_directory': args.config_dir})
         system_status.update({'start_time': startTime})
+        if "PACKAGE_VERSION" in os.environ:
+            system_status.update({'package_version': os.environ["PACKAGE_VERSION"]})
         return jsonify(data=system_status)

--- a/bazarr/logger.py
+++ b/bazarr/logger.py
@@ -103,6 +103,8 @@ def configure_logging(debug=False):
         logging.getLogger("srt").setLevel(logging.DEBUG)
         logging.debug('Bazarr version: %s', os.environ["BAZARR_VERSION"])
         logging.debug('Bazarr branch: %s', settings.general.branch)
+        if "PACKAGE_VERSION" in os.environ:
+            logging.debug('Package version: %s', os.environ["PACKAGE_VERSION"])
         logging.debug('Operating system: %s', platform.platform())
         logging.debug('Python version: %s', platform.python_version())
     else:

--- a/bazarr/main.py
+++ b/bazarr/main.py
@@ -3,12 +3,25 @@
 import os
 
 bazarr_version = 'unknown'
+package_version = package_author = ''
 
 version_file = os.path.join(os.path.dirname(__file__), '..', 'VERSION')
 if os.path.isfile(version_file):
     with open(version_file, 'r') as f:
         bazarr_version = f.readline()
         bazarr_version = bazarr_version.rstrip('\n')
+
+package_info_file = os.path.join(os.path.dirname(__file__), '..', 'package_info')
+if os.path.isfile(package_info_file):
+    with open(package_info_file, 'r') as f:
+        try:
+            package_info = {key: str(val).strip() for key, val in (l.split('=', 1) for l in f)}
+            package_version = package_info.get('PackageVersion')
+            package_author = package_info.get('PackageAuthor')
+            os.environ["PACKAGE_VERSION"] = f'{package_version} by {package_author}'
+        except:
+            # On whatever error, skip setting package info
+            pass
 
 os.environ["BAZARR_VERSION"] = bazarr_version.lstrip('v')
 

--- a/frontend/src/@types/system.d.ts
+++ b/frontend/src/@types/system.d.ts
@@ -17,6 +17,7 @@ declare namespace System {
     radarr_version: string;
     sonarr_version: string;
     start_time: number;
+    package_version: string;
   }
 
   interface Health {

--- a/frontend/src/pages/System/Status/index.tsx
+++ b/frontend/src/pages/System/Status/index.tsx
@@ -110,6 +110,11 @@ const SystemStatusView: FunctionComponent<Props> = () => {
           <CRow title="Bazarr Version">
             <span>{status?.bazarr_version}</span>
           </CRow>
+          {status?.package_version && (
+            <CRow title="Package Version">
+              <span>{status?.package_version}</span>
+            </CRow>
+          )}
           <CRow title="Sonarr Version">
             <span>{status?.sonarr_version}</span>
           </CRow>


### PR DESCRIPTION
This idea comes from *Arr where a file `package_info` can be created
during building of a package to store information about the version
and author of the package.
If this file is present, the information is shown in debug logs and
in the webinterface under System->Status.

This change supports `PackageVersion` and `PackageAuthor` keys in this
file. The other keys that the other Arrs support are not yet
implemented.

The `package_info` file is a text file with `key=value` per line.

Implements https://bazarr.featureupvote.com/suggestions/274435

Example how it will show in the webfrontend: https://capture.dropbox.com/aG3ajMQutH3A5XWr?src=ss