### PR TITLE
Read more info from package_info file

### DIFF
--- a/bazarr/api/system/status.py
+++ b/bazarr/api/system/status.py
@@ -15,8 +15,15 @@ from init import startTime
 class SystemStatus(Resource):
     @authenticate
     def get(self):
+        package_version = ''
+        if  'BAZARR_PACKAGE_VERSION' in os.environ:
+            package_version = os.environ['BAZARR_PACKAGE_VERSION']
+        if 'BAZARR_PACKAGE_AUTHOR' in os.environ and os.environ['BAZARR_PACKAGE_AUTHOR'] != '':
+            package_version = f'{package_version} by {os.environ["BAZARR_PACKAGE_AUTHOR"]}'
+
         system_status = {}
         system_status.update({'bazarr_version': os.environ["BAZARR_VERSION"]})
+        system_status.update({'package_version': package_version})
         system_status.update({'sonarr_version': get_sonarr_info.version()})
         system_status.update({'radarr_version': get_radarr_info.version()})
         system_status.update({'operating_system': platform.platform()})
@@ -24,4 +31,5 @@ class SystemStatus(Resource):
         system_status.update({'bazarr_directory': os.path.dirname(os.path.dirname(__file__))})
         system_status.update({'bazarr_config_directory': args.config_dir})
         system_status.update({'start_time': startTime})
+
         return jsonify(data=system_status)

--- a/bazarr/init.py
+++ b/bazarr/init.py
@@ -144,10 +144,10 @@ if os.path.isfile(package_info_file):
         # package author can disable update
         if package_info.get('updatemethod', '') == 'External':
             os.environ['BAZARR_UPDATE_ALLOWED'] = '0'
-            os.environ['BAZARR_UPDATE_MESSAGE'] = package_info.get('updatemethodmessage')
+            os.environ['BAZARR_UPDATE_MESSAGE'] = package_info.get('updatemethodmessage', '')
         # package author can provide version and contact info
-        os.environ['BAZARR_PACKAGE_VERSION'] = package_info.get('packageversion')
-        os.environ['BAZARR_PACKAGE_AUTHOR'] = package_info.get('packageauthor')
+        os.environ['BAZARR_PACKAGE_VERSION'] = package_info.get('packageversion', '')
+        os.environ['BAZARR_PACKAGE_AUTHOR'] = package_info.get('packageauthor', '')
     except Exception:
         pass
     else:

--- a/bazarr/init.py
+++ b/bazarr/init.py
@@ -121,7 +121,8 @@ if isinstance(settings.general.enabled_providers, str) and not settings.general.
     with open(os.path.join(args.config_dir, 'config', 'config.ini'), 'w+') as handle:
         settings.write(handle)
 
-# make sure settings.general.branch is properly set when running inside a docker container
+# Read package_info (if exists) to override some settings by package maintainers
+# This file can also provide some info about the package version and author
 package_info_file = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'package_info')
 if os.path.isfile(package_info_file):
     try:
@@ -137,8 +138,16 @@ if os.path.isfile(package_info_file):
                     package_info[splitted_line[0].lower()] = splitted_line[1].replace('\n', '')
                 else:
                     continue
+        # package author can force a branch to follow
         if 'branch' in package_info:
             settings.general.branch = package_info['branch']
+        # package author can disable update
+        if package_info.get('updatemethod', '') == 'External':
+            os.environ['BAZARR_UPDATE_ALLOWED'] = '0'
+            os.environ['BAZARR_UPDATE_MESSAGE'] = package_info.get('updatemethodmessage')
+        # package author can provide version and contact info
+        os.environ['BAZARR_PACKAGE_VERSION'] = package_info.get('packageversion')
+        os.environ['BAZARR_PACKAGE_AUTHOR'] = package_info.get('packageauthor')
     except Exception:
         pass
     else:

--- a/bazarr/init.py
+++ b/bazarr/init.py
@@ -133,7 +133,7 @@ if os.path.isfile(package_info_file):
             for line in lines:
                 splitted_lines += line.split(r'\n')
             for line in splitted_lines:
-                splitted_line = line.split('=')
+                splitted_line = line.split('=', 1)
                 if len(splitted_line) == 2:
                     package_info[splitted_line[0].lower()] = splitted_line[1].replace('\n', '')
                 else:

--- a/frontend/src/@types/system.d.ts
+++ b/frontend/src/@types/system.d.ts
@@ -13,6 +13,7 @@ declare namespace System {
     bazarr_directory: string;
     bazarr_version: string;
     operating_system: string;
+    package_version: string;
     python_version: string;
     radarr_version: string;
     sonarr_version: string;

--- a/frontend/src/pages/System/Status/index.tsx
+++ b/frontend/src/pages/System/Status/index.tsx
@@ -110,6 +110,11 @@ const SystemStatusView: FunctionComponent<Props> = () => {
           <CRow title="Bazarr Version">
             <span>{status?.bazarr_version}</span>
           </CRow>
+          {status?.package_version !== "" && (
+            <CRow title="Package Version">
+              <span>{status?.package_version}</span>
+            </CRow>
+          )}
           <CRow title="Sonarr Version">
             <span>{status?.sonarr_version}</span>
           </CRow>


### PR DESCRIPTION
The package_info file can now hold `PackageVersion` and `PackageAuthor` like the other arrs have as well.

The `UpdateMethod` and `UpdateMethodMessage` are already read and put on environment variables, but they are not actually used yet.

Implements https://bazarr.featureupvote.com/suggestions/274435