### PR TITLE
Fix addic7ed subtitle search query

### DIFF
--- a/libs/subliminal_patch/providers/addic7ed.py
+++ b/libs/subliminal_patch/providers/addic7ed.py
@@ -430,7 +430,7 @@ class Addic7edProvider(_Addic7edProvider):
         # get the page of the season of the show
         logger.info('Getting the page of show id %d, season %d', show_id, season)
         r = self.session.get(self.server_url + 'ajax_loadShow.php',
-                             params={'show': show_id, 'season': season},
+                             params={'show': show_id, 'season': season, 'langs': '|'},
                              timeout=10,
                              headers={
                                  "referer": "%sshow/%s" % (self.server_url, show_id),


### PR DESCRIPTION
Adding the parameters: 'langs' and value '|' in the ajax query search subtitles in every existing language.
Wihout this param, the query was returning subtitles in English only.