### PR TITLE
Fix titulky UnicodeEncodeError

### DIFF
--- a/libs/subliminal_patch/providers/titulky.py
+++ b/libs/subliminal_patch/providers/titulky.py
@@ -5,7 +5,7 @@ import math
 import re
 import zipfile
 from random import randint
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import urlparse, parse_qs, quote
 from threading import Thread
 
 import rarfile
@@ -314,7 +314,7 @@ class TitulkyProvider(Provider, ProviderSubtitleArchiveMixin):
 
     # GET request a page. This functions acts as a requests.session.get proxy handling expired cached cookies 
     # and subsequent relogging and sending the original request again. If all went well, returns the response.
-    def get_request(self, url, ref=None, __recursion=0):
+    def get_request(self, url, ref=server_url, __recursion=0):
         # That's deep... recursion... Stop. We don't have infinite memmory. And don't want to 
         # spam titulky's server either. So we have to just accept the defeat. Let it throw!
         if __recursion >= 5:
@@ -327,7 +327,7 @@ class TitulkyProvider(Provider, ProviderSubtitleArchiveMixin):
             url,
             timeout=self.timeout,
             allow_redirects=False,
-            headers={'Referer': ref if ref else self.server_url})
+            headers={'Referer': quote(ref)})
 
         # Check if we got redirected because login cookies expired.
         # Note: microoptimization - don't bother parsing qs for non 302 responses.


### PR DESCRIPTION
I have randomly come upon on an encoding error that I have seen at least twice in logs. This PR should fix it.

The stacktrace is printed in log:
```
07/03/2022 02:00:27|DEBUG   |subliminal_patch.providers.titulky|Titulky.com: An error occured while processing a row in the thread ID 0|
07/03/2022 02:00:27|ERROR   |subliminal_patch.core           |Unexpected error in provider 'titulky': Traceback (most recent call last):  File "/app/bazarr/bin/bazarr/../libs/subliminal_patch/core.py", line 237, in list_subtitles_provider    results = self[provider].list_subtitles(video, provider_languages)  File "/app/bazarr/bin/bazarr/../libs/subliminal_patch/providers/titulky.py", line 881, in list_subtitles    partial_subs = self.query(language,  File "/app/bazarr/bin/bazarr/../libs/subliminal_patch/providers/titulky.py", line 768, in query    raise thread_data['exception']  File "/usr/lib/python3.9/threading.py", line 954, in _bootstrap_inner    self.run()  File "/usr/lib/python3.9/threading.py", line 892, in run    self._target(*self._args, **self._kwargs)  File "/app/bazarr/bin/bazarr/../libs/subliminal_patch/providers/titulky.py", line 573, in process_row    raise e  File "/app/bazarr/bin/bazarr/../libs/subliminal_patch/providers/titulky.py", line 540, in process_row    details = self.parse_details(details_link, search_url)  File "/app/bazarr/bin/bazarr/../libs/subliminal_patch/providers/titulky.py", line 376, in parse_details    html_src = self.fetch_page(details_url, ref=search_url)  File "/app/bazarr/bin/bazarr/../libs/subliminal_patch/providers/titulky.py", line 347, in fetch_page    res = self.get_request(url, ref=ref)  File "/app/bazarr/bin/bazarr/../libs/subliminal_patch/providers/titulky.py", line 326, in get_request    res = self.session.get(  File "/app/bazarr/bin/bazarr/../libs/subliminal_patch/http.py", line 229, in get    return self.retry_method("get", *args, **kwargs)  File "/app/bazarr/bin/bazarr/../libs/subliminal_patch/http.py", line 217, in retry_method    return retry_call(getattr(super(RetryingSession, self), method), fargs=args, fkwargs=kwargs, tries=3, delay=5,  File "/app/bazarr/bin/bazarr/../libs/retry/api.py", line 101, in retry_call    return __retry_internal(partial(f, *args, **kwargs), exceptions, tries, delay, max_delay, backoff, jitter, logger)  File "/app/bazarr/bin/bazarr/../libs/retry/api.py", line 33, in __retry_internal    return f()  File "/app/bazarr/bin/bazarr/../libs/requests/sessions.py", line 542, in get    return self.request('GET', url, **kwargs)  File "/app/bazarr/bin/bazarr/../libs/subliminal_patch/http.py", line 60, in request    return super(TimeoutSession, self).request(method, url, *args, **kwargs)  File "/app/bazarr/bin/bazarr/../libs/requests/sessions.py", line 529, in request    resp = self.send(prep, **send_kwargs)  File "/app/bazarr/bin/bazarr/../libs/requests/sessions.py", line 645, in send    r = adapter.send(request, **kwargs)  File "/app/bazarr/bin/bazarr/../libs/requests/adapters.py", line 440, in send    resp = conn.urlopen(  File "/app/bazarr/bin/bazarr/../libs/urllib3/connectionpool.py", line 703, in urlopen    httplib_response = self._make_request(  File "/app/bazarr/bin/bazarr/../libs/urllib3/connectionpool.py", line 398, in _make_request    conn.request(method, url, **httplib_request_kw)  File "/app/bazarr/bin/bazarr/../libs/urllib3/connection.py", line 239, in request    super(HTTPConnection, self).request(method, url, body=body, headers=headers)  File "/usr/lib/python3.9/http/client.py", line 1253, in request    self._send_request(method, url, body, headers, encode_chunked)  File "/usr/lib/python3.9/http/client.py", line 1294, in _send_request    self.putheader(hdr, value)  File "/app/bazarr/bin/bazarr/../libs/urllib3/connection.py", line 224, in putheader    _HTTPConnection.putheader(self, header, *values)  File "/usr/lib/python3.9/http/client.py", line 1226, in putheader    values[i] = one_value.encode('latin-1')UnicodeEncodeError: 'latin-1' codec can't encode character '\u010d' in position 43: ordinal not in range(256)|Traceback (most recent call last):  File "/app/bazarr/bin/bazarr/../libs/subliminal_patch/core.py", line 237, in list_subtitles_provider    results = self[provider].list_subtitles(video, provider_languages)  File "/app/bazarr/bin/bazarr/../libs/subliminal_patch/providers/titulky.py", line 881, in list_subtitles    partial_subs = self.query(language,  File "/app/bazarr/bin/bazarr/../libs/subliminal_patch/providers/titulky.py", line 768, in query    raise thread_data['exception']  File "/usr/lib/python3.9/threading.py", line 954, in _bootstrap_inner    self.run()  File "/usr/lib/python3.9/threading.py", line 892, in run    self._target(*self._args, **self._kwargs)  File "/app/bazarr/bin/bazarr/../libs/subliminal_patch/providers/titulky.py", line 573, in process_row    raise e  File "/app/bazarr/bin/bazarr/../libs/subliminal_patch/providers/titulky.py", line 540, in process_row    details = self.parse_details(details_link, search_url)  File "/app/bazarr/bin/bazarr/../libs/subliminal_patch/providers/titulky.py", line 376, in parse_details    html_src = self.fetch_page(details_url, ref=search_url)  File "/app/bazarr/bin/bazarr/../libs/subliminal_patch/providers/titulky.py", line 347, in fetch_page    res = self.get_request(url, ref=ref)  File "/app/bazarr/bin/bazarr/../libs/subliminal_patch/providers/titulky.py", line 326, in get_request    res = self.session.get(  File "/app/bazarr/bin/bazarr/../libs/subliminal_patch/http.py", line 229, in get    return self.retry_method("get", *args, **kwargs)  File "/app/bazarr/bin/bazarr/../libs/subliminal_patch/http.py", line 217, in retry_method    return retry_call(getattr(super(RetryingSession, self), method), fargs=args, fkwargs=kwargs, tries=3, delay=5,  File "/app/bazarr/bin/bazarr/../libs/retry/api.py", line 101, in retry_call    return __retry_internal(partial(f, *args, **kwargs), exceptions, tries, delay, max_delay, backoff, jitter, logger)  File "/app/bazarr/bin/bazarr/../libs/retry/api.py", line 33, in __retry_internal    return f()  File "/app/bazarr/bin/bazarr/../libs/requests/sessions.py", line 542, in get    return self.request('GET', url, **kwargs)  File "/app/bazarr/bin/bazarr/../libs/subliminal_patch/http.py", line 60, in request    return super(TimeoutSession, self).request(method, url, *args, **kwargs)  File "/app/bazarr/bin/bazarr/../libs/requests/sessions.py", line 529, in request    resp = self.send(prep, **send_kwargs)  File "/app/bazarr/bin/bazarr/../libs/requests/sessions.py", line 645, in send    r = adapter.send(request, **kwargs)  File "/app/bazarr/bin/bazarr/../libs/requests/adapters.py", line 440, in send    resp = conn.urlopen(  File "/app/bazarr/bin/bazarr/../libs/urllib3/connectionpool.py", line 703, in urlopen    httplib_response = self._make_request(  File "/app/bazarr/bin/bazarr/../libs/urllib3/connectionpool.py", line 398, in _make_request    conn.request(method, url, **httplib_request_kw)  File "/app/bazarr/bin/bazarr/../libs/urllib3/connection.py", line 239, in request    super(HTTPConnection, self).request(method, url, body=body, headers=headers)  File "/usr/lib/python3.9/http/client.py", line 1253, in request    self._send_request(method, url, body, headers, encode_chunked)  File "/usr/lib/python3.9/http/client.py", line 1294, in _send_request    self.putheader(hdr, value)  File "/app/bazarr/bin/bazarr/../libs/urllib3/connection.py", line 224, in putheader    _HTTPConnection.putheader(self, header, *values)  File "/usr/lib/python3.9/http/client.py", line 1226, in putheader    values[i] = one_value.encode('latin-1')UnicodeEncodeError: 'latin-1' codec can't encode character '\u010d' in position 43: ordinal not in range(256)|
07/03/2022 02:00:27|INFO    |root                            |Throttling titulky for 10 minutes, until 22/03/07 02:10, because of: UnicodeEncodeError. Exception info: 'latin-1'|
```