### PR TITLE
Add `NO_UPDATE` env var

### DIFF
--- a/bazarr/get_args.py
+++ b/bazarr/get_args.py
@@ -5,6 +5,7 @@ import argparse
 
 from distutils.util import strtobool
 
+no_update = bool(os.environ.get("NO_UPDATE", False))
 parser = argparse.ArgumentParser()
 
 
@@ -16,8 +17,9 @@ def get_args():
                         dest="config_dir", help="Directory containing the configuration (default: %s)" % config_dir)
     parser.add_argument('-p', '--port', type=int, metavar="PORT", dest="port",
                         help="Port number (default: 6767)")
-    parser.add_argument('--no-update', default=False, type=bool, const=True, metavar="BOOL", nargs="?",
-                        help="Disable update functionality (default: False)")
+    if not no_update:
+        parser.add_argument('--no-update', default=False, type=bool, const=True, metavar="BOOL", nargs="?",
+                            help="Disable update functionality (default: False)")
     parser.add_argument('--debug', default=False, type=bool, const=True, metavar="BOOL", nargs="?",
                         help="Enable console debugging (default: False)")
     parser.add_argument('--release-update', default=False, type=bool, const=True, metavar="BOOL", nargs="?",
@@ -31,3 +33,5 @@ def get_args():
 
 
 args = get_args()
+if no_update:
+    args.no_update = True


### PR DESCRIPTION
If the `NO_UPDATE` env var is set to true, it removes the CLI option altogether, and disables automatic updating. This is useful for distributing bazarr as a package in e.g. [macOS Homebrew](https://github.com/Homebrew/homebrew-core/pull/97444), since it (like other package managers) has a policy of not allowing auto updates at all. This seems to be the user-friendliest way to do it.