### PR TITLE
Fix usage of "and" operator on lists

### DIFF
--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -189,9 +189,9 @@ def list_missing_subtitles_movies(no=None, send_event=True):
                         cutoff_met = True
                     elif cutoff_language in actual_subtitles_list:
                         cutoff_met = True
-                    elif cutoff_language and [cutoff_language[0], 'True', 'False'] in actual_subtitles_list:
+                    elif [cutoff_language[0], cutoff_language[1], 'False'] in actual_subtitles_list:
                         cutoff_met = True
-                    elif cutoff_language and [cutoff_language[0], 'False', 'True'] in actual_subtitles_list:
+                    elif [cutoff_language[0], 'False', cutoff_language[2]] in actual_subtitles_list:
                         cutoff_met = True
 
             if cutoff_met:

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -197,9 +197,9 @@ def list_missing_subtitles(no=None, epno=None, send_event=True):
                         cutoff_met = True
                     elif cutoff_language in actual_subtitles_list:
                         cutoff_met = True
-                    elif cutoff_language and [cutoff_language[0], 'True', 'False'] in actual_subtitles_list:
+                    elif [cutoff_language[0], cutoff_language[1], 'False'] in actual_subtitles_list:
                         cutoff_met = True
-                    elif cutoff_language and [cutoff_language[0], 'False', 'True'] in actual_subtitles_list:
+                    elif [cutoff_language[0], 'False', cutoff_language[2]] in actual_subtitles_list:
                         cutoff_met = True
 
             if cutoff_met:


### PR DESCRIPTION
The current code uses the `and` operator to combine two lists, which simply returns the second list (if the first list is not empty). I assume this is not the intended behaviour here.
I assume that the intended behaviour is to apply the `and` operator to every element, which also would not work directly, because `"True"` and `"False"` are strings and not bools.

This PR implements the correct behaviour under the above assumptions, which is to force the second or third element of the list to `"False"`.
Feel free to reject the PR if my assumptions are wrong.

I'm also not sure if the application logic makes sense, because this will consider the cutoff met if either `HearingImpaired` or `Forced` matches. For example the case where the cutoff specifies `Forced=True` and `HI=True` should not match an existing subtitle with `Forced=False` and `HI=True` in my opinion.