### PR TITLE
Titulky: Fail silently if media is missing IMDB ID.

### DIFF
--- a/libs/subliminal_patch/providers/titulky.py
+++ b/libs/subliminal_patch/providers/titulky.py
@@ -421,13 +421,13 @@ class TitulkyProvider(Provider, ProviderSubtitleArchiveMixin):
                                                     season=video.season,
                                                     episode=video.episode)
             else:
-                raise ProviderError("No IMDB ID found for the series!")
+                logger.info(f"Titulky.com: Skipping {video}! No IMDB ID found.")
         elif isinstance(video, Movie):
             if video.imdb_id:
                 logger.info("Titulky.com: Searching subtitles for a movie")
                 subtitles = self.query(languages, SubtitlesType.MOVIE, imdb_id=video.imdb_id)
             else:
-                raise ProviderError("No IMDB ID found for the movie!")
+                logger.info(f"Titulky.com: Skipping {video}! No IMDB ID found.")
 
         return subtitles
 


### PR DESCRIPTION
Replaced raised exception with a log entry and as a result the titulky provider is no longer throttled for 10 mins when a media has no IMDB ID.