### PR TITLE
Option to always use audio track for subtitle syncing

### DIFF
--- a/bazarr/app/ui.py
+++ b/bazarr/app/ui.py
@@ -2,6 +2,7 @@
 
 import os
 import requests
+import mimetypes
 
 from flask import request, abort, render_template, Response, session, send_file, stream_with_context, Blueprint
 from functools import wraps
@@ -28,6 +29,14 @@ static_bp = Blueprint('images', __name__,
                                                  'frontend', 'build', 'images'), static_url_path='/images')
 
 ui_bp.register_blueprint(static_bp)
+
+
+mimetypes.add_type('application/javascript', '.js')
+mimetypes.add_type('text/css', '.css')
+mimetypes.add_type('font/woff2', '.woff2')
+mimetypes.add_type('image/svg+xml', '.svg')
+mimetypes.add_type('image/png', '.png')
+mimetypes.add_type('image/x-icon', '.ico')
 
 
 def check_login(actual_method):

--- a/frontend/src/components/forms/TimeOffsetForm.tsx
+++ b/frontend/src/components/forms/TimeOffsetForm.tsx
@@ -47,7 +47,12 @@ const TimeOffsetForm: FunctionComponent<Props> = ({ selections, onSubmit }) => {
   return (
     <form
       onSubmit={form.onSubmit(({ positive, hour, min, sec, ms }) => {
-        const action = convertToAction(hour, min, sec, ms);
+        let action: string;
+        if (positive) {
+          action = convertToAction(hour, min, sec, ms);
+        } else {
+          action = convertToAction(-hour, -min, -sec, -ms);
+        }
 
         selections.forEach((s) =>
           task.create(s.path, TaskName, mutateAsync, {

--- a/frontend/src/pages/Settings/components/forms.tsx
+++ b/frontend/src/pages/Settings/components/forms.tsx
@@ -130,15 +130,16 @@ type SliderProps = BaseInput<number> &
 
 export const Slider: FunctionComponent<SliderProps> = (props) => {
   const { value, update, rest } = useBaseInput(props);
+  const { label, ...sliderProps } = rest;
 
   const { min = 0, max = 100 } = props;
 
   const marks = useSliderMarks([min, max]);
 
   return (
-    <InputWrapper label={rest.label}>
+    <InputWrapper label={label}>
       <MantineSlider
-        {...rest}
+        {...sliderProps}
         marks={marks}
         onChange={update}
         value={value ?? 0}

--- a/libs/subliminal_patch/core.py
+++ b/libs/subliminal_patch/core.py
@@ -70,6 +70,16 @@ def remove_crap_from_fn(fn):
     return REMOVE_CRAP_FROM_FILENAME.sub(repl, fn)
 
 
+def _nested_update(item, to_update):
+    for k, v in to_update.items():
+        if isinstance(v, dict):
+            item[k] = _nested_update(item.get(k, {}), v)
+        else:
+            item[k] = v
+
+    return item
+
+
 class _ProviderConfigs(dict):
     def __init__(self, pool, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -108,7 +118,9 @@ class _ProviderConfigs(dict):
         else:
             logger.debug("No provider config updates")
 
-        return super().update(items)
+        _nested_update(self, items)
+
+        return None
 
 
 class _Banlist:


### PR DESCRIPTION
As suggested in #1892, I've added an option to always use the audio track of the video file for subtitle syncing instead of an embedded subtitle (which is the default).