### PR TITLE
Option to always use audio track for subtitle syncing

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -219,7 +219,8 @@ defaults = {
         'subsync_threshold': '90',
         'use_subsync_movie_threshold': 'False',
         'subsync_movie_threshold': '70',
-        'debug': 'False'
+        'debug': 'False',
+        'force_audio': 'False'
     },
     'series_scores': {
         "hash": 359,

--- a/bazarr/subtitles/tools/subsyncer.py
+++ b/bazarr/subtitles/tools/subsyncer.py
@@ -54,6 +54,10 @@ class SubSyncer:
         try:
             unparsed_args = [self.reference, '-i', self.srtin, '-o', self.srtout, '--ffmpegpath', self.ffmpeg_path,
                              '--vad', self.vad, '--log-dir-path', self.log_dir_path]
+            if settings.subsync.getboolean('force_audio'):
+                unparsed_args.append('--no-fix-framerate ')
+                unparsed_args.append('--reference-stream')
+                unparsed_args.append('a:0')
             if settings.subsync.getboolean('debug'):
                 unparsed_args.append('--make-test-case')
             parser = make_parser()

--- a/frontend/src/pages/Settings/Subtitles/index.tsx
+++ b/frontend/src/pages/Settings/Subtitles/index.tsx
@@ -365,6 +365,14 @@ const SettingsSubtitlesView: FunctionComponent = () => {
           <Message>Must be 4 digit octal</Message>
         </CollapseBox>
         <Check
+          label="Always use Audio Track as Reference for Syncing"
+          settingKey="settings-subsync-force_audio"
+        ></Check>
+        <Message>
+          Use the audio track as reference for syncing, instead of using the
+          embedded subtitle.
+        </Message>
+        <Check
           label="Automatic Subtitles Synchronization"
           settingKey="settings-subsync-use_subsync"
         ></Check>

--- a/frontend/src/types/settings.d.ts
+++ b/frontend/src/types/settings.d.ts
@@ -111,6 +111,7 @@ declare namespace Settings {
     use_subsync_movie_threshold: boolean;
     subsync_movie_threshold: number;
     debug: boolean;
+    force_audio: boolean;
   }
 
   interface Analytic {


### PR DESCRIPTION
As suggested in #1892, I've added an option to always use the audio track of the video file for subtitle syncing instead of an embedded subtitle (which is the default).