### PR TITLE
Update checksum of aarch64 unrar binary

### DIFF
--- a/bazarr/utilities/binaries.json
+++ b/bazarr/utilities/binaries.json
@@ -4,7 +4,7 @@
     "machine": "aarch64",
     "directory": "unrar",
     "name": "unrar",
-    "checksum": "07a6371cc7db8493352739ce26b19ea1",
+    "checksum": "be7a08a75ffb1dcc5f8c6b16a75e822c",
     "url": "https://github.com/morpheus65535/bazarr-binaries/raw/master/bin/Linux/aarch64/unrar/unrar"
   },
   {


### PR DESCRIPTION
Companion PR to https://github.com/morpheus65535/bazarr-binaries/pull/1.