### PR TITLE
only consider alphabetic characters for uppercase detection

### DIFF
--- a/libs/subzero/modification/main.py
+++ b/libs/subzero/modification/main.py
@@ -191,7 +191,9 @@ class SubtitleModifications(object):
                     sub = processor.process(sub)
 
                 if sub.strip():
-                    if not sub.isupper():
+                    # only consider alphabetic characters to determine if uppercase
+                    alpha_sub = ''.join([i for i in sub if i.isalpha()])
+                    if alpha_sub and not alpha_sub.isupper():
                         return False
 
                     entry_used = True


### PR DESCRIPTION
currently if e.g. one of the subtitles lines is "4..." `isupper()` will return `False` breaking the `detect_uppercase()` detection.

`isupper()` does ignore all non alphabetic characters and returns `False` on an empty string.

To overcome this I've filtered out non alphabetic characters first and if any characters are left `isupper()` is called on the filtered result.