### PR TITLE
Gestdown: Check for show before checking for subtitle

### DIFF
--- a/libs/subliminal_patch/providers/gestdown.py
+++ b/libs/subliminal_patch/providers/gestdown.py
@@ -104,9 +104,24 @@ class GestdownProvider(Provider):
             logger.debug("Found subtitle: %s", sub)
             yield sub
 
+    def _show_exists(self, video):
+        try:
+            response = self._session.get(f"{_BASE_URL}/shows/search/{video.series}")
+            response.raise_for_status()
+            return True
+        except HTTPError as error:
+            if error.response.status_code == 404:
+                return False
+            raise
+
+
     @_retry_on_423
     def list_subtitles(self, video, languages):
         subtitles = []
+        if not self._show_exists(video):
+            logger.debug("Couldn't find the show")
+            return subtitles
+
         for language in languages:
             try:
                 subtitles += self._subtitles_search(video, language)


### PR DESCRIPTION
Will reduce the number of different calls to the provider and only ask for subtitle when we know the show exists.

@vitiko98 Small improvement to the previous PR, this will help a lot the service since I get a lot of requests for show that don't exist on Addic7ed.

I've also run the test suite for the provider and it passed.