### PR TITLE
Configurable timeout constants via env vars

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -427,13 +427,11 @@ def save_settings(settings_items):
             update_schedule = True
 
         if key in ['settings-general-use_sonarr', 'settings-sonarr-ip', 'settings-sonarr-port',
-                   'settings-sonarr-base_url', 'settings-sonarr-ssl', 'settings-sonarr-http_timeout',
-                   'settings-sonarr-apikey']:
+                   'settings-sonarr-base_url', 'settings-sonarr-ssl', 'settings-sonarr-apikey']:
             sonarr_changed = True
 
         if key in ['settings-general-use_radarr', 'settings-radarr-ip', 'settings-radarr-port',
-                   'settings-radarr-base_url', 'settings-radarr-ssl', 'settings-radarr-http_timeout',
-                   'settings-radarr-apikey']:
+                   'settings-radarr-base_url', 'settings-radarr-ssl', 'settings-radarr-apikey']:
             radarr_changed = True
 
         if key in ['settings-general-path_mappings', 'settings-general-path_mappings_movie']:

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -101,6 +101,7 @@ defaults = {
         'port': '8989',
         'base_url': '/',
         'ssl': 'False',
+        'http_timeout': '60',
         'apikey': '',
         'full_update': 'Daily',
         'full_update_day': '6',
@@ -119,6 +120,7 @@ defaults = {
         'port': '7878',
         'base_url': '/',
         'ssl': 'False',
+        'http_timeout': '60',
         'apikey': '',
         'full_update': 'Daily',
         'full_update_day': '6',
@@ -425,11 +427,13 @@ def save_settings(settings_items):
             update_schedule = True
 
         if key in ['settings-general-use_sonarr', 'settings-sonarr-ip', 'settings-sonarr-port',
-                   'settings-sonarr-base_url', 'settings-sonarr-ssl', 'settings-sonarr-apikey']:
+                   'settings-sonarr-base_url', 'settings-sonarr-ssl', 'settings-sonarr-http_timeout',
+                   'settings-sonarr-apikey']:
             sonarr_changed = True
 
         if key in ['settings-general-use_radarr', 'settings-radarr-ip', 'settings-radarr-port',
-                   'settings-radarr-base_url', 'settings-radarr-ssl', 'settings-radarr-apikey']:
+                   'settings-radarr-base_url', 'settings-radarr-ssl', 'settings-radarr-http_timeout',
+                   'settings-radarr-apikey']:
             radarr_changed = True
 
         if key in ['settings-general-path_mappings', 'settings-general-path_mappings_movie']:

--- a/bazarr/constants.py
+++ b/bazarr/constants.py
@@ -8,3 +8,7 @@ headers = {"User-Agent": os.environ["SZ_USER_AGENT"]}
 
 # hearing-impaired detection regex
 hi_regex = re.compile(r'[*¶♫♪].{3,}[*¶♫♪]|[\[\(\{].{3,}[\]\)\}](?<!{\\an\d})')
+
+# sync request timeouts
+radarr_http_timeout = int(os.getenv("RADARR_HTTP_TIMEOUT", "60"))
+sonarr_http_timeout = int(os.getenv("SONARR_HTTP_TIMEOUT", "60"))

--- a/bazarr/constants.py
+++ b/bazarr/constants.py
@@ -8,7 +8,3 @@ headers = {"User-Agent": os.environ["SZ_USER_AGENT"]}
 
 # hearing-impaired detection regex
 hi_regex = re.compile(r'[*¶♫♪].{3,}[*¶♫♪]|[\[\(\{].{3,}[\]\)\}](?<!{\\an\d})')
-
-# sync request timeouts
-radarr_http_timeout = int(os.getenv("RADARR_HTTP_TIMEOUT", "60"))
-sonarr_http_timeout = int(os.getenv("SONARR_HTTP_TIMEOUT", "60"))

--- a/bazarr/radarr/filesystem.py
+++ b/bazarr/radarr/filesystem.py
@@ -5,7 +5,7 @@ import logging
 
 from app.config import settings
 from radarr.info import get_radarr_info, url_radarr
-from constants import headers
+from constants import headers, radarr_http_timeout
 
 
 def browse_radarr_filesystem(path='#'):
@@ -21,7 +21,7 @@ def browse_radarr_filesystem(path='#'):
                                     "&allowFoldersWithoutTrailingSlashes=true&includeFiles=false&apikey=" + \
                                     settings.radarr.apikey
     try:
-        r = requests.get(url_radarr_api_filesystem, timeout=60, verify=False, headers=headers)
+        r = requests.get(url_radarr_api_filesystem, timeout=radarr_http_timeout, verify=False, headers=headers)
         r.raise_for_status()
     except requests.exceptions.HTTPError:
         logging.exception("BAZARR Error trying to get series from Radarr. Http error.")

--- a/bazarr/radarr/filesystem.py
+++ b/bazarr/radarr/filesystem.py
@@ -5,7 +5,7 @@ import logging
 
 from app.config import settings
 from radarr.info import get_radarr_info, url_radarr
-from constants import headers, radarr_http_timeout
+from constants import headers
 
 
 def browse_radarr_filesystem(path='#'):
@@ -21,7 +21,7 @@ def browse_radarr_filesystem(path='#'):
                                     "&allowFoldersWithoutTrailingSlashes=true&includeFiles=false&apikey=" + \
                                     settings.radarr.apikey
     try:
-        r = requests.get(url_radarr_api_filesystem, timeout=radarr_http_timeout, verify=False, headers=headers)
+        r = requests.get(url_radarr_api_filesystem, timeout=settings.radarr.http_timeout, verify=False, headers=headers)
         r.raise_for_status()
     except requests.exceptions.HTTPError:
         logging.exception("BAZARR Error trying to get series from Radarr. Http error.")

--- a/bazarr/radarr/filesystem.py
+++ b/bazarr/radarr/filesystem.py
@@ -21,7 +21,7 @@ def browse_radarr_filesystem(path='#'):
                                     "&allowFoldersWithoutTrailingSlashes=true&includeFiles=false&apikey=" + \
                                     settings.radarr.apikey
     try:
-        r = requests.get(url_radarr_api_filesystem, timeout=settings.radarr.http_timeout, verify=False, headers=headers)
+        r = requests.get(url_radarr_api_filesystem, timeout=int(settings.radarr.http_timeout), verify=False, headers=headers)
         r.raise_for_status()
     except requests.exceptions.HTTPError:
         logging.exception("BAZARR Error trying to get series from Radarr. Http error.")

--- a/bazarr/radarr/info.py
+++ b/bazarr/radarr/info.py
@@ -8,7 +8,7 @@ import json
 from dogpile.cache import make_region
 
 from app.config import settings, empty_values
-from constants import headers, radarr_http_timeout
+from constants import headers
 
 region = make_region().configure('dogpile.cache.memory')
 
@@ -29,7 +29,7 @@ class GetRadarrInfo:
         if settings.general.getboolean('use_radarr'):
             try:
                 rv = url_radarr() + "/api/system/status?apikey=" + settings.radarr.apikey
-                radarr_json = requests.get(rv, timeout=radarr_http_timeout, verify=False, headers=headers).json()
+                radarr_json = requests.get(rv, timeout=settings.radarr.http_timeout, verify=False, headers=headers).json()
                 if 'version' in radarr_json:
                     radarr_version = radarr_json['version']
                 else:
@@ -37,7 +37,7 @@ class GetRadarrInfo:
             except json.decoder.JSONDecodeError:
                 try:
                     rv = url_radarr() + "/api/v3/system/status?apikey=" + settings.radarr.apikey
-                    radarr_version = requests.get(rv, timeout=radarr_http_timeout, verify=False, headers=headers).json()['version']
+                    radarr_version = requests.get(rv, timeout=settings.radarr.http_timeout, verify=False, headers=headers).json()['version']
                 except json.decoder.JSONDecodeError:
                     logging.debug('BAZARR cannot get Radarr version')
                     radarr_version = 'unknown'

--- a/bazarr/radarr/info.py
+++ b/bazarr/radarr/info.py
@@ -8,7 +8,7 @@ import json
 from dogpile.cache import make_region
 
 from app.config import settings, empty_values
-from constants import headers
+from constants import headers, radarr_http_timeout
 
 region = make_region().configure('dogpile.cache.memory')
 
@@ -29,7 +29,7 @@ class GetRadarrInfo:
         if settings.general.getboolean('use_radarr'):
             try:
                 rv = url_radarr() + "/api/system/status?apikey=" + settings.radarr.apikey
-                radarr_json = requests.get(rv, timeout=60, verify=False, headers=headers).json()
+                radarr_json = requests.get(rv, timeout=radarr_http_timeout, verify=False, headers=headers).json()
                 if 'version' in radarr_json:
                     radarr_version = radarr_json['version']
                 else:
@@ -37,7 +37,7 @@ class GetRadarrInfo:
             except json.decoder.JSONDecodeError:
                 try:
                     rv = url_radarr() + "/api/v3/system/status?apikey=" + settings.radarr.apikey
-                    radarr_version = requests.get(rv, timeout=60, verify=False, headers=headers).json()['version']
+                    radarr_version = requests.get(rv, timeout=radarr_http_timeout, verify=False, headers=headers).json()['version']
                 except json.decoder.JSONDecodeError:
                     logging.debug('BAZARR cannot get Radarr version')
                     radarr_version = 'unknown'

--- a/bazarr/radarr/info.py
+++ b/bazarr/radarr/info.py
@@ -29,7 +29,7 @@ class GetRadarrInfo:
         if settings.general.getboolean('use_radarr'):
             try:
                 rv = url_radarr() + "/api/system/status?apikey=" + settings.radarr.apikey
-                radarr_json = requests.get(rv, timeout=settings.radarr.http_timeout, verify=False, headers=headers).json()
+                radarr_json = requests.get(rv, timeout=int(settings.radarr.http_timeout), verify=False, headers=headers).json()
                 if 'version' in radarr_json:
                     radarr_version = radarr_json['version']
                 else:
@@ -37,7 +37,7 @@ class GetRadarrInfo:
             except json.decoder.JSONDecodeError:
                 try:
                     rv = url_radarr() + "/api/v3/system/status?apikey=" + settings.radarr.apikey
-                    radarr_version = requests.get(rv, timeout=settings.radarr.http_timeout, verify=False, headers=headers).json()['version']
+                    radarr_version = requests.get(rv, timeout=int(settings.radarr.http_timeout), verify=False, headers=headers).json()['version']
                 except json.decoder.JSONDecodeError:
                     logging.debug('BAZARR cannot get Radarr version')
                     radarr_version = 'unknown'

--- a/bazarr/radarr/notify.py
+++ b/bazarr/radarr/notify.py
@@ -5,7 +5,7 @@ import requests
 
 from app.config import settings
 from radarr.info import get_radarr_info, url_radarr
-from constants import headers, radarr_http_timeout
+from constants import headers
 
 
 def notify_radarr(radarr_id):
@@ -18,6 +18,6 @@ def notify_radarr(radarr_id):
             'name': 'RescanMovie',
             'movieId': int(radarr_id)
         }
-        requests.post(url, json=data, timeout=radarr_http_timeout, verify=False, headers=headers)
+        requests.post(url, json=data, timeout=settings.radarr.http_timeout, verify=False, headers=headers)
     except Exception:
         logging.exception('BAZARR cannot notify Radarr')

--- a/bazarr/radarr/notify.py
+++ b/bazarr/radarr/notify.py
@@ -18,6 +18,6 @@ def notify_radarr(radarr_id):
             'name': 'RescanMovie',
             'movieId': int(radarr_id)
         }
-        requests.post(url, json=data, timeout=settings.radarr.http_timeout, verify=False, headers=headers)
+        requests.post(url, json=data, timeout=int(settings.radarr.http_timeout), verify=False, headers=headers)
     except Exception:
         logging.exception('BAZARR cannot notify Radarr')

--- a/bazarr/radarr/notify.py
+++ b/bazarr/radarr/notify.py
@@ -5,7 +5,7 @@ import requests
 
 from app.config import settings
 from radarr.info import get_radarr_info, url_radarr
-from constants import headers
+from constants import headers, radarr_http_timeout
 
 
 def notify_radarr(radarr_id):
@@ -18,6 +18,6 @@ def notify_radarr(radarr_id):
             'name': 'RescanMovie',
             'movieId': int(radarr_id)
         }
-        requests.post(url, json=data, timeout=60, verify=False, headers=headers)
+        requests.post(url, json=data, timeout=radarr_http_timeout, verify=False, headers=headers)
     except Exception:
         logging.exception('BAZARR cannot notify Radarr')

--- a/bazarr/radarr/rootfolder.py
+++ b/bazarr/radarr/rootfolder.py
@@ -22,7 +22,7 @@ def get_radarr_rootfolder():
         url_radarr_api_rootfolder = url_radarr() + "/api/v3/rootfolder?apikey=" + apikey_radarr
 
     try:
-        rootfolder = requests.get(url_radarr_api_rootfolder, timeout=settings.radarr.http_timeout, verify=False, headers=headers)
+        rootfolder = requests.get(url_radarr_api_rootfolder, timeout=int(settings.radarr.http_timeout), verify=False, headers=headers)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get rootfolder from Radarr. Connection Error.")
         return []

--- a/bazarr/radarr/rootfolder.py
+++ b/bazarr/radarr/rootfolder.py
@@ -8,7 +8,7 @@ from app.config import settings
 from utilities.path_mappings import path_mappings
 from app.database import TableMoviesRootfolder, TableMovies
 from radarr.info import get_radarr_info, url_radarr
-from constants import headers, radarr_http_timeout
+from constants import headers
 
 
 def get_radarr_rootfolder():
@@ -22,7 +22,7 @@ def get_radarr_rootfolder():
         url_radarr_api_rootfolder = url_radarr() + "/api/v3/rootfolder?apikey=" + apikey_radarr
 
     try:
-        rootfolder = requests.get(url_radarr_api_rootfolder, timeout=radarr_http_timeout, verify=False, headers=headers)
+        rootfolder = requests.get(url_radarr_api_rootfolder, timeout=settings.radarr.http_timeout, verify=False, headers=headers)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get rootfolder from Radarr. Connection Error.")
         return []

--- a/bazarr/radarr/rootfolder.py
+++ b/bazarr/radarr/rootfolder.py
@@ -8,7 +8,7 @@ from app.config import settings
 from utilities.path_mappings import path_mappings
 from app.database import TableMoviesRootfolder, TableMovies
 from radarr.info import get_radarr_info, url_radarr
-from constants import headers
+from constants import headers, radarr_http_timeout
 
 
 def get_radarr_rootfolder():
@@ -22,7 +22,7 @@ def get_radarr_rootfolder():
         url_radarr_api_rootfolder = url_radarr() + "/api/v3/rootfolder?apikey=" + apikey_radarr
 
     try:
-        rootfolder = requests.get(url_radarr_api_rootfolder, timeout=60, verify=False, headers=headers)
+        rootfolder = requests.get(url_radarr_api_rootfolder, timeout=radarr_http_timeout, verify=False, headers=headers)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get rootfolder from Radarr. Connection Error.")
         return []

--- a/bazarr/radarr/sync/utils.py
+++ b/bazarr/radarr/sync/utils.py
@@ -5,7 +5,7 @@ import logging
 
 from app.config import settings
 from radarr.info import get_radarr_info, url_radarr
-from constants import headers
+from constants import headers, radarr_http_timeout
 
 
 def get_profile_list():
@@ -18,7 +18,7 @@ def get_profile_list():
         url_radarr_api_movies = url_radarr() + "/api/v3/qualityprofile?apikey=" + apikey_radarr
 
     try:
-        profiles_json = requests.get(url_radarr_api_movies, timeout=60, verify=False, headers=headers)
+        profiles_json = requests.get(url_radarr_api_movies, timeout=radarr_http_timeout, verify=False, headers=headers)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get profiles from Radarr. Connection Error.")
     except requests.exceptions.Timeout:
@@ -50,7 +50,7 @@ def get_tags():
         url_radarr_api_series = url_radarr() + "/api/v3/tag?apikey=" + apikey_radarr
 
     try:
-        tagsDict = requests.get(url_radarr_api_series, timeout=60, verify=False, headers=headers)
+        tagsDict = requests.get(url_radarr_api_series, timeout=radarr_http_timeout, verify=False, headers=headers)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get tags from Radarr. Connection Error.")
         return []
@@ -79,7 +79,7 @@ def get_movies_from_radarr_api(url, apikey_radarr, radarr_id=None):
                                 apikey_radarr
 
     try:
-        r = requests.get(url_radarr_api_movies, timeout=60, verify=False, headers=headers)
+        r = requests.get(url_radarr_api_movies, timeout=radarr_http_timeout, verify=False, headers=headers)
         if r.status_code == 404:
             return
         r.raise_for_status()

--- a/bazarr/radarr/sync/utils.py
+++ b/bazarr/radarr/sync/utils.py
@@ -5,7 +5,7 @@ import logging
 
 from app.config import settings
 from radarr.info import get_radarr_info, url_radarr
-from constants import headers, radarr_http_timeout
+from constants import headers
 
 
 def get_profile_list():
@@ -18,7 +18,7 @@ def get_profile_list():
         url_radarr_api_movies = url_radarr() + "/api/v3/qualityprofile?apikey=" + apikey_radarr
 
     try:
-        profiles_json = requests.get(url_radarr_api_movies, timeout=radarr_http_timeout, verify=False, headers=headers)
+        profiles_json = requests.get(url_radarr_api_movies, timeout=settings.radarr.http_timeout, verify=False, headers=headers)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get profiles from Radarr. Connection Error.")
     except requests.exceptions.Timeout:
@@ -50,7 +50,7 @@ def get_tags():
         url_radarr_api_series = url_radarr() + "/api/v3/tag?apikey=" + apikey_radarr
 
     try:
-        tagsDict = requests.get(url_radarr_api_series, timeout=radarr_http_timeout, verify=False, headers=headers)
+        tagsDict = requests.get(url_radarr_api_series, timeout=settings.radarr.http_timeout, verify=False, headers=headers)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get tags from Radarr. Connection Error.")
         return []
@@ -79,7 +79,7 @@ def get_movies_from_radarr_api(url, apikey_radarr, radarr_id=None):
                                 apikey_radarr
 
     try:
-        r = requests.get(url_radarr_api_movies, timeout=radarr_http_timeout, verify=False, headers=headers)
+        r = requests.get(url_radarr_api_movies, timeout=settings.radarr.http_timeout, verify=False, headers=headers)
         if r.status_code == 404:
             return
         r.raise_for_status()

--- a/bazarr/radarr/sync/utils.py
+++ b/bazarr/radarr/sync/utils.py
@@ -18,7 +18,7 @@ def get_profile_list():
         url_radarr_api_movies = url_radarr() + "/api/v3/qualityprofile?apikey=" + apikey_radarr
 
     try:
-        profiles_json = requests.get(url_radarr_api_movies, timeout=settings.radarr.http_timeout, verify=False, headers=headers)
+        profiles_json = requests.get(url_radarr_api_movies, timeout=int(settings.radarr.http_timeout), verify=False, headers=headers)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get profiles from Radarr. Connection Error.")
     except requests.exceptions.Timeout:
@@ -50,7 +50,7 @@ def get_tags():
         url_radarr_api_series = url_radarr() + "/api/v3/tag?apikey=" + apikey_radarr
 
     try:
-        tagsDict = requests.get(url_radarr_api_series, timeout=settings.radarr.http_timeout, verify=False, headers=headers)
+        tagsDict = requests.get(url_radarr_api_series, timeout=int(settings.radarr.http_timeout), verify=False, headers=headers)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get tags from Radarr. Connection Error.")
         return []
@@ -79,7 +79,7 @@ def get_movies_from_radarr_api(url, apikey_radarr, radarr_id=None):
                                 apikey_radarr
 
     try:
-        r = requests.get(url_radarr_api_movies, timeout=settings.radarr.http_timeout, verify=False, headers=headers)
+        r = requests.get(url_radarr_api_movies, timeout=int(settings.radarr.http_timeout), verify=False, headers=headers)
         if r.status_code == 404:
             return
         r.raise_for_status()

--- a/bazarr/sonarr/filesystem.py
+++ b/bazarr/sonarr/filesystem.py
@@ -20,7 +20,7 @@ def browse_sonarr_filesystem(path='#'):
                                     "&allowFoldersWithoutTrailingSlashes=true&includeFiles=false&apikey=" + \
                                     settings.sonarr.apikey
     try:
-        r = requests.get(url_sonarr_api_filesystem, timeout=settings.sonarr.http_timeout, verify=False, headers=headers)
+        r = requests.get(url_sonarr_api_filesystem, timeout=int(settings.sonarr.http_timeout), verify=False, headers=headers)
         r.raise_for_status()
     except requests.exceptions.HTTPError:
         logging.exception("BAZARR Error trying to get series from Sonarr. Http error.")

--- a/bazarr/sonarr/filesystem.py
+++ b/bazarr/sonarr/filesystem.py
@@ -5,7 +5,7 @@ import logging
 
 from app.config import settings
 from sonarr.info import get_sonarr_info, url_sonarr
-from constants import headers
+from constants import headers, sonarr_http_timeout
 
 
 def browse_sonarr_filesystem(path='#'):
@@ -20,7 +20,7 @@ def browse_sonarr_filesystem(path='#'):
                                     "&allowFoldersWithoutTrailingSlashes=true&includeFiles=false&apikey=" + \
                                     settings.sonarr.apikey
     try:
-        r = requests.get(url_sonarr_api_filesystem, timeout=60, verify=False, headers=headers)
+        r = requests.get(url_sonarr_api_filesystem, timeout=sonarr_http_timeout, verify=False, headers=headers)
         r.raise_for_status()
     except requests.exceptions.HTTPError:
         logging.exception("BAZARR Error trying to get series from Sonarr. Http error.")

--- a/bazarr/sonarr/filesystem.py
+++ b/bazarr/sonarr/filesystem.py
@@ -5,7 +5,7 @@ import logging
 
 from app.config import settings
 from sonarr.info import get_sonarr_info, url_sonarr
-from constants import headers, sonarr_http_timeout
+from constants import headers
 
 
 def browse_sonarr_filesystem(path='#'):
@@ -20,7 +20,7 @@ def browse_sonarr_filesystem(path='#'):
                                     "&allowFoldersWithoutTrailingSlashes=true&includeFiles=false&apikey=" + \
                                     settings.sonarr.apikey
     try:
-        r = requests.get(url_sonarr_api_filesystem, timeout=sonarr_http_timeout, verify=False, headers=headers)
+        r = requests.get(url_sonarr_api_filesystem, timeout=settings.sonarr.http_timeout, verify=False, headers=headers)
         r.raise_for_status()
     except requests.exceptions.HTTPError:
         logging.exception("BAZARR Error trying to get series from Sonarr. Http error.")

--- a/bazarr/sonarr/info.py
+++ b/bazarr/sonarr/info.py
@@ -8,7 +8,7 @@ import json
 from dogpile.cache import make_region
 
 from app.config import settings, empty_values
-from constants import headers
+from constants import headers, sonarr_http_timeout
 
 region = make_region().configure('dogpile.cache.memory')
 
@@ -29,7 +29,7 @@ class GetSonarrInfo:
         if settings.general.getboolean('use_sonarr'):
             try:
                 sv = url_sonarr() + "/api/system/status?apikey=" + settings.sonarr.apikey
-                sonarr_json = requests.get(sv, timeout=60, verify=False, headers=headers).json()
+                sonarr_json = requests.get(sv, timeout=sonarr_http_timeout, verify=False, headers=headers).json()
                 if 'version' in sonarr_json:
                     sonarr_version = sonarr_json['version']
                 else:
@@ -37,7 +37,7 @@ class GetSonarrInfo:
             except json.decoder.JSONDecodeError:
                 try:
                     sv = url_sonarr() + "/api/v3/system/status?apikey=" + settings.sonarr.apikey
-                    sonarr_version = requests.get(sv, timeout=60, verify=False, headers=headers).json()['version']
+                    sonarr_version = requests.get(sv, timeout=sonarr_http_timeout, verify=False, headers=headers).json()['version']
                 except json.decoder.JSONDecodeError:
                     logging.debug('BAZARR cannot get Sonarr version')
                     sonarr_version = 'unknown'

--- a/bazarr/sonarr/info.py
+++ b/bazarr/sonarr/info.py
@@ -8,7 +8,7 @@ import json
 from dogpile.cache import make_region
 
 from app.config import settings, empty_values
-from constants import headers, sonarr_http_timeout
+from constants import headers
 
 region = make_region().configure('dogpile.cache.memory')
 
@@ -29,7 +29,7 @@ class GetSonarrInfo:
         if settings.general.getboolean('use_sonarr'):
             try:
                 sv = url_sonarr() + "/api/system/status?apikey=" + settings.sonarr.apikey
-                sonarr_json = requests.get(sv, timeout=sonarr_http_timeout, verify=False, headers=headers).json()
+                sonarr_json = requests.get(sv, timeout=settings.sonarr.http_timeout, verify=False, headers=headers).json()
                 if 'version' in sonarr_json:
                     sonarr_version = sonarr_json['version']
                 else:
@@ -37,7 +37,7 @@ class GetSonarrInfo:
             except json.decoder.JSONDecodeError:
                 try:
                     sv = url_sonarr() + "/api/v3/system/status?apikey=" + settings.sonarr.apikey
-                    sonarr_version = requests.get(sv, timeout=sonarr_http_timeout, verify=False, headers=headers).json()['version']
+                    sonarr_version = requests.get(sv, timeout=settings.sonarr.http_timeout, verify=False, headers=headers).json()['version']
                 except json.decoder.JSONDecodeError:
                     logging.debug('BAZARR cannot get Sonarr version')
                     sonarr_version = 'unknown'

--- a/bazarr/sonarr/info.py
+++ b/bazarr/sonarr/info.py
@@ -29,7 +29,7 @@ class GetSonarrInfo:
         if settings.general.getboolean('use_sonarr'):
             try:
                 sv = url_sonarr() + "/api/system/status?apikey=" + settings.sonarr.apikey
-                sonarr_json = requests.get(sv, timeout=settings.sonarr.http_timeout, verify=False, headers=headers).json()
+                sonarr_json = requests.get(sv, timeout=int(settings.sonarr.http_timeout), verify=False, headers=headers).json()
                 if 'version' in sonarr_json:
                     sonarr_version = sonarr_json['version']
                 else:
@@ -37,7 +37,7 @@ class GetSonarrInfo:
             except json.decoder.JSONDecodeError:
                 try:
                     sv = url_sonarr() + "/api/v3/system/status?apikey=" + settings.sonarr.apikey
-                    sonarr_version = requests.get(sv, timeout=settings.sonarr.http_timeout, verify=False, headers=headers).json()['version']
+                    sonarr_version = requests.get(sv, timeout=int(settings.sonarr.http_timeout), verify=False, headers=headers).json()['version']
                 except json.decoder.JSONDecodeError:
                     logging.debug('BAZARR cannot get Sonarr version')
                     sonarr_version = 'unknown'

--- a/bazarr/sonarr/notify.py
+++ b/bazarr/sonarr/notify.py
@@ -18,6 +18,6 @@ def notify_sonarr(sonarr_series_id):
             'name': 'RescanSeries',
             'seriesId': int(sonarr_series_id)
         }
-        requests.post(url, json=data, timeout=60, verify=False, headers=headers)
+        requests.post(url, json=data, timeout=sonarr_http_timeout, verify=False, headers=headers)
     except Exception:
         logging.exception('BAZARR cannot notify Sonarr')

--- a/bazarr/sonarr/notify.py
+++ b/bazarr/sonarr/notify.py
@@ -18,6 +18,6 @@ def notify_sonarr(sonarr_series_id):
             'name': 'RescanSeries',
             'seriesId': int(sonarr_series_id)
         }
-        requests.post(url, json=data, timeout=settings.sonarr.http_timeout, verify=False, headers=headers)
+        requests.post(url, json=data, timeout=int(settings.sonarr.http_timeout), verify=False, headers=headers)
     except Exception:
         logging.exception('BAZARR cannot notify Sonarr')

--- a/bazarr/sonarr/notify.py
+++ b/bazarr/sonarr/notify.py
@@ -18,6 +18,6 @@ def notify_sonarr(sonarr_series_id):
             'name': 'RescanSeries',
             'seriesId': int(sonarr_series_id)
         }
-        requests.post(url, json=data, timeout=sonarr_http_timeout, verify=False, headers=headers)
+        requests.post(url, json=data, timeout=settings.sonarr.http_timeout, verify=False, headers=headers)
     except Exception:
         logging.exception('BAZARR cannot notify Sonarr')

--- a/bazarr/sonarr/rootfolder.py
+++ b/bazarr/sonarr/rootfolder.py
@@ -22,7 +22,7 @@ def get_sonarr_rootfolder():
         url_sonarr_api_rootfolder = url_sonarr() + "/api/v3/rootfolder?apikey=" + apikey_sonarr
 
     try:
-        rootfolder = requests.get(url_sonarr_api_rootfolder, timeout=settings.sonarr.http_timeout, verify=False, headers=headers)
+        rootfolder = requests.get(url_sonarr_api_rootfolder, timeout=int(settings.sonarr.http_timeout), verify=False, headers=headers)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get rootfolder from Sonarr. Connection Error.")
         return []

--- a/bazarr/sonarr/rootfolder.py
+++ b/bazarr/sonarr/rootfolder.py
@@ -8,7 +8,7 @@ from app.config import settings
 from app.database import TableShowsRootfolder, TableShows
 from utilities.path_mappings import path_mappings
 from sonarr.info import get_sonarr_info, url_sonarr
-from constants import headers
+from constants import headers, sonarr_http_timeout
 
 
 def get_sonarr_rootfolder():
@@ -22,7 +22,7 @@ def get_sonarr_rootfolder():
         url_sonarr_api_rootfolder = url_sonarr() + "/api/v3/rootfolder?apikey=" + apikey_sonarr
 
     try:
-        rootfolder = requests.get(url_sonarr_api_rootfolder, timeout=60, verify=False, headers=headers)
+        rootfolder = requests.get(url_sonarr_api_rootfolder, timeout=sonarr_http_timeout, verify=False, headers=headers)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get rootfolder from Sonarr. Connection Error.")
         return []

--- a/bazarr/sonarr/rootfolder.py
+++ b/bazarr/sonarr/rootfolder.py
@@ -8,7 +8,7 @@ from app.config import settings
 from app.database import TableShowsRootfolder, TableShows
 from utilities.path_mappings import path_mappings
 from sonarr.info import get_sonarr_info, url_sonarr
-from constants import headers, sonarr_http_timeout
+from constants import headers
 
 
 def get_sonarr_rootfolder():
@@ -22,7 +22,7 @@ def get_sonarr_rootfolder():
         url_sonarr_api_rootfolder = url_sonarr() + "/api/v3/rootfolder?apikey=" + apikey_sonarr
 
     try:
-        rootfolder = requests.get(url_sonarr_api_rootfolder, timeout=sonarr_http_timeout, verify=False, headers=headers)
+        rootfolder = requests.get(url_sonarr_api_rootfolder, timeout=settings.sonarr.http_timeout, verify=False, headers=headers)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get rootfolder from Sonarr. Connection Error.")
         return []

--- a/bazarr/sonarr/sync/utils.py
+++ b/bazarr/sonarr/sync/utils.py
@@ -5,7 +5,7 @@ import logging
 
 from app.config import settings
 from sonarr.info import get_sonarr_info, url_sonarr
-from constants import headers, sonarr_http_timeout
+from constants import headers
 
 
 def get_profile_list():
@@ -22,7 +22,7 @@ def get_profile_list():
         url_sonarr_api_series = url_sonarr() + "/api/v3/languageprofile?apikey=" + apikey_sonarr
 
     try:
-        profiles_json = requests.get(url_sonarr_api_series, timeout=sonarr_http_timeout, verify=False, headers=headers)
+        profiles_json = requests.get(url_sonarr_api_series, timeout=settings.sonarr.http_timeout, verify=False, headers=headers)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get profiles from Sonarr. Connection Error.")
         return None
@@ -55,7 +55,7 @@ def get_tags():
         url_sonarr_api_series = url_sonarr() + "/api/v3/tag?apikey=" + apikey_sonarr
 
     try:
-        tagsDict = requests.get(url_sonarr_api_series, timeout=sonarr_http_timeout, verify=False, headers=headers)
+        tagsDict = requests.get(url_sonarr_api_series, timeout=settings.sonarr.http_timeout, verify=False, headers=headers)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get tags from Sonarr. Connection Error.")
         return []
@@ -73,7 +73,7 @@ def get_series_from_sonarr_api(url, apikey_sonarr, sonarr_series_id=None):
     url_sonarr_api_series = url + "/api/{0}series/{1}?apikey={2}".format(
         '' if get_sonarr_info.is_legacy() else 'v3/', sonarr_series_id if sonarr_series_id else "", apikey_sonarr)
     try:
-        r = requests.get(url_sonarr_api_series, timeout=sonarr_http_timeout, verify=False, headers=headers)
+        r = requests.get(url_sonarr_api_series, timeout=settings.sonarr.http_timeout, verify=False, headers=headers)
         r.raise_for_status()
     except requests.exceptions.HTTPError as e:
         if e.response.status_code:
@@ -108,7 +108,7 @@ def get_episodes_from_sonarr_api(url, apikey_sonarr, series_id=None, episode_id=
         return
 
     try:
-        r = requests.get(url_sonarr_api_episode, timeout=sonarr_http_timeout, verify=False, headers=headers)
+        r = requests.get(url_sonarr_api_episode, timeout=settings.sonarr.http_timeout, verify=False, headers=headers)
         r.raise_for_status()
     except requests.exceptions.HTTPError:
         logging.exception("BAZARR Error trying to get episodes from Sonarr. Http error.")
@@ -136,7 +136,7 @@ def get_episodesFiles_from_sonarr_api(url, apikey_sonarr, series_id=None, episod
         return
 
     try:
-        r = requests.get(url_sonarr_api_episodeFiles, timeout=sonarr_http_timeout, verify=False, headers=headers)
+        r = requests.get(url_sonarr_api_episodeFiles, timeout=settings.sonarr.http_timeout, verify=False, headers=headers)
         r.raise_for_status()
     except requests.exceptions.HTTPError:
         logging.exception("BAZARR Error trying to get episodeFiles from Sonarr. Http error.")

--- a/bazarr/sonarr/sync/utils.py
+++ b/bazarr/sonarr/sync/utils.py
@@ -5,7 +5,7 @@ import logging
 
 from app.config import settings
 from sonarr.info import get_sonarr_info, url_sonarr
-from constants import headers
+from constants import headers, sonarr_http_timeout
 
 
 def get_profile_list():
@@ -22,7 +22,7 @@ def get_profile_list():
         url_sonarr_api_series = url_sonarr() + "/api/v3/languageprofile?apikey=" + apikey_sonarr
 
     try:
-        profiles_json = requests.get(url_sonarr_api_series, timeout=60, verify=False, headers=headers)
+        profiles_json = requests.get(url_sonarr_api_series, timeout=sonarr_http_timeout, verify=False, headers=headers)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get profiles from Sonarr. Connection Error.")
         return None
@@ -55,7 +55,7 @@ def get_tags():
         url_sonarr_api_series = url_sonarr() + "/api/v3/tag?apikey=" + apikey_sonarr
 
     try:
-        tagsDict = requests.get(url_sonarr_api_series, timeout=60, verify=False, headers=headers)
+        tagsDict = requests.get(url_sonarr_api_series, timeout=sonarr_http_timeout, verify=False, headers=headers)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get tags from Sonarr. Connection Error.")
         return []
@@ -73,7 +73,7 @@ def get_series_from_sonarr_api(url, apikey_sonarr, sonarr_series_id=None):
     url_sonarr_api_series = url + "/api/{0}series/{1}?apikey={2}".format(
         '' if get_sonarr_info.is_legacy() else 'v3/', sonarr_series_id if sonarr_series_id else "", apikey_sonarr)
     try:
-        r = requests.get(url_sonarr_api_series, timeout=60, verify=False, headers=headers)
+        r = requests.get(url_sonarr_api_series, timeout=sonarr_http_timeout, verify=False, headers=headers)
         r.raise_for_status()
     except requests.exceptions.HTTPError as e:
         if e.response.status_code:
@@ -108,7 +108,7 @@ def get_episodes_from_sonarr_api(url, apikey_sonarr, series_id=None, episode_id=
         return
 
     try:
-        r = requests.get(url_sonarr_api_episode, timeout=60, verify=False, headers=headers)
+        r = requests.get(url_sonarr_api_episode, timeout=sonarr_http_timeout, verify=False, headers=headers)
         r.raise_for_status()
     except requests.exceptions.HTTPError:
         logging.exception("BAZARR Error trying to get episodes from Sonarr. Http error.")
@@ -136,7 +136,7 @@ def get_episodesFiles_from_sonarr_api(url, apikey_sonarr, series_id=None, episod
         return
 
     try:
-        r = requests.get(url_sonarr_api_episodeFiles, timeout=60, verify=False, headers=headers)
+        r = requests.get(url_sonarr_api_episodeFiles, timeout=sonarr_http_timeout, verify=False, headers=headers)
         r.raise_for_status()
     except requests.exceptions.HTTPError:
         logging.exception("BAZARR Error trying to get episodeFiles from Sonarr. Http error.")

--- a/bazarr/sonarr/sync/utils.py
+++ b/bazarr/sonarr/sync/utils.py
@@ -22,7 +22,7 @@ def get_profile_list():
         url_sonarr_api_series = url_sonarr() + "/api/v3/languageprofile?apikey=" + apikey_sonarr
 
     try:
-        profiles_json = requests.get(url_sonarr_api_series, timeout=settings.sonarr.http_timeout, verify=False, headers=headers)
+        profiles_json = requests.get(url_sonarr_api_series, timeout=int(settings.sonarr.http_timeout), verify=False, headers=headers)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get profiles from Sonarr. Connection Error.")
         return None
@@ -55,7 +55,7 @@ def get_tags():
         url_sonarr_api_series = url_sonarr() + "/api/v3/tag?apikey=" + apikey_sonarr
 
     try:
-        tagsDict = requests.get(url_sonarr_api_series, timeout=settings.sonarr.http_timeout, verify=False, headers=headers)
+        tagsDict = requests.get(url_sonarr_api_series, timeout=int(settings.sonarr.http_timeout), verify=False, headers=headers)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get tags from Sonarr. Connection Error.")
         return []
@@ -73,7 +73,7 @@ def get_series_from_sonarr_api(url, apikey_sonarr, sonarr_series_id=None):
     url_sonarr_api_series = url + "/api/{0}series/{1}?apikey={2}".format(
         '' if get_sonarr_info.is_legacy() else 'v3/', sonarr_series_id if sonarr_series_id else "", apikey_sonarr)
     try:
-        r = requests.get(url_sonarr_api_series, timeout=settings.sonarr.http_timeout, verify=False, headers=headers)
+        r = requests.get(url_sonarr_api_series, timeout=int(settings.sonarr.http_timeout), verify=False, headers=headers)
         r.raise_for_status()
     except requests.exceptions.HTTPError as e:
         if e.response.status_code:
@@ -108,7 +108,7 @@ def get_episodes_from_sonarr_api(url, apikey_sonarr, series_id=None, episode_id=
         return
 
     try:
-        r = requests.get(url_sonarr_api_episode, timeout=settings.sonarr.http_timeout, verify=False, headers=headers)
+        r = requests.get(url_sonarr_api_episode, timeout=int(settings.sonarr.http_timeout), verify=False, headers=headers)
         r.raise_for_status()
     except requests.exceptions.HTTPError:
         logging.exception("BAZARR Error trying to get episodes from Sonarr. Http error.")
@@ -136,7 +136,7 @@ def get_episodesFiles_from_sonarr_api(url, apikey_sonarr, series_id=None, episod
         return
 
     try:
-        r = requests.get(url_sonarr_api_episodeFiles, timeout=settings.sonarr.http_timeout, verify=False, headers=headers)
+        r = requests.get(url_sonarr_api_episodeFiles, timeout=int(settings.sonarr.http_timeout), verify=False, headers=headers)
         r.raise_for_status()
     except requests.exceptions.HTTPError:
         logging.exception("BAZARR Error trying to get episodeFiles from Sonarr. Http error.")

--- a/frontend/src/pages/Settings/Radarr/index.tsx
+++ b/frontend/src/pages/Settings/Radarr/index.tsx
@@ -9,11 +9,13 @@ import {
   Number,
   PathMappingTable,
   Section,
+  Selector,
   Slider,
   Text,
   URLTestButton,
 } from "../components";
 import { moviesEnabledKey } from "../keys";
+import { timeoutOptions } from "./options";
 
 const SettingsRadarrView: FunctionComponent = () => {
   return (
@@ -35,6 +37,11 @@ const SettingsRadarrView: FunctionComponent = () => {
               onSubmit: (v) => "/" + v,
             }}
           ></Text>
+          <Selector
+            label="HTTP Timeout"
+            options={timeoutOptions}
+            settingKey="settings-radarr-http_timeout"
+          ></Selector>
           <Text label="API Key" settingKey="settings-radarr-apikey"></Text>
           <Check label="SSL" settingKey="settings-radarr-ssl"></Check>
           <URLTestButton category="radarr"></URLTestButton>

--- a/frontend/src/pages/Settings/Radarr/options.ts
+++ b/frontend/src/pages/Settings/Radarr/options.ts
@@ -1,0 +1,28 @@
+import { SelectorOption } from "@/components";
+
+export const timeoutOptions: SelectorOption<string>[] = [
+  {
+    label: "60",
+    value: "60",
+  },
+  {
+    label: "120",
+    value: "120",
+  },
+  {
+    label: "180",
+    value: "180",
+  },
+  {
+    label: "240",
+    value: "240",
+  },
+  {
+    label: "300",
+    value: "300",
+  },
+  {
+    label: "600",
+    value: "600",
+  },
+];

--- a/frontend/src/pages/Settings/Radarr/options.ts
+++ b/frontend/src/pages/Settings/Radarr/options.ts
@@ -1,28 +1,10 @@
 import { SelectorOption } from "@/components";
 
-export const timeoutOptions: SelectorOption<string>[] = [
-  {
-    label: "60",
-    value: "60",
-  },
-  {
-    label: "120",
-    value: "120",
-  },
-  {
-    label: "180",
-    value: "180",
-  },
-  {
-    label: "240",
-    value: "240",
-  },
-  {
-    label: "300",
-    value: "300",
-  },
-  {
-    label: "600",
-    value: "600",
-  },
+export const timeoutOptions: SelectorOption<number>[] = [
+  { label: "60", value: 60 },
+  { label: "120", value: 120 },
+  { label: "180", value: 180 },
+  { label: "240", value: 240 },
+  { label: "300", value: 300 },
+  { label: "600", value: 600 },
 ];

--- a/frontend/src/pages/Settings/Sonarr/index.tsx
+++ b/frontend/src/pages/Settings/Sonarr/index.tsx
@@ -10,12 +10,14 @@ import {
   Number,
   PathMappingTable,
   Section,
+  Selector,
   Slider,
   Text,
   URLTestButton,
 } from "../components";
 import { seriesEnabledKey } from "../keys";
 import { seriesTypeOptions } from "../options";
+import { timeoutOptions } from "./options";
 
 const SettingsSonarrView: FunctionComponent = () => {
   return (
@@ -37,6 +39,11 @@ const SettingsSonarrView: FunctionComponent = () => {
               onSubmit: (v) => "/" + v,
             }}
           ></Text>
+          <Selector
+            label="HTTP Timeout"
+            options={timeoutOptions}
+            settingKey="settings-sonarr-http_timeout"
+          ></Selector>
           <Text label="API Key" settingKey="settings-sonarr-apikey"></Text>
           <Check label="SSL" settingKey="settings-sonarr-ssl"></Check>
           <URLTestButton category="sonarr"></URLTestButton>

--- a/frontend/src/pages/Settings/Sonarr/options.ts
+++ b/frontend/src/pages/Settings/Sonarr/options.ts
@@ -1,0 +1,28 @@
+import { SelectorOption } from "@/components";
+
+export const timeoutOptions: SelectorOption<string>[] = [
+  {
+    label: "60",
+    value: "60",
+  },
+  {
+    label: "120",
+    value: "120",
+  },
+  {
+    label: "180",
+    value: "180",
+  },
+  {
+    label: "240",
+    value: "240",
+  },
+  {
+    label: "300",
+    value: "300",
+  },
+  {
+    label: "600",
+    value: "600",
+  },
+];

--- a/frontend/src/pages/Settings/Sonarr/options.ts
+++ b/frontend/src/pages/Settings/Sonarr/options.ts
@@ -1,28 +1,10 @@
 import { SelectorOption } from "@/components";
 
-export const timeoutOptions: SelectorOption<string>[] = [
-  {
-    label: "60",
-    value: "60",
-  },
-  {
-    label: "120",
-    value: "120",
-  },
-  {
-    label: "180",
-    value: "180",
-  },
-  {
-    label: "240",
-    value: "240",
-  },
-  {
-    label: "300",
-    value: "300",
-  },
-  {
-    label: "600",
-    value: "600",
-  },
+export const timeoutOptions: SelectorOption<number>[] = [
+  { label: "60", value: 60 },
+  { label: "120", value: 120 },
+  { label: "180", value: 180 },
+  { label: "240", value: 240 },
+  { label: "300", value: 300 },
+  { label: "600", value: 600 },
 ];


### PR DESCRIPTION
Addresses feature request to provide configurable timeouts for Sonarr and Radarr API calls.
- https://bazarr.featureupvote.com/suggestions/82885/allow-users-to-configure-sonarr-api-timeout-time

Relates to issues #397 #738 #846

What does this change?

HTTP calls to Radarr and Sonarr APIs are configured with a 60 second timeout at multiple points in the codebase. This change consolidates these into centralized constant values.

The HTTP timeout constant values can also be configured using environment variables
`RADARR_HTTP_TIMEOUT`
`SONARR_HTTP_TIMEOUT`
with default values of `60`

Why?

Large media libraries can result in long-running calls for collection metadata in Radarr and Sonarr. Particularly if those services are running on machines with limited resources. These changes allow an administrator to adjust the HTTP timeout period according to the circumstances of the deployment environment.

Subsequent Steps:

- Submit secondary changes to documented env vars for Bazarr docker image here https://github.com/linuxserver/docker-bazarr/blob/master/README.md