### PR TITLE
allow for read-only config

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -304,9 +304,12 @@ if settings.general.page_size not in ['25', '50', '100', '250', '500', '1000']:
 
 # save updated settings to file
 if os.path.exists(os.path.join(args.config_dir, 'config', 'config.ini')):
-    with open(os.path.join(args.config_dir, 'config', 'config.ini'), 'w+') as handle:
-        settings.write(handle)
-
+    try:
+        with open(os.path.join(args.config_dir, 'config', 'config.ini'), 'w+') as handle:
+            settings.write(handle)
+    except:
+        # add log.Info("Config is read-only!") and print it in webUI
+        pass
 
 def get_settings():
     result = dict()


### PR DESCRIPTION
Some people might use Kubernetes ConfipMap or Secret which is read-only, and is is annoying having to use init-container to copy over a config that will not be changed from the UI anyways. Or even better, store the config in DB since there's support for Postgres.