### PR TITLE
Workaround for podnapisi.net SSL cipher issues with OpenSSL 3

### DIFF
--- a/libs/subliminal_patch/providers/podnapisi.py
+++ b/libs/subliminal_patch/providers/podnapisi.py
@@ -112,7 +112,7 @@ class PodnapisiSubtitle(_PodnapisiSubtitle):
 class PodnapisiAdapter(HTTPAdapter):
     def init_poolmanager(self, connections, maxsize, block=False):
         ctx = ssl.create_default_context()
-        ctx.set_ciphers('DEFAULT@SECLEVEL=1')
+        ctx.set_ciphers('DEFAULT@SECLEVEL=0')
         ctx.check_hostname = False
         self.poolmanager = poolmanager.PoolManager(
                 num_pools=connections,


### PR DESCRIPTION
podnapisi.net SSL cipher strength doesn't meet higher security standards in OpenSSL 3 resulting in `SSL: WRONG_SIGNATURE_TYPE` error. Reasoning for this workaround:
- Distros already use OpenSSL 3, eg. Alpine 3.17, Ubuntu 22.04. Issue affects lsio docker image https://github.com/linuxserver/docker-bazarr/issues/106
- podnapisi.net have historically been lackluster with their SSL implementation, making a quick fix from their side unlikely

This downgrade shouldn't have much negative impact on security and older OpenSSL 1.1.1 versions. However if there are some security considerations this could only be only done on platforms with OpenSSL 3.