### PR TITLE
Fix zimuku 403 error caused by search url change

### DIFF
--- a/libs/subliminal_patch/providers/zimuku.py
+++ b/libs/subliminal_patch/providers/zimuku.py
@@ -88,7 +88,7 @@ class ZimukuProvider(Provider):
     logger.info(str(supported_languages))
 
     server_url = "http://zimuku.org"
-    search_url = "/search?q={}&vertoken={}"
+    search_url = "/search?q={}&security_verify_data={}"
     download_url = "http://zimuku.org/"
 
     subtitle_class = ZimukuSubtitle
@@ -115,18 +115,12 @@ class ZimukuProvider(Provider):
                 self.session.cookies.set("srcurl", self.stringToHex(r.url))
                 if(tr):
                     verify_resp = self.session.get(
-                        self.server_url+tr[0]+self.stringToHex("1080,1920"), allow_redirects=False)
+                        self.server_url+tr[0]+self.stringToHex("1920,1080"), allow_redirects=False)
                     if(verify_resp.status_code == 302 and self.session.cookies.get("security_session_verify") != None):
                         pass
                     continue
             if len(self.location_re.findall(r.text)) == 0:
-                if(r.headers.get("Content-Type") == "text/html; charset=utf-8"):
-                    v = ParserBeautifulSoup(
-                        r.content.decode("utf-8", "ignore"), ["html.parser"]
-                    ).find(
-                        "input", attrs={'name': 'vertoken'})
-                    if(v):
-                        self.vertoken = v.get("value")
+                self.vertoken = self.stringToHex("1920,1080")
                 return r
 
     def initialize(self):


### PR DESCRIPTION
Although there are still short-term search limits based on IP, normal search has been fixed.
Before fix:
![1](https://user-images.githubusercontent.com/22773968/220545453-9955dad7-7ef5-4a18-98e3-5904ca8a9ca4.png)
After fix:
![2](https://user-images.githubusercontent.com/22773968/220546001-ffd5b108-940b-4a9a-8f1b-10ac8316257b.png)
![3](https://user-images.githubusercontent.com/22773968/220546009-56946e8b-b3ef-4b04-b1d7-877cff2e398b.png)
