### PR TITLE
OpenAI Whisper Provider

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -170,6 +170,10 @@ defaults = {
     'subf2m': {
         'verify_ssl': 'True'
     },
+    'whisperai': {
+        'endpoint': 'http://127.0.0.1:9000',
+        'timeout': '3600'
+    },
     'legendasdivx': {
         'username': '',
         'password': '',

--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -252,6 +252,9 @@ def get_providers_auth():
         'subf2m': {
             'verify_ssl': settings.subf2m.getboolean('verify_ssl')
         },
+        'whisperai': {
+            'endpoint': settings.whisperai.endpoint
+        }
     }
 
 

--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -253,7 +253,8 @@ def get_providers_auth():
             'verify_ssl': settings.subf2m.getboolean('verify_ssl')
         },
         'whisperai': {
-            'endpoint': settings.whisperai.endpoint
+            'endpoint': settings.whisperai.endpoint,
+            'timeout': settings.whisperai.timeout
         }
     }
 

--- a/frontend/src/pages/Settings/Providers/list.ts
+++ b/frontend/src/pages/Settings/Providers/list.ts
@@ -214,6 +214,12 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
         type: "text",
         key: "endpoint",
       },
+      {
+        type: "text",
+        key: "timeout",
+        defaultValue: 3600,
+        name: "Transcription/translation timeout in seconds",
+      },
     ],
   },
   {

--- a/frontend/src/pages/Settings/Providers/list.ts
+++ b/frontend/src/pages/Settings/Providers/list.ts
@@ -208,11 +208,14 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
   { key: "napiprojekt", description: "Polish Subtitles Provider" },
   {
     key: "whisperai",
+    name: "Whisper",
     description: "AI Generated Subtitles powered by Whisper",
     inputs: [
       {
         type: "text",
         key: "endpoint",
+        defaultValue: "http://127.0.0.1:9000",
+        name: "Whisper ASR Docker Endpoint",
       },
       {
         type: "text",

--- a/frontend/src/pages/Settings/Providers/list.ts
+++ b/frontend/src/pages/Settings/Providers/list.ts
@@ -207,6 +207,16 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
   },
   { key: "napiprojekt", description: "Polish Subtitles Provider" },
   {
+    key: "whisperai",
+    description: "AI Generated Subtitles powered by Whisper",
+    inputs: [
+      {
+        type: "text",
+        key: "endpoint",
+      },
+    ],
+  },
+  {
     key: "napisy24",
     description: "Polish Subtitles Provider",
     message:

--- a/libs/subliminal_patch/providers/whisperai.py
+++ b/libs/subliminal_patch/providers/whisperai.py
@@ -29,7 +29,12 @@ class WhisperAISubtitle(Subtitle):
 
     def get_matches(self, video):
         matches = set()
-        matches.update(["title", "series", "season", "episode"])
+
+        if isinstance(video, Episode):
+            matches.update(["series", "season", "episode"])
+        elif isinstance(video, Movie):
+            matches.update(["title"])
+
         return matches
 
 

--- a/libs/subliminal_patch/providers/whisperai.py
+++ b/libs/subliminal_patch/providers/whisperai.py
@@ -10,10 +10,157 @@ from subliminal.exceptions import ConfigurationError
 from subzero.language import Language
 from subliminal.video import Episode, Movie
 
-import ffmpeg
+from babelfish.exceptions import LanguageReverseError
 
+import ffmpeg
+import functools
+
+# These are all the languages Whisper supports.
+# from whisper.tokenizer import LANGUAGES
+
+whisper_languages = {
+    "en": "english",
+    "zh": "chinese",
+    "de": "german",
+    "es": "spanish",
+    "ru": "russian",
+    "ko": "korean",
+    "fr": "french",
+    "ja": "japanese",
+    "pt": "portuguese",
+    "tr": "turkish",
+    "pl": "polish",
+    "ca": "catalan",
+    "nl": "dutch",
+    "ar": "arabic",
+    "sv": "swedish",
+    "it": "italian",
+    "id": "indonesian",
+    "hi": "hindi",
+    "fi": "finnish",
+    "vi": "vietnamese",
+    "he": "hebrew",
+    "uk": "ukrainian",
+    "el": "greek",
+    "ms": "malay",
+    "cs": "czech",
+    "ro": "romanian",
+    "da": "danish",
+    "hu": "hungarian",
+    "ta": "tamil",
+    "no": "norwegian",
+    "th": "thai",
+    "ur": "urdu",
+    "hr": "croatian",
+    "bg": "bulgarian",
+    "lt": "lithuanian",
+    "la": "latin",
+    "mi": "maori",
+    "ml": "malayalam",
+    "cy": "welsh",
+    "sk": "slovak",
+    "te": "telugu",
+    "fa": "persian",
+    "lv": "latvian",
+    "bn": "bengali",
+    "sr": "serbian",
+    "az": "azerbaijani",
+    "sl": "slovenian",
+    "kn": "kannada",
+    "et": "estonian",
+    "mk": "macedonian",
+    "br": "breton",
+    "eu": "basque",
+    "is": "icelandic",
+    "hy": "armenian",
+    "ne": "nepali",
+    "mn": "mongolian",
+    "bs": "bosnian",
+    "kk": "kazakh",
+    "sq": "albanian",
+    "sw": "swahili",
+    "gl": "galician",
+    "mr": "marathi",
+    "pa": "punjabi",
+    "si": "sinhala",
+    "km": "khmer",
+    "sn": "shona",
+    "yo": "yoruba",
+    "so": "somali",
+    "af": "afrikaans",
+    "oc": "occitan",
+    "ka": "georgian",
+    "be": "belarusian",
+    "tg": "tajik",
+    "sd": "sindhi",
+    "gu": "gujarati",
+    "am": "amharic",
+    "yi": "yiddish",
+    "lo": "lao",
+    "uz": "uzbek",
+    "fo": "faroese",
+    "ht": "haitian creole",
+    "ps": "pashto",
+    "tk": "turkmen",
+    "nn": "nynorsk",
+    "mt": "maltese",
+    "sa": "sanskrit",
+    "lb": "luxembourgish",
+    "my": "myanmar",
+    "bo": "tibetan",
+    "tl": "tagalog",
+    "mg": "malagasy",
+    "as": "assamese",
+    "tt": "tatar",
+    "haw": "hawaiian",
+    "ln": "lingala",
+    "ha": "hausa",
+    "ba": "bashkir",
+    "jw": "javanese",
+    "su": "sundanese",
+}
 
 logger = logging.getLogger(__name__)
+
+
+@functools.lru_cache(2)
+def encode_audio_stream(path):
+    # Returns the first audio stream
+    # TODO: pick the best audio stream
+
+    logger.debug("Encoding audio stream to WAV with ffmpeg")
+
+    try:
+        # This launches a subprocess to decode audio while down-mixing and resampling as necessary.
+        # Requires the ffmpeg CLI and `ffmpeg-python` package to be installed.
+        out, _ = (
+            ffmpeg.input(path, threads=0)
+            .output("-", format="s16le", acodec="pcm_s16le", ac=1, ar=16000)
+            .run(cmd=["ffmpeg", "-nostdin"], capture_stdout=True, capture_stderr=True)
+        )
+    except ffmpeg.Error as e:
+        raise RuntimeError(f"Failed to load audio: {e.stderr.decode()}") from e
+
+    logger.debug(f"Finished encoding audio stream in {path} with no errors")
+
+    return out
+
+
+def whisper_get_language(code, name):
+    # Whisper uses an inconsistent mix of alpha2 and alpha3 language codes
+    try:
+        return Language.fromalpha2(code)
+    except LanguageReverseError:
+        return Language.fromname(name)
+
+
+def whisper_get_language_reverse(alpha3):
+    # Returns the whisper language code given an alpha3b language
+    for wl in whisper_languages:
+        lan = whisper_get_language(wl, whisper_languages[wl])
+        if lan.alpha3 == alpha3:
+            return wl
+    raise ValueError
 
 
 class WhisperAISubtitle(Subtitle):
@@ -25,6 +172,8 @@ class WhisperAISubtitle(Subtitle):
         super(WhisperAISubtitle, self).__init__(language)
 
         self.video = video
+        self.task = None
+        self.audio_language = None
 
     @property
     def id(self):
@@ -44,13 +193,11 @@ class WhisperAISubtitle(Subtitle):
 class WhisperAIProvider(Provider):
     '''Whisper AI Provider.'''
 
-    # These are all the languages Whisper supports.
-    # from whisper.tokenizer import LANGUAGES
-    whisper_languages = ['eng', 'chi', 'ger', 'spa', 'rus', 'kor', 'fre', 'jpn', 'por', 'tur', 'pol', 'cat', 'dut', 'ara', 'swe', 'ita', 'ind', 'hin', 'fin', 'vie', 'heb', 'ukr', 'gre', 'may', 'cze', 'rum', 'dan', 'hun', 'tam', 'nor', 'tha', 'urd', 'hrv', 'bul', 'lit', 'lat', 'mao', 'mal', 'wel', 'slo', 'tel', 'per', 'lav', 'ben', 'srp', 'aze', 'slv', 'kan', 'est', 'mac', 'bre', 'baq', 'ice', 'arm', 'nep', 'mon', 'bos', 'kaz', 'alb', 'swa', 'glg', 'mar', 'pan', 'sin', 'khm', 'sna', 'yor', 'som', 'afr', 'oci', 'geo', 'bel', 'tgk', 'snd', 'guj', 'amh', 'yid', 'lao', 'uzb', 'fao', 'hat', 'pus', 'tuk', 'nno', 'mlt', 'san', 'ltz', 'bur', 'tib', 'tgl', 'mlg', 'asm', 'tat', 'haw', 'lin', 'hau', 'bak', 'jav', 'sun']
+    languages = set()
 
-    languages = {
-        Language.fromalpha3b(lang) for lang in whisper_languages
-    }
+    for lan in whisper_languages:
+        languages.update({whisper_get_language(lan, whisper_languages[lan])})
+
     languages.update(set(Language.rebuild(lang, hi=True) for lang in languages))
     languages.update(set(Language.rebuild(lang, forced=True) for lang in languages))
 
@@ -74,8 +221,51 @@ class WhisperAIProvider(Provider):
     def terminate(self):
         self.session.close()
 
+
+    @functools.lru_cache(2048)
+    def detect_language(self, path) -> Language:
+        out = encode_audio_stream(path)
+
+        r = self.session.post(f"{self.endpoint}/detect-language",
+                              params={'encode': 'false'},
+                              files={'audio_file': out},
+                              timeout=self.timeout)
+
+        logger.info(f"Whisper detected language of {path} as {r.json()['detected_language']}")
+
+        return whisper_get_language(r.json()["language_code"], r.json()["detected_language"])
+
     def query(self, language, video):
-        return WhisperAISubtitle(language, video)
+        if language not in self.languages:
+            return None
+
+        sub = WhisperAISubtitle(language, video)
+        sub.task = "transcribe"
+
+        if video.audio_languages:
+            if language.alpha3 in video.audio_languages:
+                sub.audio_language = language.alpha3
+                # TODO: we should tell ffmpeg to only grab this audio stream... for now, let's hope ;)
+            else:
+                sub.task = "translate"
+                sub.audio_language = list(video.audio_languages)[0]
+        else:
+            # We must detect the language manually
+            detected_lang = self.detect_language(video.original_path)
+
+            if detected_lang != language:
+                sub.task = "translate"
+
+            sub.audio_language = detected_lang.alpha3
+
+        if sub.task == "translate":
+            if language.alpha3 != "eng":
+                logger.info(f"Translation only possible from {language} to English")
+                return None
+
+        logger.debug(f"Whisper ({video.original_path}): {sub.audio_language} -> {language.alpha3} [TASK: {sub.task}]")
+
+        return sub
 
     def list_subtitles(self, video, languages):
         subtitles = [self.query(l, video) for l in languages]
@@ -85,23 +275,10 @@ class WhisperAIProvider(Provider):
         # Invoke Whisper through the API. This may take a long time depending on the file.
         # TODO: This loads the entire file into memory, find a good way to stream the file in chunks
 
-        logger.debug("Encoding audio stream to WAV with ffmpeg")
-
-        try:
-            # This launches a subprocess to decode audio while down-mixing and resampling as necessary.
-            # Requires the ffmpeg CLI and `ffmpeg-python` package to be installed.
-            out, _ = (
-                ffmpeg.input(subtitle.video.original_path, threads=0)
-                .output("-", format="s16le", acodec="pcm_s16le", ac=1, ar=16000)
-                .run(cmd=["ffmpeg", "-nostdin"], capture_stdout=True, capture_stderr=True)
-            )
-        except ffmpeg.Error as e:
-            raise RuntimeError(f"Failed to load audio: {e.stderr.decode()}") from e
-
-        logger.debug(f"Finished encoding audio stream in {subtitle.video.original_path} with no errors")
+        out = encode_audio_stream(subtitle.video.original_path)
 
         r = self.session.post(f"{self.endpoint}/asr",
-                              params={'task': 'transcribe', 'output': 'srt', 'encode': 'false'},
+                              params={'task': subtitle.task, 'language': whisper_get_language_reverse(subtitle.audio_language), 'output': 'srt', 'encode': 'false'},
                               files={'audio_file': out},
                               timeout=self.timeout)
 

--- a/libs/subliminal_patch/providers/whisperai.py
+++ b/libs/subliminal_patch/providers/whisperai.py
@@ -101,7 +101,7 @@ class WhisperAIProvider(Provider):
         logger.debug(f"Finished encoding audio stream in {subtitle.video.original_path} with no errors")
 
         r = self.session.post(f"{self.endpoint}/asr",
-                              params={'task': 'transcribe', 'language': subtitle.language, 'output': 'srt', 'encode': 'false'},
+                              params={'task': 'transcribe', 'output': 'srt', 'encode': 'false'},
                               files={'audio_file': out},
                               timeout=self.timeout)
 

--- a/libs/subliminal_patch/providers/whisperai.py
+++ b/libs/subliminal_patch/providers/whisperai.py
@@ -53,11 +53,15 @@ class WhisperAIProvider(Provider):
 
     video_types = (Episode, Movie)
 
-    def __init__(self, endpoint=None):
+    def __init__(self, endpoint=None, timeout=None):
         if not endpoint:
             raise ConfigurationError('Whisper Web Service Endpoint must be provided')
 
+        if not timeout:
+            raise ConfigurationError('Whisper Web Service Timeout must be provided')
+
         self.endpoint = endpoint
+        self.timeout = int(timeout)
         self.session = None
 
     def initialize(self):
@@ -83,6 +87,6 @@ class WhisperAIProvider(Provider):
         r = self.session.post(f"{self.endpoint}/asr",
                               params={'task': 'transcribe', 'language': subtitle.language, 'output': 'srt'},
                               files={'audio_file': open(subtitle.video.original_path, 'rb')},
-                              timeout=600)
+                              timeout=self.timeout)
 
         subtitle.content = r.content

--- a/libs/subliminal_patch/providers/whisperai.py
+++ b/libs/subliminal_patch/providers/whisperai.py
@@ -1,0 +1,83 @@
+from __future__ import absolute_import
+import logging
+
+from requests import Session
+
+from subliminal_patch.subtitle import Subtitle
+from subliminal_patch.providers import Provider
+from subliminal import __short_version__
+from subliminal.exceptions import ConfigurationError
+from subzero.language import Language
+from subliminal.video import Episode, Movie
+
+logger = logging.getLogger(__name__)
+
+
+class WhisperAISubtitle(Subtitle):
+    '''Whisper AI Subtitle.'''
+    provider_name = 'whisperai'
+    hash_verifiable = False
+
+    def __init__(self, language, video):
+        super(WhisperAISubtitle, self).__init__(language)
+
+        self.video = video
+
+    @property
+    def id(self):
+        return self.video.original_name
+
+    def get_matches(self, video):
+        matches = set()
+        matches.update(["title", "series", "season", "episode"])
+        return matches
+
+
+class WhisperAIProvider(Provider):
+    '''Whisper AI Provider.'''
+
+    # These are all the languages Whisper supports.
+    # from whisper.tokenizer import LANGUAGES
+    whisper_languages = ['eng', 'chi', 'ger', 'spa', 'rus', 'kor', 'fre', 'jpn', 'por', 'tur', 'pol', 'cat', 'dut', 'ara', 'swe', 'ita', 'ind', 'hin', 'fin', 'vie', 'heb', 'ukr', 'gre', 'may', 'cze', 'rum', 'dan', 'hun', 'tam', 'nor', 'tha', 'urd', 'hrv', 'bul', 'lit', 'lat', 'mao', 'mal', 'wel', 'slo', 'tel', 'per', 'lav', 'ben', 'srp', 'aze', 'slv', 'kan', 'est', 'mac', 'bre', 'baq', 'ice', 'arm', 'nep', 'mon', 'bos', 'kaz', 'alb', 'swa', 'glg', 'mar', 'pan', 'sin', 'khm', 'sna', 'yor', 'som', 'afr', 'oci', 'geo', 'bel', 'tgk', 'snd', 'guj', 'amh', 'yid', 'lao', 'uzb', 'fao', 'hat', 'pus', 'tuk', 'nno', 'mlt', 'san', 'ltz', 'bur', 'tib', 'tgl', 'mlg', 'asm', 'tat', 'haw', 'lin', 'hau', 'bak', 'jav', 'sun']
+
+    languages = {
+        Language.fromalpha3b(lang) for lang in whisper_languages
+    }
+    languages.update(set(Language.rebuild(lang, hi=True) for lang in languages))
+    languages.update(set(Language.rebuild(lang, forced=True) for lang in languages))
+
+    video_types = (Episode, Movie)
+
+    def __init__(self, endpoint=None):
+        if not endpoint:
+            raise ConfigurationError('Whisper Web Service Endpoint must be provided')
+
+        self.endpoint = endpoint
+        self.session = None
+
+    def initialize(self):
+        self.session = Session()
+        self.session.headers['User-Agent'] = 'Subliminal/%s' % __short_version__
+
+    def terminate(self):
+        self.session.close()
+
+    def query(self, language, video):
+        return WhisperAISubtitle(language, video)
+
+    def list_subtitles(self, video, languages):
+        subtitles = [self.query(l, video) for l in languages]
+        return [s for s in subtitles if s is not None]
+
+    def download_subtitle(self, subtitle: WhisperAISubtitle):
+        # For this POC, the full video file will be sent to the API.
+        # TODO: we should use ffmpeg to extract the audio stream and only send that
+
+        # Invoke Whisper through the API. This may take a long time depending on the file.
+        # TODO: This loads the entire file into memory, find a good way to stream the file in chunks
+        r = self.session.post(f"{self.endpoint}/asr",
+                              params={'task': 'transcribe', 'language': subtitle.language, 'output': 'srt'},
+                              files={'audio_file': open(subtitle.video.original_path, 'rb')},
+                              timeout=600)
+
+        subtitle.content = r.content


### PR DESCRIPTION
This is a basic provider which uses OpenAI's [Whisper](https://github.com/openai/whisper/) speech recognition model. It is dependent on [Ahmet Oner's ASR web service](https://github.com/ahmetoner/whisper-asr-webservice) running in a Docker container on the same or different machine from Bazarr.

To test this, run the ASR container: `docker run -d -p 9000:9000 -e ASR_MODEL=small onerahmet/openai-whisper-asr-webservice:latest`, and add the Whisper provider to Bazarr, setting the endpoint to `http://127.0.0.1:9000` or the IP of your other machine.

Here are some immediate action items:
- [x] Use ffmpeg to extract the audio stream on the fly while it's sending it to the ASR. Currently, it sends the entire video file, and this is a huge waste of time
- [x] Detection of which audio stream to use based on language information from ffprobe, if available
- [x] ~~Don't read the entire original file into memory~~ ~~Stream the ffmpeg output to the ASR.~~ not worth the time
- [x] Add support for translation from another language into English. Not sure if this needs some kind of hacking of the provider system or an easy way to detect if the desired language is different from the language of the TV show or movie
- [x] Support for complex cases where there are multiple audio streams (i.e. English, Japanese), choose the target language first 

What thoughts do you all have on a complete implementation of this? It should be easy to pair the ASR container with either of the two maintained Docker images. Decoupling the ASR from Bazarr means you can easily run the ASR container on a machine with a GPU which makes transcription much faster.