### PR TITLE
Fix yifysubtitles url

### DIFF
--- a/libs/subliminal_patch/providers/yifysubtitles.py
+++ b/libs/subliminal_patch/providers/yifysubtitles.py
@@ -95,7 +95,7 @@ class YifySubtitlesProvider(Provider):
 
     languages = {Language(l, c) for (_, l, c) in YifyLanguages}
     languages.update(set(Language.rebuild(l, hi=True) for l in languages))
-    server_url = 'https://yifysubtitles.org'
+    server_url = 'https://yifysubtitles.ch'
     video_types = (Movie,)
 
     def initialize(self):


### PR DESCRIPTION
Sorry, I don't know what happened in  #2112. There is a new redirection from `org` to `ch` which results in:

```
07/04/2023 15:10:40|DEBUG   |urllib3.connectionpool          |https://yifysubtitles.org:443 "GET /movie-imdb/tt1630029 HTTP/1.1" 301 None|
07/04/2023 15:10:40|DEBUG   |subliminal_patch.providers.yifysubtitles|No subtitles found|
```

```
curl -Is https://yifysubtitles.org:443 | grep location
location: https://yifysubtitles.ch/
```