### PR TITLE
Switch monitored/unmonitored text on item overview bookmark icon, as it is currently incorrect

### DIFF
--- a/frontend/src/pages/views/ItemOverview.tsx
+++ b/frontend/src/pages/views/ItemOverview.tsx
@@ -167,7 +167,7 @@ const ItemOverview: FunctionComponent<Props> = (props) => {
                 <Text inherit color="white">
                   <Box component="span" mr={12}>
                     <FontAwesomeIcon
-                      title={item?.monitored ? "unmonitored" : "monitored"}
+                      title={item?.monitored ? "monitored" : "unmonitored"}
                       icon={item?.monitored ? faBookmark : farBookmark}
                     ></FontAwesomeIcon>
                   </Box>


### PR DESCRIPTION
Fixes the currently invalid tooltip text on movie/series overview. Purely cosmetical.

Currently incorrect tooltip text screenshots.

Series:
- should say monitored
![image](https://github.com/morpheus65535/bazarr/assets/2651524/59907cd5-5408-4cf4-83cc-922077d1ea9a)
- should say unmonitored
![image](https://github.com/morpheus65535/bazarr/assets/2651524/642636d7-c9b0-485f-8c02-0a262ae7aadb)

Movies:
- should say monitored
![image](https://github.com/morpheus65535/bazarr/assets/2651524/57386ce1-df2d-42b2-8c71-363f25e473b5)
- should say unmonitored
![image](https://github.com/morpheus65535/bazarr/assets/2651524/7f65e5d2-c27c-4173-ae84-c076e7204ce1)

Disclaimer:
I did not build the project to test this, just updated the code and submitted the PR. I do believe it is correct though.