### PR TITLE
Made 'id' description clearer

### DIFF
--- a/bazarr/api/subtitles/subtitles.py
+++ b/bazarr/api/subtitles/subtitles.py
@@ -31,7 +31,7 @@ class Subtitles(Resource):
     patch_request_parser.add_argument('language', type=str, required=True, help='Language code2')
     patch_request_parser.add_argument('path', type=str, required=True, help='Subtitles file path')
     patch_request_parser.add_argument('type', type=str, required=True, help='Media type from ["episode", "movie"]')
-    patch_request_parser.add_argument('id', type=int, required=True, help='Episode ID')
+    patch_request_parser.add_argument('id', type=int, required=True, help='Media ID (episodeId, radarrId)')
     patch_request_parser.add_argument('forced', type=str, required=False, help='Forced subtitles from ["True", "False"]')
     patch_request_parser.add_argument('hi', type=str, required=False, help='HI subtitles from ["True", "False"]')
     patch_request_parser.add_argument('original_format', type=str, required=False,


### PR DESCRIPTION
I've been playing with the API for the last few hours and I noticed that this wasn't clear that the ID also needs to be set if it's a movie. At first I gave it a -1 ID because I presumed the ID wasn't needed as it wasn't an episode. 

Happy to change the description further if desired, I just think it needs to be made more obvious it applies to both media types.

This small change should help people in the future when utilizing the API.