### PR TITLE
Fix notifications, provider query doesn't return dict

### DIFF
--- a/bazarr/app/notifier.py
+++ b/bazarr/app/notifier.py
@@ -133,8 +133,8 @@ def send_notifications_movie(radarr_id, message):
     apobj = apprise.Apprise(asset=asset)
 
     for provider in providers:
-        if provider['url'] is not None:
-            apobj.add(provider['url'])
+        if provider.url is not None:
+            apobj.add(provider.url)
 
     apobj.notify(
         title='Bazarr notification',


### PR DESCRIPTION
Prompted by the log error below.
The only provider I've configured is 'E-Mail' but the issue seems generic.

```
29/07/2023 03:51:57|ERROR   |app.app                         |Exception on /api/series [PATCH]|'Traceback (most recent call last):
  File "/app/bazarr/bin/bazarr/../libs/flask/app.py", line 1820, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/bazarr/bin/bazarr/../libs/flask/app.py", line 1796, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/bazarr/bin/bazarr/../libs/flask_restx/api.py", line 405, in wrapper
    resp = resource(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/bazarr/bin/bazarr/../libs/flask/views.py", line 107, in view
    return current_app.ensure_sync(self.dispatch_request)(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/bazarr/bin/bazarr/../libs/flask_restx/resource.py", line 46, in dispatch_request
    resp = meth(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/app/bazarr/bin/bazarr/api/utils.py", line 30, in wrapper
    return actual_method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/bazarr/bin/bazarr/api/series/series.py", line 211, in patch
    series_download_subtitles(seriesid)
  File "/app/bazarr/bin/bazarr/subtitles/mass_download/series.py", line 88, in series_download_subtitles
    send_notifications(no, episode.sonarrEpisodeId, result.message)
  File "/app/bazarr/bin/bazarr/app/notifier.py", line 78, in send_notifications
    if provider[\'url\'] is not None:
       ~~~~~~~~^^^^^^^
  File "/app/bazarr/bin/bazarr/../libs/sqlalchemy/engine/_py_row.py", line 110, in _get_by_int_impl
    return self._data[key]
           ~~~~~~~~~~^^^^^
TypeError: tuple indices must be integers or slices, not str'|
```
