### PR TITLE
Add timeout for call to github

### DIFF
--- a/bazarr/app/announcements.py
+++ b/bazarr/app/announcements.py
@@ -43,7 +43,9 @@ def parse_announcement_dict(announcement_dict):
 
 def get_announcements_to_file():
     try:
-        r = requests.get("https://raw.githubusercontent.com/morpheus65535/bazarr-binaries/master/announcements.json")
+        r = requests.get(
+            "https://raw.githubusercontent.com/morpheus65535/bazarr-binaries/master/announcements.json"
+            timeout=10)
     except requests.exceptions.HTTPError:
         logging.exception("Error trying to get announcements from Github. Http error.")
     except requests.exceptions.ConnectionError:


### PR DESCRIPTION
I'm having issues starting up Bazarr and I've narrowed down the issue to this line of code being stuck. It looks like Github may have some spam blocking functionality which causes the request to never succeed.

I have introduced a timeout of 10 seconds to make sure that Bazarr starts up successfully even if we can't establish a connection to Github.