### PR TITLE
Fix notifications settings page

### DIFF
--- a/bazarr/api/system/settings.py
+++ b/bazarr/api/system/settings.py
@@ -108,7 +108,7 @@ class SystemSettings(Resource):
             item = json.loads(item)
             database.execute(
                 update(TableSettingsNotifier).values(
-                    enabled=item['enabled'],
+                    enabled=int(item['enabled'] == True),
                     url=item['url'])
                 .where(TableSettingsNotifier.name == item['name']))
 


### PR DESCRIPTION
Hi, there seems to be an error when saving notifications settings page. The database was complaining that the column is of type integer. This should fix it.

More information:
```
INFO    |root                            |BAZARR Log file emptied|
ERROR   |app.app                         |Exception on /api/system/settings [POST]|Traceback (most recent call last):  File "/app/bazarr/bin/bazarr/../libs/sqlalchemy/engine/base.py", line 1964, in _exec_single_context    self.dialect.do_execute(  File "/app/bazarr/bin/bazarr/../libs/sqlalchemy/engine/default.py", line 748, in do_execute    cursor.execute(statement, parameters)psycopg2.errors.DatatypeMismatch: column "enabled" is of type integer but expression is of type booleanLINE 1: UPDATE table_settings_notifier SET enabled=true, url='https:...                                                   ^HINT:  You will need to rewrite or cast the expression.The above exception was the direct cause of the following exception:Traceback (most recent call last):  File "/app/bazarr/bin/bazarr/../libs/flask/app.py", line 1820, in full_dispatch_request    rv = self.dispatch_request()         ^^^^^^^^^^^^^^^^^^^^^^^  File "/app/bazarr/bin/bazarr/../libs/flask/app.py", line 1796, in dispatch_request    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  File "/app/bazarr/bin/bazarr/../libs/flask_restx/api.py", line 405, in wrapper    resp = resource(*args, **kwargs)           ^^^^^^^^^^^^^^^^^^^^^^^^^  File "/app/bazarr/bin/bazarr/../libs/flask/views.py", line 107, in view    return current_app.ensure_sync(self.dispatch_request)(**kwargs)           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  File "/app/bazarr/bin/bazarr/../libs/flask_restx/resource.py", line 46, in dispatch_request    resp = meth(*args, **kwargs)           ^^^^^^^^^^^^^^^^^^^^^  File "/app/bazarr/bin/bazarr/api/utils.py", line 30, in wrapper    return actual_method(*args, **kwargs)           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  File "/app/bazarr/bin/bazarr/api/system/settings.py", line 109, in post    database.execute(  File "/app/bazarr/bin/bazarr/../libs/sqlalchemy/orm/scoping.py", line 724, in execute    return self._proxied.execute(           ^^^^^^^^^^^^^^^^^^^^^^  File "/app/bazarr/bin/bazarr/../libs/sqlalchemy/orm/session.py", line 2229, in execute    return self._execute_internal(           ^^^^^^^^^^^^^^^^^^^^^^^  File "/app/bazarr/bin/bazarr/../libs/sqlalchemy/orm/session.py", line 2124, in _execute_internal    result: Result[Any] = compile_state_cls.orm_execute_statement(                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  File "/app/bazarr/bin/bazarr/../libs/sqlalchemy/orm/bulk_persistence.py", line 1524, in orm_execute_statement    return super().orm_execute_statement(           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  File "/app/bazarr/bin/bazarr/../libs/sqlalchemy/orm/context.py", line 253, in orm_execute_statement    result = conn.execute(             ^^^^^^^^^^^^^  File "/app/bazarr/bin/bazarr/../libs/sqlalchemy/engine/base.py", line 1414, in execute    return meth(           ^^^^^  File "/app/bazarr/bin/bazarr/../libs/sqlalchemy/sql/elements.py", line 486, in _execute_on_connection    return connection._execute_clauseelement(           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  File "/app/bazarr/bin/bazarr/../libs/sqlalchemy/engine/base.py", line 1638, in _execute_clauseelement    ret = self._execute_context(          ^^^^^^^^^^^^^^^^^^^^^^  File "/app/bazarr/bin/bazarr/../libs/sqlalchemy/engine/base.py", line 1842, in _execute_context    return self._exec_single_context(           ^^^^^^^^^^^^^^^^^^^^^^^^^^  File "/app/bazarr/bin/bazarr/../libs/sqlalchemy/engine/base.py", line 1983, in _exec_single_context    self._handle_dbapi_exception(  File "/app/bazarr/bin/bazarr/../libs/sqlalchemy/engine/base.py", line 2326, in _handle_dbapi_exception    raise sqlalchemy_exception.with_traceback(exc_info[2]) from e  File "/app/bazarr/bin/bazarr/../libs/sqlalchemy/engine/base.py", line 1964, in _exec_single_context    self.dialect.do_execute(  File "/app/bazarr/bin/bazarr/../libs/sqlalchemy/engine/default.py", line 748, in do_execute    cursor.execute(statement, parameters)sqlalchemy.exc.ProgrammingError: (psycopg2.errors.DatatypeMismatch) column "enabled" is of type integer but expression is of type booleanLINE 1: UPDATE table_settings_notifier SET enabled=true, url='https:...                                                   ^HINT:  You will need to rewrite or cast the expression.[SQL: UPDATE table_settings_notifier SET enabled=%(enabled)s, url=%(url)s WHERE table_settings_notifier.name = %(name_1)s][parameters: {'enabled': True, 'url': 'https://xxxxxxxxxxx', 'name_1': 'xxxxxx'}](Background on this error at: https://sqlalche.me/e/20/f405)|
```