### PR TITLE
Remove Assert from custom_lang.py

### DIFF
--- a/bazarr/languages/custom_lang.py
+++ b/bazarr/languages/custom_lang.py
@@ -67,7 +67,6 @@ class CustomLanguage:
 
     @classmethod
     def get_alpha_type(cls, subtitle: str, subtitle_path=None):
-        assert subtitle_path is not None
 
         extension = str(os.path.splitext(subtitle)[0]).lower()
         to_return = None


### PR DESCRIPTION
Remove assert to correct the following when conditions are not met:

 File "/app/bazarr/bin/bazarr/../libs/apscheduler/executors/base.py", line 125, in run_job
    retval = job.func(*job.args, **job.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/bazarr/bin/bazarr/sonarr/sync/episodes.py", line 21, in update_all_episodes
    series_full_scan_subtitles()
  File "/app/bazarr/bin/bazarr/subtitles/indexer/series.py", line 275, in series_full_scan_subtitles
    store_subtitles(episode['path'], path_mappings.path_replace(episode['path']), use_cache=use_cache)
  File "/app/bazarr/bin/bazarr/subtitles/indexer/series.py", line 113, in store_subtitles
    custom = CustomLanguage.found_external(subtitle, subtitle_path)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/bazarr/bin/bazarr/languages/custom_lang.py", line 56, in found_external
    code = sub.get_alpha_type(subtitle, subtitle_path)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/bazarr/bin/bazarr/languages/custom_lang.py", line 64, in get_alpha_type
    assert subtitle_path is not None
           ^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError

Currently this can cause the scanner to crash. 

