### PR TITLE
Adaptive search description tweak and default setting

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -61,7 +61,7 @@ defaults = {
         'ignore_pgs_subs': 'False',
         'ignore_vobsub_subs': 'False',
         'ignore_ass_subs': 'False',
-        'adaptive_searching': 'False',
+        'adaptive_searching': 'True',
         'adaptive_searching_delay': '3w',
         'adaptive_searching_delta': '1w',
         'enabled_providers': '[]',

--- a/frontend/src/pages/Settings/Subtitles/index.tsx
+++ b/frontend/src/pages/Settings/Subtitles/index.tsx
@@ -215,8 +215,8 @@ const SettingsSubtitlesView: FunctionComponent = () => {
           settingKey="settings-general-adaptive_searching"
         ></Check>
         <Message>
-          When searching for subtitles, Bazarr will reduce search frequency to
-          limit call to providers.
+          When enabled, Bazarr will skip searching providers for subtitles which
+          have been searched recently.
         </Message>
         <CollapseBox settingKey="settings-general-adaptive_searching">
           <Selector
@@ -225,8 +225,9 @@ const SettingsSubtitlesView: FunctionComponent = () => {
             options={adaptiveSearchingDelayOption}
           ></Selector>
           <Message>
-            In order to reduce search frequency, how many weeks must Bazarr wait
-            after initial search.
+            The delay from the first search to adaptive searching applying.
+            During this window Bazarr will continue to search for subtitles,
+            even if they have been searched for recently.
           </Message>
           <Selector
             settingKey="settings-general-adaptive_searching_delta"
@@ -234,8 +235,9 @@ const SettingsSubtitlesView: FunctionComponent = () => {
             options={adaptiveSearchingDeltaOption}
           ></Selector>
           <Message>
-            How often should Bazarr search for subtitles when in adaptive search
-            mode.
+            The delay between Bazarr searching for subtitles in adaptive search
+            mode. If the media has been searched for more recently than this
+            value, Bazarr will skip searching for subtitles.
           </Message>
         </CollapseBox>
         <Check


### PR DESCRIPTION
- Changes the description in the config for adaptive search

- More a proposal in a PR: Enables adaptive search by default, I'll copy the rationale from the commit to this PR.

I am happy to drop this commit, as I've proposed we enable it by default without any discussion whilst I was looking at adaptive searching anyway

```
We should enable adaptive searching be default for the following
reasons:

    * The initial search window is very generous, 3 weeks would allow us to
      find anything, if it existed, numerous times over.
    
    * If people are setting up new providers 3 weeks is long enough
      that they've probably added all the providers they're going to add
      anyway and we've had a chance to search them.
    
    * Adaptive search is based on the initial delay, for very large
      libraries it will start to apply after the first search. This means
      the above points still apply, even if it's processing slowly. It's
      not, "you have 3 weeks to find the media from first setup"
    
    * If subtitles are added, a week delay on top of 3 weeks is not going to
      be noticable. By week 4 the chances are we either have some subtitles,
      or it's going to take several months for someone to put them together.
    
    * This reduces the load on providers and gives us a better chance of
      finding new subtitles: Instead of requesting the same titles again and
      again on larger libraries on a daily basis, we can search more frequently
      for different titles each day. This spreads the queries out rather than the
      same episodes appearing at the top of the regularly search calls.
    
    The only downsides are:
    * Small libraries see little benefit from this, as they can get away
      with searching daily in a few calls. These would go from finding
      subtitles within the task interval to a week at worst.
    * If a subtitle has been added, a user needs to manually start a search
      for a given item or wait the delay period. But again this would be
      after 3 weeks of waiting....
```