### PR TITLE
Update subsyncer.py

### DIFF
--- a/bazarr/subtitles/tools/subsyncer.py
+++ b/bazarr/subtitles/tools/subsyncer.py
@@ -55,7 +55,8 @@ class SubSyncer:
         unparsed_args = [self.reference, '-i', self.srtin, '-o', self.srtout, '--ffmpegpath', self.ffmpeg_path, '--vad',
                          self.vad, '--log-dir-path', self.log_dir_path]
         if settings.subsync.force_audio:
-            unparsed_args.append('--no-fix-framerate')
+            unparsed_args.append('--max-offset-seconds')
+            unparsed_args.append('10')
             unparsed_args.append('--reference-stream')
             unparsed_args.append('a:0')
         if settings.subsync.debug:


### PR DESCRIPTION
Removed the "no fix framerate" argument so that ffsubsync is able to fix subtitles being used for TV series that lightly speed up their broadcast versions of their shows.

This argument was initially put into place because earlier versions of ffsubsync didn't do well without it. To be safe, the "max offset seconds" was also added, to avoid ffsubsync offseting a subtitle more than 10 seconds.