### PR TITLE
Remove clipboard action when not secure context

### DIFF
--- a/frontend/src/pages/Settings/General/index.tsx
+++ b/frontend/src/pages/Settings/General/index.tsx
@@ -83,24 +83,32 @@ const SettingsGeneralView: FunctionComponent = () => {
         </CollapseBox>
         <Text
           label="API Key"
-          disabled
+          // User can copy through the clipboard button
+          disabled={window.isSecureContext}
+          // Enable user to at least copy when not in secure context
+          readOnly={!window.isSecureContext}
           rightSectionWidth={95}
           rightSectionProps={{ style: { justifyContent: "flex-end" } }}
           rightSection={
             <MantineGroup spacing="xs" mx="xs" position="right">
-              <Action
-                label="Copy API Key"
-                variant="light"
-                settingKey={settingApiKey}
-                color={copied ? "green" : undefined}
-                icon={copied ? faCheck : faClipboard}
-                onClick={(update, value) => {
-                  if (value) {
-                    clipboard.copy(value);
-                    toggleState(setCopy, 1500);
-                  }
-                }}
-              ></Action>
+              {
+                // Clipboard API is only available in secure contexts See: https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API#interfaces
+                window.isSecureContext && (
+                  <Action
+                    label="Copy API Key"
+                    variant="light"
+                    settingKey={settingApiKey}
+                    color={copied ? "green" : undefined}
+                    icon={copied ? faCheck : faClipboard}
+                    onClick={(update, value) => {
+                      if (value) {
+                        clipboard.copy(value);
+                        toggleState(setCopy, 1500);
+                      }
+                    }}
+                  />
+                )
+              }
               <Action
                 label="Regenerate"
                 variant="light"


### PR DESCRIPTION
It is impossible to copy to a clipboard when not using HTTPS protocol, even in a local network (192.168....) 😢; the only exception is localhost. See: [Clipboard_API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API#interfaces)

There are a few workarounds that are possible to implement, but instead of adding countless lines of code just for copying a text and to prevent people (like me) from clicking multiple times, hoping it would work eventually.

I hid the clipboard button when it is not possible to copy, and made the API text field read-only instead of disabled





