### PR TITLE
Bump rarfile and add 7z support

### DIFF
--- a/bazarr/init.py
+++ b/bazarr/init.py
@@ -217,16 +217,28 @@ def init_binaries():
         exe = get_binary("unar")
         rarfile.UNAR_TOOL = exe
         rarfile.UNRAR_TOOL = None
-        rarfile.tool_setup(unrar=False, unar=True, bsdtar=False, force=True)
+        rarfile.SEVENZIP_TOOL = None
+        rarfile.tool_setup(unrar=False, unar=True, bsdtar=False, sevenzip=False, force=True)
     except (BinaryNotFound, rarfile.RarCannotExec):
         try:
             exe = get_binary("unrar")
             rarfile.UNRAR_TOOL = exe
             rarfile.UNAR_TOOL = None
-            rarfile.tool_setup(unrar=True, unar=False, bsdtar=False, force=True)
+            rarfile.SEVENZIP_TOOL = None
+            rarfile.tool_setup(unrar=True, unar=False, bsdtar=False, sevenzip=False, force=True)
         except (BinaryNotFound, rarfile.RarCannotExec):
-            logging.exception("BAZARR requires a rar archive extraction utilities (unrar, unar) and it can't be found.")
-            raise BinaryNotFound
+            try:
+                exe = get_binary("7z")
+                rarfile.UNRAR_TOOL = None
+                rarfile.UNAR_TOOL = None
+                rarfile.SEVENZIP_TOOL = "7z"
+                rarfile.tool_setup(unrar=False, unar=False, bsdtar=False, sevenzip=True, force=True)
+            except (BinaryNotFound, rarfile.RarCannotExec):
+                logging.exception("BAZARR requires a rar archive extraction utilities (unrar, unar, 7zip) and it can't be found.")
+                raise BinaryNotFound
+            else:
+                logging.debug("Using 7zip from: %s", exe)
+                return exe
         else:
             logging.debug("Using UnRAR from: %s", exe)
             return exe

--- a/libs/version.txt
+++ b/libs/version.txt
@@ -31,7 +31,7 @@ python-engineio==4.3.4
 python-socketio==5.7.2
 pytz==2023.3
 pytz_deprecation_shim==0.1.0.post0
-rarfile==4.0
+rarfile==4.1
 requests==2.28.1
 semver==2.13.0
 signalrcore==0.9.5


### PR DESCRIPTION
- Bump rarfile.py from 4.0 to 4.1
- Add support for 7zip for archive extractions, since unar is a steaming pile of C# and unrar is non-free, having some easy-to-package software to handle archive makes it easier to run Bazarr on Linux distributions.

This should close #2283