### PR TITLE
Slider always shows value

### DIFF
--- a/frontend/src/pages/Settings/components/forms.tsx
+++ b/frontend/src/pages/Settings/components/forms.tsx
@@ -146,6 +146,7 @@ export const Slider: FunctionComponent<SliderProps> = (props) => {
       <MantineSlider
         {...sliderProps}
         marks={marks}
+        labelAlwaysOn
         onChange={update}
         value={value ?? 0}
       ></MantineSlider>


### PR DESCRIPTION
Added "labelAlwaysOn" property to MantineSlider so that...the label is always on and you don't have to move the slider to find out its value.

Tested on Android phone, IPad and Chrome web browser.