### PR TITLE
Workaround for pop-up menu being clipped

### DIFF
--- a/frontend/src/components/modals/SubtitleToolsModal.tsx
+++ b/frontend/src/components/modals/SubtitleToolsModal.tsx
@@ -4,7 +4,15 @@ import { SimpleTable } from "@/components/tables";
 import { useCustomSelection } from "@/components/tables/plugins";
 import { withModal } from "@/modules/modals";
 import { isMovie } from "@/utilities";
-import { Badge, Button, Divider, Group, Stack, Text } from "@mantine/core";
+import {
+  Badge,
+  Button,
+  Divider,
+  Group,
+  Space,
+  Stack,
+  Text,
+} from "@mantine/core";
 import { FunctionComponent, useMemo, useState } from "react";
 import { Column, useRowSelect } from "react-table";
 
@@ -106,6 +114,7 @@ const SubtitleToolView: FunctionComponent<SubtitleToolViewProps> = ({
         canSelect={CanSelectSubtitle}
         data={data}
       ></SimpleTable>
+      <Space h="400px"></Space>
       <Divider></Divider>
       <Group>
         <SubtitleToolsMenu selections={selections}>


### PR DESCRIPTION
This adds the minimum amount of space needed to the parent form to ensure that the entire pop-up menu is displayed. 
The reason it's a workaround is because the space is always added, even if not needed. If I knew how to do math inside a .tsx file, I would have done so to adjust the amount added, if that is even possible. 
An even better solution would be to somehow attach the menu to the main window, instead of the modal dialog. However, after much searching on this and trying several things, I couldn't make it happen. Perhaps someone with Mantine experience can do better. In the meantime, this works. 
This should fix issue #2348 which actually happens for both TV Series and Movies.