### PR TITLE
Fix single blacklist item deletion

### DIFF
--- a/bazarr/radarr/blacklist.py
+++ b/bazarr/radarr/blacklist.py
@@ -29,7 +29,7 @@ def blacklist_log_movie(radarr_id, provider, subs_id, language):
 def blacklist_delete_movie(provider, subs_id):
     database.execute(
         delete(TableBlacklistMovie)
-        .where((TableBlacklistMovie.provider == provider) and (TableBlacklistMovie.subs_id == subs_id)))
+        .where((TableBlacklistMovie.provider == provider) & (TableBlacklistMovie.subs_id == subs_id)))
     event_stream(type='movie-blacklist', action='delete')
 
 

--- a/bazarr/sonarr/blacklist.py
+++ b/bazarr/sonarr/blacklist.py
@@ -30,7 +30,7 @@ def blacklist_log(sonarr_series_id, sonarr_episode_id, provider, subs_id, langua
 def blacklist_delete(provider, subs_id):
     database.execute(
         delete(TableBlacklist)
-        .where((TableBlacklist.provider == provider) and (TableBlacklist.subs_id == subs_id)))
+        .where((TableBlacklist.provider == provider) & (TableBlacklist.subs_id == subs_id)))
     event_stream(type='episode-blacklist', action='delete')
 
 


### PR DESCRIPTION
A bug in the database deletion code meant all subtitles sharing the same provider were being deleted from the blacklist table instead of one single item. This was happening because the `subs_id` was being ignored.