### PR TITLE
Fix server crash on removal of all blacklist items

### DIFF
--- a/bazarr/api/episodes/blacklist.py
+++ b/bazarr/api/episodes/blacklist.py
@@ -129,8 +129,8 @@ class EpisodesBlacklist(Resource):
 
     delete_request_parser = reqparse.RequestParser()
     delete_request_parser.add_argument('all', type=str, required=False, help='Empty episodes subtitles blacklist')
-    delete_request_parser.add_argument('provider', type=str, required=True, help='Provider name')
-    delete_request_parser.add_argument('subs_id', type=str, required=True, help='Subtitles ID')
+    delete_request_parser.add_argument('provider', type=str, required=False, help='Provider name')
+    delete_request_parser.add_argument('subs_id', type=str, required=False, help='Subtitles ID')
 
     @authenticate
     @api_ns_episodes_blacklist.doc(parser=delete_request_parser)

--- a/bazarr/api/movies/blacklist.py
+++ b/bazarr/api/movies/blacklist.py
@@ -122,8 +122,8 @@ class MoviesBlacklist(Resource):
 
     delete_request_parser = reqparse.RequestParser()
     delete_request_parser.add_argument('all', type=str, required=False, help='Empty movies subtitles blacklist')
-    delete_request_parser.add_argument('provider', type=str, required=True, help='Provider name')
-    delete_request_parser.add_argument('subs_id', type=str, required=True, help='Subtitles ID')
+    delete_request_parser.add_argument('provider', type=str, required=False, help='Provider name')
+    delete_request_parser.add_argument('subs_id', type=str, required=False, help='Subtitles ID')
 
     @authenticate
     @api_ns_movies_blacklist.doc(parser=delete_request_parser)


### PR DESCRIPTION
The API required the "provider" and "subs_id" arguments for the deletion of blacklist items, which are not provided by the frontend for the "remove all" functionality. Instead, make them optional arguments.