### PR TITLE
Provide separate values for connection and read timeouts for WhisperAI

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -228,6 +228,7 @@ validators = [
 
     # whisperai section
     Validator('whisperai.endpoint', must_exist=True, default='http://127.0.0.1:9000', is_type_of=str),
+    Validator('whisperai.response', must_exist=True, default=5, is_type_of=int, gte=1),
     Validator('whisperai.timeout', must_exist=True, default=3600, is_type_of=int, gte=1),
     Validator('whisperai.loglevel', must_exist=True, default='INFO', is_type_of=str,
               is_in=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']),

--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -311,6 +311,7 @@ def get_providers_auth():
         },
         'whisperai': {
             'endpoint': settings.whisperai.endpoint,
+            'response': settings.whisperai.response,
             'timeout': settings.whisperai.timeout,
             'ffmpeg_path': _FFMPEG_BINARY,
             'loglevel': settings.whisperai.loglevel,            

--- a/frontend/src/pages/Settings/Providers/list.ts
+++ b/frontend/src/pages/Settings/Providers/list.ts
@@ -439,6 +439,12 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
       },
       {
         type: "text",
+        key: "response",
+        defaultValue: 5,
+        name: "Connection/response timeout in seconds",
+      },
+      {
+        type: "text",
         key: "timeout",
         defaultValue: 3600,
         name: "Transcription/translation timeout in seconds",


### PR DESCRIPTION
Added `response` key with default value of `5` to pair with existing `timeout` key which has a default of `3600` sec. Both values can be updated in WhisperAI settings dialog by user. More information about these two types of timeouts here:

[https://reqbin.com/code/python/3zdpeao1/python-requests-timeout-example](https://reqbin.com/code/python/3zdpeao1/python-requests-timeout-example)
