### PR TITLE
Fix indexing bug

### DIFF
--- a/bazarr/radarr/sync/movies.py
+++ b/bazarr/radarr/sync/movies.py
@@ -135,7 +135,7 @@ def update_movies(send_event=True):
                     logging.error(f"BAZARR cannot delete movies because of {e}")
                 else:
                     for removed_movie in movies_to_delete:
-                        movies_deleted.append(removed_movie['title'])
+                        movies_deleted.append(removed_movie)
                         if send_event:
                             event_stream(type='movie', action='delete', payload=removed_movie)
 


### PR DESCRIPTION
The `removed_movie `variable is not an actual movie object but simply a tmdbid, so it can't be indexed.