### PR TITLE
Fix best forced subtitle downloads

### DIFF
--- a/libs/subliminal_patch/core.py
+++ b/libs/subliminal_patch/core.py
@@ -574,12 +574,12 @@ class SZProviderPool(ProviderPool):
                 break
 
             # stop when all languages are downloaded
-            if set(s.language.basename for s in downloaded_subtitles) == languages:
+            if set(str(s.language) for s in downloaded_subtitles) == languages:
                 logger.debug('All languages downloaded')
                 break
 
             # check downloaded languages
-            if subtitle.language in set(s.language.basename for s in downloaded_subtitles):
+            if subtitle.language in set(str(s.language) for s in downloaded_subtitles):
                 logger.debug('%r: Skipping subtitle: already downloaded', subtitle.language)
                 continue
 


### PR DESCRIPTION
Searching for the best forced subtitles for a given language was resulting in all forced subtitles for that language being downloaded in descending score order until the minimum score was reached.

Not only did this burn through any download limits imposed by providers, it left poor quality subtitles downloaded (which could later be automatically upgraded to the first choice).

This change uses the string conversion of Language objects instead of their basenames when working out when to stop downloading subtitles, as this takes into account the forced flag while still ignoring the hearing impaired flag.