### PR TITLE
Specify language country in legendasdivx provider

### DIFF
--- a/libs/subliminal_patch/providers/legendasdivx.py
+++ b/libs/subliminal_patch/providers/legendasdivx.py
@@ -228,9 +228,9 @@ class LegendasdivxProvider(Provider):
                 if th.text == 'Idioma:':
                     lang = th.find_next("td").find("img").get('src')
                     if 'brazil' in lang.lower():
-                        lang = Language.fromopensubtitles('pob')
+                        lang = Language('por', 'BR')
                     elif 'portugal' in lang.lower():
-                        lang = Language.fromopensubtitles('por')
+                        lang = Language('por', 'PT')
                     else:
                         continue
                 if th.text == "Frame Rate:":

--- a/libs/subliminal_patch/providers/legendasdivx.py
+++ b/libs/subliminal_patch/providers/legendasdivx.py
@@ -123,7 +123,7 @@ class LegendasdivxSubtitle(Subtitle):
 
 class LegendasdivxProvider(Provider):
     """Legendasdivx Provider."""
-    languages = {Language('por', 'BR')} | {Language('por')}
+    languages = {Language('por', 'BR')} | {Language('por', 'PT')}
     video_types = (Episode, Movie)
     SEARCH_THROTTLE = 8
     SAFE_SEARCH_LIMIT = 145  # real limit is 150, but we use 145 to keep a buffer and prevent IPAddressBlocked exception to be raised


### PR DESCRIPTION
Since v1.4.1, Bazarr was refusing to search for pt-PT subtitles using the "legendasdivx" provider, while logging the following information:
```
INFO    |subliminal_patch.core           |Skipping provider 'legendasdivx': no language to search for|
```

After specifying the country in the provider's languages list, it now searches for subtitles, but still says it cannot find it. After switching from using `Language.fromopensubtitles` to using just the `Language` constructor in the `_process_page` function, it actually uses the found subtitles.