### PR TITLE
Migrate `table_languages_profiles.originalFormat` from bool to int for Postgresql

### DIFF
--- a/migrations/versions/b183a2ac0dd1
+++ b/migrations/versions/b183a2ac0dd1
@@ -1,0 +1,28 @@
+"""Alter table_languages_profiles.originalFormat type to from bool to int
+
+Revision ID: b183a2ac0dd1
+Revises: 30f37e2e15e1
+Create Date: 2024-02-16 10:32:39.123456
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b183a2ac0dd1'
+down_revision = '30f37e2e15e1'
+branch_labels = None
+depends_on = None
+
+bind = op.get_context().bind
+
+
+def upgrade():
+    if bind.engine.name == 'postgresql':
+        with op.batch_alter_table('table_languages_profiles') as batch_op:
+            batch_op.alter_column('originalFormat', type_=sa.Integer())
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
I'm getting the opposite of this bug #2282 and I can't save languages with Postgres because the `table_languages_profiles.originalFormat` column is a boolean in the database but should be an integer.

`psycopg2.errors.DatatypeMismatch: column "originalFormat" is of type boolean but expression is of type integer`

The schema appeared to have changed in bccded275c3cb09dc001d66858f3200c78723935, but wasn't migrated, which isn't a problem for sqlite because it doesn't have booleans, but is for Postgres, so I tried making a migration to fix this.