### PR TITLE
Lower debounce value

### DIFF
--- a/frontend/src/modules/socketio/index.ts
+++ b/frontend/src/modules/socketio/index.ts
@@ -27,7 +27,7 @@ class SocketIOClient {
     this.socket.on("data", this.onEvent.bind(this));
 
     this.events = [];
-    this.debounceReduce = debounce(this.reduce, 20);
+    this.debounceReduce = debounce(this.reduce, 3);
     this.reducers = [];
 
     onlineManager.setOnline(false);


### PR DESCRIPTION
Lower debounce value from 20 msec to 3 msec to improve performance of Sync status updates. Any value lower than 3 msec didn't seem to make much of a difference in my testing.