### PR TITLE
Sync settings changes fix. #2413

### DIFF
--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -265,7 +265,7 @@ def list_missing_subtitles_movies(no=None, send_event=True):
 
 
 def movies_full_scan_subtitles(use_cache=None):
-    if use_cache == None:
+    if use_cache is None:
         use_cache = settings.radarr.use_ffprobe_cache
 
     movies = database.execute(

--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -264,7 +264,10 @@ def list_missing_subtitles_movies(no=None, send_event=True):
         event_stream(type='badges')
 
 
-def movies_full_scan_subtitles(use_cache=settings.radarr.use_ffprobe_cache):
+def movies_full_scan_subtitles(use_cache=None):
+    if use_cache == None:
+        use_cache = settings.radarr.use_ffprobe_cache
+
     movies = database.execute(
         select(TableMovies.path))\
         .all()

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -267,7 +267,7 @@ def list_missing_subtitles(no=None, epno=None, send_event=True):
 
 
 def series_full_scan_subtitles(use_cache=None):
-    if use_cache == None:
+    if use_cache is None:
         use_cache = settings.sonarr.use_ffprobe_cache
 
     episodes = database.execute(

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -266,7 +266,10 @@ def list_missing_subtitles(no=None, epno=None, send_event=True):
         event_stream(type='badges')
 
 
-def series_full_scan_subtitles(use_cache=settings.sonarr.use_ffprobe_cache):
+def series_full_scan_subtitles(use_cache=None):
+    if use_cache == None:
+        use_cache = settings.sonarr.use_ffprobe_cache
+
     episodes = database.execute(
         select(TableEpisodes.path))\
         .all()

--- a/bazarr/subtitles/sync.py
+++ b/bazarr/subtitles/sync.py
@@ -26,8 +26,19 @@ def sync_subtitles(video_path, srt_path, srt_lang, forced, percent_score, sonarr
 
         if not use_subsync_threshold or (use_subsync_threshold and percent_score < float(subsync_threshold)):
             subsync = SubSyncer()
-            subsync.sync(video_path=video_path, srt_path=srt_path, srt_lang=srt_lang,
-                         sonarr_series_id=sonarr_series_id, sonarr_episode_id=sonarr_episode_id, radarr_id=radarr_id)
+            sync_kwargs = {
+                'video_path': video_path,
+                'srt_path': srt_path,
+                'srt_lang': srt_lang,
+                'max_offset_seconds': str(settings.subsync.max_offset_seconds),
+                'no_fix_framerate': settings.subsync.no_fix_framerate,
+                'gss': settings.subsync.gss,
+                'reference': None, # means choose automatically within video file
+                'sonarr_series_id': sonarr_series_id, 
+                'sonarr_episode_id': sonarr_episode_id, 
+                'radarr_id': radarr_id,
+            }
+            subsync.sync(**sync_kwargs)
             del subsync
             gc.collect()
             return True

--- a/bazarr/subtitles/tools/subsyncer.py
+++ b/bazarr/subtitles/tools/subsyncer.py
@@ -30,9 +30,9 @@ class SubSyncer:
             self.vad = 'subs_then_webrtc'
         self.log_dir_path = os.path.join(args.config_dir, 'log')
 
-    def sync(self, video_path, srt_path, srt_lang, sonarr_series_id=None, sonarr_episode_id=None, radarr_id=None,
-             reference=None, max_offset_seconds=str(settings.subsync.max_offset_seconds),
-             no_fix_framerate=settings.subsync.no_fix_framerate, gss=settings.subsync.gss):
+    def sync(self, video_path, srt_path, srt_lang, 
+             max_offset_seconds, no_fix_framerate, gss, reference=None, 
+             sonarr_series_id=None, sonarr_episode_id=None, radarr_id=None):
         self.reference = video_path
         self.srtin = srt_path
         if self.srtin.casefold().endswith('.ass'):


### PR DESCRIPTION
Specify explicit values for most parameters to sync() call.
Remove settings as default parameters.
Only the load time setting would be used as the default value. It will not track changes later on.
Also updated unrelated methods with the same issue.
This fixes issue #2413.