### PR TITLE
Allow numeric passwords for all providers #2416

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -438,7 +438,7 @@ array_keys = ['excluded_tags',
 
 empty_values = ['', 'None', 'null', 'undefined', None, []]
 
-str_keys = ['chmod', 'log_include_filter', 'log_exclude_filter']
+str_keys = ['chmod', 'log_include_filter', 'log_exclude_filter', 'password', 'f_password', 'hashed_password']
 
 # Increase Sonarr and Radarr sync interval since we now use SignalR feed to update in real time
 if settings.sonarr.series_sync < 15:

--- a/frontend/src/pages/Settings/Providers/list.ts
+++ b/frontend/src/pages/Settings/Providers/list.ts
@@ -118,7 +118,7 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
     key: "cinemaz",
     name: "CinemaZ",
     description:
-      "cinemaz.to - CinemaZ is a private torrent tracker which is dedicated to little-known and cult films that you will not find on other popular torrent resources.",
+      "cinemaz.to - CinemaZ is a private torrent tracker which is dedicated to little-known\nand cult films that you will not find on other popular torrent resources.",
     inputs: [
       {
         type: "text",


### PR DESCRIPTION
Make sure all passwords are not converted to numbers.
This should handle all providers, hopefully once and for all.
Fix for issue #2416 