### PR TITLE
Fix a couple misspelled words and improve some grammar

### DIFF
--- a/frontend/src/pages/Settings/Subtitles/index.tsx
+++ b/frontend/src/pages/Settings/Subtitles/index.tsx
@@ -409,8 +409,7 @@ const SettingsSubtitlesView: FunctionComponent = () => {
           settingKey="settings-subsync-use_subsync"
         ></Check>
         <Message>
-          Enable automatic subtitles synchronization after downloading a
-          subtitle.
+          Enable automatic synchronization after downloading subtitles.
         </Message>
         <CollapseBox indent settingKey="settings-subsync-use_subsync">
           <MultiSelector


### PR DESCRIPTION
- "Synchronizarion" &rarr; "Synchronization"
- "Alignement" &rarr; "Alignment"
- Remove some unnatural-sounding verbosity in setting descriptions