### PR TITLE
feat(provider): add animetosho additional languages

### DIFF
--- a/custom_libs/subliminal_patch/providers/animetosho.py
+++ b/custom_libs/subliminal_patch/providers/animetosho.py
@@ -34,6 +34,7 @@ supported_languages = [
     "jpn",  # Japanese
     "pol",  # Polish
     "spa",  # Spanish
+    "tur",  # Turkish
 ]
 
 

--- a/custom_libs/subliminal_patch/providers/animetosho.py
+++ b/custom_libs/subliminal_patch/providers/animetosho.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 supported_languages = [
     "ara",  # Arabic
     "eng",  # English
+    "fin",  # Finnish
     "fra",  # French
     "ita",  # Italian
     "jpn",  # Japanese

--- a/custom_libs/subliminal_patch/providers/animetosho.py
+++ b/custom_libs/subliminal_patch/providers/animetosho.py
@@ -30,6 +30,7 @@ supported_languages = [
     "eng",  # English
     "fin",  # Finnish
     "fra",  # French
+    "heb",  # Hebrew
     "ita",  # Italian
     "jpn",  # Japanese
     "por",  # Portuguese

--- a/custom_libs/subliminal_patch/providers/animetosho.py
+++ b/custom_libs/subliminal_patch/providers/animetosho.py
@@ -25,10 +25,10 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-# TODO: Test and Support Other Languages
 supported_languages = [
     "eng",  # English
     "ita",  # Italian
+    "spa",  # Spanish
 ]
 
 

--- a/custom_libs/subliminal_patch/providers/animetosho.py
+++ b/custom_libs/subliminal_patch/providers/animetosho.py
@@ -26,6 +26,7 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 supported_languages = [
+    "ara",  # Arabic
     "eng",  # English
     "ita",  # Italian
     "spa",  # Spanish

--- a/custom_libs/subliminal_patch/providers/animetosho.py
+++ b/custom_libs/subliminal_patch/providers/animetosho.py
@@ -142,7 +142,7 @@ class AnimeToshoProvider(Provider, ProviderSubtitleArchiveMixin):
 
                     # For Portuguese and Portuguese Brazilian they both share the same code, the name is the only
                     # identifier AnimeTosho provides.
-                    if lang.alpha3 == 'por' and subtitle_file['info']['name'].lower().find('Brazil'):
+                    if lang.alpha3 == 'por' and subtitle_file['info']['name'].lower().find('brazil'):
                         lang = Language('por', 'BR')
 
                     subtitle = self.subtitle_class(

--- a/custom_libs/subliminal_patch/providers/animetosho.py
+++ b/custom_libs/subliminal_patch/providers/animetosho.py
@@ -29,6 +29,7 @@ supported_languages = [
     "eng",  # English
     "ita",  # Italian
     "spa",  # Spanish
+    "fra",  # French
 ]
 
 

--- a/custom_libs/subliminal_patch/providers/animetosho.py
+++ b/custom_libs/subliminal_patch/providers/animetosho.py
@@ -28,10 +28,11 @@ logger = logging.getLogger(__name__)
 supported_languages = [
     "ara",  # Arabic
     "eng",  # English
+    "fra",  # French
     "ita",  # Italian
     "jpn",  # Japanese
+    "pol",  # Polish
     "spa",  # Spanish
-    "fra",  # French
 ]
 
 

--- a/custom_libs/subliminal_patch/providers/animetosho.py
+++ b/custom_libs/subliminal_patch/providers/animetosho.py
@@ -34,6 +34,7 @@ supported_languages = [
     "jpn",  # Japanese
     "pol",  # Polish
     "spa",  # Spanish
+    "swe",  # Swedish
     "tur",  # Turkish
 ]
 

--- a/custom_libs/subliminal_patch/providers/animetosho.py
+++ b/custom_libs/subliminal_patch/providers/animetosho.py
@@ -29,6 +29,7 @@ supported_languages = [
     "ara",  # Arabic
     "eng",  # English
     "ita",  # Italian
+    "jpn",  # Japanese
     "spa",  # Spanish
     "fra",  # French
 ]

--- a/custom_libs/subliminal_patch/providers/animetosho.py
+++ b/custom_libs/subliminal_patch/providers/animetosho.py
@@ -32,6 +32,7 @@ supported_languages = [
     "fra",  # French
     "ita",  # Italian
     "jpn",  # Japanese
+    "por",  # Portuguese
     "pol",  # Polish
     "spa",  # Spanish
     "swe",  # Swedish
@@ -135,8 +136,15 @@ class AnimeToshoProvider(Provider, ProviderSubtitleArchiveMixin):
                 for subtitle_file in subtitle_files:
                     hex_id = format(subtitle_file['id'], '08x')
 
+                    lang = Language.fromalpha3b(subtitle_file['info']['lang'])
+
+                    # For Portuguese and Portuguese Brazilian they both share the same code, the name is the only
+                    # identifier AnimeTosho provides.
+                    if lang.alpha3 == 'por' and subtitle_file['info']['name'].lower().find('Brazil'):
+                        lang = Language('por', 'BR')
+
                     subtitle = self.subtitle_class(
-                        Language.fromalpha3b(subtitle_file['info']['lang']),
+                        lang,
                         storage_download_url + '{}/{}.xz'.format(hex_id, subtitle_file['id']),
                         meta=file,
                     )

--- a/custom_libs/subliminal_patch/providers/animetosho.py
+++ b/custom_libs/subliminal_patch/providers/animetosho.py
@@ -36,6 +36,7 @@ supported_languages = [
     "pol",  # Polish
     "spa",  # Spanish
     "swe",  # Swedish
+    "tha",  # Thai
     "tur",  # Turkish
 ]
 


### PR DESCRIPTION
# Description

Support additional languages for AnimeTosho provider.

> Every language on the list have been tested. AnimeTosho have other additional languages, including some not supported by Bazarr, so i might include in the future. For now, im leaving to the minimum and the ones i can properly test.