### PR TITLE
fix: manual upload table long names without spacing

### DIFF
--- a/frontend/src/components/tables/BaseTable.tsx
+++ b/frontend/src/components/tables/BaseTable.tsx
@@ -24,6 +24,7 @@ const useStyles = createStyles((theme) => {
       display: "block",
       maxWidth: "100%",
       overflowX: "auto",
+      overflowWrap: "anywhere",
     },
     table: {
       borderCollapse: "collapse",


### PR DESCRIPTION
# Description

Closes #2448. By adding the overflow wrap anywhere it allows words to break and wrap onto the next line at any character, not necessarily at natural breaking points like spaces or hyphens.

![image](https://github.com/morpheus65535/bazarr/assets/12686241/f6a80a36-c41f-4b94-93ba-6d13baee6382)

Technically the change affects all tables, however asides from the Manual upload modal will be rare a case where the content of the cells will actually be this big.