### PR TITLE
fix: subtitle toolbox popover overlapped

### DIFF
--- a/frontend/src/components/SubtitleToolsMenu.tsx
+++ b/frontend/src/components/SubtitleToolsMenu.tsx
@@ -140,7 +140,7 @@ const SubtitleToolsMenu: FunctionComponent<Props> = ({
   const disabledTools = selections.length === 0;
 
   return (
-    <Menu withArrow position="left-end" {...menu}>
+    <Menu withArrow withinPortal position="left-end" {...menu}>
       <Menu.Target>{children}</Menu.Target>
       <Menu.Dropdown>
         <Menu.Label>Tools</Menu.Label>


### PR DESCRIPTION
# Description

Closes #2348. The component is rendered for default inside of the Modal which should be the correct behavior mostly of the cases, but usually modal of modals and popovers should be displayed as a portal outside of the parent DOM to prevent obfuscation of the rendering.

You can read more on https://mantine.dev/core/portal/ or https://react.dev/reference/react-dom/createPortal

![Screenshot 2024-04-16 at 9 51 43](https://github.com/morpheus65535/bazarr/assets/12686241/8b8cdfc0-befd-486a-8cdb-b5ca6621d7b6)
