### PR TITLE
fix: table overflow wrapper specific to upload modal

### DIFF
--- a/frontend/src/components/forms/MovieUploadForm.tsx
+++ b/frontend/src/components/forms/MovieUploadForm.tsx
@@ -18,7 +18,7 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   Button,
-  Checkbox,
+  Checkbox, createStyles,
   Divider,
   MantineColor,
   Stack,
@@ -78,12 +78,21 @@ interface Props {
   onComplete?: () => void;
 }
 
+const useStyles = createStyles((theme) => {
+  return {
+    wrapper: {
+       overflowWrap: "anywhere"
+    },
+  };
+});
+
 const MovieUploadForm: FunctionComponent<Props> = ({
   files,
   movie,
   onComplete,
 }) => {
   const modals = useModals();
+  const { classes } = useStyles();
 
   const profile = useLanguageProfileBy(movie.profileId);
 
@@ -279,7 +288,7 @@ const MovieUploadForm: FunctionComponent<Props> = ({
         modals.closeSelf();
       })}
     >
-      <Stack>
+      <Stack className={classes.wrapper}>
         <SimpleTable columns={columns} data={form.values.files}></SimpleTable>
         <Divider></Divider>
         <Button type="submit">Upload</Button>

--- a/frontend/src/components/forms/MovieUploadForm.tsx
+++ b/frontend/src/components/forms/MovieUploadForm.tsx
@@ -18,7 +18,8 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   Button,
-  Checkbox, createStyles,
+  Checkbox,
+  createStyles,
   Divider,
   MantineColor,
   Stack,
@@ -81,7 +82,7 @@ interface Props {
 const useStyles = createStyles((theme) => {
   return {
     wrapper: {
-       overflowWrap: "anywhere"
+      overflowWrap: "anywhere",
     },
   };
 });

--- a/frontend/src/components/forms/SeriesUploadForm.tsx
+++ b/frontend/src/components/forms/SeriesUploadForm.tsx
@@ -22,7 +22,8 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   Button,
-  Checkbox, createStyles,
+  Checkbox,
+  createStyles,
   Divider,
   MantineColor,
   Stack,
@@ -88,7 +89,7 @@ interface Props {
 const useStyles = createStyles((theme) => {
   return {
     wrapper: {
-       overflowWrap: "anywhere"
+      overflowWrap: "anywhere",
     },
   };
 });

--- a/frontend/src/components/forms/SeriesUploadForm.tsx
+++ b/frontend/src/components/forms/SeriesUploadForm.tsx
@@ -22,7 +22,7 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   Button,
-  Checkbox,
+  Checkbox, createStyles,
   Divider,
   MantineColor,
   Stack,
@@ -85,12 +85,21 @@ interface Props {
   onComplete?: VoidFunction;
 }
 
+const useStyles = createStyles((theme) => {
+  return {
+    wrapper: {
+       overflowWrap: "anywhere"
+    },
+  };
+});
+
 const SeriesUploadForm: FunctionComponent<Props> = ({
   series,
   files,
   onComplete,
 }) => {
   const modals = useModals();
+  const { classes } = useStyles();
   const episodes = useEpisodesBySeriesId(series.sonarrSeriesId);
   const episodeOptions = useSelectorOptions(
     episodes.data ?? [],
@@ -358,7 +367,7 @@ const SeriesUploadForm: FunctionComponent<Props> = ({
         modals.closeSelf();
       })}
     >
-      <Stack>
+      <Stack className={classes.wrapper}>
         <SimpleTable columns={columns} data={form.values.files}></SimpleTable>
         <Divider></Divider>
         <Button type="submit">Upload</Button>

--- a/frontend/src/components/tables/BaseTable.tsx
+++ b/frontend/src/components/tables/BaseTable.tsx
@@ -24,7 +24,6 @@ const useStyles = createStyles((theme) => {
       display: "block",
       maxWidth: "100%",
       overflowX: "auto",
-      overflowWrap: "anywhere",
     },
     table: {
       borderCollapse: "collapse",


### PR DESCRIPTION
# Description

The #2453 caused an issue with other tables when we are using the mobile version or small screens. This PR limits the overflow wrap only to the Upload Modal instead of all tables.