### PR TITLE
Add AvistaZ and CinemaZ to supported providers list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ If you need something that is not already part of Bazarr, feel free to create a 
 - Addic7ed
 - Animetosho (requires AniDb HTTP API client described [here](https://wiki.anidb.net/HTTP_API_Definition))
 - Assrt
+- AvistaZ, CinemaZ (Get session cookies using method described [here](https://github.com/morpheus65535/bazarr/pull/2375#issuecomment-2057010996))
 - BetaSeries
 - BSplayer
 - Embedded Subtitles


### PR DESCRIPTION
New providers for AvistaZ and CinemaZ were added in the [PR](https://github.com/morpheus65535/bazarr/pull/2375), but README.md was not updated