### PR TITLE
feat: add dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,19 @@ updates:
       prefix: "[bot]"
     open-pull-requests-limit: 1
     target-branch: "development"
+    groups:
+      fortawesome:
+        patterns:
+          - "@fortawesome*"
+      mantine:
+        patterns:
+          - "@mantine*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
# Description

By default, Dependabot raises a single pull request for each dependency that needs to be updated to a newer version. You can use groups to create sets of dependencies (per package manager), so that Dependabot opens a single pull request to update multiple dependencies at the same time.

There are some references that we want to almost all the time update together since they always introduce breaking changes even tho thats the only patch version being updated.

# References

- [Dependabot Groups](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)