### PR TITLE
Fix anidb enrichment failure

### DIFF
--- a/bazarr/subtitles/refiners/anidb.py
+++ b/bazarr/subtitles/refiners/anidb.py
@@ -115,16 +115,16 @@ class AniDBClient(object):
 
 
 def refine_from_anidb(path, video):
+    if not isinstance(video, Episode) or not video.series_tvdb_id:
+        logging.debug(f'Video is not an Anime TV series, skipping refinement for {video}')
+
+        return
+
     if refined_providers.intersection(settings.general.enabled_providers) and video.series_anidb_id is None:
         refine_anidb_ids(video)
 
 
 def refine_anidb_ids(video):
-    if not isinstance(video, Episode) and not video.series_tvdb_id:
-        logging.debug(f'Video is not an Anime TV series, skipping refinement for {video}')
-
-        return video
-
     anidb_client = AniDBClient(settings.anidb.api_client, settings.anidb.api_client_ver)
 
     season = video.season if video.season else 0


### PR DESCRIPTION
# Description

Closes #2463. The refiner is trying to access the `series_tvdb_id` before checking if the video is an Episode, the logic of the checking the episode was inside of the method already, being too late.

There was also an issue with the flipped logic where we should use `or` instead of `and`.