### PR TITLE
Fix anidb refiner enrichment return type

### DIFF
--- a/bazarr/subtitles/refiners/anidb.py
+++ b/bazarr/subtitles/refiners/anidb.py
@@ -53,7 +53,7 @@ class AniDBClient(object):
         ]
 
         if not animes:
-            return None
+            return None, None
 
         # Sort the anime by offset in ascending order
         animes.sort(key=lambda a: a.episode_offset)


### PR DESCRIPTION
# Description

Closes #2469. We are expecting to get `series_id` and `episode_no` from that method so we try to always unpack, but for mistake it is returning only 1 value when it is not an anime.