### PR TITLE
Improve cutoff options label

### DIFF
--- a/frontend/src/components/forms/ProfileEditForm.tsx
+++ b/frontend/src/components/forms/ProfileEditForm.tsx
@@ -82,7 +82,11 @@ const ProfileEditForm: FunctionComponent<Props> = ({
 
   const itemCutoffOptions = useSelectorOptions(
     form.values.items,
-    (v) => v.language,
+    (v) => {
+      const suffix = v.hi === "True" ? ':hi' : v.forced === "True" ? ':forced': '';
+
+      return v.language + suffix;
+    },
     (v) => String(v.id),
   );
 

--- a/frontend/src/components/forms/ProfileEditForm.tsx
+++ b/frontend/src/components/forms/ProfileEditForm.tsx
@@ -83,7 +83,8 @@ const ProfileEditForm: FunctionComponent<Props> = ({
   const itemCutoffOptions = useSelectorOptions(
     form.values.items,
     (v) => {
-      const suffix = v.hi === "True" ? ':hi' : v.forced === "True" ? ':forced': '';
+      const suffix =
+        v.hi === "True" ? ":hi" : v.forced === "True" ? ":forced" : "";
 
       return v.language + suffix;
     },


### PR DESCRIPTION
# Description

Closes #2466. Add a small suffix in the label to identify what option is that related to.

![Screenshot 2024-04-25 at 11 06 04](https://github.com/morpheus65535/bazarr/assets/12686241/2e93363e-0ac3-4c8e-bd37-3465206c99fc)

