### PR TITLE
Fix animetosho encoding parser

### DIFF
--- a/libs/pysubs2/substation.py
+++ b/libs/pysubs2/substation.py
@@ -201,7 +201,8 @@ class SubstationFormat(FormatBase):
             elif f in {"bold", "underline", "italic", "strikeout"}:
                 return v == "-1"
             elif f in {"borderstyle", "encoding", "marginl", "marginr", "marginv", "layer", "alphalevel"}:
-                return int(v)
+                # There are subtitle cases where layer could be empty which represents the single 0 layer.
+                return int(v) if v != "" else 0
             elif f in {"fontsize", "scalex", "scaley", "spacing", "angle", "outline", "shadow"}:
                 return float(v)
             elif f == "marked":


### PR DESCRIPTION
# Description

This is not directly related to AnimeTosho tho, but that's the one issue identified on #2470. It could cover other providers as well.

There are subtitles where the layer is `''` empty instead of 0. You can find an example of [Delicious in Dungeon Season 1 Episode 17](https://animetosho.org/storage/attach/001e6590/1992080.xz). There are several more that follows the same pattern.