### PR TITLE
Fix Animetosho provider error for tv shows

### DIFF
--- a/custom_libs/subliminal_patch/providers/animetosho.py
+++ b/custom_libs/subliminal_patch/providers/animetosho.py
@@ -88,7 +88,9 @@ class AnimeToshoProvider(Provider, ProviderSubtitleArchiveMixin):
 
     def list_subtitles(self, video, languages):
         if not video.series_anidb_episode_id:
-            raise ProviderError("Video does not have an AnimeTosho Episode ID!")
+            logger.debug('Skipping video %r. It is not an anime or the anidb_episode_id could not be identified', video)
+
+            return
 
         return [s for s in self._get_series(video.series_anidb_episode_id) if s.language in languages]
 

--- a/custom_libs/subliminal_patch/providers/animetosho.py
+++ b/custom_libs/subliminal_patch/providers/animetosho.py
@@ -90,7 +90,7 @@ class AnimeToshoProvider(Provider, ProviderSubtitleArchiveMixin):
         if not video.series_anidb_episode_id:
             logger.debug('Skipping video %r. It is not an anime or the anidb_episode_id could not be identified', video)
 
-            return
+            return []
 
         return [s for s in self._get_series(video.series_anidb_episode_id) if s.language in languages]
 


### PR DESCRIPTION
The videos there is no category of Anime, so it will search for any Episode of a TV Show in the provider, which will cause a provider error and throttle the provider without any real reason. Instead we should just log and skip for non-animes.