### PR TITLE
Fix for writing clean ASS subtitles

### DIFF
--- a/custom_libs/subliminal_patch/providers/embeddedsubtitles.py
+++ b/custom_libs/subliminal_patch/providers/embeddedsubtitles.py
@@ -382,7 +382,7 @@ def _clean_ass_subtitles(path, output_path):
 
     logger.debug("Cleaned lines: %d", abs(len(lines) - len(clean_lines)))
 
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8", errors="ignore") as f:
         f.writelines(clean_lines)
         logger.debug("Lines written to output path: %s", output_path)
 


### PR DESCRIPTION
For a couple of files, I had UnicodeEncodeErrors raised when writing out a file it had successfully read in. 
In my case, the output file was truncated to 1 KB.