### PR TITLE
Add animetosho release info

### DIFF
--- a/custom_libs/subliminal_patch/providers/animetosho.py
+++ b/custom_libs/subliminal_patch/providers/animetosho.py
@@ -46,10 +46,11 @@ class AnimeToshoSubtitle(Subtitle):
     """AnimeTosho.org Subtitle."""
     provider_name = 'animetosho'
 
-    def __init__(self, language, download_link, meta):
+    def __init__(self, language, download_link, meta, release_info):
         super(AnimeToshoSubtitle, self).__init__(language, page_link=download_link)
         self.meta = meta
         self.download_link = download_link
+        self.release_info = release_info
 
     @property
     def id(self):
@@ -152,6 +153,7 @@ class AnimeToshoProvider(Provider, ProviderSubtitleArchiveMixin):
                         lang,
                         storage_download_url + '{}/{}.xz'.format(hex_id, subtitle_file['id']),
                         meta=file,
+                        release_info=entry.get('title'),
                     )
 
                     logger.debug('Found subtitle %r', subtitle)


### PR DESCRIPTION
# Description

Without the release info it is hard for the user to identify what is the subtitle that can be manually downloaded. Added the Release Info, so the user can pick the uploader of his choice.

I actually tried to retrieve the Uploader to add in the Uploader column too, but there are so many patterns that will most likely it will be a bug feature, so i would rather do not support uploader at all in the AnimeTosho provider, i found at least 6 patterns for the Uploader:

The ones easier to parse via regex would be:

- [`{uploader}`]`{title}`...
- `{title}`...(`{uploader}`)...

However we won't be able to cover such the one separated via dots for example {title}.{uploader}... since the title also may and does contain dots.

![Screenshot 2024-05-04 at 23 01 33](https://github.com/morpheus65535/bazarr/assets/12686241/bba3e1d7-144b-48fc-8c3e-3365db318acd)

The release info using the title will 100% the time cover the uploader as well, so i believe being enough instead of fighting with a monstrous regex trying to extract the release info from the title.

> The API response does not provides the Uploader as a separated field.
