### PR TITLE
Fix husky prepare

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -77,7 +77,7 @@
     "test:ui": "vitest --ui",
     "coverage": "vitest run --coverage",
     "format": "prettier -w .",
-    "prepare": "cd .. && husky install frontend/.husky"
+    "prepare": "cd .. && husky frontend/.husky"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
# Description

Husky pre commit hooks got broken when upgraded to version 9 that "deprecated" the `install` command, to be honest, it says deprecated but it is broken.

![Screenshot 2024-05-07 at 23 28 40](https://github.com/morpheus65535/bazarr/assets/12686241/d15ab962-2eb1-4040-8cad-15eb858c9090)