### PR TITLE
Fix throttled_providers.dat reset

### DIFF
--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -496,7 +496,7 @@ def get_throttled_providers():
     except Exception:
         # set empty content in throttled_providers.dat
         logging.error("Invalid content in throttled_providers.dat. Resetting")
-        set_throttled_providers(providers)
+        set_throttled_providers(str(providers))
     finally:
         return providers
 


### PR DESCRIPTION
Found this after I saw `Invalid content in throttled_providers.dat. Resetting` being spammed in my logs. All other calls to `set_throttled_providers` convert to str correctly, looks like this one was just missed.

Another approach could be to force to str within `set_throttled_providers` itself and drop the str calls everywhere else, since I don't think there would ever be a situation where that's not needed.