### PR TITLE
Fix for case insensitive filesystem updates

### DIFF
--- a/bazarr/app/check_update.py
+++ b/bazarr/app/check_update.py
@@ -165,6 +165,9 @@ def apply_update():
                             parent_dir = os.path.dirname(file_path)
                             os.makedirs(parent_dir, exist_ok=True)
                             if not os.path.isdir(file_path):
+                                if os.path.exists(file_path):
+                                    # remove the file first to handle case-insensitive file systems
+                                    os.remove(file_path)
                                 with open(file_path, 'wb+') as f:
                                     f.write(archive.read(file))
             except Exception:


### PR DESCRIPTION
This fix was made necessary when a library changed the case of one of its files, but kept the name the same. When the file was updated in place, the case did not change. The solution is to delete the file on disk first before extracting the new one from the zip file with the changed case.