### PR TITLE
Fix bazarr update job graceful restart

### DIFF
--- a/libs/apscheduler/executors/base.py
+++ b/libs/apscheduler/executors/base.py
@@ -123,6 +123,8 @@ def run_job(job, jobstore_alias, run_times, logger_name):
         logger.info('Running job "%s" (scheduled at %s)', job, run_time)
         try:
             retval = job.func(*job.args, **job.kwargs)
+        except SystemExit as se:
+            raise se
         except BaseException:
             exc, tb = sys.exc_info()[1:]
             formatted_tb = ''.join(format_tb(tb))

--- a/libs/apscheduler/executors/base.py
+++ b/libs/apscheduler/executors/base.py
@@ -128,9 +128,7 @@ def run_job(job, jobstore_alias, run_times, logger_name):
         except SystemExit as se:
             # System exit will terminate the process regardless if we don't re-raise the exception at this point, so we
             # can swallow for a graceful shutdown when the exit code is EXIT_NORMAL since it is an expected result.
-            if se.code == EXIT_NORMAL:
-                pass
-            else:
+            if se.code != EXIT_NORMAL:
                 raise se
         except BaseException:
             exc, tb = sys.exc_info()[1:]


### PR DESCRIPTION
When bazarr is updated, we are performing via a background job, which all exceptions are captured to be swallowed which is not expected on this case since we want the process to be kileed and respawned as a new process.

```
2024-05-29 10:15:14,807 - apscheduler.executors.default    (3b450b000) :  INFO (base:125) - Running job "Update Bazarr (trigger: interval[0:00:15], next run at: 2024-05-29 10:15:29 JST)" (scheduled at 2024-05-29 10:15:14.799763+09:00)
2024-05-29 10:15:14,807 - engineio.server                  (30f007000) :  INFO (socket:76) - v6sVeUjiLlpgRYa6AAAA: Sending packet MESSAGE data 2["data",{"type":"task","action":"update","payload":null}]
2024-05-29 10:15:14,809 - apscheduler.scheduler            (30f007000) :  DEBUG (base:1034) - Next wakeup is due at 2024-05-29 10:15:29.799763+09:00 (in 14.990329 seconds)
2024-05-29 10:15:14,813 - root                             (3b450b000) :  INFO (central:55) - Bazarr is being restarted...
Closing database...
Closing webserver...
```

The way we handle is:

1 - We raise a SystemExit(0) in the job
2 - The exception is captured and swallowed since it is expected
3 - Python interpreter will receive the SIGNAL and terminate the process