### PR TITLE
Fix bazarr restart traceback exception

### DIFF
--- a/bazarr/utilities/central.py
+++ b/bazarr/utilities/central.py
@@ -49,21 +49,13 @@ def stop_bazarr(status_code=EXIT_NORMAL, exit_main=True):
 
 
 def restart_bazarr():
-    """
-    Inner function to act as a wrapper for gracefully exit to be performed.
-
-    The concept is to wrap this inner function with a try except statement or contextlib.supress where the cleanup
-    still performed but the exception is not raised making the python process to exit with the desired exit code, but
-    not in due to the exception.
-    """
-    def restart():
-        raise SystemExit(EXIT_NORMAL)
-
     try:
         Path(get_restart_file_path()).touch()
     except Exception as e:
         logging.error(f'BAZARR Cannot create restart file: {repr(e)}')
     logging.info('Bazarr is being restarted...')
 
+    # Wrap the SystemExit for a graceful restart. The SystemExit still performs the cleanup but the traceback is omitted
+    # preventing to throw the exception to the caller but still terminates the Python process with the desired Exit Code
     with contextlib.suppress(SystemExit):
-        restart()
+        raise SystemExit(EXIT_NORMAL)

--- a/bazarr/utilities/central.py
+++ b/bazarr/utilities/central.py
@@ -3,6 +3,7 @@
 # only methods can be specified here that do not cause other moudules to be loaded
 # for other methods that use settings, etc., use utilities/helper.py
 
+import contextlib
 import logging
 import os
 from pathlib import Path
@@ -48,9 +49,14 @@ def stop_bazarr(status_code=EXIT_NORMAL, exit_main=True):
 
 
 def restart_bazarr():
+    def restart():
+        raise SystemExit(EXIT_NORMAL)
+
     try:
         Path(get_restart_file_path()).touch()
     except Exception as e:
         logging.error(f'BAZARR Cannot create restart file: {repr(e)}')
     logging.info('Bazarr is being restarted...')
-    raise SystemExit(EXIT_NORMAL)
+
+    with contextlib.suppress(SystemExit):
+        restart()

--- a/bazarr/utilities/central.py
+++ b/bazarr/utilities/central.py
@@ -49,6 +49,13 @@ def stop_bazarr(status_code=EXIT_NORMAL, exit_main=True):
 
 
 def restart_bazarr():
+    """
+    Inner function to act as a wrapper for gracefully exit to be performed.
+
+    The concept is to wrap this inner function with a try except statement or contextlib.supress where the cleanup
+    still performed but the exception is not raised making the python process to exit with the desired exit code, but
+    not in due to the exception.
+    """
     def restart():
         raise SystemExit(EXIT_NORMAL)
 


### PR DESCRIPTION
Wrap the SystemExit exception with contextlib to swallow the exit traceback while keeping the functionality of terminate the python process using a graceful shutdown.