### PR TITLE
Fixed provider legendasdivx unable to find series subtitles

### DIFF
--- a/custom_libs/subliminal_patch/providers/legendasdivx.py
+++ b/custom_libs/subliminal_patch/providers/legendasdivx.py
@@ -327,7 +327,7 @@ class LegendasdivxProvider(Provider):
                     query=querytext,
                     season=video.season,
                     episode=video.episode,
-                    imdbid=video.series_imdb_id.replace('tt', ''),
+                    imdbid=video.series_imdb_id.replace('tt', '') if video.series_imdb_id else None,
                     op=op,
                     d_op=d_op,
             )
@@ -358,7 +358,7 @@ class LegendasdivxProvider(Provider):
                         querytext = re.sub(r"(e|E)(\d{2})", "", querytext)
                         # sleep for a 1 second before another request
                         sleep(1)
-                        res = self.session.get(_searchurl.format(query=querytext), allow_redirects=False)
+                        res = self.session.get(search_url, allow_redirects=False)
                         res.raise_for_status()
                         if res.status_code == 200 and "<!--pesquisas:" in res.text:
                             searches_count_groups = re.search(r'<!--pesquisas: (\d*)-->', res.text)
@@ -429,7 +429,7 @@ class LegendasdivxProvider(Provider):
             if num_pages > 1:
                 for num_page in range(2, num_pages + 1):
                     sleep(1) # another 1 sec before requesting...
-                    _search_next = self.searchurl.format(query=querytext) + "&page={0}".format(str(num_page))
+                    _search_next = search_url + "&page={0}".format(str(num_page))
                     logger.debug("Legendasdivx.pt :: Moving on to next page: %s", _search_next)
                     # sleep for a 1 second before another request
                     sleep(1)

--- a/custom_libs/subliminal_patch/providers/legendasdivx.py
+++ b/custom_libs/subliminal_patch/providers/legendasdivx.py
@@ -115,6 +115,11 @@ class LegendasdivxSubtitle(Subtitle):
                 matches.update(['season'])
             if video.episode and 'e{:02d}'.format(video.episode) in description:
                 matches.update(['episode'])
+            # All the search is already based on the series_imdb_id when present in the video and controlled via the
+            # the legendasdivx backend it, so if there is a result, it matches, either inside of a pack or a specific
+            # series and episode, so we can assume the season and episode matches.
+            if video.series_imdb_id:
+                matches.update(['series', 'series_imdb_id', 'season', 'episode'])
 
         # release_group
         if video.release_group and sanitize_release_group(video.release_group) in sanitize_release_group(description):

--- a/custom_libs/subliminal_patch/providers/legendasdivx.py
+++ b/custom_libs/subliminal_patch/providers/legendasdivx.py
@@ -282,7 +282,7 @@ class LegendasdivxProvider(Provider):
             querytext = video.imdb_id if video.imdb_id else video.title
 
         if isinstance(video, Episode):
-            querytext = '%22{}%20S{:02d}E{:02d}%22'.format(video.series, video.season, video.episode)
+            querytext = '%22{}%22%20S{:02d}E{:02d}'.format(video.series, video.season, video.episode)
             querytext = quote(querytext.lower())
 
         # language query filter


### PR DESCRIPTION
# Description

Fix #2509. This changes consists in 2 parts:

1 - The ordinary series search term is being surrounded by double quotes including the series and episode id, take for example `"stranger things s01e01"`, but for the match to work, the double quotes needs to surround only the series name such as `"stranger things" s01e01`.

2 - The ordinary series search term is not accurate enough and we could benefit of the IMDB search id since we have the information if series_imdbid. When the series_imdb is present, we prioritize the accurate search that can find the specific episode or even packs that contains the specific episode, this way we have a much more reliable priority and results instead or rely the plain text search. This we need to specify the season, and the episode, alongside with specific parameters that is provided by the legendasdivx.

> For series that doesn't have the imdbid it will fallback with the current search implementation.
