### PR TITLE
Fixed minor styles loss after Mantine v7 update

### DIFF
--- a/frontend/src/App/Header.tsx
+++ b/frontend/src/App/Header.tsx
@@ -52,7 +52,7 @@ const AppHeader: FunctionComponent = () => {
             size="sm"
             hiddenFrom="sm"
           ></Burger>
-          <Badge size="lg" radius="sm">
+          <Badge size="lg" radius="sm" variant="brand">
             Bazarr
           </Badge>
         </Group>

--- a/frontend/src/assets/action_icon.module.scss
+++ b/frontend/src/assets/action_icon.module.scss
@@ -4,10 +4,19 @@
       color: var(--mantine-color-dark-0);
     }
 
+    &[data-variant="dark"] {
+      --ai-bg: var(--mantine-color-grape-light);
+      --ai-hover: darken(var(--mantine-color-grape-light), 0.2);
+    }
+
     @include light {
       &[data-variant="light"] {
         background-color: var(--mantine-color-gray-1);
         color: var(--mantine-color-dark-2);
+      }
+
+      &[data-variant="dark"] {
+        --ai-color: var(--mantine-color-dark-filled);
       }
     }
   }

--- a/frontend/src/assets/action_icon.module.scss
+++ b/frontend/src/assets/action_icon.module.scss
@@ -1,11 +1,13 @@
 @layer mantine {
   .root {
+    background-color: transparent;
+
     &[data-variant="light"] {
       color: var(--mantine-color-dark-0);
     }
 
     &[data-variant="dark"] {
-      --ai-bg: var(--mantine-color-grape-light);
+      --ai-bg: transparent;
       --ai-hover: darken(var(--mantine-color-grape-light), 0.2);
     }
 

--- a/frontend/src/assets/badge.module.scss
+++ b/frontend/src/assets/badge.module.scss
@@ -1,8 +1,8 @@
 .root {
   background-color: var(--mantine-color-grape-light);
 
-  &[data-variant="gray"] {
-    background-color: var(--mantine-color-gray-light);
+  &[data-variant="disabled"] {
+    background-color: rgba(52, 58, 64, 0.2);
   }
 
   @include light {
@@ -14,7 +14,7 @@
       color: var(--mantine-color-primary);
     }
 
-    &[data-variant="gray"] {
+    &[data-variant="disabled"] {
       background-color: rgb(248, 249, 250);
       color: rgb(134, 142, 150);
     }

--- a/frontend/src/assets/badge.module.scss
+++ b/frontend/src/assets/badge.module.scss
@@ -9,6 +9,11 @@
     color: var(--mantine-color-primary);
     background-color: var(--mantine-color-grape-light);
 
+    &[data-variant="brand"] {
+      background-color: $color-brand-6;
+      color: var(--mantine-color-primary);
+    }
+
     &[data-variant="gray"] {
       background-color: rgb(248, 249, 250);
       color: rgb(134, 142, 150);

--- a/frontend/src/assets/badge.module.scss
+++ b/frontend/src/assets/badge.module.scss
@@ -1,8 +1,17 @@
 .root {
   background-color: var(--mantine-color-grape-light);
 
+  &[data-variant="gray"] {
+    background-color: var(--mantine-color-gray-light);
+  }
+
   @include light {
-    color: var(--mantine-color-dark-filled);
+    color: var(--mantine-color-primary);
     background-color: var(--mantine-color-grape-light);
+
+    &[data-variant="gray"] {
+      background-color: rgb(248, 249, 250);
+      color: rgb(134, 142, 150);
+    }
   }
 }

--- a/frontend/src/assets/button.module.scss
+++ b/frontend/src/assets/button.module.scss
@@ -9,4 +9,7 @@
       color: var(--mantine-color-red-0);
     }
   }
+  .root:disabled {
+    color: var(--mantine-color-dark-9);
+  }
 }

--- a/frontend/src/assets/button.module.scss
+++ b/frontend/src/assets/button.module.scss
@@ -10,6 +10,8 @@
     }
   }
   .root:disabled {
-    color: var(--mantine-color-dark-9);
+    @include dark {
+      color: var(--mantine-color-dark-9);
+    }
   }
 }

--- a/frontend/src/components/toolbox/Toolbox.tsx
+++ b/frontend/src/components/toolbox/Toolbox.tsx
@@ -10,7 +10,7 @@ declare type ToolboxComp = FunctionComponent<PropsWithChildren> & {
 
 const Toolbox: ToolboxComp = ({ children }) => {
   return (
-    <Group p={12} justify="apart" className={styles.group}>
+    <Group p={12} justify="space-between" className={styles.group}>
       {children}
     </Group>
   );

--- a/frontend/src/pages/Episodes/components.tsx
+++ b/frontend/src/pages/Episodes/components.tsx
@@ -52,7 +52,7 @@ export const Subtitle: FunctionComponent<Props> = ({
   const ctx = (
     <Badge
       color={color}
-      variant={color}
+      variant={disabled ? "disabled" : ""}
       style={{ cursor: disabled ? "default" : "pointer" }}
     >
       <Language.Text value={subtitle} long={false}></Language.Text>

--- a/frontend/src/pages/Episodes/components.tsx
+++ b/frontend/src/pages/Episodes/components.tsx
@@ -50,7 +50,11 @@ export const Subtitle: FunctionComponent<Props> = ({
   }, [episodeId, subtitle.code2, subtitle.path]);
 
   const ctx = (
-    <Badge color={color}>
+    <Badge
+      color={color}
+      variant={color}
+      style={{ cursor: disabled ? "default" : "pointer" }}
+    >
       <Language.Text value={subtitle} long={false}></Language.Text>
     </Badge>
   );

--- a/frontend/src/pages/Episodes/table.tsx
+++ b/frontend/src/pages/Episodes/table.tsx
@@ -169,7 +169,7 @@ const Table: FunctionComponent<Props> = ({
               <Action
                 label="Manual Search"
                 disabled={disabled}
-                color="dark"
+                variant="dark"
                 onClick={() => {
                   modals.openContextModal(EpisodeSearchModal, {
                     item: row.original,
@@ -182,7 +182,7 @@ const Table: FunctionComponent<Props> = ({
               <Action
                 label="History"
                 disabled={disabled}
-                color="dark"
+                variant="dark"
                 onClick={() => {
                   modals.openContextModal(
                     EpisodeHistoryModal,

--- a/frontend/src/pages/Movies/Details/index.tsx
+++ b/frontend/src/pages/Movies/Details/index.tsx
@@ -198,7 +198,6 @@ const MovieDetailView: FunctionComponent = () => {
               <Menu.Target>
                 <Action
                   label="More Actions"
-                  color="dark"
                   icon={faEllipsis}
                   disabled={hasTask}
                 />

--- a/frontend/src/pages/Movies/Details/table.tsx
+++ b/frontend/src/pages/Movies/Details/table.tsx
@@ -161,7 +161,7 @@ const Table: FunctionComponent<Props> = ({ movie, profile, disabled }) => {
               <Action
                 label="Subtitle Actions"
                 disabled={isSubtitleTrack(path)}
-                color="dark"
+                variant="dark"
                 icon={faEllipsis}
               ></Action>
             </SubtitleToolsMenu>

--- a/frontend/src/pages/views/ItemOverview.tsx
+++ b/frontend/src/pages/views/ItemOverview.tsx
@@ -132,7 +132,7 @@ const ItemOverview: FunctionComponent<Props> = (props) => {
           flexWrap: "nowrap",
         }}
       >
-        <Grid.Col span={3} hiddenFrom="sm">
+        <Grid.Col span={3} visibleFrom="sm">
           <Image
             src={item?.poster}
             mx="auto"


### PR DESCRIPTION
There we some loss of style on the components when we updated Mantine on #2465. There are still minor adjustments for the quality of the developer and some inconsistent colors that could be adjusted but since we migrated the Brand colors as it was, it will require some more refactoring later with more time.