### PR TITLE
Fixed adjust time button icon not displayed

### DIFF
--- a/frontend/src/components/forms/TimeOffsetForm.tsx
+++ b/frontend/src/components/forms/TimeOffsetForm.tsx
@@ -74,6 +74,7 @@ const TimeOffsetForm: FunctionComponent<Props> = ({ selections, onSubmit }) => {
           <Button
             color="gray"
             variant="filled"
+            style={{ overflow: "visible" }}
             onClick={() =>
               form.setValues((f) => ({ ...f, positive: !f.positive }))
             }


### PR DESCRIPTION
# Description

Fixed an issue where the icon was slightly overflowing falling back to an `-` instead of displaying the actual icon.

Before (Any icon is displayed as a `-`:
![Screenshot 2024-06-09 at 22 06 58](https://github.com/morpheus65535/bazarr/assets/12686241/1dc87844-5d79-4daf-8c15-56ce07927925)

After (Positive Values):
![Screenshot 2024-06-09 at 22 07 17](https://github.com/morpheus65535/bazarr/assets/12686241/45d3a7ef-b1ae-4c1a-ab1b-d7b3f64d8e95)

After (Negative Values):
![Screenshot 2024-06-09 at 22 07 24](https://github.com/morpheus65535/bazarr/assets/12686241/cbb1dca0-b68a-4861-b50a-96e4cf07dc0e)