### PR TITLE
Fixed history modal auto scrolling to top on open

### DIFF
--- a/frontend/src/components/modals/HistoryModal.tsx
+++ b/frontend/src/components/modals/HistoryModal.tsx
@@ -269,6 +269,7 @@ const EpisodeHistoryView: FunctionComponent<EpisodeHistoryViewProps> = ({
   return (
     <QueryOverlay result={history}>
       <PageTable
+        autoScroll={false}
         tableStyles={{ emptyText: "No history found", placeholder: 5 }}
         columns={columns}
         data={data ?? []}


### PR DESCRIPTION
# Description:

The PageTable component scrolls to the top as default as we want go to the top when we change the page, however for the history modal, we want to open the modal without scrolling the parent page to the top as well to keep consistent with any other modals that are opened without actually scrolling the page.

## Before:

https://github.com/morpheus65535/bazarr/assets/12686241/f3606be9-7a0e-4fbf-bad7-1bda8d8eea2c

## After:

https://github.com/morpheus65535/bazarr/assets/12686241/691dbded-f9d9-4ffa-b320-6336767cedc7



