### PR TITLE
Fixed background color of media overview badge on light theme

### DIFF
--- a/frontend/src/assets/badge.module.scss
+++ b/frontend/src/assets/badge.module.scss
@@ -35,6 +35,11 @@
         color: darken($color-highlight-6, 1);
         background-color: transparentize($color-highlight-5, 0.8);
       }
+
+      &[data-variant="light"] {
+        color: var(--mantine-color-black);
+        background-color: var(--mantine-color-gray-5);
+      }
     }
   }
 }

--- a/frontend/src/pages/views/ItemOverview.tsx
+++ b/frontend/src/pages/views/ItemOverview.tsx
@@ -200,8 +200,8 @@ const ItemBadge: FunctionComponent<ItemBadgeProps> = ({
 }) => (
   <Badge
     leftSection={<FontAwesomeIcon icon={icon}></FontAwesomeIcon>}
+    variant="light"
     radius="sm"
-    color="dark"
     size="sm"
     style={{ textTransform: "none" }}
     aria-label={title}


### PR DESCRIPTION
# Description

Fixed an issue where the badge background color for light theme is dimmed out and looks like the same as the subtitle badges.