### PR TITLE
Fixed settings profile style button on light theme

### DIFF
--- a/frontend/src/pages/Settings/Languages/table.tsx
+++ b/frontend/src/pages/Settings/Languages/table.tsx
@@ -132,6 +132,8 @@ const Table: FunctionComponent = () => {
               <Action
                 label="Edit Profile"
                 icon={faWrench}
+                c="gray"
+                variant="dark"
                 onClick={() => {
                   modals.openContextModal(ProfileEditModal, {
                     languages,
@@ -142,8 +144,9 @@ const Table: FunctionComponent = () => {
               ></Action>
               <Action
                 label="Remove"
+                variant="dark"
                 icon={faTrash}
-                color="red"
+                c="red"
                 onClick={() => action.remove(row.index)}
               ></Action>
             </Group>


### PR DESCRIPTION
# Description

Fixed an issue where the buttons on the profile edit table are almost invisible making it bad for usability.

## Before

![Screenshot 2024-06-11 at 16 13 11](https://github.com/morpheus65535/bazarr/assets/12686241/503c20c3-c53b-43ba-98d2-ab0fbc612f7e)

## After

![Screenshot 2024-06-11 at 16 13 48](https://github.com/morpheus65535/bazarr/assets/12686241/92843541-f3a8-4265-b3fe-8ae0bf34d38d)