### PR TITLE
Fixed mass edit language clear not available

### DIFF
--- a/frontend/src/components/forms/SyncSubtitleForm.tsx
+++ b/frontend/src/components/forms/SyncSubtitleForm.tsx
@@ -9,18 +9,17 @@ import {
   useRefTracksByMovieId,
   useSubtitleAction,
 } from "@/apis/hooks";
-import { GroupedSelector, Selector } from "@/components/inputs";
+import {
+  GroupedSelector,
+  GroupedSelectorOptions,
+  Selector,
+} from "@/components/inputs";
 import { useModals, withModal } from "@/modules/modals";
 import { task } from "@/modules/task";
 import { syncMaxOffsetSecondsOptions } from "@/pages/Settings/Subtitles/options";
 import { toPython } from "@/utilities";
 
 const TaskName = "Syncing Subtitle";
-
-interface SelectOptions {
-  group: string;
-  items: { value: string; label: string }[];
-}
 
 function useReferencedSubtitles(
   mediaType: "episode" | "movie",
@@ -41,13 +40,13 @@ function useReferencedSubtitles(
 
   const mediaData = mediaType === "episode" ? episodeData : movieData;
 
-  const subtitles: SelectOptions[] = [];
+  const subtitles: GroupedSelectorOptions<string>[] = [];
 
   if (!mediaData.data) {
     return [];
   } else {
     if (mediaData.data.audio_tracks.length > 0) {
-      const embeddedAudioGroup: SelectOptions = {
+      const embeddedAudioGroup: GroupedSelectorOptions<string> = {
         group: "Embedded audio tracks",
         items: [],
       };
@@ -63,7 +62,7 @@ function useReferencedSubtitles(
     }
 
     if (mediaData.data.embedded_subtitles_tracks.length > 0) {
-      const embeddedSubtitlesTrackGroup: SelectOptions = {
+      const embeddedSubtitlesTrackGroup: GroupedSelectorOptions<string> = {
         group: "Embedded subtitles tracks",
         items: [],
       };
@@ -79,7 +78,7 @@ function useReferencedSubtitles(
     }
 
     if (mediaData.data.external_subtitles_tracks.length > 0) {
-      const externalSubtitlesFilesGroup: SelectOptions = {
+      const externalSubtitlesFilesGroup: GroupedSelectorOptions<string> = {
         group: "External Subtitles files",
         items: [],
       };
@@ -127,11 +126,7 @@ const SyncSubtitleForm: FunctionComponent<Props> = ({
   const mediaId = selections[0].id;
   const subtitlesPath = selections[0].path;
 
-  const subtitles: SelectOptions[] = useReferencedSubtitles(
-    mediaType,
-    mediaId,
-    subtitlesPath,
-  );
+  const subtitles = useReferencedSubtitles(mediaType, mediaId, subtitlesPath);
 
   const form = useForm<FormValues>({
     initialValues: {

--- a/frontend/src/components/inputs/Selector.tsx
+++ b/frontend/src/components/inputs/Selector.tsx
@@ -6,7 +6,6 @@ import {
   MultiSelectProps,
   Select,
   SelectProps,
-  useCombobox,
 } from "@mantine/core";
 import { isNull, isUndefined, noop } from "lodash";
 import { LOG } from "@/utilities/console";
@@ -45,7 +44,6 @@ export type GroupedSelectorProps<T> = Override<
   {
     options: ComboboxItemGroup[];
     getkey?: (value: T) => string;
-    selectable?: boolean;
   },
   Omit<SelectProps, "data">
 >;
@@ -54,26 +52,13 @@ export function GroupedSelector<T>({
   value,
   options,
   getkey = DefaultKeyBuilder,
-  selectable = true,
   onOptionSubmit = noop,
   ...select
 }: GroupedSelectorProps<T>) {
-  const combobox = useCombobox({});
-
-  const props = selectable
-    ? undefined
-    : {
-        store: combobox,
-        onOptionSubmit: () => {
-          combobox.resetSelectedOption();
-        },
-      };
-
   return (
     <Select
-      onClick={() => combobox.openDropdown()}
       data-testid="input-selector"
-      comboboxProps={{ withinPortal: true, ...props }}
+      comboboxProps={{ withinPortal: true }}
       data={options}
       {...select}
     ></Select>

--- a/frontend/src/components/inputs/Selector.tsx
+++ b/frontend/src/components/inputs/Selector.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef } from "react";
 import {
   ComboboxItem,
-  ComboboxParsedItemGroup,
+  ComboboxItemGroup,
   MultiSelect,
   MultiSelectProps,
   Select,
@@ -35,9 +35,14 @@ function DefaultKeyBuilder<T>(value: T) {
   }
 }
 
+export interface GroupedSelectorOptions<T> {
+  group: string;
+  items: SelectorOption<T>[];
+}
+
 export type GroupedSelectorProps<T> = Override<
   {
-    options: ComboboxParsedItemGroup[];
+    options: ComboboxItemGroup[];
     getkey?: (value: T) => string;
   },
   Omit<SelectProps, "data">

--- a/frontend/src/components/inputs/Selector.tsx
+++ b/frontend/src/components/inputs/Selector.tsx
@@ -6,8 +6,9 @@ import {
   MultiSelectProps,
   Select,
   SelectProps,
+  useCombobox,
 } from "@mantine/core";
-import { isNull, isUndefined } from "lodash";
+import { isNull, isUndefined, noop } from "lodash";
 import { LOG } from "@/utilities/console";
 
 export type SelectorOption<T> = Override<
@@ -44,6 +45,7 @@ export type GroupedSelectorProps<T> = Override<
   {
     options: ComboboxItemGroup[];
     getkey?: (value: T) => string;
+    selectable?: boolean;
   },
   Omit<SelectProps, "data">
 >;
@@ -52,12 +54,26 @@ export function GroupedSelector<T>({
   value,
   options,
   getkey = DefaultKeyBuilder,
+  selectable = true,
+  onOptionSubmit = noop,
   ...select
 }: GroupedSelectorProps<T>) {
+  const combobox = useCombobox({});
+
+  const props = selectable
+    ? undefined
+    : {
+        store: combobox,
+        onOptionSubmit: () => {
+          combobox.resetSelectedOption();
+        },
+      };
+
   return (
     <Select
+      onClick={() => combobox.openDropdown()}
       data-testid="input-selector"
-      comboboxProps={{ withinPortal: true }}
+      comboboxProps={{ withinPortal: true, ...props }}
       data={options}
       {...select}
     ></Select>

--- a/frontend/src/pages/views/MassEditor.tsx
+++ b/frontend/src/pages/views/MassEditor.tsx
@@ -131,7 +131,6 @@ function MassEditor<T extends Item.Base>(props: MassEditorProps<T>) {
       <Toolbox>
         <Box>
           <GroupedSelector
-            selectable={false}
             onClick={() => combobox.openDropdown()}
             onDropdownClose={() => {
               combobox.resetSelectedOption();

--- a/frontend/src/pages/views/MassEditor.tsx
+++ b/frontend/src/pages/views/MassEditor.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Column, useRowSelect } from "react-table";
-import { Box, Container } from "@mantine/core";
+import { Box, Container, useCombobox } from "@mantine/core";
 import { faCheck, faUndo } from "@fortawesome/free-solid-svg-icons";
 import { UseMutationResult } from "@tanstack/react-query";
-import { get, uniqBy } from "lodash";
+import { uniqBy } from "lodash";
 import { useIsAnyMutationRunning, useLanguageProfiles } from "@/apis/hooks";
 import {
   GroupedSelector,
@@ -52,7 +52,7 @@ function MassEditor<T extends Item.Base>(props: MassEditorProps<T>) {
         group: "Profiles",
         items: profileOptions.options.map((a) => {
           return {
-            value: a.value.name,
+            value: a.value.profileId.toString(),
             label: a.label,
             profileId: a.value.profileId,
           };
@@ -124,20 +124,28 @@ function MassEditor<T extends Item.Base>(props: MassEditorProps<T>) {
     [selections],
   );
 
+  const combobox = useCombobox();
+
   return (
     <Container fluid px={0}>
       <Toolbox>
         <Box>
           <GroupedSelector
+            selectable={false}
+            onClick={() => combobox.openDropdown()}
+            onDropdownClose={() => {
+              combobox.resetSelectedOption();
+            }}
             placeholder="Change Profile"
             withCheckIcon={false}
             options={profileOptionsWithAction}
             getkey={getKey}
             disabled={selections.length === 0}
-            onChange={(value, item) => {
-              const profileId = get(item, "profileId", null) as number | null;
-
-              setProfiles(profileId);
+            comboboxProps={{
+              store: combobox,
+              onOptionSubmit: (value) => {
+                setProfiles(value ? +value : null);
+              },
             }}
           ></GroupedSelector>
         </Box>


### PR DESCRIPTION
# Description

During Mantine v7 update, all Select behavior changed, and we have an special case for the Mass Edit that we clear the language and got accidentally removed with the new behavior.

There are a few improvements on the behavior that makes the current select value to don't persist in the dropdown, because it causes a very confusing behavior when you select multiple values.