### PR TITLE
Fixed sync and translate not considering hi and forced

### DIFF
--- a/frontend/src/components/SubtitleToolsMenu.tsx
+++ b/frontend/src/components/SubtitleToolsMenu.tsx
@@ -127,6 +127,8 @@ const SubtitleToolsMenu: FunctionComponent<Props> = ({
           type: s.type,
           language: s.language,
           path: s.path,
+          hi: s.hi,
+          forced: s.forced,
         };
         task.create(s.path, name, mutateAsync, { action, form });
       });

--- a/frontend/src/components/forms/SyncSubtitleForm.tsx
+++ b/frontend/src/components/forms/SyncSubtitleForm.tsx
@@ -17,7 +17,7 @@ import {
 import { useModals, withModal } from "@/modules/modals";
 import { task } from "@/modules/task";
 import { syncMaxOffsetSecondsOptions } from "@/pages/Settings/Subtitles/options";
-import { toPython } from "@/utilities";
+import { fromPython, toPython } from "@/utilities";
 
 const TaskName = "Syncing Subtitle";
 
@@ -109,6 +109,8 @@ interface FormValues {
   maxOffsetSeconds?: string;
   noFixFramerate: boolean;
   gss: boolean;
+  hi?: boolean;
+  forced?: boolean;
 }
 
 const SyncSubtitleForm: FunctionComponent<Props> = ({
@@ -122,9 +124,11 @@ const SyncSubtitleForm: FunctionComponent<Props> = ({
   const { mutateAsync } = useSubtitleAction();
   const modals = useModals();
 
-  const mediaType = selections[0].type;
-  const mediaId = selections[0].id;
-  const subtitlesPath = selections[0].path;
+  const subtitle = selections[0];
+
+  const mediaType = subtitle.type;
+  const mediaId = subtitle.id;
+  const subtitlesPath = subtitle.path;
 
   const subtitles = useReferencedSubtitles(mediaType, mediaId, subtitlesPath);
 
@@ -132,6 +136,8 @@ const SyncSubtitleForm: FunctionComponent<Props> = ({
     initialValues: {
       noFixFramerate: false,
       gss: false,
+      hi: fromPython(subtitle.hi),
+      forced: fromPython(subtitle.forced),
     },
   });
 

--- a/frontend/src/pages/Episodes/components.tsx
+++ b/frontend/src/pages/Episodes/components.tsx
@@ -4,6 +4,7 @@ import { useEpisodeSubtitleModification } from "@/apis/hooks";
 import Language from "@/components/bazarr/Language";
 import SubtitleToolsMenu from "@/components/SubtitleToolsMenu";
 import { task, TaskGroup } from "@/modules/task";
+import { toPython } from "@/utilities";
 
 interface Props {
   seriesId: number;
@@ -43,11 +44,13 @@ export const Subtitle: FunctionComponent<Props> = ({
         type: "episode",
         language: subtitle.code2,
         path: subtitle.path,
+        forced: toPython(subtitle.forced),
+        hi: toPython(subtitle.hi),
       });
     }
 
     return list;
-  }, [episodeId, subtitle.code2, subtitle.path]);
+  }, [episodeId, subtitle.code2, subtitle.path, subtitle.forced, subtitle.hi]);
 
   const ctx = (
     <Badge variant={variant}>

--- a/frontend/src/pages/Movies/Details/table.tsx
+++ b/frontend/src/pages/Movies/Details/table.tsx
@@ -9,7 +9,7 @@ import { Action, SimpleTable } from "@/components";
 import Language from "@/components/bazarr/Language";
 import SubtitleToolsMenu from "@/components/SubtitleToolsMenu";
 import { task, TaskGroup } from "@/modules/task";
-import { filterSubtitleBy } from "@/utilities";
+import { filterSubtitleBy, toPython } from "@/utilities";
 import { useProfileItemsToLanguages } from "@/utilities/languages";
 
 const missingText = "Missing Subtitles";
@@ -95,11 +95,13 @@ const Table: FunctionComponent<Props> = ({ movie, profile, disabled }) => {
                 path,
                 id: movie.radarrId,
                 language: code2,
+                forced: toPython(forced),
+                hi: toPython(hi),
               });
             }
 
             return list;
-          }, [code2, path]);
+          }, [code2, path, forced, hi]);
 
           if (movie === null) {
             return null;

--- a/frontend/src/utilities/index.test.ts
+++ b/frontend/src/utilities/index.test.ts
@@ -1,0 +1,25 @@
+import { fromPython, toPython } from "@/utilities/index";
+
+describe("fromPythonConversion", () => {
+  it("should convert a true value", () => {
+    expect(fromPython("True")).toBe(true);
+  });
+
+  it("should convert a false value", () => {
+    expect(fromPython("False")).toBe(false);
+  });
+
+  it("should convert an undefined value", () => {
+    expect(fromPython(undefined)).toBe(false);
+  });
+});
+
+describe("toPythonConversion", () => {
+  it("should convert a true value", () => {
+    expect(toPython(true)).toBe("True");
+  });
+
+  it("should convert a false value", () => {
+    expect(toPython(false)).toBe("False");
+  });
+});

--- a/frontend/src/utilities/index.ts
+++ b/frontend/src/utilities/index.ts
@@ -59,6 +59,10 @@ export function filterSubtitleBy(
   }
 }
 
+export function fromPython(value: PythonBoolean | undefined): boolean {
+  return value === "True";
+}
+
 export function toPython(value: boolean): PythonBoolean {
   return value ? "True" : "False";
 }


### PR DESCRIPTION
# Description

Initially it should had been implemented on [0e648b](https://github.com/morpheus65535/bazarr/commit/0e648b5588c7d8675238b1ceb2e04a29e23d8fb1#diff-88804982a6937dc9471033d6c499df5d7155d33f4ee6b17e9e2103126366aba4) but `hi` and `forced` was never added to the payload that needs to be passed from the subtitle that is on the table and it is being selected by the user.

> @morpheus65535 I had not tested if the actual backend is working as expected 🫠 but the payload is definitely reaching the backend now.