### PR TITLE
Fixed usage of pysubs2 removed exception

### DIFF
--- a/custom_libs/subliminal_patch/subtitle.py
+++ b/custom_libs/subliminal_patch/subtitle.py
@@ -357,7 +357,7 @@ class Subtitle(Subtitle_):
                 fragment = fragment.replace(r"\n", u"\n")
                 fragment = fragment.replace(r"\N", u"\n")
                 if sty.drawing:
-                    raise pysubs2.ContentNotUsable
+                    return None
 
                 if format == "srt":
                     if sty.italic:
@@ -390,9 +390,10 @@ class Subtitle(Subtitle_):
         for i, line in enumerate(visible_lines, 1):
             start = ms_to_timestamp(line.start, mssep=mssep)
             end = ms_to_timestamp(line.end, mssep=mssep)
-            try:
-                text = prepare_text(line.text, sub.styles.get(line.style, SSAStyle.DEFAULT_STYLE))
-            except pysubs2.ContentNotUsable:
+
+            text = prepare_text(line.text, sub.styles.get(line.style, SSAStyle.DEFAULT_STYLE))
+
+            if text is None:
                 continue
 
             out.append(u"%d\n" % i)


### PR DESCRIPTION
# Description

Closes #2549 .ContentNotUsable has been removed from `pysubs2` on version `1.7.0` as it was not used as intended and should not be exposed, as well we should not be using it manually as per https://github.com/tkarabela/pysubs2/commit/c95870b00dcf43f54ecaf01ee62aa3999c112572#diff-c0f1f87b923e2644057bf1b1e3f7b9efd408c5c6f9bd72b5294a626b442ad237.