### PR TITLE
Fixed uptime calculation overflowing hours

### DIFF
--- a/frontend/src/utilities/time.test.ts
+++ b/frontend/src/utilities/time.test.ts
@@ -30,7 +30,7 @@ describe("formatTime", () => {
       { unit: "s", divisor: divisorSecond },
     ]);
 
-    expect(formattedTime).toBe("581d 25:27:41");
+    expect(formattedTime).toBe("581d 01:27:41");
   });
 
   it("should format time day hour minute", () => {

--- a/frontend/src/utilities/time.ts
+++ b/frontend/src/utilities/time.ts
@@ -11,19 +11,28 @@ export const divisorSecond = 1;
 export const formatTime = (
   timeInSeconds: number,
   formats: TimeFormat[],
-): string =>
-  formats.reduce(
-    (formattedTime: string, { unit, divisor }: TimeFormat, index: number) => {
-      const timeValue: number =
-        index === 0
-          ? Math.floor(timeInSeconds / divisor)
-          : Math.floor(timeInSeconds / divisor) % 60;
-      return (
+): string => {
+  return formats.reduce(
+    (
+      { formattedTime, remainingSeconds },
+      { unit, divisor }: TimeFormat,
+      index: number,
+    ) => {
+      const timeValue = Math.floor(remainingSeconds / divisor);
+
+      const seconds = remainingSeconds % divisor;
+
+      const time =
         formattedTime +
         (index === 0
           ? `${timeValue}${unit} `
-          : `${timeValue.toString().padStart(2, "0")}${index < formats.length - 1 ? ":" : ""}`)
-      );
+          : `${timeValue.toString().padStart(2, "0")}${index < formats.length - 1 ? ":" : ""}`);
+
+      return {
+        formattedTime: time,
+        remainingSeconds: seconds,
+      };
     },
-    "",
-  );
+    { formattedTime: "", remainingSeconds: timeInSeconds },
+  ).formattedTime;
+};


### PR DESCRIPTION
# Description

Once the day is formatted, i need to use the remaining time that has been distributed to the days already instead of the total hours. For example instead of 25, it should be 1, instead of 28, it should be 4.

> I might had been very sleepy, even my test was wrong 🤯 