### PR TITLE
Fixed popover text wrap browser compatibility

### DIFF
--- a/frontend/src/components/TextPopover.tsx
+++ b/frontend/src/components/TextPopover.tsx
@@ -25,7 +25,7 @@ const TextPopover: FunctionComponent<TextPopoverProps> = ({
       opened={hovered}
       label={text}
       {...tooltip}
-      style={{ textWrap: "pretty" }}
+      style={{ textWrap: "wrap" }}
     >
       <div ref={ref}>{children}</div>
     </Tooltip>


### PR DESCRIPTION
# Description

The `text-wrap` *pretty* still not compatible with Mobile Firefox and Safari causing the popover to overflow outside of the screen, to maximize the compatibility as the pretty does not do too much to us on our current use cases , replace the style with wrap instead and rely in the whitespaces to break.