### PR TITLE
Fixed get movie monitored status

### DIFF
--- a/bazarr/radarr/sync/movies.py
+++ b/bazarr/radarr/sync/movies.py
@@ -59,7 +59,7 @@ def update_movie(updated_movie, send_event):
 def get_movie_monitored_status(movie_id):
     existing_movie_monitored = database.execute(
         select(TableMovies.monitored)
-        .where(TableMovies.tmdbId == movie_id))\
+        .where(TableMovies.tmdbId == str(movie_id)))\
         .first()
     if existing_movie_monitored is None:
         return True


### PR DESCRIPTION
# Description

Fixes #2585

The `movie_id` argument is a integer but the column is a text where sqlalchemy ends transforming the query into `WHERE tmdbId = 12345` instead of `where tmdbId = '12345'` and it would fail since that is not the correct syntax for query a text column.

Casted the argument to string so to comparison can be done with the expected types.