### PR TITLE
Support binding IPv4 AND IPv6 instead of just either one or the other

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -31,6 +31,8 @@ def base_url_slash_cleaner(uri):
 
 
 def validate_ip_address(ip_string):
+    if ip_string == '*':
+        return True
     try:
         ip_address(ip_string)
         return True
@@ -67,7 +69,7 @@ validators = [
     # general section
     Validator('general.flask_secret_key', must_exist=True, default=hexlify(os.urandom(16)).decode(),
               is_type_of=str),
-    Validator('general.ip', must_exist=True, default='0.0.0.0', is_type_of=str, condition=validate_ip_address),
+    Validator('general.ip', must_exist=True, default='*', is_type_of=str, condition=validate_ip_address),
     Validator('general.port', must_exist=True, default=6767, is_type_of=int, gte=1, lte=65535),
     Validator('general.base_url', must_exist=True, default='', is_type_of=str),
     Validator('general.path_mappings', must_exist=True, default=[], is_type_of=list),

--- a/bazarr/app/logger.py
+++ b/bazarr/app/logger.py
@@ -58,9 +58,12 @@ class NoExceptionFormatter(logging.Formatter):
 
 class UnwantedWaitressMessageFilter(logging.Filter):
     def filter(self, record):
-        if settings.general.debug:
-            # no filtering in debug mode
+        if settings.general.debug or "BAZARR" in record.msg:
+            # no filtering in debug mode or if originating from us
             return True
+
+        if record.level != loggin.ERROR:
+            return False
 
         unwantedMessages = [
             "Exception while serving /api/socket.io/",
@@ -161,7 +164,7 @@ def configure_logging(debug=False):
         logging.getLogger("websocket").setLevel(logging.CRITICAL)
         logging.getLogger("ga4mp.ga4mp").setLevel(logging.ERROR)
 
-    logging.getLogger("waitress").setLevel(logging.ERROR)
+    logging.getLogger("waitress").setLevel(logging.INFO)
     logging.getLogger("waitress").addFilter(UnwantedWaitressMessageFilter())
     logging.getLogger("knowit").setLevel(logging.CRITICAL)
     logging.getLogger("enzyme").setLevel(logging.CRITICAL)

--- a/bazarr/app/server.py
+++ b/bazarr/app/server.py
@@ -50,7 +50,7 @@ class Server:
             self.connected = True
         except OSError as error:
             if error.errno == errno.EADDRNOTAVAIL:
-                logging.exception("BAZARR cannot bind to specified IP, trying with default (0.0.0.0)")
+                logging.exception("BAZARR cannot bind to specified IP, trying with 0.0.0.0")
                 self.address = '0.0.0.0'
                 self.connected = False
                 super(Server, self).__init__()

--- a/bazarr/app/server.py
+++ b/bazarr/app/server.py
@@ -76,8 +76,7 @@ class Server:
             self.shutdown(EXIT_INTERRUPT)
 
     def start(self):
-        logging.info(f'BAZARR is started and waiting for request on http://{self.server.effective_host}:'
-                     f'{self.server.effective_port}')
+        self.server.print_listen("BAZARR is started and waiting for requests on: http://{}:{}")
         signal.signal(signal.SIGINT, self.interrupt_handler)
         try:
             self.server.run()

--- a/frontend/src/pages/Settings/General/index.tsx
+++ b/frontend/src/pages/Settings/General/index.tsx
@@ -43,10 +43,10 @@ const SettingsGeneralView: FunctionComponent = () => {
       <Section header="Host">
         <Text
           label="Address"
-          placeholder="0.0.0.0"
+          placeholder="*"
           settingKey="settings-general-ip"
         ></Text>
-        <Message>Valid IPv4 address or '0.0.0.0' for all interfaces</Message>
+        <Message>Valid IP address or '*' for all interfaces</Message>
         <Number
           label="Port"
           placeholder="6767"


### PR DESCRIPTION
At the moment the configuration is limiting input to either an IPv4 address or an IPv6 address even though the underlying waitress server has no problem binding both at the same time.  
This updates the configuration to pass the wildcard value on to the waitress server so Bazarr can serve in both single and dual stack environments ootb.