### PR TITLE
Create a deepcopy of provider Language object for use in subtitles

### DIFF
--- a/custom_libs/subliminal_patch/subtitle.py
+++ b/custom_libs/subliminal_patch/subtitle.py
@@ -12,6 +12,7 @@ import chardet
 import pysrt
 import pysubs2
 from bs4 import UnicodeDammit
+from copy import deepcopy
 from pysubs2 import SSAStyle
 from pysubs2.formats.subrip import parse_tags, MAX_REPRESENTABLE_TIME
 from pysubs2.time import ms_to_times
@@ -65,6 +66,11 @@ class Subtitle(Subtitle_):
     # format = "srt" # default format is srt
 
     def __init__(self, language, hearing_impaired=False, page_link=None, encoding=None, mods=None, original_format=False):
+        # language needs to be cloned because it is actually a reference to the provider language object
+        # if a new copy is not created then all subsequent subtitles for this provider will incorrectly be modified
+        # at least until Bazarr is restarted or the provider language object is recreated somehow
+        language = deepcopy(language)
+
         # set subtitle language to hi if it's hearing_impaired
         if hearing_impaired:
             language = Language.rebuild(language, hi=True)


### PR DESCRIPTION
This prevents unwanted changes to the provider copy of its language object. 
Thanks to @vitiko98 for suggesting a better place for this fix.