### PR TITLE
Added settings provider maximum description lines

### DIFF
--- a/frontend/src/pages/Settings/Providers/components.tsx
+++ b/frontend/src/pages/Settings/Providers/components.tsx
@@ -112,6 +112,7 @@ export const ProviderView: FunctionComponent<ProviderViewProps> = ({
             header={v.name ?? capitalize(v.key)}
             description={v.description}
             onClick={() => select(v)}
+            lineClamp={2}
           ></Card>
         ));
     } else {

--- a/frontend/src/pages/Settings/Providers/components.tsx
+++ b/frontend/src/pages/Settings/Providers/components.tsx
@@ -108,6 +108,7 @@ export const ProviderView: FunctionComponent<ProviderViewProps> = ({
         })
         .map((v, idx) => (
           <Card
+            titleStyles={{ overflow: "hidden", textOverflow: "ellipsis" }}
             key={BuildKey(v.key, idx)}
             header={v.name ?? capitalize(v.key)}
             description={v.description}

--- a/frontend/src/pages/Settings/components/Card.tsx
+++ b/frontend/src/pages/Settings/components/Card.tsx
@@ -2,13 +2,15 @@ import { FunctionComponent } from "react";
 import { Center, Stack, Text, UnstyledButton } from "@mantine/core";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import TextPopover from "@/components/TextPopover";
 import styles from "./Card.module.scss";
 
 interface CardProps {
-  header?: string;
   description?: string;
-  plus?: boolean;
+  header?: string;
+  lineClamp?: number | undefined;
   onClick?: () => void;
+  plus?: boolean;
 }
 
 export const Card: FunctionComponent<CardProps> = ({
@@ -16,6 +18,7 @@ export const Card: FunctionComponent<CardProps> = ({
   description,
   plus,
   onClick,
+  lineClamp,
 }) => {
   return (
     <UnstyledButton p="lg" onClick={onClick} className={styles.card}>
@@ -26,7 +29,11 @@ export const Card: FunctionComponent<CardProps> = ({
       ) : (
         <Stack h="100%" gap={0} align="flex-start">
           <Text fw="bold">{header}</Text>
-          <Text hidden={description === undefined}>{description}</Text>
+          <TextPopover text={description}>
+            <Text hidden={description === undefined} lineClamp={lineClamp}>
+              {description}
+            </Text>
+          </TextPopover>
         </Stack>
       )}
     </UnstyledButton>

--- a/frontend/src/pages/Settings/components/Card.tsx
+++ b/frontend/src/pages/Settings/components/Card.tsx
@@ -1,5 +1,11 @@
 import { FunctionComponent } from "react";
-import { Center, Stack, Text, UnstyledButton } from "@mantine/core";
+import {
+  Center,
+  MantineStyleProp,
+  Stack,
+  Text,
+  UnstyledButton,
+} from "@mantine/core";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import TextPopover from "@/components/TextPopover";
@@ -11,6 +17,7 @@ interface CardProps {
   lineClamp?: number | undefined;
   onClick?: () => void;
   plus?: boolean;
+  titleStyles?: MantineStyleProp | undefined;
 }
 
 export const Card: FunctionComponent<CardProps> = ({
@@ -19,6 +26,7 @@ export const Card: FunctionComponent<CardProps> = ({
   plus,
   onClick,
   lineClamp,
+  titleStyles,
 }) => {
   return (
     <UnstyledButton p="lg" onClick={onClick} className={styles.card}>
@@ -27,8 +35,10 @@ export const Card: FunctionComponent<CardProps> = ({
           <FontAwesomeIcon size="2x" icon={faPlus}></FontAwesomeIcon>
         </Center>
       ) : (
-        <Stack h="100%" gap={0} align="flex-start">
-          <Text fw="bold">{header}</Text>
+        <Stack h="100%" gap={0}>
+          <Text fw="bold" style={titleStyles}>
+            {header}
+          </Text>
           <TextPopover text={description}>
             <Text hidden={description === undefined} lineClamp={lineClamp}>
               {description}


### PR DESCRIPTION
# Description:

There is no limit on the amount of content in the description that is currently displayed generating clutter on the settings screen, there is no need for such long description on the providers which degrades the visual experience.

Limit the amount of the max lines to 2, so the users can still have a grasp and remember what this provider is about, and if they need the full description they can still hover of the provider to read the full description.

## Before:

![Screenshot 2024-08-07 at 10 52 00](https://github.com/user-attachments/assets/45e045ad-415d-4ec4-b8f1-93a0510575f5)

## After:

![Screenshot 2024-08-07 at 10 50 26](https://github.com/user-attachments/assets/e14521a9-9bdf-46dd-b731-b9b5a9a5f12f)

![Screenshot 2024-08-07 at 10 51 19](https://github.com/user-attachments/assets/0e8a72ba-086b-4996-8514-ff3d56c9af67)
