### PR TITLE
Fix subf2m to now find movies and series again

### DIFF
--- a/custom_libs/subliminal_patch/providers/subf2m.py
+++ b/custom_libs/subliminal_patch/providers/subf2m.py
@@ -220,7 +220,7 @@ class Subf2mProvider(Provider):
 
         results = []
         for result in self._gen_results(title):
-            text = result.text.lower()
+            text = result.text.strip().lower()
             match = self._movie_title_regex.match(text)
             if not match:
                 continue
@@ -254,7 +254,7 @@ class Subf2mProvider(Provider):
 
         results = []
         for result in self._gen_results(title):
-            text = result.text.lower()
+            text = result.text.strip().lower()
 
             match = self._tv_show_title_regex.match(text)
             if not match:


### PR DESCRIPTION
Movies and series titles had a space at the end of the html result which made the regex not find any results.

For more details look at what this fixes.
Fixes [#2616](https://github.com/morpheus65535/bazarr/issues/2616)