### PR TITLE
Fixed language code nullable values

### DIFF
--- a/frontend/src/components/bazarr/Language.test.tsx
+++ b/frontend/src/components/bazarr/Language.test.tsx
@@ -11,7 +11,7 @@ describe("Language text", () => {
   it("should show short text", () => {
     render(<Language.Text value={testLanguage}></Language.Text>);
 
-    expect(screen.getByText(testLanguage.code2)).toBeDefined();
+    expect(screen.getByText(testLanguage.code2 ?? "")).toBeDefined();
   });
 
   it("should show long text", () => {

--- a/frontend/src/components/bazarr/LanguageSelector.tsx
+++ b/frontend/src/components/bazarr/LanguageSelector.tsx
@@ -25,7 +25,7 @@ const LanguageSelector: FunctionComponent<LanguageSelectorProps> = ({
   const options = useSelectorOptions(
     filteredData ?? [],
     (value) => value.name,
-    (value) => value.code3,
+    (value) => value.code3 ?? "",
   );
 
   return <Selector {...options} searchable {...selector}></Selector>;

--- a/frontend/src/components/forms/ItemEditForm.tsx
+++ b/frontend/src/components/forms/ItemEditForm.tsx
@@ -44,7 +44,7 @@ const ItemEditForm: FunctionComponent<Props> = ({
   const options = useSelectorOptions(
     item?.audio_language ?? [],
     (v) => v.name,
-    (v) => v.code2,
+    (v) => v.code2 ?? "",
   );
 
   const isOverlayVisible = isPending || isFetching || item === null;

--- a/frontend/src/components/forms/MovieUploadForm.tsx
+++ b/frontend/src/components/forms/MovieUploadForm.tsx
@@ -90,7 +90,7 @@ const MovieUploadForm: FunctionComponent<Props> = ({
   const languageOptions = useSelectorOptions(
     languages,
     (v) => v.name,
-    (v) => v.code2,
+    (v) => v.code2 ?? "",
   );
 
   const defaultLanguage = useMemo(
@@ -282,7 +282,7 @@ const MovieUploadForm: FunctionComponent<Props> = ({
 
           task.create(file.name, TaskGroup.UploadSubtitle, upload.mutateAsync, {
             radarrId,
-            form: { file, language: language.code2, hi, forced },
+            form: { file, language: language.code2 ?? "", hi, forced },
           });
         });
 

--- a/frontend/src/components/forms/SeriesUploadForm.tsx
+++ b/frontend/src/components/forms/SeriesUploadForm.tsx
@@ -102,7 +102,7 @@ const SeriesUploadForm: FunctionComponent<Props> = ({
   const languageOptions = useSelectorOptions(
     languages,
     (v) => v.name,
-    (v) => v.code2,
+    (v) => v.code2 ?? "",
   );
 
   const defaultLanguage = useMemo(
@@ -360,7 +360,7 @@ const SeriesUploadForm: FunctionComponent<Props> = ({
             episodeId,
             form: {
               file,
-              language: code2,
+              language: code2 ?? "",
               hi,
               forced,
             },

--- a/frontend/src/components/forms/TranslationForm.tsx
+++ b/frontend/src/components/forms/TranslationForm.tsx
@@ -145,14 +145,14 @@ const TranslationForm: FunctionComponent<Props> = ({
   });
 
   const available = useMemo(
-    () => languages.filter((v) => v.code2 in translations),
+    () => languages.filter((v) => v.code2 ?? "" in translations),
     [languages],
   );
 
   const options = useSelectorOptions(
     available,
     (v) => v.name,
-    (v) => v.code2,
+    (v) => v.code2 ?? "",
   );
 
   return (
@@ -164,7 +164,7 @@ const TranslationForm: FunctionComponent<Props> = ({
               action: "translate",
               form: {
                 ...s,
-                language: language.code2,
+                language: language.code2 ?? "",
               },
             }),
           );

--- a/frontend/src/components/modals/SubtitleToolsModal.tsx
+++ b/frontend/src/components/modals/SubtitleToolsModal.tsx
@@ -116,7 +116,7 @@ const SubtitleToolView: FunctionComponent<SubtitleToolViewProps> = ({
               {
                 id,
                 type,
-                language: v.code2,
+                language: v.code2 ?? "",
                 path: v.path,
                 // eslint-disable-next-line camelcase
                 raw_language: v,

--- a/frontend/src/pages/Episodes/components.tsx
+++ b/frontend/src/pages/Episodes/components.tsx
@@ -42,7 +42,7 @@ export const Subtitle: FunctionComponent<Props> = ({
       list.push({
         id: episodeId,
         type: "episode",
-        language: subtitle.code2,
+        language: subtitle.code2 ?? "",
         path: subtitle.path,
         forced: toPython(subtitle.forced),
         hi: toPython(subtitle.hi),
@@ -80,7 +80,7 @@ export const Subtitle: FunctionComponent<Props> = ({
               seriesId,
               episodeId,
               form: {
-                language: subtitle.code2,
+                language: subtitle.code2 ?? "",
                 hi: subtitle.hi,
                 forced: subtitle.forced,
               },
@@ -95,7 +95,7 @@ export const Subtitle: FunctionComponent<Props> = ({
               seriesId,
               episodeId,
               form: {
-                language: subtitle.code2,
+                language: subtitle.code2 ?? "",
                 hi: subtitle.hi,
                 forced: subtitle.forced,
                 path: subtitle.path,

--- a/frontend/src/pages/Movies/Details/table.tsx
+++ b/frontend/src/pages/Movies/Details/table.tsx
@@ -47,7 +47,7 @@ const Table: FunctionComponent<Props> = ({ movie, profile, disabled }) => {
           type: "movie",
           path,
           id: movie.radarrId,
-          language: code2,
+          language: code2 ?? "",
           forced: toPython(forced),
           hi: toPython(hi),
         });
@@ -76,7 +76,7 @@ const Table: FunctionComponent<Props> = ({ movie, profile, disabled }) => {
               {
                 radarrId,
                 form: {
-                  language: code2,
+                  language: code2 ?? "",
                   forced,
                   hi,
                 },
@@ -99,7 +99,7 @@ const Table: FunctionComponent<Props> = ({ movie, profile, disabled }) => {
               {
                 radarrId,
                 form: {
-                  language: code2,
+                  language: code2 ?? "",
                   forced,
                   hi,
                   path,

--- a/frontend/src/pages/Settings/Languages/equals.tsx
+++ b/frontend/src/pages/Settings/Languages/equals.tsx
@@ -65,7 +65,9 @@ export function decodeEqualData(
   };
 }
 
-function encodeEqualTarget(data: GenericEqualTarget<Language.Server>): string {
+function encodeEqualTarget(
+  data: GenericEqualTarget<Language.Server>,
+): string | null {
   let text = data.content.code3;
   if (data.hi) {
     text += "@hi";

--- a/frontend/src/pages/Settings/Languages/index.tsx
+++ b/frontend/src/pages/Settings/Languages/index.tsx
@@ -92,7 +92,7 @@ const SettingsLanguagesView: FunctionComponent = () => {
             label="Treat unknown language audio track as (changing this will trigger missing subtitles calculation)"
             placeholder="Select languages"
             options={undAudioLanguages.map((v) => {
-              return { label: v.name, value: v.code2 };
+              return { label: v.name, value: v.code2 ?? "" };
             })}
             settingOptions={{
               onSubmit: (v) => (v === null ? "" : v),
@@ -105,7 +105,7 @@ const SettingsLanguagesView: FunctionComponent = () => {
           label="Treat unknown language embedded subtitles track as (changing this will trigger full subtitles indexing using cache)"
           placeholder="Select languages"
           options={undEmbeddedSubtitlesLanguages.map((v) => {
-            return { label: v.name, value: v.code2 };
+            return { label: v.name, value: v.code2 ?? "" };
           })}
           settingOptions={{
             onSubmit: (v) => (v === null ? "" : v),

--- a/frontend/src/pages/Wanted/Movies/index.tsx
+++ b/frontend/src/pages/Wanted/Movies/index.tsx
@@ -59,7 +59,7 @@ const WantedMoviesView: FunctionComponent = () => {
                       {
                         radarrId,
                         form: {
-                          language: item.code2,
+                          language: item.code2 ?? "",
                           hi: item.hi,
                           forced: item.forced,
                         },

--- a/frontend/src/pages/Wanted/Series/index.tsx
+++ b/frontend/src/pages/Wanted/Series/index.tsx
@@ -63,7 +63,7 @@ const WantedSeriesView: FunctionComponent = () => {
                 <Badge
                   color={download.isPending ? "gray" : undefined}
                   leftSection={<FontAwesomeIcon icon={faSearch} />}
-                  key={BuildKey(idx, item.code2)}
+                  key={BuildKey(idx, item.code2 ?? "")}
                   style={{ cursor: "pointer" }}
                   onClick={() => {
                     task.create(
@@ -74,7 +74,7 @@ const WantedSeriesView: FunctionComponent = () => {
                         seriesId,
                         episodeId,
                         form: {
-                          language: item.code2,
+                          language: item.code2 ?? "",
                           hi: item.hi,
                           forced: item.forced,
                         },

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -9,7 +9,7 @@ interface Badge {
 }
 
 declare namespace Language {
-  type CodeType = string;
+  type CodeType = string | null;
   interface Server {
     code2: CodeType;
     code3: CodeType;


### PR DESCRIPTION
# Description:

Fix #2614.

When the language does not exist as a supported language, the language won't have a code, which technically are not used on the forms but the type check will prevent from proceeding.
