### PR TITLE
Avistaz&Cinemaz: Fix error on missing Uploader in subtitle info

### DIFF
--- a/custom_libs/subliminal_patch/providers/avistaz_network.py
+++ b/custom_libs/subliminal_patch/providers/avistaz_network.py
@@ -318,7 +318,7 @@ class AvistazNetworkProviderBase(Provider):
             release_name = release['Title'].get_text().strip()
             lang = lookup_lang(subtitle_cols['Language'].get_text().strip())
             download_link = subtitle_cols['Download'].a['href']
-            uploader_name = subtitle_cols['Uploader'].get_text().strip()
+            uploader_name = subtitle_cols['Uploader'].get_text().strip() if 'Uploader' in subtitle_cols else None
 
             if lang not in languages:
                 continue

--- a/custom_libs/subliminal_patch/providers/avistaz_network.py
+++ b/custom_libs/subliminal_patch/providers/avistaz_network.py
@@ -354,7 +354,10 @@ class AvistazNetworkProviderBase(Provider):
 
     def _parse_release_table(self, html):
         release_data_table = (ParserBeautifulSoup(html, ['html.parser'])
-                              .select_one('#content-area > div:nth-child(4) > div.table-responsive > table > tbody'))
+                              .select_one('#content-area > div.block > div.table-responsive > table > tbody'))
+
+        if release_data_table is None:
+            raise Exception('Unexpected HTML page layout - no release data table found')
 
         rows = {}
         for tr in release_data_table.find_all('tr', recursive=False):

--- a/custom_libs/subliminal_patch/providers/avistaz_network.py
+++ b/custom_libs/subliminal_patch/providers/avistaz_network.py
@@ -5,7 +5,7 @@ from random import randint
 
 import pycountry
 from requests.cookies import RequestsCookieJar
-from subliminal.exceptions import AuthenticationError
+from subliminal.exceptions import AuthenticationError, ProviderError
 from subliminal.providers import ParserBeautifulSoup
 from subliminal_patch.http import RetryingCFSession
 from subliminal_patch.pitcher import store_verification
@@ -357,7 +357,7 @@ class AvistazNetworkProviderBase(Provider):
                               .select_one('#content-area > div.block > div.table-responsive > table > tbody'))
 
         if release_data_table is None:
-            raise Exception('Unexpected HTML page layout - no release data table found')
+            raise ProviderError('Unexpected HTML page layout - no release data table found')
 
         rows = {}
         for tr in release_data_table.find_all('tr', recursive=False):


### PR DESCRIPTION
Looks like the sites removed the 'Uploader' column in subtitle info. That resulted in error in the provider:
```
2024-08-19 13:04:13|INFO    |root                            |Throttling avistaz for 10 minutes, until 24/08/19 13:14, because of: KeyError. Exception info: "''Uploader'' ~ avistaz_network.py@321"|
```