### PR TITLE
AvistaZ&CinemaZ: fix broken scraping due to missing Uploader column

### DIFF
--- a/custom_libs/subliminal_patch/providers/avistaz_network.py
+++ b/custom_libs/subliminal_patch/providers/avistaz_network.py
@@ -318,7 +318,7 @@ class AvistazNetworkProviderBase(Provider):
             release_name = release['Title'].get_text().strip()
             lang = lookup_lang(subtitle_cols['Language'].get_text().strip())
             download_link = subtitle_cols['Download'].a['href']
-            uploader_name = subtitle_cols['Uploader'].get_text().strip()
+            uploader_name = subtitle_cols['Uploader'].get_text().strip() if 'Uploader' in subtitle_cols else None
 
             if lang not in languages:
                 continue


### PR DESCRIPTION
AvistaZ & CinemaZ had an update which removed the Uploader column in subtitle info. The provider didn't handle Uploader as optional, so it's broken at the moment. This PR should fix that.