### PR TITLE
Fixed nullable audio language code

### DIFF
--- a/frontend/src/components/bazarr/AudioList.tsx
+++ b/frontend/src/components/bazarr/AudioList.tsx
@@ -3,7 +3,7 @@ import { Badge, BadgeProps, Group, GroupProps } from "@mantine/core";
 import { BuildKey } from "@/utilities";
 
 export type AudioListProps = GroupProps & {
-  audios: Language.Info[];
+  audios: Language.NullableCodeInfo[];
   badgeProps?: BadgeProps;
 };
 

--- a/frontend/src/components/forms/ItemEditForm.tsx
+++ b/frontend/src/components/forms/ItemEditForm.tsx
@@ -44,7 +44,7 @@ const ItemEditForm: FunctionComponent<Props> = ({
   const options = useSelectorOptions(
     item?.audio_language ?? [],
     (v) => v.name,
-    (v) => v.code2,
+    (v) => v.code2 ?? "",
   );
 
   const isOverlayVisible = isPending || isFetching || item === null;

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -10,6 +10,8 @@ interface Badge {
 
 declare namespace Language {
   type CodeType = string;
+  type NullableCodeType = string | null;
+
   interface Server {
     code2: CodeType;
     code3: CodeType;
@@ -19,6 +21,13 @@ declare namespace Language {
 
   interface Info {
     code2: CodeType;
+    name: string;
+    hi?: boolean;
+    forced?: boolean;
+  }
+
+  interface NullableCodeInfo {
+    code2: NullableCodeType;
     name: string;
     hi?: boolean;
     forced?: boolean;
@@ -124,7 +133,7 @@ interface TitleType {
 }
 
 interface AudioLanguageType {
-  audio_language: Language.Info[];
+  audio_language: Language.NullableCodeInfo[];
 }
 
 interface ItemHistoryType {


### PR DESCRIPTION
# Description

Fixes #2614.

The audio languages where we use to display the Language of the Movie that are not present on the `table_settings_languages` won't have `code2` nor `code3`.