### PR TITLE
Fixed audio language chinese

### DIFF
--- a/bazarr/languages/get_languages.py
+++ b/bazarr/languages/get_languages.py
@@ -54,6 +54,13 @@ def create_languages_dict():
                TableSettingsLanguages.code3b))
         .all()]
 
+def audio_language_from_alpha2(lang):
+    lang_map = {
+        'Chinese': 'zh',
+        'Portuguese (Brazil)': 'pb'
+    }
+
+    return language_from_alpha2(lang_map.get(lang, lang))
 
 def language_from_alpha2(lang):
     return next((item['name'] for item in languages_dict if item['code2'] == lang[:2]), None)

--- a/bazarr/radarr/sync/parser.py
+++ b/bazarr/radarr/sync/parser.py
@@ -3,7 +3,7 @@
 import os
 
 from app.config import settings
-from languages.get_languages import language_from_alpha2
+from languages.get_languages import audio_language_from_alpha2
 from radarr.info import get_radarr_info
 from utilities.video_analyzer import embedded_audio_reader
 from utilities.path_mappings import path_mappings
@@ -117,9 +117,7 @@ def movieParser(movie, action, tags_dict, language_profiles, movie_default_profi
                     for item in movie['movieFile']['languages']:
                         if isinstance(item, dict):
                             if 'name' in item:
-                                language = item['name']
-                                if item['name'] == 'Portuguese (Brazil)':
-                                    language = language_from_alpha2('pb')
+                                language = audio_language_from_alpha2(item['name'])
                                 audio_language.append(language)
 
         tags = [d['label'] for d in tags_dict if d['id'] in movie['tags']]

--- a/bazarr/sonarr/sync/parser.py
+++ b/bazarr/sonarr/sync/parser.py
@@ -5,6 +5,7 @@ import os
 from app.config import settings
 from app.database import TableShows, database, select
 from constants import MINIMUM_VIDEO_SIZE
+from languages.get_languages import audio_language_from_alpha2
 from utilities.path_mappings import path_mappings
 from utilities.video_analyzer import embedded_audio_reader
 from sonarr.info import get_sonarr_info
@@ -115,13 +116,13 @@ def episodeParser(episode):
                             item = episode['episodeFile']['language']
                             if isinstance(item, dict):
                                 if 'name' in item:
-                                    audio_language.append(item['name'])
+                                    audio_language.append(audio_language_from_alpha2(item['name']))
                         elif 'languages' in episode['episodeFile'] and len(episode['episodeFile']['languages']):
                             items = episode['episodeFile']['languages']
                             if isinstance(items, list):
                                 for item in items:
                                     if 'name' in item:
-                                        audio_language.append(item['name'])
+                                        audio_language.append(audio_language_from_alpha2(item['name']))
                         else:
                             audio_language = database.execute(
                                 select(TableShows.audio_language)

--- a/frontend/src/components/bazarr/AudioList.tsx
+++ b/frontend/src/components/bazarr/AudioList.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent } from "react";
 import { Badge, BadgeProps, Group, GroupProps } from "@mantine/core";
 import { BuildKey } from "@/utilities";
+import { normalizeAudioLanguage } from "@/utilities/languages";
 
 export type AudioListProps = GroupProps & {
   audios: Language.Info[];
@@ -16,7 +17,7 @@ const AudioList: FunctionComponent<AudioListProps> = ({
     <Group gap="xs" {...group}>
       {audios.map((audio, idx) => (
         <Badge color="blue" key={BuildKey(idx, audio.code2)} {...badgeProps}>
-          {audio.name}
+          {normalizeAudioLanguage(audio.name)}
         </Badge>
       ))}
     </Group>

--- a/frontend/src/pages/views/ItemOverview.tsx
+++ b/frontend/src/pages/views/ItemOverview.tsx
@@ -31,6 +31,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Language } from "@/components/bazarr";
 import { BuildKey } from "@/utilities";
 import {
+  normalizeAudioLanguage,
   useLanguageProfileBy,
   useProfileItemsToLanguages,
 } from "@/utilities/languages";
@@ -87,7 +88,7 @@ const ItemOverview: FunctionComponent<Props> = (props) => {
           icon={faMusic}
           title="Audio Language"
         >
-          {v.name}
+          {normalizeAudioLanguage(v.name)}
         </ItemBadge>
       )) ?? [],
     [item?.audio_language],

--- a/frontend/src/utilities/languages.ts
+++ b/frontend/src/utilities/languages.ts
@@ -51,3 +51,7 @@ export function useLanguageFromCode3(code3: string) {
     [data, code3],
   );
 }
+
+export const normalizeAudioLanguage = (name: string) => {
+  return name === "Chinese Simplified" ? "Chinese" : name;
+};


### PR DESCRIPTION
# Description

Fix #2614

`Chinese` language in Bazarr have been replaced with `Chinese Simplified` they are technically are the same however we separate on the custom languages on Chinese Simplified and Chinese Traditional.

Radarr / Sonarr will send to us `Chinese` on the audio language and that's totally correct since the 2 types of chinese we separate are for writing only, and that also makes sense to us since we deal with Subtitles.

Since we rely on our languages, and use it to identify the `code2` or `code3`, etc, the Chinese Language becomes orphan, and we are unable to proceed in a few operations that rely on the language code, so we identify it as Chinese Simplified.

As it is quite not correct to display `Chinese Simplified` as "Audio" since it is only for written, the display is corrected to show as `Chinese` only instead of `Chinese Simplified`.

> An additional information is that we don't need to manually update the database records to correct it, but users experiencing issues should run or wait to the schedule of the Tasks `Sync with Sonarr` and `Sync with Radarr`.