### PR TITLE
Fixed Zimuku filename case

### DIFF
--- a/custom_libs/subliminal_patch/providers/zimuku.py
+++ b/custom_libs/subliminal_patch/providers/zimuku.py
@@ -316,7 +316,7 @@ class ZimukuProvider(Provider):
         r = self.yunsuo_bypass(download_link, headers={'Referer': subtitle.page_link}, timeout=30)
         r.raise_for_status()
         try:
-            filename = r.headers["Content-Disposition"]
+            filename = r.headers["Content-Disposition"].lower()
         except KeyError:
             logger.debug("Unable to parse subtitles filename. Dropping this subtitles.")
             return


### PR DESCRIPTION
# Description

Closes #2588

Zimuku filename is returned from the response header Content-Disposition which can be mixed letter case, and won't guarantee. Since we make several comparisons and assumes that extension would be `.rar` or `.zip` it won't handle when the extension have uppercase letters.

Since the filename is used for comparison and logs only, we can simply cast it to lowercase.