### PR TITLE
Fixed async audio languages not mapped fallback

### DIFF
--- a/bazarr/languages/get_languages.py
+++ b/bazarr/languages/get_languages.py
@@ -61,10 +61,12 @@ def audio_language_from_name(lang):
         'Portuguese (Brazil)': 'pb'
     }
 
-    if lang_map.get(lang, None) is None:
+    alpha2_code = lang_map.get(lang, None)
+
+    if alpha2_code is None:
         return lang
 
-    return language_from_alpha2(lang_map.get(lang, None))
+    return language_from_alpha2(alpha2_code)
 
 def language_from_alpha2(lang):
     return next((item['name'] for item in languages_dict if item['code2'] == lang[:2]), None)

--- a/bazarr/languages/get_languages.py
+++ b/bazarr/languages/get_languages.py
@@ -54,14 +54,17 @@ def create_languages_dict():
                TableSettingsLanguages.code3b))
         .all()]
 
-def audio_language_from_alpha2(lang):
+def audio_language_from_name(lang):
     lang_map = {
         'Chinese': 'zh',
         'Greek': 'el',
         'Portuguese (Brazil)': 'pb'
     }
 
-    return language_from_alpha2(lang_map.get(lang, lang)) or lang
+    if lang_map.get(lang, None) is None:
+        return lang
+
+    return language_from_alpha2(lang_map.get(lang, None))
 
 def language_from_alpha2(lang):
     return next((item['name'] for item in languages_dict if item['code2'] == lang[:2]), None)

--- a/bazarr/languages/get_languages.py
+++ b/bazarr/languages/get_languages.py
@@ -57,10 +57,11 @@ def create_languages_dict():
 def audio_language_from_alpha2(lang):
     lang_map = {
         'Chinese': 'zh',
+        'Greek': 'el',
         'Portuguese (Brazil)': 'pb'
     }
 
-    return language_from_alpha2(lang_map.get(lang, lang))
+    return language_from_alpha2(lang_map.get(lang, lang)) or lang
 
 def language_from_alpha2(lang):
     return next((item['name'] for item in languages_dict if item['code2'] == lang[:2]), None)

--- a/bazarr/languages/get_languages.py
+++ b/bazarr/languages/get_languages.py
@@ -57,7 +57,6 @@ def create_languages_dict():
 def audio_language_from_name(lang):
     lang_map = {
         'Chinese': 'zh',
-        'Greek': 'el',
         'Portuguese (Brazil)': 'pb'
     }
 

--- a/bazarr/radarr/sync/parser.py
+++ b/bazarr/radarr/sync/parser.py
@@ -3,7 +3,7 @@
 import os
 
 from app.config import settings
-from languages.get_languages import audio_language_from_alpha2
+from languages.get_languages import audio_language_from_name
 from radarr.info import get_radarr_info
 from utilities.video_analyzer import embedded_audio_reader
 from utilities.path_mappings import path_mappings
@@ -117,7 +117,7 @@ def movieParser(movie, action, tags_dict, language_profiles, movie_default_profi
                     for item in movie['movieFile']['languages']:
                         if isinstance(item, dict):
                             if 'name' in item:
-                                language = audio_language_from_alpha2(item['name'])
+                                language = audio_language_from_name(item['name'])
                                 audio_language.append(language)
 
         tags = [d['label'] for d in tags_dict if d['id'] in movie['tags']]

--- a/bazarr/sonarr/sync/parser.py
+++ b/bazarr/sonarr/sync/parser.py
@@ -5,7 +5,7 @@ import os
 from app.config import settings
 from app.database import TableShows, database, select
 from constants import MINIMUM_VIDEO_SIZE
-from languages.get_languages import audio_language_from_alpha2
+from languages.get_languages import audio_language_from_name
 from utilities.path_mappings import path_mappings
 from utilities.video_analyzer import embedded_audio_reader
 from sonarr.info import get_sonarr_info
@@ -122,13 +122,13 @@ def episodeParser(episode):
                             item = episode['episodeFile']['language']
                             if isinstance(item, dict):
                                 if 'name' in item:
-                                    audio_language.append(audio_language_from_alpha2(item['name']))
+                                    audio_language.append(audio_language_from_name(item['name']))
                         elif 'languages' in episode['episodeFile'] and len(episode['episodeFile']['languages']):
                             items = episode['episodeFile']['languages']
                             if isinstance(items, list):
                                 for item in items:
                                     if 'name' in item:
-                                        audio_language.append(audio_language_from_alpha2(item['name']))
+                                        audio_language.append(audio_language_from_name(item['name']))
                         else:
                             audio_language = database.execute(
                                 select(TableShows.audio_language)


### PR DESCRIPTION
# Description

#2632 Caused an issue to do not identify the audio language if it was not mapped in due to a mistake of not having the fallback.