### PR TITLE
Fixed upload subtitle language selection duplicated languages

### DIFF
--- a/frontend/src/components/forms/MovieUploadForm.tsx
+++ b/frontend/src/components/forms/MovieUploadForm.tsx
@@ -17,7 +17,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { ColumnDef } from "@tanstack/react-table";
-import { isString } from "lodash";
+import { isString, uniqBy } from "lodash";
 import { useMovieSubtitleModification } from "@/apis/hooks";
 import { Action, Selector } from "@/components/inputs";
 import SimpleTable from "@/components/tables/SimpleTable";
@@ -88,7 +88,7 @@ const MovieUploadForm: FunctionComponent<Props> = ({
 
   const languages = useProfileItemsToLanguages(profile);
   const languageOptions = useSelectorOptions(
-    languages,
+    uniqBy(languages, "code2"),
     (v) => v.name,
     (v) => v.code2,
   );

--- a/frontend/src/components/forms/SeriesUploadForm.tsx
+++ b/frontend/src/components/forms/SeriesUploadForm.tsx
@@ -17,7 +17,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { ColumnDef } from "@tanstack/react-table";
-import { isString } from "lodash";
+import { isString, uniqBy } from "lodash";
 import {
   useEpisodesBySeriesId,
   useEpisodeSubtitleModification,
@@ -100,7 +100,7 @@ const SeriesUploadForm: FunctionComponent<Props> = ({
   const profile = useLanguageProfileBy(series.profileId);
   const languages = useProfileItemsToLanguages(profile);
   const languageOptions = useSelectorOptions(
-    languages,
+    uniqBy(languages, "code2"),
     (v) => v.name,
     (v) => v.code2,
   );

--- a/frontend/src/pages/Movies/index.tsx
+++ b/frontend/src/pages/Movies/index.tsx
@@ -6,6 +6,7 @@ import { faBookmark as farBookmark } from "@fortawesome/free-regular-svg-icons";
 import { faBookmark, faWrench } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { ColumnDef } from "@tanstack/react-table";
+import { uniqueId } from "lodash";
 import { useMovieModification, useMoviesPagination } from "@/apis/hooks";
 import { Action } from "@/components";
 import { AudioList } from "@/components/bazarr";
@@ -95,7 +96,7 @@ const MovieView: FunctionComponent = () => {
                 <Badge
                   mr="xs"
                   color="yellow"
-                  key={BuildKey(v.code2, v.hi, v.forced)}
+                  key={uniqueId(`${BuildKey(v.code2, v.hi, v.forced)}_`)}
                 >
                   <Language.Text value={v}></Language.Text>
                 </Badge>


### PR DESCRIPTION
# Description

Since we use the language profile created by the user to retrieve the languages, there could be duplicated languages being added such as Forced, and HI, since Forced and HI are checkboxes on the Upload. form, we should remove any languages where the code2 are duplicated.

The issue is being fixed for both Series and Movies. Ideally in the future we should discuss again to do not allow duplicated records in the Contact profile.

Closes #2670

> I'm including a fix to similar issue with unique keys in the movie table which is affecting rendering performance.

---

The Checkboxes that were confusing before are now single selection dropdown for Hi and Forced in both Movies or Series:

![Screenshot 2024-09-19 at 10 33 45](https://github.com/user-attachments/assets/c5ce9742-8891-4b34-b6ce-986f20ddb5c1)
