### PR TITLE
Adds the option to skip mismatched fps to Titulky provider

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -328,6 +328,7 @@ validators = [
     Validator('titulky.username', must_exist=True, default='', is_type_of=str, cast=str),
     Validator('titulky.password', must_exist=True, default='', is_type_of=str, cast=str),
     Validator('titulky.approved_only', must_exist=True, default=False, is_type_of=bool),
+    Validator('titulky.skip_wrong_fps', must_exist=True, default=False, is_type_of=bool),
 
     # embeddedsubtitles section
     Validator('embeddedsubtitles.included_codecs', must_exist=True, default=[], is_type_of=list),

--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -284,6 +284,7 @@ def get_providers_auth():
             'username': settings.titulky.username,
             'password': settings.titulky.password,
             'approved_only': settings.titulky.approved_only,
+            'skip_wrong_fps': settings.titulky.skip_wrong_fps,
         },
         'titlovi': {
             'username': settings.titlovi.username,

--- a/custom_libs/subliminal_patch/providers/titulky.py
+++ b/custom_libs/subliminal_patch/providers/titulky.py
@@ -71,7 +71,7 @@ class TitulkySubtitle(Subtitle):
         self.page_link = page_link
         self.uploader = uploader
         self.download_link = download_link
-        self.fps = fps
+        self.fps = fps if skip_wrong_fps else None # This attribute should be ignored if skip_wrong_fps is false
         self.skip_wrong_fps = skip_wrong_fps
         self.asked_for_episode = asked_for_episode
         self.matches = None
@@ -84,14 +84,9 @@ class TitulkySubtitle(Subtitle):
         matches = set()
         media_type = 'movie' if isinstance(video, Movie) else 'episode'
 
-        # video has fps info, sub also, and sub's fps is greater than 0
-        if video.fps and self.fps and not framerate_equal(video.fps, self.fps):
-            if self.skip_wrong_fps:
-                logger.debug(f"Titulky.com: Wrong FPS (expected: {video.fps}, got: {self.fps}, lowering score massively)")
-                # fixme: may be too harsh
-                return set()
-            else:
-                logger.debug(f"Titulky.com: Wrong FPS (expected: {video.fps}, got: {self.fps}, continuing)")
+        if self.skip_wrong_fps and video.fps and self.fps and not framerate_equal(video.fps, self.fps):
+            logger.debug(f"Titulky.com: Wrong FPS (expected: {video.fps}, got: {self.fps}, lowering score massively)")
+            return set()
 
         if media_type == 'episode':
             # match imdb_id of a series
@@ -438,7 +433,7 @@ class TitulkyProvider(Provider, ProviderSubtitleArchiveMixin):
                     'uploader': uploader,
                     'details_link': details_link,
                     'download_link': download_link,
-                    'fps': self.retrieve_subtitles_fps(sub_id),
+                    'fps': self.retrieve_subtitles_fps(sub_id) if skip_wrong_fps else None,
                 }
 
                 # If this row contains the first subtitles to an episode number,

--- a/custom_libs/subliminal_patch/providers/titulky.py
+++ b/custom_libs/subliminal_patch/providers/titulky.py
@@ -142,7 +142,7 @@ class TitulkyProvider(Provider, ProviderSubtitleArchiveMixin):
         if type(approved_only) is not bool:
             raise ConfigurationError(f"Approved_only {approved_only} must be a boolean!")
         if type(skip_wrong_fps) is not bool:
-            raise ConfigurationError(f"Approved_only {approved_only} must be a boolean!")
+            raise ConfigurationError(f"Skip_wrong_fps {skip_wrong_fps} must be a boolean!")
 
         self.username = username
         self.password = password

--- a/custom_libs/subliminal_patch/providers/titulky.py
+++ b/custom_libs/subliminal_patch/providers/titulky.py
@@ -320,7 +320,7 @@ class TitulkyProvider(Provider, ProviderSubtitleArchiveMixin):
         try:
             fps = float(fps_text)
             logger.debug(f"Titulky.com: Retrieved FPS value {fps} from details page for subtitles with id {subtitles_id}")
-            cache.set(cache_key, fps)            
+            cache.set(cache_key, fps)
             return fps
         except:
             logger.debug(f"Titulky.com: There was an error parsing FPS value string for subtitles with id {subtitles_id}")

--- a/frontend/src/pages/Settings/Providers/list.ts
+++ b/frontend/src/pages/Settings/Providers/list.ts
@@ -517,6 +517,11 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
         key: "approved_only",
         name: "Skip unapproved subtitles",
       },
+      {
+        type: "switch",
+        key: "skip_wrong_fps",
+        name: "Skip subtitles with mismatched fps to video's",
+      },
     ],
   },
   {


### PR DESCRIPTION
Proof of concept. 

Do we really want such functionality? To get subtitles fps from the provider, it would cost an extra request per subtitle, but caching is utilized.

~~Untested~~