### PR TITLE
Clear log file contents on Empty log

### DIFF
--- a/bazarr/app/logger.py
+++ b/bazarr/app/logger.py
@@ -172,9 +172,14 @@ def configure_logging(debug=False):
     logging.getLogger("rebulk").setLevel(logging.WARNING)
     logging.getLogger("stevedore.extension").setLevel(logging.CRITICAL)
 
+def empty_file(filename):
+    # Open the log file in write mode to clear its contents
+    with open(filename, 'w'):
+        pass  # Just opening and closing the file will clear it
 
 def empty_log():
     fh.doRollover()
+    empty_file(get_log_file_path())
     logging.info('BAZARR Log file emptied')
 
 


### PR DESCRIPTION
In addition to doing a log file rotation, emptying the log file will now actually empty it. The difference will be noticed if you empty the log file more than once in a given day.