### PR TITLE
Fixed profile item regenerate id when not duplicated

### DIFF
--- a/frontend/src/pages/Settings/Languages/table.tsx
+++ b/frontend/src/pages/Settings/Languages/table.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, useCallback, useMemo } from "react";
 import { Badge, Button, Group } from "@mantine/core";
 import { faTrash, faWrench } from "@fortawesome/free-solid-svg-icons";
 import { ColumnDef } from "@tanstack/react-table";
-import { cloneDeep } from "lodash";
+import { cloneDeep, includes, maxBy } from "lodash";
 import { Action } from "@/components";
 import {
   anyCutoff,
@@ -148,12 +148,24 @@ const Table: FunctionComponent = () => {
                 icon={faWrench}
                 c="gray"
                 onClick={() => {
+                  let ids: number[] = [];
+                  let duplicatedIds: number[] = [];
+                  const lastId = maxBy(profile.items, "id")?.id || 0;
+
                   // We once had an issue on the past where there were duplicated
                   // item ids that needs to become unique upon editing.
                   const sanitizedProfile = {
                     ...cloneDeep(profile),
-                    items: profile.items.map((value, index) => {
-                      return { ...value, id: index + 1 };
+                    items: profile.items.map((value) => {
+                      if (includes(ids, value.id)) {
+                        duplicatedIds = [...duplicatedIds, value.id];
+
+                        return { ...value, id: lastId + duplicatedIds.length };
+                      }
+
+                      ids = [...ids, value.id];
+
+                      return value;
                     }),
                     tag: profile.tag || undefined,
                   };

--- a/frontend/src/pages/Settings/Languages/table.tsx
+++ b/frontend/src/pages/Settings/Languages/table.tsx
@@ -148,25 +148,39 @@ const Table: FunctionComponent = () => {
                 icon={faWrench}
                 c="gray"
                 onClick={() => {
-                  let ids: number[] = [];
-                  let duplicatedIds: number[] = [];
                   const lastId = maxBy(profile.items, "id")?.id || 0;
 
                   // We once had an issue on the past where there were duplicated
                   // item ids that needs to become unique upon editing.
                   const sanitizedProfile = {
                     ...cloneDeep(profile),
-                    items: profile.items.map((value) => {
-                      if (includes(ids, value.id)) {
-                        duplicatedIds = [...duplicatedIds, value.id];
+                    items: profile.items.reduce(
+                      (acc, value) => {
+                        const { ids, duplicatedIds, items } = acc;
 
-                        return { ...value, id: lastId + duplicatedIds.length };
-                      }
+                        // We once had an issue on the past where there were duplicated
+                        // item ids that needs to become unique upon editing.
+                        if (includes(ids, value.id)) {
+                          duplicatedIds.push(value.id);
+                          items.push({
+                            ...value,
+                            id: lastId + duplicatedIds.length,
+                          });
 
-                      ids = [...ids, value.id];
+                          return acc;
+                        }
 
-                      return value;
-                    }),
+                        ids.push(value.id);
+                        items.push(value);
+
+                        return acc;
+                      },
+                      {
+                        ids: [] as number[],
+                        duplicatedIds: [] as number[],
+                        items: [] as typeof profile.items,
+                      },
+                    ).items,
                     tag: profile.tag || undefined,
                   };
 


### PR DESCRIPTION
Only regenerate the profile item id when it is duplicated and always preserve the cutoff.

Since we can have multiple duplicates, the ID will always be the last id + the length of the duplicated items.