### PR TITLE
Fixed duplicated search result name for series and movies

### DIFF
--- a/frontend/src/components/Search.tsx
+++ b/frontend/src/components/Search.tsx
@@ -18,16 +18,20 @@ function useSearch(query: string) {
   return useMemo<SearchResultItem[]>(
     () =>
       data?.map((v) => {
-        let link: string;
-        if (v.sonarrSeriesId) {
-          link = `/series/${v.sonarrSeriesId}`;
-        } else if (v.radarrId) {
-          link = `/movies/${v.radarrId}`;
-        } else {
+        const { link, typeLabel } = (() => {
+          if (v.sonarrSeriesId) {
+            return { link: `/series/${v.sonarrSeriesId}`, typeLabel: "S" };
+          }
+
+          if (v.radarrId) {
+            return { link: `/movies/${v.radarrId}`, typeLabel: "M" };
+          }
+
           throw new Error("Unknown search result");
-        }
+        })();
+
         return {
-          value: `${v.title} (${v.year})`,
+          value: `${v.title} (${v.year}) (${typeLabel})`,
           link,
         };
       }) ?? [],


### PR DESCRIPTION
# Description

Closes #2674

Since we perform a global search that unions Series and Movies from sonarr and radarr, there is a chance of having the same Movie and TV Show that belongs to the same year causing a conflict in the auto complete, and also the users won't know which one is the one they are looking for.

As a "fix" to prevent duplicated records, we appended `(S)` or `(M)` to represent if the result are from Movies or Series. This way you can visual identify what if the result is either a TV Show or Movie.

![image](https://github.com/user-attachments/assets/20919d11-b4d5-4b2d-b7a5-337460afa638)


> In favor to immutability the `let` is being dropped and refactoring in the frontend codebase.