### PR TITLE
Disabled chinese hi auto detection

### DIFF
--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -54,8 +54,13 @@ HI_REGEX_WITH_PARENTHESIS = re.compile(r'[*¶♫♪].{3,}[*¶♫♪]|[\[\(\{].{3
 
 HI_REGEX_PARENTHESIS_EXCLUDED_LANGUAGES = ['ara']
 
+HI_REGEX_DISABLED_LANGUAGES = ['zho']
+
 
 def parse_for_hi_regex(subtitle_text, alpha3_language):
+    if alpha3_language in HI_REGEX_DISABLED_LANGUAGES:
+        return False
+
     if alpha3_language in HI_REGEX_PARENTHESIS_EXCLUDED_LANGUAGES:
         return bool(re.search(HI_REGEX_WITHOUT_PARENTHESIS, subtitle_text))
     else:


### PR DESCRIPTION
# Description

Disable HI detection for Chinese languages. I'm not an specialist, but according to an user that frequently uses Chinese subtitles has never seem a HI subtitle before, and the usage of `[]` is not intended to identify environment sounds nor anything related, and it is most likely indicators of place, etc.