### PR TITLE
When multiple audio streams exist, pick the correct one for whisper to process

### DIFF
--- a/custom_libs/subliminal_patch/providers/whisperai.py
+++ b/custom_libs/subliminal_patch/providers/whisperai.py
@@ -16,7 +16,7 @@ from babelfish.exceptions import LanguageReverseError
 
 import ffmpeg
 import functools
-import pycountry
+from pycountry import languages
 
 # These are all the languages Whisper supports.
 # from whisper.tokenizer import LANGUAGES
@@ -139,7 +139,7 @@ set_log_level()
 #                   or 'fre' instead of 'fra' for the French language
 def get_ISO_639_2_code(iso639_3_code):
     # find the language using ISO 639-3 code
-    language = pycountry.languages.get(alpha_3=iso639_3_code)
+    language = languages.get(alpha_3=iso639_3_code)
     # get the ISO 639-2 code or use the original input if there isn't a match
     iso639_2_code = language.bibliographic if language and hasattr(language, 'bibliographic') else iso639_3_code
     logger.debug(f"ffmpeg using language code '{iso639_2_code}' (instead of '{iso639_3_code}')")


### PR DESCRIPTION
ffmpeg uses the older ISO 639-2 code when extracting audio streams based on language. 
If we give it the newer ISO 639-3 code it won't find the audio stream because its trying to match it by name.
So, convert the newer code to the older code only for use by ffmpeg when determining which audio stream to extract.