### PR TITLE
no log: Bump axios from 1.6.8 to 1.7.4 in /frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,7 @@
         "@mantine/notifications": "^7.12.2",
         "@tanstack/react-query": "^5.40.1",
         "@tanstack/react-table": "^8.19.2",
-        "axios": "^1.6.8",
+        "axios": "^1.7.4",
         "braces": "^3.0.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -4696,9 +4696,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
     "@mantine/notifications": "^7.12.2",
     "@tanstack/react-query": "^5.40.1",
     "@tanstack/react-table": "^8.19.2",
-    "axios": "^1.6.8",
+    "axios": "^1.7.4",
     "braces": "^3.0.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",


### PR DESCRIPTION
# Description

The security issue of dependabot was for default targeting `master` on #2658 and was merged for mistake instead of being merged into `development`.