### PR TITLE
Providers/Embedded: Fix bad non-HI fallback with forced subtitles

### DIFF
--- a/custom_libs/subliminal_patch/providers/embeddedsubtitles.py
+++ b/custom_libs/subliminal_patch/providers/embeddedsubtitles.py
@@ -287,7 +287,7 @@ def _check_hi_fallback(streams, languages):
         logger.debug("Checking HI fallback for '%r' language", language)
 
         streams_ = [
-            stream for stream in streams if stream.language.alpha3 == language.alpha3
+            stream for stream in streams if stream.language.alpha3 == language.alpha3 and stream.language.forced == language.forced
         ]
         if len(streams_) == 1 and streams_[0].disposition.hearing_impaired:
             stream_ = streams_[0]


### PR DESCRIPTION
The HI fallback logic's language check ignores the forced flag and doesn't fall back to HI when no subtitle without HI is found, but a forced one is.