### PR TITLE
Added Anilist error log when the record exists on mapping but does not enrich with Anilist id

### DIFF
--- a/bazarr/subtitles/refiners/anilist.py
+++ b/bazarr/subtitles/refiners/anilist.py
@@ -43,10 +43,15 @@ class AniListClient(object):
         logger.debug(f"Based on '{mapped_tag}': '{candidate_id_value}', anime-list matched: {obj}")
 
         if len(obj) > 0:
-            return obj[0]["anilist_id"]
+            anilist_id = obj[0].get("anilist_id")
+            if not anilist_id:
+                logger.error("This entry does not have an AniList ID")
+            
+            return anilist_id
         else:
             logger.debug(f"Could not find corresponding AniList ID with '{mapped_tag}': {candidate_id_value}")
-            return None
+        
+        return None
 
 
 def refine_from_anilist(path, video):


### PR DESCRIPTION
This change prevents the refiner from throwing an error in situations where matched entries in the [reference list](https://github.com/Fribb/anime-lists/) don't have an `anilist_id` attribute, as it is the case with this entry (at time of writing):  
```pwsh
> $list | ? imdb_id -eq "tt3138698"

thetvdb_id    : 102261
imdb_id       : tt3138698
anisearch_id  : 6334
themoviedb_id : 357786
anidb_id      : 8357
type          : MOVIE
```