### PR TITLE
Fixed anidb refiner special episode without offset

### DIFF
--- a/bazarr/subtitles/refiners/anidb.py
+++ b/bazarr/subtitles/refiners/anidb.py
@@ -91,11 +91,11 @@ class AniDBClient(object):
                 return None, None, None
 
             is_special_entry = True
+
             for special_entry in special_entries:
                 mapping_list = special_entry.findall(f".//mapping[@tvdbseason='{tvdb_series_season}']")
-                if len(mapping_list) > 0:
-                    anidb_id = int(special_entry.attrib.get('anidbid'))
-                    offset = int(mapping_list[0].attrib.get('offset', 0))
+                anidb_id = int(special_entry.attrib.get('anidbid'))
+                offset = int(mapping_list[0].attrib.get('offset', 0)) if len(mapping_list) > 0 else 0
 
         if not is_special_entry:
             # Sort the anime by offset in ascending order


### PR DESCRIPTION
# Description

There are records of special episode types that are supposed to be using the the special tvdb season but they don't contain any mapping and use absolute episode numberings that fails with `(cannot access local variable 'anidb_id' where it is not associated with a value) trying to get video information for this file:`

The anidb_id does not depend of the mappings and can be moved outside of the if statement. Also the offset should be set to `0` if the mappings are not present.

```xml
 <anime anidbid="2766" tvdbid="76113" defaulttvdbseason="a">
    <name>Yuu Gi Ou: Duel Monsters GX</name>
  </anime>
```

```xml
 <anime anidbid="2908" tvdbid="72858" defaulttvdbseason="a">
    <name>Monster Farm: Enbanseki no Himitsu</name>
  </anime>
```

```xml
<anime anidbid="3626" tvdbid="286895" defaulttvdbseason="a">
    <name>Nintama Rantarou</name>
  </anime>
```