### PR TITLE
Handle bad response from provider

### DIFF
--- a/custom_libs/subliminal_patch/providers/subsynchro.py
+++ b/custom_libs/subliminal_patch/providers/subsynchro.py
@@ -6,6 +6,7 @@ import os
 from zipfile import ZipFile, is_zipfile
 from requests import Session
 from guessit import guessit
+from requests.exceptions import JSONDecodeError
 
 from subliminal import Movie
 from subliminal.subtitle import SUBTITLE_EXTENSIONS, fix_line_ending
@@ -91,7 +92,11 @@ class SubsynchroProvider(Provider):
         result.raise_for_status()
 
         subtitles = []
-        results = result.json() or {}
+
+        try:
+            results = result.json()
+        except JSONDecodeError:
+            results = {}
 
         status_ = results.get("status")
 


### PR DESCRIPTION
Fix for issue #2735 
When the subtitle is not found for the given show, the website returns the following content along with JSON which makes it not parseable as JSON:

'<br />\n<b>Warning</b>:  Undefined variable $data in <b>/home/subsynch/www/include/ajax/subMarin.php</b> on line <b>57</b><br />\n{"status":403,"data":null}'