### PR TITLE
Added boolean switch to control passing of video filename to whisper

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -274,6 +274,7 @@ validators = [
     Validator('whisperai.endpoint', must_exist=True, default='http://127.0.0.1:9000', is_type_of=str),
     Validator('whisperai.response', must_exist=True, default=5, is_type_of=int, gte=1),
     Validator('whisperai.timeout', must_exist=True, default=3600, is_type_of=int, gte=1),
+    Validator('whisperai.pass_video_name', must_exist=True, default=False, is_type_of=bool),
     Validator('whisperai.loglevel', must_exist=True, default='INFO', is_type_of=str,
               is_in=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']),
 

--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -330,6 +330,7 @@ def get_providers_auth():
             'timeout': settings.whisperai.timeout,
             'ffmpeg_path': _FFMPEG_BINARY,
             'loglevel': settings.whisperai.loglevel,
+            'pass_video_name': settings.whisperai.pass_video_name,
         },
         "animetosho": {
             'search_threshold': settings.animetosho.search_threshold,

--- a/frontend/src/pages/Settings/Providers/list.ts
+++ b/frontend/src/pages/Settings/Providers/list.ts
@@ -562,6 +562,12 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
         options: logLevelOptions,
       },
       {
+        type: "switch",
+        key: "pass_video_name",
+        name: "Pass video filename to Whisper (for logging)",
+        defaultValue: false,
+      },
+      {
         type: "testbutton",
         key: "whisperai",
         name: "Test Connection button",


### PR DESCRIPTION
This is done solely to aid debug logging in implementations of whisper like Subgen. For privacy concerns with remote whisper providers, this switch is initially false but can be changed in the whisper provider modal.