### PR TITLE
Added matches dialog alert and column titles

### DIFF
--- a/frontend/src/components/StateIcon.tsx
+++ b/frontend/src/components/StateIcon.tsx
@@ -1,6 +1,15 @@
 import { FunctionComponent } from "react";
-import { Alert, Flex, Group, List, Popover, Stack, Text } from "@mantine/core";
-import { useHover } from "@mantine/hooks";
+import {
+  Alert,
+  em,
+  Flex,
+  Group,
+  List,
+  Popover,
+  Stack,
+  Text,
+} from "@mantine/core";
+import { useHover, useMediaQuery } from "@mantine/hooks";
 import {
   faCheckCircle,
   faExclamationCircle,
@@ -26,6 +35,8 @@ const StateIcon: FunctionComponent<StateIconProps> = ({
 
   const { hovered, ref } = useHover();
 
+  const isMobile = useMediaQuery(`(max-width: ${em(750)})`);
+
   const PopoverTarget: FunctionComponent = () => {
     if (isHistory) {
       return <FontAwesomeIcon icon={faListCheck} />;
@@ -48,10 +59,15 @@ const StateIcon: FunctionComponent<StateIconProps> = ({
         </Text>
       </Popover.Target>
       <Popover.Dropdown>
-        <Alert variant="light" color="blue" mb="sm">
-          Not matching attributes will not prevent the subtitle to be downloaded
-          and are strictly used for scoring the subtitle.
-        </Alert>
+        <Text size="xl" ta="center">
+          Scoring Criteria
+        </Text>
+        {isMobile ? null : (
+          <Alert variant="light" color="blue" mb="sm">
+            Not matching attributes will not prevent the subtitle to be
+            downloaded and are strictly used for scoring the subtitle.
+          </Alert>
+        )}
         <Group justify="left" gap="xl" wrap="nowrap" grow>
           <Stack align="flex-start" justify="flex-start" gap="xs" mb="auto">
             <Flex gap="sm">

--- a/frontend/src/components/StateIcon.tsx
+++ b/frontend/src/components/StateIcon.tsx
@@ -1,12 +1,12 @@
 import { FunctionComponent } from "react";
-import { Group, List, Popover, Stack, Text } from "@mantine/core";
+import { Alert, Flex, Group, List, Popover, Stack, Text } from "@mantine/core";
 import { useHover } from "@mantine/hooks";
 import {
-  faCheck,
   faCheckCircle,
   faExclamationCircle,
   faListCheck,
-  faTimes,
+  faMinus,
+  faPlus,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { BuildKey } from "@/utilities";
@@ -48,11 +48,18 @@ const StateIcon: FunctionComponent<StateIconProps> = ({
         </Text>
       </Popover.Target>
       <Popover.Dropdown>
+        <Alert variant="light" color="blue" mb="sm">
+          Not matching attributes will not prevent the subtitle to be downloaded
+          and are strictly used for scoring the subtitle.
+        </Alert>
         <Group justify="left" gap="xl" wrap="nowrap" grow>
           <Stack align="flex-start" justify="flex-start" gap="xs" mb="auto">
-            <Text c="green">
-              <FontAwesomeIcon icon={faCheck}></FontAwesomeIcon>
-            </Text>
+            <Flex gap="sm">
+              <Text c="green">
+                <FontAwesomeIcon icon={faPlus}></FontAwesomeIcon>
+              </Text>
+              <Text c="green">Matching</Text>
+            </Flex>
             <List>
               {matches.map((v, idx) => (
                 <List.Item key={BuildKey(idx, v, "match")}>{v}</List.Item>
@@ -60,9 +67,12 @@ const StateIcon: FunctionComponent<StateIconProps> = ({
             </List>
           </Stack>
           <Stack align="flex-start" justify="flex-start" gap="xs" mb="auto">
-            <Text c="yellow">
-              <FontAwesomeIcon icon={faTimes}></FontAwesomeIcon>
-            </Text>
+            <Flex gap="sm">
+              <Text c="yellow">
+                <FontAwesomeIcon icon={faMinus}></FontAwesomeIcon>
+              </Text>
+              <Text c="yellow">Not Matching</Text>
+            </Flex>
             <List>
               {dont.map((v, idx) => (
                 <List.Item key={BuildKey(idx, v, "miss")}>{v}</List.Item>


### PR DESCRIPTION
# Description

Since the match is not intuitive and it is not clear what is the attribute used for, added a title for the attributes and an alert to explain what are the matching attributes for on the top of the dialog, it has been hidden.

> The usability in mobile is affected if we increase the height too much of the modal specially because we can't scroll on this dialog desktop since it only opens on hover.

# Preview

| Desktop | Mobile |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/10d4d9dc-0d5d-48b3-bd37-7627e476c4e0) | ![image](https://github.com/user-attachments/assets/797c857e-33af-4c79-8119-59ed4636e915)