### PR TITLE
Fixed item overview path label overflow

### DIFF
--- a/frontend/src/pages/views/ItemOverview.tsx
+++ b/frontend/src/pages/views/ItemOverview.tsx
@@ -49,7 +49,15 @@ const ItemOverview: FunctionComponent<Props> = (props) => {
 
     if (item) {
       badges.push(
-        <ItemBadge key="file-path" icon={faFolder} title="File Path">
+        <ItemBadge
+          key="file-path"
+          icon={faFolder}
+          title="File Path"
+          styles={{
+            root: { overflow: "unset" },
+            label: { overflow: "hidden" },
+          }}
+        >
           <Tooltip
             label={item.path}
             multiline


### PR DESCRIPTION
# Description

The default style of the `ItemBadge` is centered and allow overflow causing unexpected behavior when used for long texts such as the Item Overview Path label.

Overwrite the global values to apply specific behavior to the label.