### PR TITLE
Fixed EmbeddedSubtitles provider results caching

### DIFF
--- a/custom_libs/subliminal_patch/providers/embeddedsubtitles.py
+++ b/custom_libs/subliminal_patch/providers/embeddedsubtitles.py
@@ -255,8 +255,6 @@ class EmbeddedSubtitlesProvider(Provider):
 
 
 class _MemoizedFFprobeVideoContainer(FFprobeVideoContainer):
-    # 128 is the default value for maxsize since Python 3.8. We ste it here for previous versions.
-    @functools.lru_cache(maxsize=128)
     def get_subtitles(self, *args, **kwargs):
         return super().get_subtitles(*args, **kwargs)
 


### PR DESCRIPTION
Caching was removed because it caused erroneous results if the provider settings were changed. It still used the old settings until a restart.