### PR TITLE
Fix podnapisi.net not returning results

### DIFF
--- a/custom_libs/subliminal_patch/providers/podnapisi.py
+++ b/custom_libs/subliminal_patch/providers/podnapisi.py
@@ -209,7 +209,7 @@ class PodnapisiProvider(_PodnapisiProvider, ProviderSubtitleArchiveMixin):
                 break
 
             # exit if no results
-            if (not xml.find('pagination/results') or not xml.find('pagination/results').text or not
+            if (xml.find('pagination/results') is None or not xml.find('pagination/results').text or not
                     int(xml.find('pagination/results').text)):
                 logger.debug('No subtitles found')
                 break


### PR DESCRIPTION
Fixes the following issue which always triggered no results condition.
```
/app/bazarr/bin/bazarr/../custom_libs/subliminal_patch/providers/podnapisi.py:212: FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
  if (not xml.find('pagination/results') or not xml.find('pagination/results').text or not
```

This would result in bazarr iterating over all alternative titles and eventually triggering 
`WARNING (api:40) - HTTPSConnectionPool(host='www.podnapisi.net', port=443): Read timed out. (read timeout=30), retrying in 5 seconds...`

The above still happens because podnapisi.net is utterly broken, but now it at least sometimes returns results.