### PR TITLE
Shorter timespan for retrying Opensubtitles.com API

### DIFF
--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -90,7 +90,7 @@ def provider_throttle_map():
         },
         "opensubtitlescom": {
             TooManyRequests: (datetime.timedelta(minutes=1), "1 minute"),
-            DownloadLimitExceeded: (datetime.timedelta(hours=24), "24 hours"),
+            DownloadLimitExceeded: (datetime.timedelta(hours=6), "6 hours"),
         },
         "addic7ed": {
             DownloadLimitExceeded: (datetime.timedelta(hours=3), "3 hours"),


### PR DESCRIPTION
Gives a higher chance of leveraging the full download quota after it was exceeded on the previous day, independently of the schedule of search tasks.