### PR TITLE
Fix incorrect path joining for UNC paths - Use direct full path to movie file from Radarr

### DIFF
--- a/bazarr/radarr/sync/parser.py
+++ b/bazarr/radarr/sync/parser.py
@@ -124,7 +124,7 @@ def movieParser(movie, action, tags_dict, language_profiles, movie_default_profi
 
         parsed_movie = {'radarrId': int(movie["id"]),
                         'title': movie["title"],
-                        'path': os.path.join(movie["path"], movie['movieFile']['relativePath']),
+                        'path': movie['movieFile']['path'],
                         'tmdbId': str(movie["tmdbId"]),
                         'poster': poster,
                         'fanart': fanart,


### PR DESCRIPTION
### Context
I was using the docker container and had to use path mapping, and couldn't get it to show any subtitle search results for any movies. 

I have my video files on a NAS, so I have the paths looking like this in Sonarr/Radarr, where the files use a UNC path:
`\\192.168.1.xxx\path\to\show\season\episode.mkv`
`\\192.168.1.xxx\path\to\WhateverMoviesFolder\movie.mkv`

### Non-Root Cause

Turns out that the file paths Bazarr was using after fetching the info from Radarr was not correct. For example, `parsed_movie.path` after escaping would end up being `\\\\192.168.1.xxx\\path\\to\\WhateverMoviesFolder/movie.mkv` (Note the forward slash).
 
And even after the path went through `path_replace_movie` or `path_replace_reverse_movie`, the incorrect slash in front of the file name was still there, and would cause the search to fail. Because in `bazarr/subtitles/refinders/database.py`, when this line compares the paths, the forward slash (which would appar in `TableMovies.path` but not `path` for some reason), would not match and cause it to fail to find what movie was being searched, therefore not ever getting any results.
`.where(TableMovies.path == path_mappings.path_replace_reverse_movie(path))) \`

### Root Cause
In the parser that gets the movie info from the Radarr API (`bazarr/radarr/sync/parser.py`), even though Radarr was correctly returning the info in these two properties:
- `movie["path"]` → `\\\\192.168.1.xxx\\path\\to\\WhateverMoviesFolder`
- `movie['movieFile']['relativePath']` → `movie.mkv`

...Apparently `os.path.join` doesn't recognize the UNC path with the extra escaped slashes (or maybe it wouldn't recognize a UNC path regardless, not sure), and so this line ends up causing that incorrect path with the forward slash I mentioned above:
`'path': os.path.join(movie["path"], movie['movieFile']['relativePath']),`

You can see this here, I just added a Watch in VSCode on the after/before with the fix:

<img width="1015" alt="image" src="https://github.com/user-attachments/assets/43105802-f202-4d71-a68e-644de8d2a87c" />


----------

### Solution (This pull request)

Fortunately the Radarr API also has a property that returns the complete path to the video file all in one, so we can use that instead of getting the separate parts and joining them, so we can do this:
` movie['movieFile']['path']` →   `\\\\192.168.1.xxx\\path\\to\\WhateverMoviesFolder\\movie.mkv`

(See the screenshot in the previous section for result)

----

#### Extra Note:

This appears to only be an issue with the info from Radarr, not Sonarr. `parser.py` for Sonarr already appears to use the equivalent to direct path so it already gets the correct full path:
`'path': episode['episodeFile']['path'],`

So there is even precedent for this pull request's change since that's how the Sonarr parser works.