### PR TITLE
Mods/Fix Uppercase: Fix broken uppercase detection in certain cases

### DIFF
--- a/custom_libs/subzero/modification/main.py
+++ b/custom_libs/subzero/modification/main.py
@@ -199,7 +199,7 @@ class SubtitleModifications(object):
                 entry_used = True
             else:
                 # skip full entry
-                break
+                continue
 
             if entry_used:
                 entries_used += 1


### PR DESCRIPTION
When a stripped entry of a subtitle is empty, the whole subtitle is considered uppercased and is fixed erroneously, if the modification is enabled (oversight from previous commit on this mod; we break the for loop instead of continuing)