### PR TITLE
fix(zimuku): Wrong archives subtitle language identified

### DIFF
--- a/custom_libs/subliminal_patch/providers/zimuku.py
+++ b/custom_libs/subliminal_patch/providers/zimuku.py
@@ -177,31 +177,40 @@ class ZimukuProvider(Provider):
             ]  # remove ext because it can be an archive type
 
             language = Language("eng")
+            language_list = []
+
             for img in sub.find("td", class_="tac lang").find_all("img"):
                 if (
                         "china" in img.attrs["src"]
                         and "hongkong" in img.attrs["src"]
                 ):
-                    language = Language("zho").add(Language('zho', 'TW', None))
                     logger.debug("language:" + str(language))
+                    
+                    language = Language("zho").add(Language('zho', 'TW', None))
+                    language_list.append(language)
                 elif (
                         "china" in img.attrs["src"]
                         or "jollyroger" in img.attrs["src"]
                 ):
-                    language = Language("zho")
                     logger.debug("language chinese simplified found: " + str(language))
-                    break
+
+                    language = Language("zho")
+                    language_list.append(language)
                 elif "hongkong" in img.attrs["src"]:
-                    language = Language('zho', 'TW', None)
                     logger.debug("language chinese traditional found: " + str(language))
-                    break
+
+                    language = Language('zho', 'TW', None)
+                    language_list.append(language)
             sub_page_link = urljoin(self.server_url, a.attrs["href"])
             backup_session = copy.deepcopy(self.session)
             backup_session.headers["Referer"] = link
 
-            subs.append(
-                self.subtitle_class(language, sub_page_link, name, backup_session, year)
-            )
+            # Mark each language of the subtitle as its own subtitle, and add it to the list, when handling archives or subtitles with multiple languages
+            # to ensure each language is downloaded separately.
+            for language in language_list:
+                subs.append(
+                    self.subtitle_class(language, sub_page_link, name, backup_session, year)
+                )
 
         return subs
 

--- a/custom_libs/subliminal_patch/providers/zimuku.py
+++ b/custom_libs/subliminal_patch/providers/zimuku.py
@@ -189,8 +189,11 @@ class ZimukuProvider(Provider):
                         or "jollyroger" in img.attrs["src"]
                 ):
                     language = Language("zho")
+                    logger.debug("language chinese simplified found: " + str(language))
+                    break
                 elif "hongkong" in img.attrs["src"]:
                     language = Language('zho', 'TW', None)
+                    logger.debug("language chinese traditional found: " + str(language))
                     break
             sub_page_link = urljoin(self.server_url, a.attrs["href"])
             backup_session = copy.deepcopy(self.session)

--- a/custom_libs/subliminal_patch/providers/zimuku.py
+++ b/custom_libs/subliminal_patch/providers/zimuku.py
@@ -205,8 +205,9 @@ class ZimukuProvider(Provider):
             backup_session = copy.deepcopy(self.session)
             backup_session.headers["Referer"] = link
 
-            # Mark each language of the subtitle as its own subtitle, and add it to the list, when handling archives or subtitles with multiple languages
-            # to ensure each language is downloaded separately.
+            # Mark each language of the subtitle as its own subtitle, and add it to the list, when handling archives or subtitles
+            # with multiple languages to ensure each language is identified as its own subtitle since they are the same archive file
+            # but will have its own file when downloaded and extracted.
             for language in language_list:
                 subs.append(
                     self.subtitle_class(language, sub_page_link, name, backup_session, year)


### PR DESCRIPTION
# Description

One of the issues is the way we use to identify the language on Zimuku based on the country flags and we always mark a subtitle of a specific language, however there are subtitle packs that contains multiple languages inside of a zip file, take as example [太太请小心轻放 电影版 劇場版 奥様は、取り扱い注意 (2021) ](https://zimuku.org/detail/159083.html)

![Screenshot 2025-02-23 at 21 52 34](https://github.com/user-attachments/assets/6ae3d941-4344-4761-accf-8be5c44af8eb)

This is one example where the archive contains both `Chinese Traditional` and `Chinese Simplified`. It may contain other languages asides chinese as well but it follows the same pattern.

Fix #2832
