### PR TITLE
Add option to include language only when matching audio

### DIFF
--- a/bazarr/app/database.py
+++ b/bazarr/app/database.py
@@ -531,6 +531,9 @@ def upgrade_languages_profile_hi_values():
                 language['hi'] = "True"
             elif language['hi'] in ["also", "never"]:
                 language['hi'] = "False"
+
+            if 'audio_only_include' not in language:
+                language['audio_only_include'] = "False"
         database.execute(
             update(TableLanguagesProfiles)
             .values({"items": json.dumps(items)})

--- a/bazarr/app/database.py
+++ b/bazarr/app/database.py
@@ -512,7 +512,7 @@ def convert_list_to_clause(arr: list):
         return ""
 
 
-def upgrade_languages_profile_hi_values():
+def upgrade_languages_profile_values():
     for languages_profile in (database.execute(
             select(
                 TableLanguagesProfiles.profileId,

--- a/bazarr/main.py
+++ b/bazarr/main.py
@@ -35,7 +35,7 @@ else:
     # there's missing embedded packages after a commit
     check_if_new_update()
 
-from app.database import (System, database, update, migrate_db, create_db_revision, upgrade_languages_profile_hi_values,
+from app.database import (System, database, update, migrate_db, create_db_revision, upgrade_languages_profile_values,
                           fix_languages_profiles_with_duplicate_ids)  # noqa E402
 from app.notifier import update_notifier  # noqa E402
 from languages.get_languages import load_language_in_db  # noqa E402
@@ -50,7 +50,7 @@ if args.create_db_revision:
     stop_bazarr(EXIT_NORMAL)
 else:
     migrate_db(app)
-    upgrade_languages_profile_hi_values()
+    upgrade_languages_profile_values()
     fix_languages_profiles_with_duplicate_ids()
 
 configure_proxy_func()

--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -170,6 +170,9 @@ def list_missing_subtitles_movies(no=None, send_event=True):
 
     use_embedded_subs = settings.general.use_embedded_subs
 
+    matches_audio = lambda language: any(x['code2'] == language['language'] for x in get_audio_profile_languages(
+                                movie_subtitles.audio_language))
+
     for movie_subtitles in movies_subtitles:
         missing_subtitles_text = '[]'
         if movie_subtitles.profileId:
@@ -179,8 +182,10 @@ def list_missing_subtitles_movies(no=None, send_event=True):
             if desired_subtitles_temp:
                 for language in desired_subtitles_temp['items']:
                     if language['audio_exclude'] == "True":
-                        if any(x['code2'] == language['language'] for x in get_audio_profile_languages(
-                                movie_subtitles.audio_language)):
+                        if matches_audio(language):
+                            continue
+                    if language['audio_only_include'] == "True":
+                        if not matches_audio(language):
                             continue
                     desired_subtitles_list.append({'language': language['language'],
                                                    'forced': language['forced'],
@@ -219,9 +224,9 @@ def list_missing_subtitles_movies(no=None, send_event=True):
                     cutoff_language = {'language': cutoff_temp['language'],
                                        'forced': cutoff_temp['forced'],
                                        'hi': cutoff_temp['hi']}
-                    if cutoff_temp['audio_exclude'] == 'True' and \
-                            any(x['code2'] == cutoff_temp['language'] for x in
-                                get_audio_profile_languages(movie_subtitles.audio_language)):
+                    if cutoff_temp['audio_only_include'] == 'True' and not matches_audio(cutoff_temp):
+                        cutoff_met = True
+                    elif cutoff_temp['audio_exclude'] == 'True' and matches_audio(cutoff_temp):
                         cutoff_met = True
                     elif cutoff_language in actual_subtitles_list:
                         cutoff_met = True

--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -225,8 +225,11 @@ def list_missing_subtitles_movies(no=None, send_event=True):
                                        'forced': cutoff_temp['forced'],
                                        'hi': cutoff_temp['hi']}
                     if cutoff_temp['audio_only_include'] == 'True' and not matches_audio(cutoff_temp):
+                        # We don't want subs in this language unless it matches
+                        # the audio. Don't use it to meet the cutoff.
                         continue
                     elif cutoff_temp['audio_exclude'] == 'True' and matches_audio(cutoff_temp):
+                        # The cutoff is met through one of the audio tracks.
                         cutoff_met = True
                     elif cutoff_language in actual_subtitles_list:
                         cutoff_met = True

--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -152,21 +152,15 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True):
 
 
 def list_missing_subtitles_movies(no=None, send_event=True):
+    stmt = select(TableMovies.radarrId,
+                  TableMovies.subtitles,
+                  TableMovies.profileId,
+                  TableMovies.audio_language)
+
     if no:
-        movies_subtitles = database.execute(
-            select(TableMovies.radarrId,
-                   TableMovies.subtitles,
-                   TableMovies.profileId,
-                   TableMovies.audio_language)
-            .where(TableMovies.radarrId == no)) \
-            .all()
+        movies_subtitles = database.execute(stmt.where(TableMovies.radarrId == no)).all()
     else:
-        movies_subtitles = database.execute(
-            select(TableMovies.radarrId,
-                   TableMovies.subtitles,
-                   TableMovies.profileId,
-                   TableMovies.audio_language)) \
-            .all()
+        movies_subtitles = database.execute(stmt).all()
 
     use_embedded_subs = settings.general.use_embedded_subs
 

--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -225,7 +225,7 @@ def list_missing_subtitles_movies(no=None, send_event=True):
                                        'forced': cutoff_temp['forced'],
                                        'hi': cutoff_temp['hi']}
                     if cutoff_temp['audio_only_include'] == 'True' and not matches_audio(cutoff_temp):
-                        cutoff_met = True
+                        continue
                     elif cutoff_temp['audio_exclude'] == 'True' and matches_audio(cutoff_temp):
                         cutoff_met = True
                     elif cutoff_language in actual_subtitles_list:

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -170,6 +170,9 @@ def list_missing_subtitles(no=None, epno=None, send_event=True):
 
     use_embedded_subs = settings.general.use_embedded_subs
 
+    matches_audio = lambda language: any(x['code2'] == language['language'] for x in get_audio_profile_languages(
+                                episode_subtitles.audio_language))
+
     for episode_subtitles in episodes_subtitles:
         missing_subtitles_text = '[]'
         if episode_subtitles.profileId:
@@ -179,8 +182,10 @@ def list_missing_subtitles(no=None, epno=None, send_event=True):
             if desired_subtitles_temp:
                 for language in desired_subtitles_temp['items']:
                     if language['audio_exclude'] == "True":
-                        if any(x['code2'] == language['language'] for x in get_audio_profile_languages(
-                                episode_subtitles.audio_language)):
+                        if matches_audio(language):
+                            continue
+                    if language['audio_only_include'] == "True":
+                        if not matches_audio(language):
                             continue
                     desired_subtitles_list.append({'language': language['language'],
                                                    'forced': language['forced'],
@@ -219,9 +224,9 @@ def list_missing_subtitles(no=None, epno=None, send_event=True):
                     cutoff_language = {'language': cutoff_temp['language'],
                                        'forced': cutoff_temp['forced'],
                                        'hi': cutoff_temp['hi']}
-                    if cutoff_temp['audio_exclude'] == 'True' and \
-                            any(x['code2'] == cutoff_temp['language'] for x in
-                                get_audio_profile_languages(episode_subtitles.audio_language)):
+                    if cutoff_temp['audio_only_include'] == 'True' and not matches_audio(cutoff_temp):
+                        cutoff_met = True
+                    elif cutoff_temp['audio_exclude'] == 'True' and matches_audio(cutoff_temp):
                         cutoff_met = True
                     elif cutoff_language in actual_subtitles_list:
                         cutoff_met = True

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -225,8 +225,11 @@ def list_missing_subtitles(no=None, epno=None, send_event=True):
                                        'forced': cutoff_temp['forced'],
                                        'hi': cutoff_temp['hi']}
                     if cutoff_temp['audio_only_include'] == 'True' and not matches_audio(cutoff_temp):
+                        # We don't want subs in this language unless it matches
+                        # the audio. Don't use it to meet the cutoff.
                         continue
                     elif cutoff_temp['audio_exclude'] == 'True' and matches_audio(cutoff_temp):
+                        # The cutoff is met through one of the audio tracks.
                         cutoff_met = True
                     elif cutoff_language in actual_subtitles_list:
                         cutoff_met = True

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -225,7 +225,7 @@ def list_missing_subtitles(no=None, epno=None, send_event=True):
                                        'forced': cutoff_temp['forced'],
                                        'hi': cutoff_temp['hi']}
                     if cutoff_temp['audio_only_include'] == 'True' and not matches_audio(cutoff_temp):
-                        cutoff_met = True
+                        continue
                     elif cutoff_temp['audio_exclude'] == 'True' and matches_audio(cutoff_temp):
                         cutoff_met = True
                     elif cutoff_language in actual_subtitles_list:

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -151,22 +151,20 @@ def store_subtitles(original_path, reversed_path, use_cache=True):
 
 
 def list_missing_subtitles(no=None, epno=None, send_event=True):
-    if epno is not None:
-        episodes_subtitles_clause = (TableEpisodes.sonarrEpisodeId == epno)
-    elif no is not None:
-        episodes_subtitles_clause = (TableEpisodes.sonarrSeriesId == no)
-    else:
-        episodes_subtitles_clause = None
-    episodes_subtitles = database.execute(
-        select(TableShows.sonarrSeriesId,
-               TableEpisodes.sonarrEpisodeId,
-               TableEpisodes.subtitles,
-               TableShows.profileId,
-               TableEpisodes.audio_language)
-        .select_from(TableEpisodes)
+    stmt = select(TableShows.sonarrSeriesId,
+                  TableEpisodes.sonarrEpisodeId,
+                  TableEpisodes.subtitles,
+                  TableShows.profileId,
+                  TableEpisodes.audio_language) \
+        .select_from(TableEpisodes) \
         .join(TableShows)
-        .where(episodes_subtitles_clause))\
-        .all()
+
+    if epno is not None:
+        episodes_subtitles = database.execute(stmt.where(TableEpisodes.sonarrEpisodeId == epno)).all()
+    elif no is not None:
+        episodes_subtitles = database.execute(stmt.where(TableEpisodes.sonarrSeriesId == no)).all()
+    else:
+        episodes_subtitles = database.execute(stmt).all()
 
     use_embedded_subs = settings.general.use_embedded_subs
 

--- a/frontend/src/components/forms/ProfileEditForm.tsx
+++ b/frontend/src/components/forms/ProfileEditForm.tsx
@@ -60,11 +60,11 @@ const inclusionOptions: SelectorOption<string>[] = [
     value: "always_include",
   },
   {
-    label: "When matching audio",
+    label: "audio track matches",
     value: "audio_only_include",
   },
   {
-    label: "When not matching audio",
+    label: "no audio track matches",
     value: "audio_exclude",
   },
 ];
@@ -281,7 +281,7 @@ const ProfileEditForm: FunctionComponent<Props> = ({
         },
       },
       {
-        header: "Include",
+        header: "Search only when...",
         accessorKey: "audio_exclude",
         cell: ({ row: { original: item, index } }) => {
           return <InclusionCell item={item} index={index} />;

--- a/frontend/src/components/forms/ProfileEditForm.tsx
+++ b/frontend/src/components/forms/ProfileEditForm.tsx
@@ -31,6 +31,7 @@ const defaultCutoffOptions: SelectorOption<Language.ProfileItem>[] = [
       id: anyCutoff,
       // eslint-disable-next-line camelcase
       audio_exclude: "False",
+      audio_only_include: "False",
       forced: "False",
       hi: "False",
       language: "any",
@@ -50,6 +51,21 @@ const subtitlesTypeOptions: SelectorOption<string>[] = [
   {
     label: "Forced (foreign part only)",
     value: "forced",
+  },
+];
+
+const inclusionOptions: SelectorOption<string>[] = [
+  {
+    label: "Always",
+    value: "always_include",
+  },
+  {
+    label: "When matching audio",
+    value: "audio_only_include",
+  },
+  {
+    label: "When not matching audio",
+    value: "audio_exclude",
   },
 ];
 
@@ -145,6 +161,7 @@ const ProfileEditForm: FunctionComponent<Props> = ({
         language,
         // eslint-disable-next-line camelcase
         audio_exclude: "False",
+        audio_only_include: "False",
         hi: "False",
         forced: "False",
       };
@@ -209,6 +226,36 @@ const ProfileEditForm: FunctionComponent<Props> = ({
     },
   );
 
+  const InclusionCell = React.memo(
+    ({ item, index }: { item: Language.ProfileItem; index: number }) => {
+      const selectValue = useMemo(() => {
+        if (item.audio_exclude === "True") {
+          return "audio_exclude";
+        } else if (item.audio_only_include === "True") {
+          return "audio_only_include";
+        } else {
+          return "always_include";
+        }
+      }, [item.audio_exclude, item.audio_only_include]);
+
+      return (
+        <Select
+          value={selectValue}
+          data={inclusionOptions}
+          onChange={(value) => {
+            if (value) {
+              action.mutate(index, {
+                ...item,
+                audio_exclude: value === "audio_exclude" ? "True" : "False",
+                audio_only_include: value === "audio_only_include" ? "True" : "False",
+              });
+            }
+          }}
+        ></Select>
+      );
+    },
+  );
+
   const columns = useMemo<ColumnDef<Language.ProfileItem>[]>(
     () => [
       {
@@ -230,21 +277,10 @@ const ProfileEditForm: FunctionComponent<Props> = ({
         },
       },
       {
-        header: "Exclude If Matching Audio",
+        header: "Include",
         accessorKey: "audio_exclude",
         cell: ({ row: { original: item, index } }) => {
-          return (
-            <Checkbox
-              checked={item.audio_exclude === "True"}
-              onChange={({ currentTarget: { checked } }) => {
-                action.mutate(index, {
-                  ...item,
-                  // eslint-disable-next-line camelcase
-                  audio_exclude: checked ? "True" : "False",
-                });
-              }}
-            ></Checkbox>
-          );
+          return <InclusionCell item={item} index={index} />;
         },
       },
       {

--- a/frontend/src/components/forms/ProfileEditForm.tsx
+++ b/frontend/src/components/forms/ProfileEditForm.tsx
@@ -2,7 +2,6 @@ import React, { FunctionComponent, useCallback, useMemo } from "react";
 import {
   Accordion,
   Button,
-  Checkbox,
   Flex,
   Select,
   Stack,
@@ -31,6 +30,7 @@ const defaultCutoffOptions: SelectorOption<Language.ProfileItem>[] = [
       id: anyCutoff,
       // eslint-disable-next-line camelcase
       audio_exclude: "False",
+      // eslint-disable-next-line camelcase
       audio_only_include: "False",
       forced: "False",
       hi: "False",
@@ -161,6 +161,7 @@ const ProfileEditForm: FunctionComponent<Props> = ({
         language,
         // eslint-disable-next-line camelcase
         audio_exclude: "False",
+        // eslint-disable-next-line camelcase
         audio_only_include: "False",
         hi: "False",
         forced: "False",
@@ -246,8 +247,11 @@ const ProfileEditForm: FunctionComponent<Props> = ({
             if (value) {
               action.mutate(index, {
                 ...item,
+                // eslint-disable-next-line camelcase
                 audio_exclude: value === "audio_exclude" ? "True" : "False",
-                audio_only_include: value === "audio_only_include" ? "True" : "False",
+                // eslint-disable-next-line camelcase
+                audio_only_include:
+                  value === "audio_only_include" ? "True" : "False",
               });
             }
           }}
@@ -297,7 +301,7 @@ const ProfileEditForm: FunctionComponent<Props> = ({
         },
       },
     ],
-    [action, LanguageCell, SubtitleTypeCell],
+    [action, LanguageCell, SubtitleTypeCell, InclusionCell],
   );
 
   return (

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -27,6 +27,7 @@ declare namespace Language {
   interface ProfileItem {
     id: number;
     audio_exclude: PythonBoolean;
+    audio_only_include: PythonBoolean;
     forced: PythonBoolean;
     hi: PythonBoolean;
     language: CodeType;


### PR DESCRIPTION
Addresses feature request [541865](https://bazarr.featureupvote.com/suggestions/541865).

When configuring a language profile, the user can now choose to include a language:
- Always
- When matching audio
- When not matching audio

The change includes the following UI changes:

Before:
<img width="2560" alt="before" src="https://github.com/user-attachments/assets/a89062ff-75ab-4260-8e6a-15f0b1352a20" />

After:
<img width="2559" alt="after" src="https://github.com/user-attachments/assets/cec734f3-ca1a-409f-94dd-ffbbf1a17635" />
