### PR TITLE
Added passing of video filename to detect-language for whisper provider

### DIFF
--- a/custom_libs/subliminal_patch/providers/whisperai.py
+++ b/custom_libs/subliminal_patch/providers/whisperai.py
@@ -272,9 +272,10 @@ class WhisperAIProvider(Provider):
         if out == None:
             logger.info(f"Whisper cannot detect language of {path} because of missing/bad audio track")
             return None
+        video_name = path if self.pass_video_name else None
 
         r = self.session.post(f"{self.endpoint}/detect-language",
-                              params={'encode': 'false'},
+                              params={'encode': 'false', 'video_file': {video_name}},
                               files={'audio_file': out},
                               timeout=(self.response, self.timeout))
         


### PR DESCRIPTION
/asr endpoint for the whisper provider already has this option as a param, just added it to detect-language as well.  

Example showing it working:
![image](https://github.com/user-attachments/assets/f7cde252-9464-4cca-a6c2-a5d2f91848e1)
