### PR TITLE
Regielive fix - Removed overwrite of provider language object

### DIFF
--- a/custom_libs/subliminal_patch/providers/regielive.py
+++ b/custom_libs/subliminal_patch/providers/regielive.py
@@ -29,7 +29,6 @@ class RegieLiveSubtitle(Subtitle):
         self.page_link = link
         self.video = video
         self.rating = rating
-        self.language = language
         self.release_info = filename
 
     @property


### PR DESCRIPTION
The superclass cloned and updated the language object so that the provider version of it was not inadvertently changed downstream. This is a follow-up to PR #2605 and completes the fix for this provider. Some other less popular providers will probably have similar issues.