### PR TITLE
Multiple providers - Removed overwrite of provider language object

### DIFF
--- a/custom_libs/subliminal_patch/providers/avistaz_network.py
+++ b/custom_libs/subliminal_patch/providers/avistaz_network.py
@@ -217,7 +217,6 @@ class AvistazNetworkSubtitle(Subtitle):
         super().__init__(language, page_link=page_link)
         self.provider_name = provider_name
         self.hearing_impaired = None
-        self.language = language
         self.filename = filename
         self.release_info = release
         self.page_link = page_link

--- a/custom_libs/subliminal_patch/providers/bsplayer.py
+++ b/custom_libs/subliminal_patch/providers/bsplayer.py
@@ -30,7 +30,6 @@ class BSPlayerSubtitle(Subtitle):
 
     def __init__(self, language, filename, subtype, video, link, subid):
         super(BSPlayerSubtitle, self).__init__(language)
-        self.language = language
         self.filename = filename
         self.page_link = link
         self.subtype = subtype

--- a/custom_libs/subliminal_patch/providers/legendasdivx.py
+++ b/custom_libs/subliminal_patch/providers/legendasdivx.py
@@ -36,7 +36,6 @@ class LegendasdivxSubtitle(Subtitle):
 
     def __init__(self, language, video, data, skip_wrong_fps=True):
         super(LegendasdivxSubtitle, self).__init__(language)
-        self.language = language
         self.page_link = data['link']
         self.hits = data['hits']
         self.exact_match = data['exact_match']

--- a/custom_libs/subliminal_patch/providers/soustitreseu.py
+++ b/custom_libs/subliminal_patch/providers/soustitreseu.py
@@ -31,7 +31,7 @@ class SoustitreseuSubtitle(Subtitle):
     provider_name = 'soustitreseu'
 
     def __init__(self, language, video, name, data, content, is_perfect_match):
-        self.language = language
+        super().__init__(language)
         self.srt_filename = name
         self.release_info = name
         self.page_link = None

--- a/custom_libs/subliminal_patch/providers/subsynchro.py
+++ b/custom_libs/subliminal_patch/providers/subsynchro.py
@@ -38,7 +38,6 @@ class SubsynchroSubtitle(Subtitle):
             language, hearing_impaired=False, page_link=download_url
         )
         self.download_url = download_url
-        self.language = language
         self.file_type = file_type
         self.release_info = release_info
         self.filename = filename

--- a/custom_libs/subliminal_patch/providers/titulky.py
+++ b/custom_libs/subliminal_patch/providers/titulky.py
@@ -66,7 +66,6 @@ class TitulkySubtitle(Subtitle):
         self.episode = episode
         self.releases = [release_info]
         self.release_info = release_info
-        self.language = language
         self.approved = approved
         self.page_link = page_link
         self.uploader = uploader

--- a/custom_libs/subliminal_patch/providers/tusubtitulo.py
+++ b/custom_libs/subliminal_patch/providers/tusubtitulo.py
@@ -37,7 +37,6 @@ class TuSubtituloSubtitle(Subtitle):
         super(TuSubtituloSubtitle, self).__init__(
             language, hearing_impaired=False, page_link=sub_dict["download_url"]
         )
-        self.language = language
         self.sub_dict = sub_dict
         self.release_info = sub_dict["metadata"]
         self.found_matches = matches


### PR DESCRIPTION
This is a follow-up to PR #2605 and completes the fix for the remaining providers.