### PR TITLE
Fix pipes dependency py3.13

### DIFF
--- a/custom_libs/imghdr.py
+++ b/custom_libs/imghdr.py
@@ -1,0 +1,11 @@
+import filetype
+
+_IMG_MIME = {
+    'image/jpeg': 'jpeg',
+    'image/png': 'png',
+    'image/gif': 'gif'
+}
+
+def what(_, img):
+    img_type = filetype.guess(img)
+    return _IMG_MIME.get(img_type.mime) if img_type else None

--- a/custom_libs/libfilebot/main.py
+++ b/custom_libs/libfilebot/main.py
@@ -11,7 +11,7 @@ import binascii
 import types
 import os
 
-from pipes import quote
+from shlex import quote
 from .lib import find_executable
 
 mswindows = False


### PR DESCRIPTION
- Replaces `pipes` with `shlex` in `custom_libs/libfilebot/main.py`
- Allows for compatibility with Python 3.13, and is backwards compatible
- Should fully resolve #2803 when combined with PR 2899