### PR TITLE
refactor: replaced pipes with shlex in custom_libs/libfilebot/main.py

### DIFF
--- a/custom_libs/libfilebot/main.py
+++ b/custom_libs/libfilebot/main.py
@@ -11,7 +11,7 @@ import binascii
 import types
 import os
 
-from pipes import quote
+from shlex import quote
 from .lib import find_executable
 
 mswindows = False


### PR DESCRIPTION
- Replaces `pipes` with `shlex` to ensure compatibility with python 3.13+
- Is backwards compatible
- Combined with PR 2899, should fully resolve #2803 