### PR TITLE
Fix score.py - BHDStudio release group matching with FraMeSToR

### DIFF
--- a/custom_libs/subliminal/score.py
+++ b/custom_libs/subliminal/score.py
@@ -45,7 +45,7 @@ movie_scores = {'hash': 119, 'title': 60, 'year': 30, 'release_group': 15,
                 'source': 7, 'audio_codec': 3, 'resolution': 2, 'video_codec': 2, 'hearing_impaired': 1}
 
 #: Equivalent release groups
-equivalent_release_groups = ({'FraMeSToR', 'W4NK3R', 'BHDStudio'}, {'LOL', 'DIMENSION'}, {'ASAP', 'IMMERSE', 'FLEET'}, {'AVS', 'SVA'})
+equivalent_release_groups = ({'FRAMESTOR', 'W4NK3R', 'BHDSTUDIO'}, {'LOL', 'DIMENSION'}, {'ASAP', 'IMMERSE', 'FLEET'}, {'AVS', 'SVA'})
 
 
 def get_equivalent_release_groups(release_group):


### PR DESCRIPTION
**Issue:**

Release group `FraMeSToR` & `BHDStudio` are defined in equivalent release group in [score.py](https://github.com/morpheus65535/bazarr/blob/6e43690ee593352c477e5538c4bdcc7975eeb6a5/custom_libs/subliminal/score.py#L48) but not matching/working.

**Fix:**
The release_group passed to the [function](https://github.com/morpheus65535/bazarr/blob/6e43690ee593352c477e5538c4bdcc7975eeb6a5/custom_libs/subliminal/score.py#L51) are [sanitized](https://github.com/morpheus65535/bazarr/blob/6e43690ee593352c477e5538c4bdcc7975eeb6a5/custom_libs/subliminal/utils.py#L127) (converted to uppercase), while defined release group are not uppercased, causing it to fail for `BHStudio`, `Framestor` releases. Fix the issue by converting it to uppercase.