### PR TITLE
Enable test requests on Radarr/Sonarr Webhooks

### DIFF
--- a/bazarr/api/webhooks/radarr.py
+++ b/bazarr/api/webhooks/radarr.py
@@ -17,7 +17,7 @@ api_ns_webhooks_radarr = Namespace('Webhooks Radarr', description='Webhooks to t
 @api_ns_webhooks_radarr.route('webhooks/radarr')
 class WebHooksRadarr(Resource):
     post_request_parser = reqparse.RequestParser()
-    post_request_parser.add_argument('radarr_moviefile_id', type=int, required=True, help='Movie file ID')
+    post_request_parser.add_argument('radarr_moviefile_id', type=int, required=False, help='Movie file ID')
 
     @authenticate
     @api_ns_webhooks_radarr.doc(parser=post_request_parser)
@@ -27,6 +27,8 @@ class WebHooksRadarr(Resource):
         """Search for missing subtitles for a specific movie file id"""
         args = self.post_request_parser.parse_args()
         movie_file_id = args.get('radarr_moviefile_id')
+        if movie_file_id is None:
+            return 'No ID sent, skipping database search.', 200
 
         radarrMovieId = database.execute(
             select(TableMovies.radarrId, TableMovies.path)

--- a/bazarr/api/webhooks/radarr.py
+++ b/bazarr/api/webhooks/radarr.py
@@ -24,15 +24,16 @@ class WebHooksRadarr(Resource):
     @api_ns_webhooks_radarr.doc(parser=post_request_parser)
     @api_ns_webhooks_radarr.response(200, 'Success')
     @api_ns_webhooks_radarr.response(401, 'Not Authenticated')
+    @api_ns_webhooks_radarr.response(404, 'Movie file ID not provided')
     def post(self):
         """Search for missing subtitles for a specific movie file id"""
         args = self.post_request_parser.parse_args()
         event_type = args.get('eventType')
         movie_file_id = args.get('radarr_moviefile_id')
         if event_type == 'Test':
-            return 'Received test hook, skipping database search.', 200
+            return '', 200
         elif not movie_file_id:
-            return 'Movie file ID not provided', 400
+            return 'Movie file ID not provided', 404
 
         radarrMovieId = database.execute(
             select(TableMovies.radarrId, TableMovies.path)

--- a/bazarr/api/webhooks/radarr.py
+++ b/bazarr/api/webhooks/radarr.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 import logging
 
-from flask_restx import Resource, Namespace, reqparse
+from flask_restx import Resource, Namespace, fields
 
 from app.database import TableMovies, database, select
 from radarr.sync.movies import update_one_movie
@@ -13,29 +13,41 @@ from ..utils import authenticate
 
 
 api_ns_webhooks_radarr = Namespace('Webhooks Radarr', description='Webhooks to trigger subtitles search based on '
-                                                                  'Radarr webhooks or Radarr file IDs.')
+                                                                  'Radarr webhooks or Radarr file IDs. '
+                                                                  'Requires at least one of eventType or '
+                                                                  'radarr_movie_file_id to be sent in the request body.')
 
 
 @api_ns_webhooks_radarr.route('webhooks/radarr')
 class WebHooksRadarr(Resource):
-    post_request_parser = reqparse.RequestParser()
-    post_request_parser.add_argument('radarr_movie_file_id', type=int, required=False, help='Movie file ID')
-    post_request_parser.add_argument('eventType', type=str, required=False, help='Event type', location='json')
-    post_request_parser.add_argument('movieFile', type=dict, required=False, help='Episode file details payload', location='json')
-    post_request_parser.add_argument('movie', type=dict, required=False, help='Episode file details payload', location='json')
+
+    movie_model = api_ns_webhooks_radarr.model('RadarrMovie', {
+        'id': fields.Integer(required=True, description='Movie ID'),
+    }, strict=False)
+        
+
+    movie_file_model = api_ns_webhooks_radarr.model('RadarrMovieFile', {
+        'id': fields.Integer(required=True, description='Movie file ID'),
+    }, strict=False)
+
+    radarr_webhook_model = api_ns_webhooks_radarr.model('RadarrWebhook', {
+        'eventType': fields.String(required=True, description='Type of event (e.g. MovieAdded)'),
+        'movieFile': fields.Nested(movie_file_model, required=False, description='Full movie file details payload'),
+        'movie': fields.Nested(movie_model, required=False, description='Full movie details payload'),
+        # Keep this field for backwards compatibility with user-scripts
+        'radarr_movie_file_id': fields.Integer(required=False, description='Radarr movie file ID for use with user scripts. Takes precedence over movieFile'),
+    }, strict=False)
 
     @authenticate
-    @api_ns_webhooks_radarr.doc(parser=post_request_parser)
+    @api_ns_webhooks_radarr.expect(radarr_webhook_model, validate=True)
     @api_ns_webhooks_radarr.response(200, 'Success')
     @api_ns_webhooks_radarr.response(401, 'Not Authenticated')
     @api_ns_webhooks_radarr.response(422, 'Invalid request: need at least one of event type or movie file ID.')
     def post(self):
         """Search for missing subtitles for a specific movie file id"""
-        args = self.post_request_parser.parse_args()
-
+        args = api_ns_webhooks_radarr.payload
         event_type = args.get('eventType')
         radarr_movie_file_id = args.get('radarr_movie_file_id')
-
         if not event_type and not radarr_movie_file_id:
             logging.debug('Invalid request: need at least one of event type or movie file ID.')
             return 'Invalid request: need at least one of event type or movie file ID.', 422
@@ -47,33 +59,30 @@ class WebHooksRadarr(Resource):
             return 'Received test hook, skipping database search.', 200
 
         if not radarr_movie_file_id:
-            try:
-                radarr_movie_file_id = args.get('movieFile', {}).get('id')
-            except AttributeError:
-                logging.debug('No movie file ID found in the webhook request. Nothing to do.')
-                # Radarr reports the webhook as 'unhealthy' and requires
-                # user interaction if we return anything except 200s.
-                return 'No movie file ID found in the webhook request. Nothing to do.', 200
+            radarr_movie_file_id = args.get('movieFile', {}).get('id')
+
+        if not radarr_movie_file_id:
+            logging.debug('No movie file ID found in the webhook request. Nothing to do.')
+            # Radarr reports the webhook as 'unhealthy' and requires
+            # user interaction if we return anything except 200s.
+            return 'No movie file ID found in the webhook request. Nothing to do.', 200
 
         # This webhook is often faster than the database update,
         # so we update the movie first if we can.
-        try:
-            radarr_id = args.get('movie', {}).get('id')
-        except AttributeError:
-            radarr_id = None
-
+        radarr_id = args.get('movie', {}).get('id')
         if radarr_id:
             update_one_movie(radarr_id, 'updated')
+            
 
-        radarr_movie = database.execute(
+        radarrMovieId = database.execute(
             select(TableMovies.radarrId, TableMovies.path)
             .where(TableMovies.movie_file_id == radarr_movie_file_id)) \
             .first()
-        if not radarr_movie:
+        if not radarrMovieId:
             logging.debug('No movie file ID found in the database. Nothing to do.')
             return 'No movie file ID found in the database. Nothing to do.', 200
         
-        store_subtitles_movie(radarr_movie.path, path_mappings.path_replace_movie(radarr_movie.path))
-        movies_download_subtitles(no=radarr_movie.radarrId)
+        store_subtitles_movie(radarrMovieId.path, path_mappings.path_replace_movie(radarrMovieId.path))
+        movies_download_subtitles(no=radarrMovieId.radarrId)
 
         return 'Finished processing subtitles.', 200

--- a/bazarr/api/webhooks/radarr.py
+++ b/bazarr/api/webhooks/radarr.py
@@ -20,18 +20,18 @@ api_ns_webhooks_radarr = Namespace('Webhooks Radarr', description='Webhooks to t
 class WebHooksRadarr(Resource):
 
     movie_model = api_ns_webhooks_radarr.model('RadarrMovie', {
-        'id':              fields.Integer(required=True, description='Movie ID'),
+        'id': fields.Integer(required=True, description='Movie ID'),
     }, strict=False)
         
 
     movie_file_model = api_ns_webhooks_radarr.model('RadarrMovieFile', {
-        'id':              fields.Integer(required=True, description='Movie file ID'),
+        'id': fields.Integer(required=True, description='Movie file ID'),
     }, strict=False)
 
     radarr_webhook_model = api_ns_webhooks_radarr.model('RadarrWebhook', {
-        'eventType':           fields.String(required=True, description='Type of event (e.g. MovieAdded)'),
-        'movieFile':               fields.Nested(movie_file_model, required=False, description='Full movie file details payload'),
-        'movie':                  fields.Nested(movie_model, required=False, description='Full movie details payload'),
+        'eventType': fields.String(required=True, description='Type of event (e.g. MovieAdded)'),
+        'movieFile': fields.Nested(movie_file_model, required=False, description='Full movie file details payload'),
+        'movie': fields.Nested(movie_model, required=False, description='Full movie details payload'),
     }, strict=False)
 
     @authenticate

--- a/bazarr/api/webhooks/radarr.py
+++ b/bazarr/api/webhooks/radarr.py
@@ -42,6 +42,7 @@ class WebHooksRadarr(Resource):
     @api_ns_webhooks_radarr.expect(radarr_webhook_model, validate=True)
     @api_ns_webhooks_radarr.response(200, 'Success')
     @api_ns_webhooks_radarr.response(401, 'Not Authenticated')
+    @api_ns_webhooks_radarr.response(422, 'Invalid request: need at least one of event type or movie file ID.')
     def post(self):
         """Search for missing subtitles for a specific movie file id"""
         args = api_ns_webhooks_radarr.payload

--- a/bazarr/api/webhooks/radarr.py
+++ b/bazarr/api/webhooks/radarr.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 import logging
 
-from flask_restx import Resource, Namespace, fields
+from flask_restx import Resource, Namespace, reqparse
 
 from app.database import TableMovies, database, select
 from radarr.sync.movies import update_one_movie
@@ -13,41 +13,29 @@ from ..utils import authenticate
 
 
 api_ns_webhooks_radarr = Namespace('Webhooks Radarr', description='Webhooks to trigger subtitles search based on '
-                                                                  'Radarr webhooks or Radarr file IDs. '
-                                                                  'Requires at least one of eventType or '
-                                                                  'radarr_movie_file_id to be sent in the request body.')
+                                                                  'Radarr webhooks or Radarr file IDs.')
 
 
 @api_ns_webhooks_radarr.route('webhooks/radarr')
 class WebHooksRadarr(Resource):
-
-    movie_model = api_ns_webhooks_radarr.model('RadarrMovie', {
-        'id': fields.Integer(required=True, description='Movie ID'),
-    }, strict=False)
-        
-
-    movie_file_model = api_ns_webhooks_radarr.model('RadarrMovieFile', {
-        'id': fields.Integer(required=True, description='Movie file ID'),
-    }, strict=False)
-
-    radarr_webhook_model = api_ns_webhooks_radarr.model('RadarrWebhook', {
-        'eventType': fields.String(required=True, description='Type of event (e.g. MovieAdded)'),
-        'movieFile': fields.Nested(movie_file_model, required=False, description='Full movie file details payload'),
-        'movie': fields.Nested(movie_model, required=False, description='Full movie details payload'),
-        # Keep this field for backwards compatibility with user-scripts
-        'radarr_movie_file_id': fields.Integer(required=False, description='Radarr movie file ID for use with user scripts. Takes precedence over movieFile'),
-    }, strict=False)
+    post_request_parser = reqparse.RequestParser()
+    post_request_parser.add_argument('radarr_movie_file_id', type=int, required=False, help='Movie file ID')
+    post_request_parser.add_argument('eventType', type=str, required=False, help='Event type', location='json')
+    post_request_parser.add_argument('movieFile', type=dict, required=False, help='Episode file details payload', location='json')
+    post_request_parser.add_argument('movie', type=dict, required=False, help='Episode file details payload', location='json')
 
     @authenticate
-    @api_ns_webhooks_radarr.expect(radarr_webhook_model, validate=True)
+    @api_ns_webhooks_radarr.doc(parser=post_request_parser)
     @api_ns_webhooks_radarr.response(200, 'Success')
     @api_ns_webhooks_radarr.response(401, 'Not Authenticated')
     @api_ns_webhooks_radarr.response(422, 'Invalid request: need at least one of event type or movie file ID.')
     def post(self):
         """Search for missing subtitles for a specific movie file id"""
-        args = api_ns_webhooks_radarr.payload
+        args = self.post_request_parser.parse_args()
+
         event_type = args.get('eventType')
         radarr_movie_file_id = args.get('radarr_movie_file_id')
+
         if not event_type and not radarr_movie_file_id:
             logging.debug('Invalid request: need at least one of event type or movie file ID.')
             return 'Invalid request: need at least one of event type or movie file ID.', 422
@@ -59,30 +47,33 @@ class WebHooksRadarr(Resource):
             return 'Received test hook, skipping database search.', 200
 
         if not radarr_movie_file_id:
-            radarr_movie_file_id = args.get('movieFile', {}).get('id')
-
-        if not radarr_movie_file_id:
-            logging.debug('No movie file ID found in the webhook request. Nothing to do.')
-            # Radarr reports the webhook as 'unhealthy' and requires
-            # user interaction if we return anything except 200s.
-            return 'No movie file ID found in the webhook request. Nothing to do.', 200
+            try:
+                radarr_movie_file_id = args.get('movieFile', {}).get('id')
+            except AttributeError:
+                logging.debug('No movie file ID found in the webhook request. Nothing to do.')
+                # Radarr reports the webhook as 'unhealthy' and requires
+                # user interaction if we return anything except 200s.
+                return 'No movie file ID found in the webhook request. Nothing to do.', 200
 
         # This webhook is often faster than the database update,
         # so we update the movie first if we can.
-        radarr_id = args.get('movie', {}).get('id')
+        try:
+            radarr_id = args.get('movie', {}).get('id')
+        except AttributeError:
+            radarr_id = None
+
         if radarr_id:
             update_one_movie(radarr_id, 'updated')
-            
 
-        radarrMovieId = database.execute(
+        radarr_movie = database.execute(
             select(TableMovies.radarrId, TableMovies.path)
             .where(TableMovies.movie_file_id == radarr_movie_file_id)) \
             .first()
-        if not radarrMovieId:
+        if not radarr_movie:
             logging.debug('No movie file ID found in the database. Nothing to do.')
             return 'No movie file ID found in the database. Nothing to do.', 200
         
-        store_subtitles_movie(radarrMovieId.path, path_mappings.path_replace_movie(radarrMovieId.path))
-        movies_download_subtitles(no=radarrMovieId.radarrId)
+        store_subtitles_movie(radarr_movie.path, path_mappings.path_replace_movie(radarr_movie.path))
+        movies_download_subtitles(no=radarr_movie.radarrId)
 
         return 'Finished processing subtitles.', 200

--- a/bazarr/api/webhooks/radarr.py
+++ b/bazarr/api/webhooks/radarr.py
@@ -12,48 +12,71 @@ from utilities.path_mappings import path_mappings
 from ..utils import authenticate
 
 
-api_ns_webhooks_radarr = Namespace('Webhooks Radarr', description='Webhooks to trigger subtitles search based on '
-                                                                  'Radarr webhooks')
+api_ns_webhooks_radarr = Namespace(
+    "Webhooks Radarr",
+    description="Webhooks to trigger subtitles search based on Radarr webhooks",
+)
 
 
-@api_ns_webhooks_radarr.route('webhooks/radarr')
+@api_ns_webhooks_radarr.route("webhooks/radarr")
 class WebHooksRadarr(Resource):
+    movie_model = api_ns_webhooks_radarr.model(
+        "RadarrMovie",
+        {
+            "id": fields.Integer(required=True, description="Movie ID"),
+        },
+        strict=False,
+    )
 
-    movie_model = api_ns_webhooks_radarr.model('RadarrMovie', {
-        'id': fields.Integer(required=True, description='Movie ID'),
-    }, strict=False)
-        
+    movie_file_model = api_ns_webhooks_radarr.model(
+        "RadarrMovieFile",
+        {
+            "id": fields.Integer(required=True, description="Movie file ID"),
+        },
+        strict=False,
+    )
 
-    movie_file_model = api_ns_webhooks_radarr.model('RadarrMovieFile', {
-        'id': fields.Integer(required=True, description='Movie file ID'),
-    }, strict=False)
-
-    radarr_webhook_model = api_ns_webhooks_radarr.model('RadarrWebhook', {
-        'eventType': fields.String(required=True, description='Type of Radarr event (e.g. MovieAdded, Test, etc)'),
-        'movieFile': fields.Nested(movie_file_model, required=False, description='Radarr movie file payload. Required for anything other than test hooks'),
-        'movie': fields.Nested(movie_model, required=False, description='Radarr movie payload. Can be used to sync movies from Radarr if not found in Bazarr'),
-    }, strict=False)
+    radarr_webhook_model = api_ns_webhooks_radarr.model(
+        "RadarrWebhook",
+        {
+            "eventType": fields.String(
+                required=True,
+                description="Type of Radarr event (e.g. MovieAdded, Test, etc)",
+            ),
+            "movieFile": fields.Nested(
+                movie_file_model,
+                required=False,
+                description="Radarr movie file payload. Required for anything other than test hooks",
+            ),
+            "movie": fields.Nested(
+                movie_model,
+                required=False,
+                description="Radarr movie payload. Can be used to sync movies from Radarr if not found in Bazarr",
+            ),
+        },
+        strict=False,
+    )
 
     @authenticate
     @api_ns_webhooks_radarr.expect(radarr_webhook_model, validate=True)
-    @api_ns_webhooks_radarr.response(200, 'Success')
-    @api_ns_webhooks_radarr.response(401, 'Not Authenticated')
+    @api_ns_webhooks_radarr.response(200, "Success")
+    @api_ns_webhooks_radarr.response(401, "Not Authenticated")
     def post(self):
         """Search for missing subtitles based on Radarr webhooks"""
         args = api_ns_webhooks_radarr.payload
-        event_type = args.get('eventType')
+        event_type = args.get("eventType")
 
-        logging.debug(f'Received Radarr webhook event: {event_type}')
+        logging.debug(f"Received Radarr webhook event: {event_type}")
 
-        if event_type == 'Test':
-            message = 'Received test hook, skipping database search.'
+        if event_type == "Test":
+            message = "Received test hook, skipping database search."
             logging.debug(message)
             return message, 200
 
-        movie_file_id = args.get('movieFile', {}).get('id')
+        movie_file_id = args.get("movieFile", {}).get("id")
 
         if not movie_file_id:
-            message = 'No movie file ID found in the webhook request. Nothing to do.'
+            message = "No movie file ID found in the webhook request. Nothing to do."
             logging.debug(message)
             # Radarr reports the webhook as 'unhealthy' and requires
             # user interaction if we return anything except 200s.
@@ -61,21 +84,27 @@ class WebHooksRadarr(Resource):
 
         # This webhook is often faster than the database update,
         # so we update the movie first if we can.
-        radarr_id = args.get('movie', {}).get('id')
-            
-        q = select(TableMovies.radarrId, TableMovies.path).where(TableMovies.movie_file_id == movie_file_id).first()
+        radarr_id = args.get("movie", {}).get("id")
+
+        q = (
+            select(TableMovies.radarrId, TableMovies.path)
+            .where(TableMovies.movie_file_id == movie_file_id)
+            .first()
+        )
 
         movie = database.execute(q)
         if not movie and radarr_id:
-            logging.debug(f'No movie matching file ID {movie_file_id} found in the database. Attempting to sync from Radarr.')
-            update_one_movie(radarr_id, 'updated')
+            logging.debug(
+                f"No movie matching file ID {movie_file_id} found in the database. Attempting to sync from Radarr."
+            )
+            update_one_movie(radarr_id, "updated")
             movie = database.execute(q)
         if not movie:
-            message = f'No movie matching file ID {movie_file_id} found in the database. Nothing to do.'
+            message = f"No movie matching file ID {movie_file_id} found in the database. Nothing to do."
             logging.debug(message)
             return message, 200
-        
+
         store_subtitles_movie(movie.path, path_mappings.path_replace_movie(movie.path))
         movies_download_subtitles(no=movie.radarrId)
 
-        return 'Finished processing subtitles.', 200
+        return "Finished processing subtitles.", 200

--- a/bazarr/api/webhooks/radarr.py
+++ b/bazarr/api/webhooks/radarr.py
@@ -42,7 +42,6 @@ class WebHooksRadarr(Resource):
     @api_ns_webhooks_radarr.expect(radarr_webhook_model, validate=True)
     @api_ns_webhooks_radarr.response(200, 'Success')
     @api_ns_webhooks_radarr.response(401, 'Not Authenticated')
-    @api_ns_webhooks_radarr.response(422, 'Invalid request: need at least one of event type or movie file ID.')
     def post(self):
         """Search for missing subtitles for a specific movie file id"""
         args = api_ns_webhooks_radarr.payload

--- a/bazarr/api/webhooks/radarr.py
+++ b/bazarr/api/webhooks/radarr.py
@@ -17,6 +17,7 @@ api_ns_webhooks_radarr = Namespace('Webhooks Radarr', description='Webhooks to t
 @api_ns_webhooks_radarr.route('webhooks/radarr')
 class WebHooksRadarr(Resource):
     post_request_parser = reqparse.RequestParser()
+    post_request_parser.add_argument('eventType', type=str, required=False, help='Event type - used when receiving test hooks from Radarr.')
     post_request_parser.add_argument('radarr_moviefile_id', type=int, required=False, help='Movie file ID')
 
     @authenticate
@@ -26,9 +27,12 @@ class WebHooksRadarr(Resource):
     def post(self):
         """Search for missing subtitles for a specific movie file id"""
         args = self.post_request_parser.parse_args()
+        event_type = args.get('eventType')
         movie_file_id = args.get('radarr_moviefile_id')
-        if movie_file_id is None:
-            return 'No ID sent, skipping database search.', 200
+        if event_type == 'Test':
+            return 'Received test hook, skipping database search.', 200
+        elif not movie_file_id:
+            return 'Movie file ID not provided', 400
 
         radarrMovieId = database.execute(
             select(TableMovies.radarrId, TableMovies.path)

--- a/bazarr/api/webhooks/sonarr.py
+++ b/bazarr/api/webhooks/sonarr.py
@@ -4,7 +4,7 @@ import logging
 from flask_restx import Resource, Namespace, fields
 
 from app.database import TableEpisodes, TableShows, database, select
-from sonarr.sync.series import update_one_series
+from sonarr.sync.episodes import sync_one_episode
 from subtitles.mass_download import episode_download_subtitles
 from subtitles.indexer.series import store_subtitles
 from utilities.path_mappings import path_mappings
@@ -20,18 +20,18 @@ api_ns_webhooks_sonarr = Namespace('Webhooks Sonarr', description='Webhooks to t
 @api_ns_webhooks_sonarr.route('webhooks/sonarr')
 class WebHooksSonarr(Resource):
 
+    episode_model = api_ns_webhooks_sonarr.model('SonarrEpisode', {
+        'id': fields.Integer(required=True, description='Episode ID'),
+    }, strict=False)
+
     episode_file_model = api_ns_webhooks_sonarr.model('SonarrEpisodeFile', {
         'id': fields.Integer(required=True, description='Episode file ID'),
     }, strict=False)
     
-    series_model = api_ns_webhooks_sonarr.model('SonarrSeries', {
-        'id': fields.Integer(required=True, description='Series ID'),
-    }, strict=False)
-    
     sonarr_webhook_model = api_ns_webhooks_sonarr.model('SonarrWebhook', {
-        'episodeFiles': fields.List(fields.Nested(episode_file_model), required=False, description='List of episode files'),
-        'series': fields.Nested(series_model, required=False, description='Full series details payload'),
-        'eventType': fields.String(required=True, description='Type of event (e.g. Test)'),
+        'episodes': fields.List(fields.Nested(episode_model), required=False, description='List of episodes. Can be used to sync episodes from Sonarr if not found in Bazarr.'),
+        'episodeFiles': fields.List(fields.Nested(episode_file_model), required=False, description='List of episode files; required for anything other than test hooks'),
+        'eventType': fields.String(required=True, description='Type of Sonarr event (e.g. Test, Download, etc.)'),
     }, strict=False)
 
     @authenticate
@@ -52,31 +52,36 @@ class WebHooksSonarr(Resource):
 
         # Sonarr hooks only differentiate a download starting vs. ending by
         # the inclusion of episodeFiles in the payload.
-        episode_file_ids = [e.get('id') for e in args.get('episodeFiles', [])]
+        sonarr_episode_file_ids = [e.get('id') for e in args.get('episodeFiles', [])]
 
-        if not episode_file_ids:
+        if not sonarr_episode_file_ids:
             logging.debug('No episode file IDs found in the webhook request. Nothing to do.')
             # Sonarr reports the webhook as 'unhealthy' and requires
             # user interaction if we return anything except 200s.
             return 'No episode file IDs found in the webhook request. Nothing to do.', 200
 
-        # This webhook is often faster than the database update,
-        # so we update the series first if we can.
-        series_id = args.get('series', {}).get('id')
-        if series_id:
-            update_one_series(series_id, 'updated')
+        sonarr_episode_ids = [e.get('id') for e in args.get('episodes', [])]
 
-        for efid in episode_file_ids:
-            episode = database.execute(
-                select(TableEpisodes.sonarrEpisodeId, TableEpisodes.path)
+        if len(sonarr_episode_ids) != len(sonarr_episode_file_ids):
+            logging.debug('Episode IDs and episode file IDs do not match, ignoring episode IDs.')
+            sonarr_episode_ids = []
+            
+        for i, efid in enumerate(sonarr_episode_file_ids):
+            q = (select(TableEpisodes.sonarrEpisodeId, TableEpisodes.path)
                 .select_from(TableEpisodes)
                 .join(TableShows)
-                .where(TableEpisodes.episode_file_id == efid)) \
-                .first()
+                .where(TableEpisodes.episode_file_id == efid)) 
 
-            if episode:
-                store_subtitles(episode.path, path_mappings.path_replace(episode.path))
-                episode_download_subtitles(no=episode.sonarrEpisodeId, send_progress=True)
-            else:
+            episode = database.execute(q).first()
+            if not episode and sonarr_episode_ids:
+                logging.debug('No episode found for episode file ID %s, attempting to sync from Sonarr.', efid)
+                sync_one_episode(sonarr_episode_ids[i])
+                episode = database.execute(q).first()
+            if not episode:
                 logging.debug('No episode found for episode file ID %s, skipping.', efid)
+                continue
+
+            store_subtitles(episode.path, path_mappings.path_replace(episode.path))
+            episode_download_subtitles(no=episode.sonarrEpisodeId, send_progress=True)
+
         return 'Finished processing subtitles.', 200

--- a/bazarr/api/webhooks/sonarr.py
+++ b/bazarr/api/webhooks/sonarr.py
@@ -1,50 +1,82 @@
 # coding=utf-8
+import logging
 
-from flask_restx import Resource, Namespace, reqparse
+from flask_restx import Resource, Namespace, fields
 
 from app.database import TableEpisodes, TableShows, database, select
+from sonarr.sync.series import update_one_series
 from subtitles.mass_download import episode_download_subtitles
 from subtitles.indexer.series import store_subtitles
 from utilities.path_mappings import path_mappings
+
 
 from ..utils import authenticate
 
 
 api_ns_webhooks_sonarr = Namespace('Webhooks Sonarr', description='Webhooks to trigger subtitles search based on '
-                                                                  'Sonarr episode file ID')
+                                                                  'Sonarr webhooks')
 
 
 @api_ns_webhooks_sonarr.route('webhooks/sonarr')
 class WebHooksSonarr(Resource):
-    post_request_parser = reqparse.RequestParser()
-    post_request_parser.add_argument('eventType', type=str, required=False, help='Event type - used when receiving test hooks from Sonarr.')
-    post_request_parser.add_argument('sonarr_episodefile_id', type=int, required=False, help='Episode file ID')
+
+    episode_file_model = api_ns_webhooks_sonarr.model('SonarrEpisodeFile', {
+        'id':       fields.Integer(required=True, description='Episode file ID'),
+    }, strict=False)
+    
+    series_model = api_ns_webhooks_sonarr.model('SonarrSeries', {
+        'id':         fields.Integer(required=True, description='Series ID'),
+    }, strict=False)
+    
+    sonarr_webhook_model = api_ns_webhooks_sonarr.model('SonarrWebhook', {
+        'episodeFiles':   fields.List(fields.Nested(episode_file_model), required=False, description='List of episode files'),
+        'series':         fields.Nested(series_model, required=False, description='Full series details payload'),
+        'eventType':      fields.String(required=True, description='Type of event (e.g. Test)'),
+    }, strict=False)
 
     @authenticate
-    @api_ns_webhooks_sonarr.doc(parser=post_request_parser)
+    @api_ns_webhooks_sonarr.expect(sonarr_webhook_model, validate=True)
     @api_ns_webhooks_sonarr.response(200, 'Success')
     @api_ns_webhooks_sonarr.response(401, 'Not Authenticated')
-    @api_ns_webhooks_sonarr.response(404, 'Episode file ID not provided')
     def post(self):
         """Search for missing subtitles for a specific episode file id"""
-        args = self.post_request_parser.parse_args()
+        args = api_ns_webhooks_sonarr.payload
         event_type = args.get('eventType')
-        episode_file_id = args.get('sonarr_episodefile_id')
+
+        logging.debug('Received Sonarr webhook event: %s', event_type)
+
         if event_type == 'Test':
-            return '', 200
-        elif not episode_file_id:
-            return 'Episode file ID not provided', 404
+            logging.debug('Received test hook, skipping database search.')
+            return 'Received test hook, skipping database search.', 200
 
 
-        sonarrEpisodeId = database.execute(
-            select(TableEpisodes.sonarrEpisodeId, TableEpisodes.path)
-            .select_from(TableEpisodes)
-            .join(TableShows)
-            .where(TableEpisodes.episode_file_id == episode_file_id)) \
-            .first()
+        # Sonarr hooks only differentiate a download starting vs. ending by
+        # the inclusion of episodeFiles in the payload.
+        episode_file_ids = [e.get('id') for e in args.get('episodeFiles', [])]
 
-        if sonarrEpisodeId:
-            store_subtitles(sonarrEpisodeId.path, path_mappings.path_replace(sonarrEpisodeId.path))
-            episode_download_subtitles(no=sonarrEpisodeId.sonarrEpisodeId, send_progress=True)
+        if not episode_file_ids:
+            logging.debug('No episode file IDs found in the webhook request. Nothing to do.')
+            # Sonarr reports the webhook as 'unhealthy' and requires
+            # user interaction if we return anything except 200s.
+            return 'No episode file IDs found in the webhook request. Nothing to do.', 200
 
-        return '', 200
+        # This webhook is often faster than the database update,
+        # so we update the series first if we can.
+        series_id = args.get('series', {}).get('id')
+        if series_id:
+            update_one_series(series_id, 'updated')
+
+        for efid in episode_file_ids:
+            episode = database.execute(
+                select(TableEpisodes.sonarrEpisodeId, TableEpisodes.path)
+                .select_from(TableEpisodes)
+                .join(TableShows)
+                .where(TableEpisodes.episode_file_id == efid)) \
+                .first()
+
+            if episode:
+                store_subtitles(episode.path, path_mappings.path_replace(episode.path))
+                episode_download_subtitles(no=episode.sonarrEpisodeId, send_progress=True)
+            else:
+                logging.debug('No episode found for episode file ID %s, skipping.', efid)
+        return 'Finished processing subtitles.', 200

--- a/bazarr/api/webhooks/sonarr.py
+++ b/bazarr/api/webhooks/sonarr.py
@@ -24,15 +24,16 @@ class WebHooksSonarr(Resource):
     @api_ns_webhooks_sonarr.doc(parser=post_request_parser)
     @api_ns_webhooks_sonarr.response(200, 'Success')
     @api_ns_webhooks_sonarr.response(401, 'Not Authenticated')
+    @api_ns_webhooks_sonarr.response(404, 'Episode file ID not provided')
     def post(self):
         """Search for missing subtitles for a specific episode file id"""
         args = self.post_request_parser.parse_args()
         event_type = args.get('eventType')
         episode_file_id = args.get('sonarr_episodefile_id')
         if event_type == 'Test':
-            return 'Received test hook, skipping database search.', 200
+            return '', 200
         elif not episode_file_id:
-            return 'Episode file ID not provided', 400
+            return 'Episode file ID not provided', 404
 
 
         sonarrEpisodeId = database.execute(

--- a/bazarr/api/webhooks/sonarr.py
+++ b/bazarr/api/webhooks/sonarr.py
@@ -21,17 +21,17 @@ api_ns_webhooks_sonarr = Namespace('Webhooks Sonarr', description='Webhooks to t
 class WebHooksSonarr(Resource):
 
     episode_file_model = api_ns_webhooks_sonarr.model('SonarrEpisodeFile', {
-        'id':       fields.Integer(required=True, description='Episode file ID'),
+        'id': fields.Integer(required=True, description='Episode file ID'),
     }, strict=False)
     
     series_model = api_ns_webhooks_sonarr.model('SonarrSeries', {
-        'id':         fields.Integer(required=True, description='Series ID'),
+        'id': fields.Integer(required=True, description='Series ID'),
     }, strict=False)
     
     sonarr_webhook_model = api_ns_webhooks_sonarr.model('SonarrWebhook', {
-        'episodeFiles':   fields.List(fields.Nested(episode_file_model), required=False, description='List of episode files'),
-        'series':         fields.Nested(series_model, required=False, description='Full series details payload'),
-        'eventType':      fields.String(required=True, description='Type of event (e.g. Test)'),
+        'episodeFiles': fields.List(fields.Nested(episode_file_model), required=False, description='List of episode files'),
+        'series': fields.Nested(series_model, required=False, description='Full series details payload'),
+        'eventType': fields.String(required=True, description='Type of event (e.g. Test)'),
     }, strict=False)
 
     @authenticate

--- a/bazarr/api/webhooks/sonarr.py
+++ b/bazarr/api/webhooks/sonarr.py
@@ -14,7 +14,9 @@ from ..utils import authenticate
 
 
 api_ns_webhooks_sonarr = Namespace('Webhooks Sonarr', description='Webhooks to trigger subtitles search based on '
-                                                                  'Sonarr webhooks')
+                                                                  'Sonarr webhooks or Sonarr file IDs. Requires '
+                                                                  'at least one of eventType or sonarr_episodefile_id '
+                                                                  'to be sent in the request body.')
 
 
 @api_ns_webhooks_sonarr.route('webhooks/sonarr')
@@ -29,9 +31,11 @@ class WebHooksSonarr(Resource):
     }, strict=False)
     
     sonarr_webhook_model = api_ns_webhooks_sonarr.model('SonarrWebhook', {
-        'episodeFiles': fields.List(fields.Nested(episode_file_model), required=False, description='List of episode files'),
-        'series': fields.Nested(series_model, required=False, description='Full series details payload'),
-        'eventType': fields.String(required=True, description='Type of event (e.g. Test)'),
+        'episodeFiles': fields.List(fields.Nested(episode_file_model), required=False, description='Episode File payload from Sonarr Webhook'),
+        'series': fields.Nested(series_model, required=False, description='Series payload from Sonarr Webhook'),
+        'eventType': fields.String(required=False, description='Type of event (e.g. Test) from Sonarr Webhook'),
+        # Keep this field for backwards compatibility with user-scripts
+        'sonarr_episodefile_id': fields.Integer(required=False, description='Sonarr episode file ID for use with user scripts. Takes precedence over episodeFiles'),
     }, strict=False)
 
     @authenticate
@@ -42,6 +46,11 @@ class WebHooksSonarr(Resource):
         """Search for missing subtitles for a specific episode file id"""
         args = api_ns_webhooks_sonarr.payload
         event_type = args.get('eventType')
+        sonarr_episodefile_id = args.get('sonarr_episodefile_id')
+
+        if not event_type and not sonarr_episodefile_id:
+            logging.debug('Invalid request: need at least one of event type or episode file ID.')
+            return 'Invalid request: need at least one of event type or episode file ID.', 422
 
         logging.debug('Received Sonarr webhook event: %s', event_type)
 
@@ -49,10 +58,12 @@ class WebHooksSonarr(Resource):
             logging.debug('Received test hook, skipping database search.')
             return 'Received test hook, skipping database search.', 200
 
-
-        # Sonarr hooks only differentiate a download starting vs. ending by
-        # the inclusion of episodeFiles in the payload.
-        episode_file_ids = [e.get('id') for e in args.get('episodeFiles', [])]
+        if sonarr_episodefile_id:
+            episode_file_ids = [sonarr_episodefile_id]
+        else:
+            # Sonarr hooks only differentiate a download starting vs. ending by
+            # the inclusion of episodeFiles in the payload.
+            episode_file_ids = [e.get('id') for e in args.get('episodeFiles', [])]
 
         if not episode_file_ids:
             logging.debug('No episode file IDs found in the webhook request. Nothing to do.')

--- a/bazarr/api/webhooks/sonarr.py
+++ b/bazarr/api/webhooks/sonarr.py
@@ -13,77 +13,109 @@ from utilities.path_mappings import path_mappings
 from ..utils import authenticate
 
 
-api_ns_webhooks_sonarr = Namespace('Webhooks Sonarr', description='Webhooks to trigger subtitles search based on '
-                                                                  'Sonarr webhooks')
+api_ns_webhooks_sonarr = Namespace(
+    "Webhooks Sonarr",
+    description="Webhooks to trigger subtitles search based on Sonarr webhooks",
+)
 
 
-@api_ns_webhooks_sonarr.route('webhooks/sonarr')
+@api_ns_webhooks_sonarr.route("webhooks/sonarr")
 class WebHooksSonarr(Resource):
+    episode_model = api_ns_webhooks_sonarr.model(
+        "SonarrEpisode",
+        {
+            "id": fields.Integer(required=True, description="Episode ID"),
+        },
+        strict=False,
+    )
 
-    episode_model = api_ns_webhooks_sonarr.model('SonarrEpisode', {
-        'id': fields.Integer(required=True, description='Episode ID'),
-    }, strict=False)
+    episode_file_model = api_ns_webhooks_sonarr.model(
+        "SonarrEpisodeFile",
+        {
+            "id": fields.Integer(required=True, description="Episode file ID"),
+        },
+        strict=False,
+    )
 
-    episode_file_model = api_ns_webhooks_sonarr.model('SonarrEpisodeFile', {
-        'id': fields.Integer(required=True, description='Episode file ID'),
-    }, strict=False)
-    
-    sonarr_webhook_model = api_ns_webhooks_sonarr.model('SonarrWebhook', {
-        'episodes': fields.List(fields.Nested(episode_model), required=False, description='List of episodes. Can be used to sync episodes from Sonarr if not found in Bazarr.'),
-        'episodeFiles': fields.List(fields.Nested(episode_file_model), required=False, description='List of episode files; required for anything other than test hooks'),
-        'eventType': fields.String(required=True, description='Type of Sonarr event (e.g. Test, Download, etc.)'),
-    }, strict=False)
+    sonarr_webhook_model = api_ns_webhooks_sonarr.model(
+        "SonarrWebhook",
+        {
+            "episodes": fields.List(
+                fields.Nested(episode_model),
+                required=False,
+                description="List of episodes. Can be used to sync episodes from Sonarr if not found in Bazarr.",
+            ),
+            "episodeFiles": fields.List(
+                fields.Nested(episode_file_model),
+                required=False,
+                description="List of episode files; required for anything other than test hooks",
+            ),
+            "eventType": fields.String(
+                required=True,
+                description="Type of Sonarr event (e.g. Test, Download, etc.)",
+            ),
+        },
+        strict=False,
+    )
 
     @authenticate
     @api_ns_webhooks_sonarr.expect(sonarr_webhook_model, validate=True)
-    @api_ns_webhooks_sonarr.response(200, 'Success')
-    @api_ns_webhooks_sonarr.response(401, 'Not Authenticated')
+    @api_ns_webhooks_sonarr.response(200, "Success")
+    @api_ns_webhooks_sonarr.response(401, "Not Authenticated")
     def post(self):
         """Search for missing subtitles based on Sonarr webhooks"""
         args = api_ns_webhooks_sonarr.payload
-        event_type = args.get('eventType')
+        event_type = args.get("eventType")
 
-        logging.debug(f'Received Sonarr webhook event: {event_type}')
+        logging.debug(f"Received Sonarr webhook event: {event_type}")
 
-        if event_type == 'Test':
-            message = 'Received test hook, skipping database search.'
+        if event_type == "Test":
+            message = "Received test hook, skipping database search."
             logging.debug(message)
             return message, 200
 
-
         # Sonarr hooks only differentiate a download starting vs. ending by
         # the inclusion of episodeFiles in the payload.
-        sonarr_episode_file_ids = [e.get('id') for e in args.get('episodeFiles', [])]
+        sonarr_episode_file_ids = [e.get("id") for e in args.get("episodeFiles", [])]
 
         if not sonarr_episode_file_ids:
-            message = 'No episode file IDs found in the webhook request. Nothing to do.'
+            message = "No episode file IDs found in the webhook request. Nothing to do."
             logging.debug(message)
             # Sonarr reports the webhook as 'unhealthy' and requires
             # user interaction if we return anything except 200s.
             return message, 200
 
-        sonarr_episode_ids = [e.get('id') for e in args.get('episodes', [])]
+        sonarr_episode_ids = [e.get("id") for e in args.get("episodes", [])]
 
         if len(sonarr_episode_ids) != len(sonarr_episode_file_ids):
-            logging.debug('Episode IDs and episode file IDs are different lengths, ignoring episode IDs.')
+            logging.debug(
+                "Episode IDs and episode file IDs are different lengths, ignoring episode IDs."
+            )
             sonarr_episode_ids = []
-            
+
         for i, efid in enumerate(sonarr_episode_file_ids):
-            q = (select(TableEpisodes.sonarrEpisodeId, TableEpisodes.path)
+            q = (
+                select(TableEpisodes.sonarrEpisodeId, TableEpisodes.path)
                 .select_from(TableEpisodes)
                 .join(TableShows)
-                .where(TableEpisodes.episode_file_id == efid)) 
+                .where(TableEpisodes.episode_file_id == efid)
+            )
 
             episode = database.execute(q).first()
             if not episode and sonarr_episode_ids:
-                logging.debug('No episode found for episode file ID %s, attempting to sync from Sonarr.', efid)
+                logging.debug(
+                    "No episode found for episode file ID %s, attempting to sync from Sonarr.",
+                    efid,
+                )
                 sync_one_episode(sonarr_episode_ids[i])
                 episode = database.execute(q).first()
             if not episode:
-                logging.debug('No episode found for episode file ID %s, skipping.', efid)
+                logging.debug(
+                    "No episode found for episode file ID %s, skipping.", efid
+                )
                 continue
 
             store_subtitles(episode.path, path_mappings.path_replace(episode.path))
             episode_download_subtitles(no=episode.sonarrEpisodeId, send_progress=True)
 
-        return 'Finished processing subtitles.', 200
+        return "Finished processing subtitles.", 200

--- a/bazarr/api/webhooks/sonarr.py
+++ b/bazarr/api/webhooks/sonarr.py
@@ -43,11 +43,12 @@ class WebHooksSonarr(Resource):
         args = api_ns_webhooks_sonarr.payload
         event_type = args.get('eventType')
 
-        logging.debug('Received Sonarr webhook event: %s', event_type)
+        logging.debug(f'Received Sonarr webhook event: {event_type}')
 
         if event_type == 'Test':
-            logging.debug('Received test hook, skipping database search.')
-            return 'Received test hook, skipping database search.', 200
+            message = 'Received test hook, skipping database search.'
+            logging.debug(message)
+            return message, 200
 
 
         # Sonarr hooks only differentiate a download starting vs. ending by
@@ -55,15 +56,16 @@ class WebHooksSonarr(Resource):
         sonarr_episode_file_ids = [e.get('id') for e in args.get('episodeFiles', [])]
 
         if not sonarr_episode_file_ids:
-            logging.debug('No episode file IDs found in the webhook request. Nothing to do.')
+            message = 'No episode file IDs found in the webhook request. Nothing to do.'
+            logging.debug(message)
             # Sonarr reports the webhook as 'unhealthy' and requires
             # user interaction if we return anything except 200s.
-            return 'No episode file IDs found in the webhook request. Nothing to do.', 200
+            return message, 200
 
         sonarr_episode_ids = [e.get('id') for e in args.get('episodes', [])]
 
         if len(sonarr_episode_ids) != len(sonarr_episode_file_ids):
-            logging.debug('Episode IDs and episode file IDs do not match, ignoring episode IDs.')
+            logging.debug('Episode IDs and episode file IDs are different lengths, ignoring episode IDs.')
             sonarr_episode_ids = []
             
         for i, efid in enumerate(sonarr_episode_file_ids):

--- a/bazarr/api/webhooks/sonarr.py
+++ b/bazarr/api/webhooks/sonarr.py
@@ -17,7 +17,7 @@ api_ns_webhooks_sonarr = Namespace('Webhooks Sonarr', description='Webhooks to t
 @api_ns_webhooks_sonarr.route('webhooks/sonarr')
 class WebHooksSonarr(Resource):
     post_request_parser = reqparse.RequestParser()
-    post_request_parser.add_argument('sonarr_episodefile_id', type=int, required=True, help='Episode file ID')
+    post_request_parser.add_argument('sonarr_episodefile_id', type=int, required=False, help='Episode file ID')
 
     @authenticate
     @api_ns_webhooks_sonarr.doc(parser=post_request_parser)
@@ -27,6 +27,8 @@ class WebHooksSonarr(Resource):
         """Search for missing subtitles for a specific episode file id"""
         args = self.post_request_parser.parse_args()
         episode_file_id = args.get('sonarr_episodefile_id')
+        if episode_file_id is None:
+            return 'No ID sent, skipping database search.', 200
 
         sonarrEpisodeId = database.execute(
             select(TableEpisodes.sonarrEpisodeId, TableEpisodes.path)

--- a/bazarr/api/webhooks/sonarr.py
+++ b/bazarr/api/webhooks/sonarr.py
@@ -42,7 +42,6 @@ class WebHooksSonarr(Resource):
     @api_ns_webhooks_sonarr.expect(sonarr_webhook_model, validate=True)
     @api_ns_webhooks_sonarr.response(200, 'Success')
     @api_ns_webhooks_sonarr.response(401, 'Not Authenticated')
-    @api_ns_webhooks_sonarr.response(422, 'Invalid request: need at least one of event type or episode file ID.')
     def post(self):
         """Search for missing subtitles for a specific episode file id"""
         args = api_ns_webhooks_sonarr.payload

--- a/bazarr/api/webhooks/sonarr.py
+++ b/bazarr/api/webhooks/sonarr.py
@@ -42,6 +42,7 @@ class WebHooksSonarr(Resource):
     @api_ns_webhooks_sonarr.expect(sonarr_webhook_model, validate=True)
     @api_ns_webhooks_sonarr.response(200, 'Success')
     @api_ns_webhooks_sonarr.response(401, 'Not Authenticated')
+    @api_ns_webhooks_sonarr.response(422, 'Invalid request: need at least one of event type or episode file ID.')
     def post(self):
         """Search for missing subtitles for a specific episode file id"""
         args = api_ns_webhooks_sonarr.payload

--- a/bazarr/api/webhooks/sonarr.py
+++ b/bazarr/api/webhooks/sonarr.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 import logging
 
-from flask_restx import Resource, Namespace, fields
+from flask_restx import Resource, Namespace, reqparse
 
 from app.database import TableEpisodes, TableShows, database, select
 from sonarr.sync.series import update_one_series
@@ -14,38 +14,26 @@ from ..utils import authenticate
 
 
 api_ns_webhooks_sonarr = Namespace('Webhooks Sonarr', description='Webhooks to trigger subtitles search based on '
-                                                                  'Sonarr webhooks or Sonarr file IDs. Requires '
-                                                                  'at least one of eventType or sonarr_episodefile_id '
-                                                                  'to be sent in the request body.')
+                                                                  'Sonarr webhooks or Sonarr file IDs.')
 
 
 @api_ns_webhooks_sonarr.route('webhooks/sonarr')
 class WebHooksSonarr(Resource):
 
-    episode_file_model = api_ns_webhooks_sonarr.model('SonarrEpisodeFile', {
-        'id': fields.Integer(required=True, description='Episode file ID'),
-    }, strict=False)
-    
-    series_model = api_ns_webhooks_sonarr.model('SonarrSeries', {
-        'id': fields.Integer(required=True, description='Series ID'),
-    }, strict=False)
-    
-    sonarr_webhook_model = api_ns_webhooks_sonarr.model('SonarrWebhook', {
-        'episodeFiles': fields.List(fields.Nested(episode_file_model), required=False, description='Episode File payload from Sonarr Webhook'),
-        'series': fields.Nested(series_model, required=False, description='Series payload from Sonarr Webhook'),
-        'eventType': fields.String(required=False, description='Type of event (e.g. Test) from Sonarr Webhook'),
-        # Keep this field for backwards compatibility with user-scripts
-        'sonarr_episodefile_id': fields.Integer(required=False, description='Sonarr episode file ID for use with user scripts. Takes precedence over episodeFiles'),
-    }, strict=False)
+    post_request_parser = reqparse.RequestParser()
+    post_request_parser.add_argument('sonarr_episodefile_id', type=int, required=False, help='Movie file ID')
+    post_request_parser.add_argument('eventType', type=str, required=False, help='Event type', location='json')
+    post_request_parser.add_argument('episodeFiles', type=list, required=False, help='Episode file details payload', location='json')
+    post_request_parser.add_argument('series', type=dict, required=False, help='Series details payload', location='json')
 
     @authenticate
-    @api_ns_webhooks_sonarr.expect(sonarr_webhook_model, validate=True)
+    @api_ns_webhooks_sonarr.doc(parser=post_request_parser)
     @api_ns_webhooks_sonarr.response(200, 'Success')
     @api_ns_webhooks_sonarr.response(401, 'Not Authenticated')
     @api_ns_webhooks_sonarr.response(422, 'Invalid request: need at least one of event type or episode file ID.')
     def post(self):
         """Search for missing subtitles for a specific episode file id"""
-        args = api_ns_webhooks_sonarr.payload
+        args = self.post_request_parser.parse_args()
         event_type = args.get('eventType')
         sonarr_episodefile_id = args.get('sonarr_episodefile_id')
 
@@ -59,13 +47,11 @@ class WebHooksSonarr(Resource):
             logging.debug('Received test hook, skipping database search.')
             return 'Received test hook, skipping database search.', 200
 
+        episode_file_ids = []
         if sonarr_episodefile_id:
             episode_file_ids = [sonarr_episodefile_id]
-        else:
-            # Sonarr hooks only differentiate a download starting vs. ending by
-            # the inclusion of episodeFiles in the payload.
+        elif isinstance(args.get('episodeFiles'), list):
             episode_file_ids = [e.get('id') for e in args.get('episodeFiles', [])]
-
         if not episode_file_ids:
             logging.debug('No episode file IDs found in the webhook request. Nothing to do.')
             # Sonarr reports the webhook as 'unhealthy' and requires
@@ -74,7 +60,11 @@ class WebHooksSonarr(Resource):
 
         # This webhook is often faster than the database update,
         # so we update the series first if we can.
-        series_id = args.get('series', {}).get('id')
+        try:
+            series_id = args.get('series', {}).get('id')
+        except AttributeError:
+            series_id = None
+
         if series_id:
             update_one_series(series_id, 'updated')
 

--- a/frontend/src/pages/Settings/Radarr/index.tsx
+++ b/frontend/src/pages/Settings/Radarr/index.tsx
@@ -84,9 +84,10 @@ const SettingsRadarrView: FunctionComponent = () => {
           <Message>
             Search can be triggered using this command
             <Code>
-              curl -d "radarr_moviefile_id=$radarr_moviefile_id" -H "x-api-key:
-              ###############################" -X POST
-              http://localhost:6767/api/webhooks/radarr
+              {`curl -H "Content-Type: application/json" -H "X-API-KEY: ###############################" -X POST 
+                -d '{ "eventType": "Download", "movieFile": [ { "id": "$radarr_moviefile_id" } ] }' 
+                http://localhost:6767/api/webhooks/radarr
+              `}
             </Code>
           </Message>
         </Section>

--- a/frontend/src/pages/Settings/Radarr/index.tsx
+++ b/frontend/src/pages/Settings/Radarr/index.tsx
@@ -82,11 +82,12 @@ const SettingsRadarrView: FunctionComponent = () => {
             as soon as movies are imported.
           </Message>
           <Message>
-            Search can be triggered via a Radarr Webhook or by running:
+            Search can be triggered using this command
             <Code>
-              curl -d "radarr_moviefile_id=$radarr_moviefile_id" -H "x-api-key:
-              ###############################" -X POST
-              http://localhost:6767/api/webhooks/radarr
+              {`curl -H "Content-Type: application/json" -H "X-API-KEY: ###############################" -X POST 
+                -d '{ "eventType": "Download", "movieFile": [ { "id": "$radarr_moviefile_id" } ] }' 
+                http://localhost:6767/api/webhooks/radarr
+              `}
             </Code>
           </Message>
         </Section>

--- a/frontend/src/pages/Settings/Radarr/index.tsx
+++ b/frontend/src/pages/Settings/Radarr/index.tsx
@@ -82,12 +82,11 @@ const SettingsRadarrView: FunctionComponent = () => {
             as soon as movies are imported.
           </Message>
           <Message>
-            Search can be triggered using this command
+            Search can be triggered via a Radarr Webhook or by running:
             <Code>
-              {`curl -H "Content-Type: application/json" -H "X-API-KEY: ###############################" -X POST 
-                -d '{ "eventType": "Download", "movieFile": [ { "id": "$radarr_moviefile_id" } ] }' 
-                http://localhost:6767/api/webhooks/radarr
-              `}
+              curl -d "radarr_moviefile_id=$radarr_moviefile_id" -H "x-api-key:
+              ###############################" -X POST
+              http://localhost:6767/api/webhooks/radarr
             </Code>
           </Message>
         </Section>

--- a/frontend/src/pages/Settings/Sonarr/index.tsx
+++ b/frontend/src/pages/Settings/Sonarr/index.tsx
@@ -93,11 +93,12 @@ const SettingsSonarrView: FunctionComponent = () => {
             as soon as episodes are imported.
           </Message>
           <Message>
-            Search can be triggered using this command
+            Search can be triggered using this command:
             <Code>
-              curl -d "sonarr_episodefile_id=$sonarr_episodefile_id" -H
-              "x-api-key: ###############################" -X POST
-              http://localhost:6767/api/webhooks/sonarr
+              {`curl -H "Content-Type: application/json" -H "X-API-KEY: ###############################" -X POST 
+                -d '{ "eventType": "Download", "episodeFiles": [ { "id": "$sonarr_episodefile_id" } ] }' 
+                http://localhost:6767/api/webhooks/sonarr
+              `}
             </Code>
           </Message>
           <Check

--- a/frontend/src/pages/Settings/Sonarr/index.tsx
+++ b/frontend/src/pages/Settings/Sonarr/index.tsx
@@ -93,12 +93,11 @@ const SettingsSonarrView: FunctionComponent = () => {
             as soon as episodes are imported.
           </Message>
           <Message>
-            Search can be triggered using this command:
+            Search can be triggered via a Sonarr webhook or by running:
             <Code>
-              {`curl -H "Content-Type: application/json" -H "X-API-KEY: ###############################" -X POST 
-                -d '{ "eventType": "Download", "episodeFiles": [ { "id": "$sonarr_episodefile_id" } ] }' 
-                http://localhost:6767/api/webhooks/sonarr
-              `}
+              curl -d "sonarr_episodefile_id=$sonarr_episodefile_id" -H
+              "x-api-key: ###############################" -X POST
+              http://localhost:6767/api/webhooks/sonarr
             </Code>
           </Message>
           <Check

--- a/frontend/src/pages/Settings/Sonarr/index.tsx
+++ b/frontend/src/pages/Settings/Sonarr/index.tsx
@@ -93,11 +93,12 @@ const SettingsSonarrView: FunctionComponent = () => {
             as soon as episodes are imported.
           </Message>
           <Message>
-            Search can be triggered via a Sonarr webhook or by running:
+            Search can be triggered using this command:
             <Code>
-              curl -d "sonarr_episodefile_id=$sonarr_episodefile_id" -H
-              "x-api-key: ###############################" -X POST
-              http://localhost:6767/api/webhooks/sonarr
+              {`curl -H "Content-Type: application/json" -H "X-API-KEY: ###############################" -X POST 
+                -d '{ "eventType": "Download", "episodeFiles": [ { "id": "$sonarr_episodefile_id" } ] }' 
+                http://localhost:6767/api/webhooks/sonarr
+              `}
             </Code>
           </Message>
           <Check


### PR DESCRIPTION
Allows for sending 200 responses when receiving the 'test' requests sent by Sonarr and Radarr when configuring webhooks in their respective UIs. Also adds a custom message in such cases.

Fixes: #2935