### PR TITLE
Add history indexes

### DIFF
--- a/bazarr/app/database.py
+++ b/bazarr/app/database.py
@@ -90,7 +90,6 @@ signal.signal(signal.SIGTERM, lambda signal_no, frame: close_database())
 Base = declarative_base()
 metadata = Base.metadata
 
-
 class System(Base):
     __tablename__ = 'system'
 
@@ -308,6 +307,9 @@ def init_db():
 
     # Create tables if they don't exist.
     metadata.create_all(engine)
+
+    # Apply any missing index
+    ensure_indexes()
 
 
 def create_db_revision(app):
@@ -568,3 +570,23 @@ def fix_languages_profiles_with_duplicate_ids():
                 .values({"items": json.dumps(languages_profile_items)})
                 .where(TableLanguagesProfiles.profileId == languages_profile.profileId)
             )
+
+def ensure_indexes():
+    """Create indexes needed for fast look‑ups (no‑op if they exist)."""
+    index_ddl = [
+        # Series history
+        "CREATE INDEX IF NOT EXISTS idx_table_history_timestamp  ON table_history (timestamp)",
+        "CREATE INDEX IF NOT EXISTS idx_table_history_action     ON table_history (action)",
+        "CREATE INDEX IF NOT EXISTS idx_table_history_provider   ON table_history (provider)",
+        "CREATE INDEX IF NOT EXISTS idx_table_history_language   ON table_history (language)",
+
+        # Movie history
+        "CREATE INDEX IF NOT EXISTS idx_table_history_movie_timestamp  ON table_history_movie (timestamp)",
+        "CREATE INDEX IF NOT EXISTS idx_table_history_movie_action     ON table_history_movie (action)",
+        "CREATE INDEX IF NOT EXISTS idx_table_history_movie_provider   ON table_history_movie (provider)",
+        "CREATE INDEX IF NOT EXISTS idx_table_history_movie_language   ON table_history_movie (language)",
+    ]
+
+    with engine.begin() as conn:
+        for ddl in index_ddl:
+            conn.execute(text(ddl))


### PR DESCRIPTION
Hi folks!

This change creates indexes in the history tables making the website navigation way faster. For the most part, all queries were doing full table scans and it takes seconds for every pane to load up. After applying these indexes, navigation is smooth.

The main source of information to find which indexes are necessary was the [stats.py](https://github.com/morpheus65535/bazarr/blob/master/bazarr/api/history/stats.py) file.

If there's a better way to ensure these indexes are created, feel free to correct it.

Thanks!