### PR TITLE
Override translated subtitles language code option

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -179,6 +179,8 @@ validators = [
     Validator('translator.gemini_model', must_exist=True, default='gemini-2.0-flash', is_type_of=str, cast=str),
     Validator('translator.translator_info', must_exist=True, default=True, is_type_of=bool),
     Validator('translator.translator_type', must_exist=True, default='google_translate', is_type_of=str, cast=str),
+    Validator('translator.override_language', must_exist=True, default=False, is_type_of=bool),
+    Validator('translator.override_code', must_exist=True, default='ai', is_type_of=str, cast=str),
 
     # sonarr section
     Validator('sonarr.ip', must_exist=True, default='127.0.0.1', is_type_of=str),

--- a/bazarr/subtitles/tools/translate.py
+++ b/bazarr/subtitles/tools/translate.py
@@ -3,6 +3,8 @@
 import logging
 import datetime
 import os
+import re
+
 import pysubs2
 import srt
 
@@ -29,6 +31,7 @@ def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, fo
                              sonarr_episode_id, radarr_id):
 
     orig_to_lang = to_lang
+
     to_lang = alpha3_from_alpha2(to_lang)
     try:
         lang_obj = Language(to_lang)
@@ -51,6 +54,11 @@ def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, fo
                                       extension='.srt',
                                       forced_tag=forced,
                                       hi_tag=hi)
+
+    if settings.translator.override_language:
+        pattern = rf"\.{lang_obj.basename}\."
+        replacement = f".{settings.translator.override_code}."
+        dest_srt_file = re.sub(pattern, replacement, dest_srt_file)
 
     if settings.translator.translator_type == 'gemini':
         translate_subtitles_file_gemini(dest_srt_file, source_srt_file, to_lang, media_type, sonarr_series_id,

--- a/frontend/src/pages/Settings/Subtitles/index.tsx
+++ b/frontend/src/pages/Settings/Subtitles/index.tsx
@@ -550,6 +550,24 @@ const SettingsSubtitlesView: FunctionComponent = () => {
           label="Add translation info at the beginning"
           settingKey="settings-translator-translator_info"
         ></Check>
+        <Message>
+          Add information about the translation service and AI model used at the
+          beginning of the subtitle file.
+        </Message>
+        <Check
+          label="Override subtitles language code"
+          settingKey="settings-translator-override_language"
+        ></Check>
+        <Message>
+          Change the translated subtitle file's language code (this can help
+          monitor your language for new subtitles).
+        </Message>
+        <CollapseBox indent settingKey="settings-translator-override_language">
+          <Text
+            label="Language code"
+            settingKey="settings-translator-override_code"
+          />
+        </CollapseBox>
       </Section>
     </Layout>
   );

--- a/frontend/src/types/settings.d.ts
+++ b/frontend/src/types/settings.d.ts
@@ -179,6 +179,8 @@ declare namespace Settings {
     gemini_model: string;
     translator_info: boolean;
     translator_type: string;
+    override_language: boolean;
+    override_code: string;
   }
 
   interface Plex {


### PR DESCRIPTION
I have added small feature that could be helpful for poeple using subtitle translating.
My usecase:
1. I use Google / Gemini translator feature to get subtitles in my language.
2. After translating it is saved as my language subtitles
3. I want to get subtitles from legit providers when they are released but I dont because I already have subtitles.

My way to handle it is to override subtitle language in file name so I will have translated subtitles but the new one from providers will be still searched.
It is added as an option in "Translating" settings.
For example: move.it.hi.srt will be changed to move.ai.hi.srt
It is helpful for other apps like Kometa that can generate poster with info that movie has AI translated subtitles.