### PR TITLE
Add Plex OAuth

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -217,7 +217,7 @@ validators = [
     Validator('radarr.defer_search_signalr', must_exist=True, default=False, is_type_of=bool),
     Validator('radarr.sync_only_monitored_movies', must_exist=True, default=False, is_type_of=bool),
 
-    # plex section
+    # plex section - Legacy settings for backward compatibility
     Validator('plex.ip', must_exist=True, default='127.0.0.1', is_type_of=str),
     Validator('plex.port', must_exist=True, default=32400, is_type_of=int, gte=1, lte=65535),
     Validator('plex.ssl', must_exist=True, default=False, is_type_of=bool),
@@ -228,6 +228,17 @@ validators = [
     Validator('plex.set_episode_added', must_exist=True, default=False, is_type_of=bool),
     Validator('plex.update_movie_library', must_exist=True, default=False, is_type_of=bool),
     Validator('plex.update_series_library', must_exist=True, default=False, is_type_of=bool),
+    
+    # New Plex OAuth settings
+    Validator('plex.servers', must_exist=True, default=[], is_type_of=list),
+    Validator('plex.notifications', must_exist=True, default={}, is_type_of=dict),
+    Validator('plex.notifications.on_download', must_exist=True, default=True, is_type_of=bool),
+    Validator('plex.notifications.on_upgrade', must_exist=True, default=True, is_type_of=bool),
+    Validator('plex.notifications.on_rename', must_exist=True, default=False, is_type_of=bool),
+    Validator('plex.notifications.on_subtitle_download', must_exist=True, default=True, is_type_of=bool),
+    Validator('plex.notifications.on_health_issue', must_exist=True, default=False, is_type_of=bool),
+    Validator('plex.notifications.on_health_restored', must_exist=True, default=False, is_type_of=bool),
+    Validator('plex.notifications.on_manual_interaction_required', must_exist=True, default=False, is_type_of=bool),
 
     # proxy section
     Validator('proxy.type', must_exist=True, default=None, is_type_of=(NoneType, str),
@@ -502,7 +513,8 @@ array_keys = ['excluded_tags',
               'remove_profile_tags',
               'language_equals',
               'blacklisted_languages',
-              'blacklisted_providers']
+              'blacklisted_providers',
+              'servers']  # Added 'servers' for Plex OAuth support
 
 empty_values = ['', 'None', 'null', 'undefined', None, []]
 
@@ -531,6 +543,32 @@ if hasattr(settings.embeddedsubtitles, 'unknown_as_english'):
         settings.embeddedsubtitles.unknown_as_fallback = True
         settings.embeddedsubtitles.fallback_lang = 'en'
     del settings.embeddedsubtitles.unknown_as_english
+
+# Backward compatibility for legacy Plex settings
+# Migrate old single-server config to new multi-server format
+if settings.plex.apikey and not settings.plex.servers:
+    legacy_server = {
+        'id': 'legacy',
+        'name': 'Plex Media Server',
+        'host': settings.plex.ip,
+        'port': settings.plex.port,
+        'protocol': 'https' if settings.plex.ssl else 'http',
+        'token': settings.plex.apikey,
+        'updateLibrary': settings.plex.update_movie_library or settings.plex.update_series_library
+    }
+    settings.plex.servers = [legacy_server]
+    # Migrate notification settings
+    if not settings.plex.notifications:
+        settings.plex.notifications = {
+            'on_download': True,
+            'on_subtitle_download': True,
+            'on_upgrade': True,
+            'on_rename': False,
+            'on_health_issue': False,
+            'on_health_restored': False,
+            'on_manual_interaction_required': False
+        }
+
 # save updated settings to file
 write_config()
 
@@ -580,6 +618,7 @@ def save_settings(settings_items):
     update_schedule = False
     sonarr_changed = False
     radarr_changed = False
+    plex_changed = False  # Added for Plex OAuth support
     update_path_map = False
     configure_proxy = False
     exclusion_updated = False
@@ -675,6 +714,10 @@ def save_settings(settings_items):
         if key in ['settings-general-use_radarr', 'settings-radarr-ip', 'settings-radarr-port',
                    'settings-radarr-base_url', 'settings-radarr-ssl', 'settings-radarr-apikey']:
             radarr_changed = True
+            
+        # Handle Plex OAuth settings changes
+        if key in ['settings-general-use_plex', 'settings-plex-servers', 'settings-plex-notifications']:
+            plex_changed = True
 
         if key in ['settings-general-path_mappings', 'settings-general-path_mappings_movie']:
             update_path_map = True
@@ -837,6 +880,12 @@ def save_settings(settings_items):
                 radarr_signalr_client.restart()
             except Exception:
                 pass
+                
+        # Handle Plex OAuth changes
+        if plex_changed:
+            # Clear any cached Plex clients when settings change
+            from plex.plex_client import plex_clients
+            plex_clients.clear()
 
         if update_path_map:
             from utilities.path_mappings import path_mappings


### PR DESCRIPTION
I have not tested this, but maybe it could be a starting ground for adding something similar to what Sonarr and Radarr does?

### Key Features:

- Maintains Full Backward Compatibility: Existing Plex configurations using API keys will automatically be migrated to the new format
- Supports Multiple Plex Servers: The new servers list can store multiple Plex servers obtained through OAuth
- Notification Settings: Matches Sonarr's notification options but adapted for subtitle events
- Automatic Migration: When users upgrade, their existing Plex settings are preserved and converted to the new format

This merged config.py maintains all existing functionality while adding the OAuth authentication support needed to match Sonarr's implementation.