### PR TITLE
Fixed lingarr translation ModuleNotFoundError

### DIFF
--- a/bazarr/subtitles/tools/translate/services/lingarr_translator.py
+++ b/bazarr/subtitles/tools/translate/services/lingarr_translator.py
@@ -17,7 +17,6 @@ from languages.get_languages import alpha3_from_alpha2, language_from_alpha2, la
 from radarr.history import history_log_movie
 from sonarr.history import history_log
 from subtitles.processing import ProcessSubtitlesResult
-from subtitles.tools.translator_gemini import TranslatorGemini
 from app.event_handler import show_progress, hide_progress, show_message
 from utilities.path_mappings import path_mappings
 


### PR DESCRIPTION
This fixes a `ModuleNotFoundError` when translating with the new lingarr translation integration

Here is a Traceback of the issue I had
```
Traceback (most recent call last):

  File "/app/bazarr/bin/bazarr/subtitles/tools/translate/main.py", line 33, in translate_subtitles_file

    translator = TranslatorFactory.create_translator(

                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/app/bazarr/bin/bazarr/subtitles/tools/translate/services/translator_factory.py", line 16, in create_translator

    from .lingarr_translator import LingarrTranslatorService

  File "/app/bazarr/bin/bazarr/subtitles/tools/translate/services/lingarr_translator.py", line 20, in <module>

    from subtitles.tools.translator_gemini import TranslatorGemini

ModuleNotFoundError: No module named \'subtitles.tools.translator_gemini\
```

The fix was tested by applying the patch to the file directly from a custom Dockerfile that was based on linuxserver/bazarr:development image. I did not test it any other way

It seemed to me like that line was not needed in the file and was causing the error.