### PR TITLE
Refactor logging levels for improved clarity and debugging

### DIFF
--- a/bazarr/api/plex/oauth.py
+++ b/bazarr/api/plex/oauth.py
@@ -680,7 +680,7 @@ class PlexApiKey(Resource):
 
             write_config()
 
-            logging.info("API key saved and encrypted")
+            logging.debug("API key saved and encrypted")
             return {'success': True, 'message': 'API key saved securely'}
 
         except Exception as e:

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -505,7 +505,7 @@ while failed_validator:
         if hasattr(current_validator_details, 'default') and current_validator_details.default is not empty:
             old_value = settings.get(current_validator_details.names[0], 'undefined')
             settings[current_validator_details.names[0]] = current_validator_details.default
-            logging.info(f"VALIDATOR RESET: {current_validator_details.names[0]} from '{old_value}' to '{current_validator_details.default}'")
+            logging.warning(f"VALIDATOR RESET: {current_validator_details.names[0]} from '{old_value}' to '{current_validator_details.default}'")
         else:
             logging.critical(f"Value for {current_validator_details.names[0]} doesn't pass validation and there's no "
                              f"default value. This issue must be reported to and fixed by the development team. "
@@ -979,11 +979,11 @@ def migrate_plex_config():
     # Generate encryption key if not exists or is empty
     existing_key = settings.plex.get('encryption_key')
     if not existing_key or existing_key.strip() == "":
-        logging.info("Generating new encryption key for Plex token storage")
+        logging.debug("Generating new encryption key for Plex token storage")
         key = secrets.token_urlsafe(32)
         settings.plex.encryption_key = key
         write_config()
-        logging.info("Plex encryption key generated")
+        logging.debug("Plex encryption key generated")
     
     # Check if user needs seamless migration from API key to OAuth
     migrate_apikey_to_oauth()

--- a/bazarr/app/logger.py
+++ b/bazarr/app/logger.py
@@ -173,6 +173,7 @@ def configure_logging(debug=False):
     logging.getLogger("guessit").setLevel(logging.WARNING)
     logging.getLogger("rebulk").setLevel(logging.WARNING)
     logging.getLogger("stevedore.extension").setLevel(logging.CRITICAL)
+    logging.getLogger("plexapi").setLevel(logging.ERROR)
 
 def empty_file(filename):
     # Open the log file in write mode to clear its contents

--- a/bazarr/utilities/cache.py
+++ b/bazarr/utilities/cache.py
@@ -14,7 +14,7 @@ def cache_maintenance():
     main_cache_validity = 14  # days
     pack_cache_validity = 4  # days
 
-    logging.info("BAZARR Running cache maintenance")
+    logging.debug("BAZARR Running cache maintenance")
     now = datetime.datetime.now()
 
     def remove_expired(path, expiry):


### PR DESCRIPTION
I'm thinking if we put the default logging to error it won't be as many messages spamming the logs for normal users.

Kept most of the different levels and put some logging to debug that are obvious there.