### PR TITLE
Remove API Key from Plex API hook

### DIFF
--- a/bazarr/api/plex/oauth.py
+++ b/bazarr/api/plex/oauth.py
@@ -807,21 +807,17 @@ class PlexWebhookCreate(Resource):
             # Try to get base URL from settings first, then fall back to request host
             configured_base_url = getattr(settings.general, 'base_url', '').rstrip('/')
             
-            # Get the API key for webhook authentication
-            apikey = getattr(settings.auth, 'apikey', '')
-            if not apikey:
-                logger.error("No API key configured - cannot create webhook")
-                return {'error': 'No API key configured. Set up API key in Settings > General first.'}, 400
-            
+            # Construct webhook URL without authentication 
+            # This is safe because the webhook only triggers subtitle downloads
             if configured_base_url:
-                webhook_url = f"{configured_base_url}/api/webhooks/plex?apikey={apikey}"
-                logger.info(f"Using configured base URL for webhook: {configured_base_url}/api/webhooks/plex")
+                webhook_url = f"{configured_base_url}/api/webhooks/plex"
+                logger.info(f"Using configured base URL for webhook: {webhook_url}")
             else:
                 # Fall back to using the current request's host
                 scheme = 'https' if request.is_secure else 'http'
                 host = request.host
-                webhook_url = f"{scheme}://{host}/api/webhooks/plex?apikey={apikey}"
-                logger.info(f"Using request host for webhook (no base URL configured): {scheme}://{host}/api/webhooks/plex")
+                webhook_url = f"{scheme}://{host}/api/webhooks/plex"
+                logger.info(f"Using request host for webhook (no base URL configured): {webhook_url}")
                 logger.info("Note: If Bazarr is behind a reverse proxy, configure Base URL in General Settings for better reliability")
             
             # Get existing webhooks
@@ -923,7 +919,9 @@ class PlexWebhookDelete(Resource):
             args = self.post_request_parser.parse_args()
             webhook_url = args.get('webhook_url')
             
-            logger.info(f"Attempting to delete Plex webhook: {webhook_url}")
+            # Sanitize webhook URL for logging (in case it contains sensitive data)
+            safe_webhook_url = sanitize_log_data(webhook_url) if webhook_url else 'None'
+            logger.info(f"Attempting to delete Plex webhook: {safe_webhook_url}")
             
             decrypted_token = get_decrypted_token()
             if not decrypted_token:
@@ -932,14 +930,16 @@ class PlexWebhookDelete(Resource):
             from plexapi.myplex import MyPlexAccount
             account = MyPlexAccount(token=decrypted_token)
             
-            # First, let's see what webhooks actually exist
+            # First, let's see what webhooks actually exist  
             existing_webhooks = account.webhooks()
-            logger.info(f"Existing webhooks before deletion: {[str(w) for w in existing_webhooks]}")
+            # Sanitize webhook URLs in the list for logging
+            safe_webhook_list = [sanitize_log_data(str(w)) for w in existing_webhooks]
+            logger.info(f"Existing webhooks before deletion: {safe_webhook_list}")
             
             # Delete the webhook
             account.deleteWebhook(webhook_url)
             
-            logger.info(f"Successfully deleted Plex webhook: {webhook_url}")
+            logger.info(f"Successfully deleted Plex webhook: {safe_webhook_url}")
             
             return {
                 'data': {

--- a/bazarr/api/webhooks/plex.py
+++ b/bazarr/api/webhooks/plex.py
@@ -13,8 +13,6 @@ from subtitles.mass_download import episode_download_subtitles, movies_download_
 from app.logger import logger
 from ..plex.security import sanitize_log_data
 
-from ..utils import authenticate
-
 
 api_ns_webhooks_plex = Namespace('Webhooks Plex', description='Webhooks endpoint that can be configured in Plex to '
                                                               'trigger a subtitles search when playback start.')
@@ -25,12 +23,10 @@ class WebHooksPlex(Resource):
     post_request_parser = reqparse.RequestParser()
     post_request_parser.add_argument('payload', type=str, required=True, help='Webhook payload')
 
-    @authenticate
     @api_ns_webhooks_plex.doc(parser=post_request_parser)
     @api_ns_webhooks_plex.response(200, 'Success')
     @api_ns_webhooks_plex.response(204, 'Unhandled event or no processable data')
     @api_ns_webhooks_plex.response(400, 'Bad request - missing required data')
-    @api_ns_webhooks_plex.response(401, 'Not Authenticated')
     @api_ns_webhooks_plex.response(404, 'IMDB series/movie ID not found')
     @api_ns_webhooks_plex.response(500, 'Internal server error')
     def post(self):

--- a/bazarr/app/logger.py
+++ b/bazarr/app/logger.py
@@ -32,7 +32,8 @@ class FileHandlerFormatter(logging.Formatter):
         return repr(result)  # or format into one line however you want to
 
     def formatApikey(self, s):
-        return re.sub(self.APIKEY_RE, 'apikey=(removed)', s)
+        s = re.sub(self.APIKEY_RE, 'apikey=(removed)', s)
+        return s
 
     def formatIPv4(self, s):
         return re.sub(self.IPv4_RE, '***.***.***.***', s)


### PR DESCRIPTION
Changes Made
Removed authentication from webhook endpoint ([plex.py](vscode-file://vscode-app/snap/code/205/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)):

Removed @authenticate_webhook decorator
Updated error responses (removed 401 response)
Updated webhook URL creation ([oauth.py](vscode-file://vscode-app/snap/code/205/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)):

Webhook URLs no longer include API key: https://domain/api/webhooks/plex
Updated logging to be safe since URLs no longer contain secrets
Added safety for webhook deletion logging:

URLs passed to delete endpoint are sanitized before logging (in case old URLs with API keys are still being deleted)
Cleaned up unused code:

Removed webhook token validation from config
Removed webhook authentication function
Removed webhook token generation endpoint
Simplified logging formatter