### PR TITLE
Enhance season guessing

### DIFF
--- a/bazarr/api/subtitles/subtitles_info.py
+++ b/bazarr/api/subtitles/subtitles_info.py
@@ -53,7 +53,18 @@ class SubtitleNameInfo(Resource):
                     result['episode'] = guessit_result['episode']
 
             if 'season' in guessit_result:
-                result['season'] = guessit_result['season']
+                if isinstance(guessit_result['season'], list):
+                    # for multiple seasons file, choose the first season number
+                    if len(guessit_result['season']):
+                        # make sure that guessit returned a list of more than 0 items
+                        result['season'] = guessit_result['season'][0]
+                    else:
+                        result['season'] = 0
+                elif isinstance(guessit_result['season'], int):
+                    # if single season
+                    result['season'] = guessit_result['season']
+                else:
+                    result['season'] = 0
             else:
                 result['season'] = 0
 


### PR DESCRIPTION
Updated the season processing to:

1. Check if the season is a list
2. If it's a list, take the first value  
3. If it's an integer, use it directly
4. Handle any other cases gracefully by defaulting to 0

This PR properly addresses issue #3030 by handling cases where guessit returns season information as a list instead of a single integer.