### PR TITLE
Add support for specifying Postgres URL explicitly

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -452,6 +452,7 @@ validators = [
     Validator('postgresql.database', must_exist=True, default='', is_type_of=str),
     Validator('postgresql.username', must_exist=True, default='', is_type_of=str, cast=str),
     Validator('postgresql.password', must_exist=True, default='', is_type_of=str, cast=str),
+    Validator('postgresql.url', must_exist=True, default='', is_type_of=str, cast=str),
 
     # anidb section
     Validator('anidb.api_client', must_exist=True, default='', is_type_of=str),


### PR DESCRIPTION
This allows users to specify the Postgres URL explicitly via the settings file or env var. This allows users to:
* Require connections to use TLS
* Configure the trusted CA for the server's serving cert
* Specify a client certificate to use for mTLS (this is what I personally want this for)
* Configure database pooling

By implementing this via a URL/connection string setting, this will support all query parameters that the underlying driver supports. Based on the psycopg2 docs, I _think_ this is [everything that libpq supports](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS).

This should be 100% backwards compatible and is opt-in only.

I'm not really sure how to build let alone test this project... any advice here would be appreciated.