### PR TITLE
Fix SubsRo provider episode number matching from archives with multiple files

### DIFF
--- a/custom_libs/subliminal_patch/providers/subsro.py
+++ b/custom_libs/subliminal_patch/providers/subsro.py
@@ -41,8 +41,8 @@ class SubsRoSubtitle(Subtitle):
         self.page_link = download_link
         self.imdb_id = imdb_id
         self.matches = None
-        self.is_episode = is_episode
-        self.episode_number = episode_number
+        self.asked_for_episode = is_episode
+        self.episode = episode_number
         self.year = year
         self.release_info = self.releases = release_info
         self.season = season


### PR DESCRIPTION
Episode number matching never worked for this provider when an archive containing multiple subtitles is downloaded. 

Explanation for faster PR approval: the variable names in the [initial commit](https://github.com/morpheus65535/bazarr/commit/dd270372ffbb7329cffdabddf991efd1de6f933c#diff-0ed5527fd8272e5351226a71a894cc50ad67872f01d7e0c14daf4b62209f2b0bR44-R45) / [pull](https://github.com/morpheus65535/bazarr/pull/2964) were wrongly defined. The provider is using default `ProviderSubtitleArchiveMixin.get_subtitle_from_archive()` which expects `asked_for_episode` https://github.com/morpheus65535/bazarr/blob/master/custom_libs/subliminal_patch/providers/mixins.py#L92
and `episode` https://github.com/morpheus65535/bazarr/blob/master/custom_libs/subliminal_patch/providers/mixins.py#L106 fields instead of current defined `is_episode` and `episode_number` fields