### PR TITLE
subtitle translation by retrieving source language from the db

### DIFF
--- a/bazarr/api/subtitles/subtitles.py
+++ b/bazarr/api/subtitles/subtitles.py
@@ -182,7 +182,7 @@ class Subtitles(Resource):
                             from_language = subtitle_entry[0]
                             break
 
-                if not from_language:
+                if not from_language or not alpha3_from_alpha2(from_language):
                     from_language = subtitles_lang_from_filename(subtitles_path)
                 if not from_language or not alpha3_from_alpha2(from_language):
                     return 'Invalid source language code', 400


### PR DESCRIPTION
After a user reported that subtitles without language tags were failing, I created this PR to retrieve the language from the database when the subtitle matches one of the subtitles stored in the subtitle column. If not, it falls back to the original method of retrieving it from the filename.