### PR TITLE
Fix minor bugs in Jobs Manager

### DIFF
--- a/frontend/src/App/Header.tsx
+++ b/frontend/src/App/Header.tsx
@@ -163,7 +163,7 @@ const AppHeader: FunctionComponent = () => {
           !jobsError &&
           (Array.isArray(jobs) ? (
             <>
-              {jobs.length > 0 &&
+              {jobs.length > 0 ? (
                 (() => {
                   const grouped = (jobs as Jobs[]).reduce<
                     Record<string, Jobs[]>
@@ -210,9 +210,9 @@ const AppHeader: FunctionComponent = () => {
                               ).getTime();
                               return timeB - timeA; // Latest first (descending order)
                             })
-                            .map((job) => (
+                            .map((job, index) => (
                               <Card
-                                key={job?.job_id}
+                                key={job?.job_id ?? `job-fallback-${index}`}
                                 withBorder
                                 radius="sm"
                                 padding="sm"
@@ -238,7 +238,7 @@ const AppHeader: FunctionComponent = () => {
                                   </Text>
                                   <Badge size="sm">
                                     <TimeAgo
-                                      date={job?.last_run_time}
+                                      date={job?.last_run_time || new Date()}
                                       minPeriod={5}
                                     />
                                   </Badge>
@@ -247,9 +247,11 @@ const AppHeader: FunctionComponent = () => {
                                   <>
                                     <Progress
                                       value={
-                                        (job.progress_value /
-                                          job.progress_max) *
-                                        100
+                                        job.progress_max > 0
+                                          ? (job.progress_value /
+                                              job.progress_max) *
+                                            100
+                                          : 0
                                       }
                                       size="sm"
                                       radius="sm"
@@ -275,7 +277,12 @@ const AppHeader: FunctionComponent = () => {
                         </Stack>
                       </Stack>
                     ));
-                })()}
+                })()
+              ) : (
+                <Text c="dimmed" ta="center" py="xl">
+                  No jobs to display
+                </Text>
+              )}
             </>
           ) : (
             <Card withBorder padding="md" radius="sm">


### PR DESCRIPTION
Fixes 5 issues found in PR #3014:

1. **Division by zero crash** - Progress calculation crashes when max is 0
2. **Undefined React keys** - Missing fallback for job IDs
3. **Memory leak** - Unbounded cache growth, added 100 item limit
4. **Missing empty state** - Jobs count shows but no message when empty
5. **TimeAgo errors** - Missing fallback for undefined timestamps

Changes:
- `Header.tsx`: Fixed progress calc, React keys, empty state, TimeAgo
- `reducer.ts`: Added cache trimming to prevent memory leak