### PR TITLE
Added null check for subtitle_entry

### DIFF
--- a/bazarr/api/subtitles/subtitles.py
+++ b/bazarr/api/subtitles/subtitles.py
@@ -176,7 +176,7 @@ class Subtitles(Resource):
                 subtitles_filename = os.path.basename(subtitles_path)
 
                 for subtitle_entry in subtitles_list:
-                    if len(subtitle_entry) >= 2:
+                    if len(subtitle_entry) >= 2 and subtitle_entry[1] is not None:
                         db_subtitle_filename = os.path.basename(subtitle_entry[1])
                         if db_subtitle_filename == subtitles_filename:
                             from_language = subtitle_entry[0]


### PR DESCRIPTION
Added a null check for subtitle_entry[1] in subtitles.py for issue [#3046](https://github.com/morpheus65535/bazarr/issues/3046#issuecomment-3403170659)
But sadly I can’t replicate the issue since I don’t know/have a proper test case, but the error indicates that it fails when subtitle_entry[1] is null. However, if that value is null, the if condition fails and from_language should be set from the filename fallback instead.