### PR TITLE
Fixes `TypeError: tuple indices must be integers or slices, not str` when logging episode deletions during Sonarr syncs

### DIFF
--- a/bazarr/sonarr/sync/episodes.py
+++ b/bazarr/sonarr/sync/episodes.py
@@ -242,7 +242,7 @@ def sync_one_episode(episode_id, defer_search=False):
         else:
             event_stream(type='episode', action='delete', payload=int(episode_id))
             logging.debug(
-                f'BAZARR deleted this episode from the database:{path_mappings.path_replace(existing_episode["path"])}')
+                f'BAZARR deleted this episode from the database:{path_mappings.path_replace(existing_episode.path)}')
         return
 
     # Update existing episodes in DB

--- a/tests/bazarr/test_sonarr_sync_episodes.py
+++ b/tests/bazarr/test_sonarr_sync_episodes.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+"""
+Test for Sonarr episode sync functionality.
+
+Specifically tests the fix for TypeError when logging deleted episodes
+where SQLAlchemy Row objects were accessed with dict-style syntax instead
+of attribute access.
+
+This bug occurred in bazarr/sonarr/sync/episodes.py line 245 where the code
+used existing_episode["path"] (dict-style access) instead of existing_episode.path
+(attribute access) on a SQLAlchemy Row object.
+"""
+import pytest
+
+
+@pytest.fixture
+def mock_row():
+    """Mock SQLAlchemy Row object behavior.
+    
+    SQLAlchemy Row objects (returned by select().first()) behave like named tuples:
+    - They support attribute access: row.column_name
+    - They support integer indexing: row[0]
+    - They do NOT support string key access: row["column_name"] raises TypeError
+    """
+    class MockRow:
+        """Simulates SQLAlchemy Row object returned from select().first()"""
+        def __init__(self, path, episode_file_id):
+            # Store as tuple internally (like SQLAlchemy Row)
+            self._data = (path, episode_file_id)
+            # Set attributes for attribute access
+            self.path = path
+            self.episode_file_id = episode_file_id
+        
+        def __getitem__(self, key):
+            """Simulate SQLAlchemy Row behavior - only integer indices work"""
+            if isinstance(key, str):
+                raise TypeError("tuple indices must be integers or slices, not str")
+            return self._data[key]
+    
+    return MockRow
+
+
+def test_row_object_attribute_access(mock_row):
+    """Test that Row object supports attribute access (the correct way)."""
+    row = mock_row("/path/to/episode.mkv", 12345)
+    
+    # Attribute access should work (this is what the fix uses)
+    assert row.path == "/path/to/episode.mkv"
+    assert row.episode_file_id == 12345
+
+
+def test_row_object_dict_access_fails(mock_row):
+    """Test that Row object raises TypeError with dict-style string key access.
+    
+    This test demonstrates the bug that was fixed in line 245.
+    The code originally used: existing_episode["path"]
+    Which raised: TypeError: tuple indices must be integers or slices, not str
+    """
+    row = mock_row("/path/to/episode.mkv", 12345)
+    
+    # Dict-style access with string key should raise TypeError (the bug)
+    with pytest.raises(TypeError, match="tuple indices must be integers or slices, not str"):
+        _ = row["path"]
+    
+    with pytest.raises(TypeError, match="tuple indices must be integers or slices, not str"):
+        _ = row["episode_file_id"]
+
+
+def test_row_object_integer_index_access(mock_row):
+    """Test that Row object supports integer index access."""
+    row = mock_row("/path/to/episode.mkv", 12345)
+    
+    # Integer index access should work
+    assert row[0] == "/path/to/episode.mkv"
+    assert row[1] == 12345
+
+
+def test_bug_reproduction_dict_vs_attribute_access(mock_row):
+    """Demonstrate the exact bug that was fixed.
+    
+    This test reproduces the bug from bazarr/sonarr/sync/episodes.py line 245:
+    - Bug: path_mappings.path_replace(existing_episode["path"]) - TypeError
+    - Fix: path_mappings.path_replace(existing_episode.path) - Works
+    """
+    # Create a Row-like object as returned by:
+    # database.execute(select(TableEpisodes.path, TableEpisodes.episode_file_id).where(...)).first()
+    existing_episode = mock_row("/tv/Show/S01E01.mkv", 12345)
+    
+    # ❌ The bug: trying to use dict-style access on Row object
+    with pytest.raises(TypeError) as exc_info:
+        path = existing_episode["path"]
+        # This would be in: path_mappings.path_replace(existing_episode["path"])
+    
+    assert "tuple indices must be integers or slices, not str" in str(exc_info.value)
+    
+    # ✅ The fix: using attribute access instead
+    path = existing_episode.path  # This works!
+    assert path == "/tv/Show/S01E01.mkv"
+    
+    # Simulate the fixed line 245:
+    # f'BAZARR deleted this episode from the database:{path_mappings.path_replace(existing_episode.path)}'
+    result_path = existing_episode.path  # No TypeError!
+    assert result_path == "/tv/Show/S01E01.mkv"
+


### PR DESCRIPTION
## Description

This PR fixes an error `TypeError: tuple indices must be integers or slices, not str` that occurs when Bazarr logs episode deletions during Sonarr sync events.

## The Problem

When Sonarr signals that an episode has been deleted, Bazarr attempts to log the deletion but crashes with a `TypeError` due to inconsistent SQLAlchemy Row object access.

**Full Stack Trace:**
```python
File "/app/bazarr/bin/bazarr/app/jobs_queue.py", line 200, in consume_jobs_pending_queue
  getattr(importlib.import_module(job.module), job.func)(*job.args, **job.kwargs)
File "/app/bazarr/bin/bazarr/sonarr/sync/episodes.py", line 245, in sync_one_episode
  f'BAZARR deleted this episode from the database:{path_mappings.path_replace(existing_episode["path"])}'
                                                                              ~~~~~~~~~~~~~~~~^^^^^^^^
File "/app/bazarr/bin/bazarr/../libs/sqlalchemy/engine/_py_row.py", line 92, in __getitem__
  return self._data[key]
         ~~~~~~~~~~^^^^^
TypeError: tuple indices must be integers or slices, not str
```

## Root Cause

**bazarr/sonarr/sync/episodes.py lines 208-211** query only specific columns:
```python
existing_episode = database.execute(
    select(TableEpisodes.path, TableEpisodes.episode_file_id)
    .where(TableEpisodes.sonarrEpisodeId == episode_id)) \
    .first()
```

This returns a SQLAlchemy `Row` object (tuple-like) rather than a full ORM object. Row objects support:
- ✅ Attribute access: `row.column_name`
- ✅ Integer index: `row[0]`
- ❌ String key access: `row["column_name"]`

**Inconsistent access in the same function:**
- ✅ **Line 241**: `existing_episode.path` - Works correctly
- ❌ **Line 245**: `existing_episode["path"]` - Causes `TypeError`

## The Solution

Change `bazarr/sonarr/sync/episodes.py` line 245 to use attribute access (matching line 241):

```python
# Before:
f'BAZARR deleted this episode from the database:{path_mappings.path_replace(existing_episode["path"])}'

# After:
f'BAZARR deleted this episode from the database:{path_mappings.path_replace(existing_episode.path)}'
```

## Impact

**Before this fix:**
- Episode deletion succeeds (occurs before logging)
- Error logged to console/logs
- Job marked as failed in jobs queue
- Debug logging incomplete

**After this fix:**
- Episode deletion succeeds
- Logging completes successfully
- Job completes cleanly
- Debug information properly recorded

## Testing Performed

- [x] Verified code change matches existing pattern on line 241
- [x] Confirmed SQLAlchemy Row object behavior with tuple-like access
- [x] One-line change, minimal risk
- [x] Maintains existing functionality

## Environment Details

This bug was identified in:
- **Bazarr Version**: v1.5.3-ls319 (LinuxServer.io container)
- **Python**: 3.12
- **Occurrence**: Intermittent - only when Sonarr sends episode deletion events

## Additional Notes

This is a cosmetic bug affecting logging only. The actual episode deletion operation completes successfully before the logging error occurs, so functionality is not impacted. However, it does cause:
- Failed job entries in the jobs queue
- Incomplete debug logs
- Error messages in application logs

The fix ensures consistent SQLAlchemy Row object access patterns throughout the function.