### PR TITLE
Fix forum login to use correct username and password fields

### DIFF
--- a/custom_libs/subliminal_patch/providers/karagarga.py
+++ b/custom_libs/subliminal_patch/providers/karagarga.py
@@ -104,8 +104,8 @@ class KaragargaProvider(Provider):
             "auth_key": "880ea6a14ea49e853634fbdc5015a024",
             #
             "referer": "https://forum.karagarga.in/",
-            "ips_username": self._username,
-            "ips_password": self._password,
+            "ips_username": self._f_username,
+            "ips_password": self._f_password,
             "rememberMe": "1",
             "anonymous": "1",
         }


### PR DESCRIPTION
The Karagarga.in provider has separate usernames and passwords for the main site and the forum. Bazarr already supports both in the configuration. However the forum username and password are not actually used by bazarr to login to the forum, it incorrectly uses the main site for both. 