### PR TITLE
Fix lingarr connection pt-BR issue

### DIFF
--- a/bazarr/subtitles/tools/translate/services/lingarr_translator.py
+++ b/bazarr/subtitles/tools/translate/services/lingarr_translator.py
@@ -42,6 +42,7 @@ class LingarrTranslatorService:
         self.language_code_convert_dict = {
             'zh': 'zh-CN',
             'zt': 'zh-TW',
+            'pb': 'pt-BR',
         }
 
     def translate(self, job_id=None):


### PR DESCRIPTION
Hey team, im having an issue that when calling lingarr to translate subtitles its using the PB language code for brazilian portuguese. But the iso code standard is pt-BR, i saw someone else had this issue as well at this issue #3106. Anyways i saw this easy fix in the code and implemented it.

Example error from lingarr:
```
Invalid language code: pb Exception: System.ArgumentException: Invalid language code: 'pb' (Parameter 'languageCode') at Lingarr.Server.Services.LanguageCodeService.GetCulture(String languageCode) in /src/Lingarr.Server/Services/LanguageCodeService.cs:line 71 at Lingarr.Server.Services.LanguageCodeService.GetCultureName(String languageCode) in /src/Lingarr.Server/Services/LanguageCodeService.cs:line 35 at Lingarr.Server.Services.Translation.Base.BaseLanguageService.GetFullLanguageName(String languageCode) in /src/Lingarr.Server/Services/Translation/Base/BaseLanguageService.cs:line 188
```