### PR TITLE
Fix audio stream language mapping in WhisperAIProvider

### DIFF
--- a/custom_libs/subliminal_patch/providers/whisperai.py
+++ b/custom_libs/subliminal_patch/providers/whisperai.py
@@ -352,7 +352,7 @@ class WhisperAIProvider(Provider):
                 # 0 = Pick first stream in case there are multiple language streams of the same language,
                 # otherwise ffmpeg will try to combine multiple streams, but our output format doesn't support that.
                 # The first stream is probably the correct one, as later streams are usually commentaries
-                lang_map = f"0:m:language:{audio_stream_language}"
+                lang_map = f"0:a:m:language:{audio_stream_language}"
                 out = inp.output("-", format="s16le", acodec="pcm_s16le", ac=1, ar=16000, af="aresample=async=1",
                                  map=lang_map)
             else:


### PR DESCRIPTION
- **Problem**: WhisperAI ffmpeg mapping used `0:m:language:<lang>`, which can select subtitle or attachment streams instead of audio.

- **Fix**: Restrict stream selection to audio only by using `0:a:m:language:<lang>`.

- **Impact**: Prevents ffmpeg “codec none / missing/bad audio track” errors on files with language-tagged subtitle streams (e.g. Blu-ray anime releases).
