### PR TITLE
refactor(sonarr): parallelize series sync with ThreadPoolExecutor

### DIFF
--- a/bazarr/sonarr/sync/series.py
+++ b/bazarr/sonarr/sync/series.py
@@ -2,6 +2,9 @@
 
 import logging
 
+from concurrent.futures import ThreadPoolExecutor
+from threading import Lock
+
 from sqlalchemy.exc import IntegrityError
 from datetime import datetime
 
@@ -22,6 +25,9 @@ bool_map = {"True": True, "False": False}
 
 FEATURE_PREFIX = "SYNC_SERIES "
 
+# Thread-safe progress tracking
+progress_lock = Lock()
+completed = 0
 
 def trace(message):
     if settings.general.debug:
@@ -42,6 +48,9 @@ def get_series_monitored_table():
 
 
 def update_series(job_id=None):
+    global completed
+    completed = 0
+
     if not job_id:
         jobs_queue.add_job_from_function("Syncing series with Sonarr", is_progress=True)
         return
@@ -75,109 +84,153 @@ def update_series(job_id=None):
     series = get_series_from_sonarr_api(apikey_sonarr=apikey_sonarr)
     if not isinstance(series, list):
         return
-    else:
-        # Get current shows in DB
-        current_shows_db = [x.sonarrSeriesId for x in
-                            database.execute(
-                                select(TableShows.sonarrSeriesId))
-                            .all()]
-        current_shows_sonarr = []
 
-        series_count = len(series)
-        sync_monitored = settings.sonarr.sync_only_monitored_series
-        if sync_monitored:
-            series_monitored = get_series_monitored_table()
-            skipped_count = 0
-        trace(f"Starting sync for {series_count} shows")
+    # Get current shows in DB
+    current_shows_db = [x.sonarrSeriesId for x in
+                        database.execute(select(TableShows.sonarrSeriesId)).all()]
+    current_shows_sonarr = []
 
-        jobs_queue.update_job_progress(job_id=job_id, progress_max=series_count)
-        for i, show in enumerate(series, start=1):
-            jobs_queue.update_job_progress(job_id=job_id, progress_value=i, progress_message=show['title'])
-            if sync_monitored:
-                try:
-                    monitored_status_db = bool_map[series_monitored[show['id']]]
-                except KeyError:
-                    monitored_status_db = None
-                if monitored_status_db is None:
-                    # not in db, need to add
-                    pass
-                elif monitored_status_db != show['monitored']:
-                    # monitored status changed and we don't know about it until now
-                    trace(f"{i}: (Monitor Status Mismatch) {show['title']}")
-                    # pass
-                elif not show['monitored']:
-                    # Add unmonitored series in sonarr to current series list, otherwise it will be deleted from db
-                    trace(f"{i}: (Skipped Unmonitored) {show['title']}")
-                    current_shows_sonarr.append(show['id'])
-                    skipped_count += 1
-                    continue
+    sync_monitored = settings.sonarr.sync_only_monitored_series
 
-            trace(f"{i}: (Processing) {show['title']}")
-            # Add shows in Sonarr to current shows list
-            current_shows_sonarr.append(show['id'])
+    # Filter monitored series if needed
+    if sync_monitored:
+        series_monitored = get_series_monitored_table()
+        series_to_process = []
+        skipped_count = 0
 
-            if show['id'] in current_shows_db:
-                updated_series = seriesParser(show, action='update', tags_dict=tagsDict,
-                                              language_profiles=language_profiles,
-                                              serie_default_profile=serie_default_profile,
-                                              audio_profiles=audio_profiles)
+        for i, show in series:
+            try:
+                monitored_status_db = bool_map[series_monitored[show['id']]]
+            except (KeyError, AttributeError):
+                monitored_status_db = None
 
-                if not database.execute(
-                        select(TableShows)
-                        .filter_by(**updated_series))\
-                        .first():
-                    try:
-                        trace(f"Updating {show['title']}")
-                        updated_series['updated_at_timestamp'] = datetime.now()
-                        database.execute(
-                            update(TableShows)
-                            .values(updated_series)
-                            .where(TableShows.sonarrSeriesId == show['id']))
-                    except IntegrityError as e:
-                        logging.error(f"BAZARR cannot update series {updated_series['path']} because of {e}")
-                        continue
-
-                event_stream(type='series', payload=show['id'])
+            if monitored_status_db is None:
+                # not in db, need to add
+                trace(f"{i}: (Monitor Status Missing) {show['title']}")
+                series_to_process.append(show)
+            elif monitored_status_db != show['monitored']:
+                # monitored status changed and we don't know about it until now
+                trace(f"{i}: (Monitor Status Mismatch) {show['title']}")
+                series_to_process.append(show)
+            elif not show['monitored']:
+                # Add unmonitored series in sonarr to current series list, otherwise it will be deleted from db
+                trace(f"{i}: (Skipped Unmonitored) {show['title']}")
+                current_shows_sonarr.append(show['id'])
+                skipped_count += 1
             else:
-                added_series = seriesParser(show, action='insert', tags_dict=tagsDict,
-                                            language_profiles=language_profiles,
-                                            serie_default_profile=serie_default_profile,
-                                            audio_profiles=audio_profiles)
+                series_to_process.append(show)
 
-                try:
-                    trace(f"Inserting {show['title']}")
-                    added_series['created_at_timestamp'] = datetime.now()
-                    database.execute(
-                        insert(TableShows)
-                        .values(added_series))
-                except IntegrityError as e:
-                    logging.error(f"BAZARR cannot insert series {added_series['path']} because of {e}")
-                    continue
+        trace(f"Processing {len(series_to_process)} series, skipped {skipped_count} unmonitored")
+    else:
+        series_to_process = series
+
+    series_count = len(series)
+    trace(f"Starting sync for {series_count} shows")
+
+    # Get worker count from settings with 5 default
+    # (setting doesn't exist yet, but maybe later?)
+    worker_count = getattr(settings.sonarr, 'sonarr_sync_workers', 5)
+    # Cap at 10 to avoid overwhelming Sonarr
+    worker_count = min(worker_count, 10)
+
+    trace(f"Starting parallel sync with {worker_count} workers for {len(series_to_process)} series")
+    jobs_queue.update_job_progress(job_id=job_id, progress_max=len(series_to_process))
+
+    # Process series in parallel
+    with ThreadPoolExecutor(max_workers=worker_count, thread_name_prefix="SonarrSync") as executor:
+        futures = {
+            executor.submit(
+                sync_single_series,
+                show, tagsDict, language_profiles, serie_default_profile,
+                audio_profiles, current_shows_db, job_id, len(series_to_process)
+            ): show
+            for show in series_to_process
+        }
+
+        # Collect results and track processed series
+        for future in futures:
+            show = futures[future]
+            try:
+                series_id, success, error = future.result(timeout=300)  # 5 min timeout per series
+                if success:
+                    # Add shows in Sonarr to current shows list
+                    current_shows_sonarr.append(series_id)
                 else:
                     list_missing_subtitles(no=show['id'])
+                    logging.error(f"Failed to sync series {show['title']}: {error}")
+            except Exception as e:
+                logging.exception(f"Exception syncing series {show['title']}: {e}")
 
-                    event_stream(type='series', action='update', payload=show['id'])
+    # Remove old series from DB
+    removed_series = list(set(current_shows_db) - set(current_shows_sonarr))
+    for series_id in removed_series:
+        if settings.general.debug:
+            series_title = database.execute(
+                select(TableShows.title).where(TableShows.sonarrSeriesId == series_id)
+            ).first()[0]
+            trace(f"Deleting {series_title}")
+        database.execute(delete(TableShows).where(TableShows.sonarrSeriesId == series_id))
+        event_stream(type='series', action='delete', payload=series_id)
 
-            sync_episodes(series_id=show['id'])
-
-        # Remove old series from DB
-        removed_series = list(set(current_shows_db) - set(current_shows_sonarr))
-
-        for series in removed_series:
-            # try to avoid unnecessary database calls
-            if settings.general.debug:
-                series_title = database.execute(select(TableShows.title).where(TableShows.sonarrSeriesId == series)).first()[0]
-                trace(f"Deleting {series_title}")
-            database.execute(
-                delete(TableShows)
-                .where(TableShows.sonarrSeriesId == series))
-            event_stream(type='series', action='delete', payload=series)
-
-        if sync_monitored:
-            trace(f"skipped {skipped_count} unmonitored series out of {i}")
-        logging.debug('BAZARR All series synced from Sonarr into database.')
+    logging.debug('BAZARR All series synced from Sonarr into database.')
     jobs_queue.update_job_name(job_id=job_id, new_job_name="Synced series with Sonarr")
 
+def sync_single_series(show, tagsDict, language_profiles, serie_default_profile, 
+                       audio_profiles, current_shows_db, job_id, total):
+    """Process a single series with all its episodes"""
+    global completed
+
+    series_id = show['id']
+    thread_name = f"Series-{series_id}"
+
+    try:
+        trace(f"[{thread_name}] Processing {show['title']}")
+
+        # Determine if update or insert
+        if series_id in current_shows_db:
+            series_data = seriesParser(show, action='update', tags_dict=tagsDict,
+                                      language_profiles=language_profiles,
+                                      serie_default_profile=serie_default_profile,
+                                      audio_profiles=audio_profiles)
+
+            if not database.execute(select(TableShows).filter_by(**series_data)).first():
+                series_data['updated_at_timestamp'] = datetime.now()
+                database.execute(
+                    update(TableShows)
+                    .values(series_data)
+                    .where(TableShows.sonarrSeriesId == series_id))
+                trace(f"[{thread_name}] Updated {show['title']}")
+        else:
+            series_data = seriesParser(show, action='insert', tags_dict=tagsDict,
+                                      language_profiles=language_profiles,
+                                      serie_default_profile=serie_default_profile,
+                                      audio_profiles=audio_profiles)
+
+            series_data['created_at_timestamp'] = datetime.now()
+            database.execute(insert(TableShows).values(series_data))
+            trace(f"[{thread_name}] Inserted {show['title']}")
+
+        # Sync episodes (this is the expensive part)
+        sync_episodes(series_id=series_id)
+
+        # Thread-safe progress update
+        with progress_lock:
+            completed += 1
+            jobs_queue.update_job_progress(
+                job_id=job_id, 
+                progress_value=completed,
+                progress_message=f"{show['title']} ({completed}/{total})"
+            )
+
+        event_stream(type='series', payload=series_id)
+        return series_id, True, None
+
+    except IntegrityError as e:
+        logging.error(f"[{thread_name}] Cannot process series {show.get('path', 'unknown')}: {e}")
+        return series_id, False, str(e)
+    except Exception as e:
+        logging.exception(f"[{thread_name}] Unexpected error processing {show['title']}")
+        return series_id, False, str(e)
 
 def update_one_series(series_id, action, is_signalr=False):
     logging.debug(f'BAZARR syncing this specific series from Sonarr: {series_id}')


### PR DESCRIPTION
- Add concurrent.futures ThreadPoolExecutor for parallel series processing
- Implement thread-safe progress tracking with Lock
- Extract sync_single_series function for individual series processing
- Add configurable worker count with default of 5 and max cap of 10
- Add 5 minute timeout per series to prevent hanging
- Improve error handling with per-series success/failure tracking
- Simplify monitored series filtering logic

Improves the situation referenced in #2260