### PR TITLE
fix(subssabbz): fix search, diacritics, language comparison, and download error handling

### DIFF
--- a/custom_libs/subliminal_patch/providers/subssabbz.py
+++ b/custom_libs/subliminal_patch/providers/subssabbz.py
@@ -5,6 +5,7 @@ import re
 import io
 import os
 import codecs
+import unicodedata
 from hashlib import sha1
 from random import randint
 from bs4 import BeautifulSoup
@@ -121,6 +122,8 @@ class SubsSabBzProvider(Provider):
     languages = {Language(l) for l in [
         'bul', 'eng'
     ]}
+    languages.update(set(Language.rebuild(l, hi=True) for l in languages))
+    languages.update(set(Language.rebuild(l, forced=True) for l in languages))
     video_types = (Episode, Movie)
 
     def initialize(self):
@@ -151,16 +154,19 @@ class SubsSabBzProvider(Provider):
         }
 
         if isEpisode:
-            params['movie'] = "%s %02d %02d" % (sanitize(fix_tv_naming(video.series), {'\''}), video.season, video.episode)
+            title = sanitize(fix_tv_naming(video.series), {'\''})
         else:
             params['yr'] = video.year
-            params['movie'] = sanitize(fix_movie_naming(video.title), {'\''})
+            title = sanitize(fix_movie_naming(video.title), {'\''})
 
-        if language == 'en' or language == 'eng':
+        # Strip diacritics/accents (e.g. Shōgun -> Shogun) for search compatibility
+        params['movie'] = unicodedata.normalize('NFKD', title).encode('ascii', 'ignore').decode('ascii')
+
+        if language.alpha3 == 'eng':
             params['select-language'] = 1
 
         logger.info('Searching subtitle %r', params)
-        response = self.session.post('http://subs.sab.bz/index.php?', params=params, allow_redirects=False, timeout=10, headers={
+        response = self.session.post('http://subs.sab.bz/index.php?', params=params, allow_redirects=False, timeout=30, headers={
             'Referer': 'http://subs.sab.bz/',
             })
 
@@ -211,7 +217,11 @@ class SubsSabBzProvider(Provider):
                         imdb_id = None
 
                     logger.info('Found subtitle link %r', link)
-                    sub = self.download_archive_and_add_subtitle_files(link, language, video, fps, num_cds)
+                    try:
+                        sub = self.download_archive_and_add_subtitle_files(link, language, video, fps, num_cds)
+                    except Exception as e:
+                        logger.warning('Failed to download %s: %s', link, e)
+                        continue
                     for s in sub:
                         s.title = title
                         s.notes = notes


### PR DESCRIPTION
## Summary

Fix multiple bugs in the `subssabbz` subtitle provider (`subs.sab.bz`) that prevented it from finding and downloading subtitles correctly.

## Changes

### 1. Search by series name only (instead of "title SS EE" format)
The old code searched for `"Shogun 01 09"` (series + season + episode), which returned very few or no results because the site indexes subtitles by series name, not by individual episode identifiers. Changed to search by series name only (e.g. `"Shogun"`), which returns all available subtitles for that series.

### 2. Strip diacritics/accents from search terms
Titles with Unicode characters (e.g. `Shōgun`) were sent as-is to the search, but the site doesn't match diacritical characters. Added `unicodedata.normalize('NFKD')` to convert `Shōgun` → `Shogun` before searching.

### 3. Fix language comparison bug
The existing code compared a `Language` object to string literals:
```python
if language == 'en' or language == 'eng':
```
This always evaluated to `False` because `Language` objects don't equal plain strings. Fixed to:
```python
if language.alpha3 == 'eng':
```

### 4. Graceful download error handling
A single failed download (e.g. HTTP 403 on one archived file) would crash the entire provider via `raise_for_status()`, discarding all other successfully found subtitles. Added `try/except` around individual downloads so failures are logged and skipped, allowing the remaining subtitles to be returned.

### 5. HI and forced language variant support
Added `Language.rebuild()` calls for `hi=True` and `forced=True` so Bazarr properly recognizes the provider's language capabilities.

### 6. Increased timeout (10s → 30s)
The site can be slow; increased the search request timeout from 10s to 30s for reliability.

## Testing
All changes were systematically tested in a Docker container running Bazarr v1.5.5:
- Verified search returns 17 results vs 1 with the old format (Shogun S01)
- Confirmed diacritics stripping works for Unicode titles
- Confirmed language filtering now correctly applies for English subtitles
- Verified that failed downloads are skipped without crashing the provider
- End-to-end: Bazarr successfully returns subtitles from subssabbz provider