### PR TITLE
Fix Assrt provider failing to download single-file subtitles

### DIFF
--- a/custom_libs/subliminal_patch/providers/assrt.py
+++ b/custom_libs/subliminal_patch/providers/assrt.py
@@ -94,6 +94,10 @@ class AssrtSubtitle(Subtitle):
             return False
         sub = result['sub']['subs'][0]
         if not len(sub['filelist']):
+            # Single-file subtitle: URL is directly in the sub entry
+            if 'url' in sub and sub['url']:
+                self._detail = sub
+                return sub
             logger.error('Can\'t get filelist from subtitle details')
             return False
         files = sub['filelist']


### PR DESCRIPTION
## Summary

Follow-up fix to #3196. While using the Assrt provider after the previous fix, I discovered another failure mode: some subtitles on Assrt have an empty `filelist` (empty dict `{}`), but provide the download URL directly in the sub entry's `url` field. The current code treats an empty filelist as an error and returns `False` from `_get_detail()`, which causes the subtitle download to silently fail with "Downloaded subtitles isn't valid".

I didn't catch this in the first PR because it only manifests for certain subtitle entries on Assrt (single-file subtitles). After running into this repeatedly with different series, I traced the issue to the API response structure.

### Example API response for subtitle ID 713005

```json
{
  "sub": {
    "subs": [{
      "filelist": {},
      "url": "http://file1.assrt.net/download/713005/...",
      ...
    }]
  }
}
```

`filelist` is `{}` but `url` is present and valid.

## Changes

When `filelist` is empty, fall back to checking `sub['url']` directly. If present, use the `sub` entry itself as the detail (since `download_link` only accesses `detail['url']`, this is fully compatible).

## Test plan

- [x] Verified with `curl` that the Assrt API returns empty `filelist` with a direct `url` for subtitle 713005
- [x] Confirmed the fix correctly returns the sub entry and `download_link` resolves to the direct URL
- [x] Existing subtitles with populated `filelist` are unaffected (the new code path only triggers when filelist is empty)