### PR TITLE
Fix assrt provider skipping season pack subtitles for episode searches

### DIFF
--- a/custom_libs/subliminal_patch/providers/assrt.py
+++ b/custom_libs/subliminal_patch/providers/assrt.py
@@ -131,6 +131,17 @@ class AssrtSubtitle(Subtitle):
 
     def get_matches(self, video):
         self.matches = guess_matches(video, guessit(self.video_name))
+        # Season pack handling: assrt often returns season packs (e.g.
+        # "Rick.and.Morty.S06.1080p.BluRay.x264-STORiES") when searching for a
+        # specific episode.  guessit won't extract an episode number from such a
+        # name, so the subtitle gets skipped by Bazarr's "doesn't match our
+        # series/episode" filter even though _get_detail will pick the correct
+        # episode file from the pack's filelist at download time.
+        if (isinstance(video, Episode) and "series" in self.matches
+                and "season" in self.matches and "episode" not in self.matches):
+            guess = guessit(self.video_name) if self.video_name else {}
+            if "episode" not in guess:
+                self.matches.add("episode")
         return self.matches
 
 


### PR DESCRIPTION
## Summary

- When searching for a specific episode (e.g. S06E08), the assrt provider often returns season packs (e.g. `Rick.and.Morty.S06.1080p.BluRay.x264-STORiES`) that contain individual episode subtitle files inside
- Since the pack name has no episode number, `guessit` cannot extract it, and Bazarr skips the result with _"doesn't match our series/episode"_
- This is incorrect because `_get_detail()` already handles selecting the correct episode file from the pack's filelist at download time
- Fix: when `series` and `season` match but `episode` is absent from both the match set and the guessit parse result (confirming it's a season pack, not a wrong episode), add `episode` to matches so the subtitle is not filtered out

## Test plan

- Search for subtitles on a specific episode (e.g. Rick and Morty S06E08) using the assrt provider
- Verify that season pack results from assrt are no longer skipped
- Verify that the correct individual episode file is still selected when downloading from the pack