### PR TITLE
Add multi-instance Radarr support

### DIFF
--- a/bazarr/api/__init__.py
+++ b/bazarr/api/__init__.py
@@ -9,6 +9,7 @@ from .files import api_ns_list_files
 from .history import api_ns_list_history
 from .movies import api_ns_list_movies
 from .providers import api_ns_list_providers
+from .radarr import api_ns_list_radarr
 from .series import api_ns_list_series
 from .subtitles import api_ns_list_subtitles
 from .system import api_ns_list_system
@@ -23,6 +24,7 @@ api_ns_list = [
     api_ns_list_history,
     api_ns_list_movies,
     api_ns_list_providers,
+    api_ns_list_radarr,
     api_ns_list_series,
     api_ns_list_subtitles,
     api_ns_list_system,

--- a/bazarr/api/radarr/__init__.py
+++ b/bazarr/api/radarr/__init__.py
@@ -1,0 +1,7 @@
+# coding=utf-8
+
+from .instances import api_ns_radarr_instances
+
+api_ns_list_radarr = [
+    api_ns_radarr_instances,
+]

--- a/bazarr/api/radarr/instances.py
+++ b/bazarr/api/radarr/instances.py
@@ -1,0 +1,256 @@
+# coding=utf-8
+
+import logging
+import requests
+
+from flask_restx import Resource, Namespace, fields
+
+from app.database import (TableRadarrInstances, database, select, insert, update, delete,
+                          get_radarr_instances)
+from radarr.info import url_radarr_from_instance, is_radarr_instance_legacy
+from constants import HEADERS
+from ..utils import authenticate
+
+api_ns_radarr_instances = Namespace(
+    "Radarr Instances",
+    description="Manage multiple Radarr instances for multi-library support",
+)
+
+instance_model = api_ns_radarr_instances.model(
+    "RadarrInstance",
+    {
+        "id": fields.Integer(readonly=True, description="Instance ID"),
+        "name": fields.String(required=True, description="Display name for this instance"),
+        "ip": fields.String(required=True, description="Radarr host IP or hostname"),
+        "port": fields.Integer(required=True, description="Radarr port"),
+        "base_url": fields.String(description="Radarr base URL", default="/"),
+        "ssl": fields.Boolean(description="Use SSL", default=False),
+        "apikey": fields.String(required=True, description="Radarr API key"),
+        "http_timeout": fields.Integer(description="HTTP timeout in seconds", default=60),
+        "enabled": fields.Boolean(description="Whether this instance is enabled", default=True),
+        "full_update": fields.String(description="Full update frequency (Daily/Weekly/Manually)", default="Daily"),
+        "full_update_day": fields.Integer(description="Day of week for weekly full update (0-6)", default=6),
+        "full_update_hour": fields.Integer(description="Hour for daily/weekly full update", default=4),
+        "movies_sync": fields.Integer(description="Movie sync interval in minutes", default=60),
+        "movies_sync_on_live": fields.Boolean(description="Sync movies on SignalR event", default=True),
+        "only_monitored": fields.Boolean(description="Only sync monitored movies", default=False),
+        "sync_only_monitored_movies": fields.Boolean(description="Skip unmonitored during sync", default=False),
+        "defer_search_signalr": fields.Boolean(description="Defer subtitle search after SignalR event", default=False),
+        "use_ffprobe_cache": fields.Boolean(description="Use ffprobe cache", default=True),
+    }
+)
+
+test_result_model = api_ns_radarr_instances.model(
+    "RadarrInstanceTestResult",
+    {
+        "status": fields.String(description="ok or error"),
+        "version": fields.String(description="Radarr version if reachable"),
+        "message": fields.String(description="Error message if not reachable"),
+    }
+)
+
+
+def _row_to_dict(row):
+    d = row.to_dict()
+    # Convert integer booleans to Python bools for nicer JSON
+    for bool_field in ('ssl', 'enabled', 'movies_sync_on_live', 'only_monitored',
+                       'sync_only_monitored_movies', 'defer_search_signalr', 'use_ffprobe_cache'):
+        if bool_field in d:
+            d[bool_field] = bool(d[bool_field])
+    return d
+
+
+def _payload_to_db(payload):
+    """Convert API payload to DB dict (booleans -> int for SQLite)."""
+    db_dict = {}
+    bool_fields = ('ssl', 'enabled', 'movies_sync_on_live', 'only_monitored',
+                   'sync_only_monitored_movies', 'defer_search_signalr', 'use_ffprobe_cache')
+    for key, value in payload.items():
+        if key == 'id':
+            continue
+        if key in bool_fields:
+            db_dict[key] = 1 if value else 0
+        else:
+            db_dict[key] = value
+    if 'excluded_tags' not in db_dict:
+        db_dict['excluded_tags'] = '[]'
+    return db_dict
+
+
+@api_ns_radarr_instances.route("radarr/instances")
+class RadarrInstancesList(Resource):
+    @authenticate
+    @api_ns_radarr_instances.marshal_list_with(instance_model)
+    @api_ns_radarr_instances.response(200, "Success")
+    @api_ns_radarr_instances.response(401, "Not Authenticated")
+    def get(self):
+        """List all configured Radarr instances."""
+        rows = database.execute(
+            select(TableRadarrInstances).order_by(TableRadarrInstances.id)
+        ).scalars().all()
+        return [_row_to_dict(row) for row in rows]
+
+    @authenticate
+    @api_ns_radarr_instances.expect(instance_model, validate=False)
+    @api_ns_radarr_instances.response(201, "Instance created")
+    @api_ns_radarr_instances.response(400, "Bad request")
+    @api_ns_radarr_instances.response(401, "Not Authenticated")
+    def post(self):
+        """Add a new Radarr instance."""
+        payload = api_ns_radarr_instances.payload or {}
+        db_dict = _payload_to_db(payload)
+
+        try:
+            result = database.execute(
+                insert(TableRadarrInstances).values(**db_dict)
+            )
+            new_id = result.inserted_primary_key[0]
+        except Exception as e:
+            logging.exception("BAZARR Error creating Radarr instance")
+            return {"message": str(e)}, 400
+
+        # Start SignalR client for the new instance
+        try:
+            from app.signalr_client import radarr_signalr_client
+            from app.config import settings
+            if settings.general.use_radarr:
+                new_row = database.execute(
+                    select(TableRadarrInstances).where(TableRadarrInstances.id == new_id)
+                ).scalar_one_or_none()
+                if new_row and new_row.enabled:
+                    radarr_signalr_client.add_instance(new_row.to_dict())
+        except Exception:
+            logging.exception("BAZARR Could not start SignalR for new Radarr instance")
+
+        return {"id": new_id, "message": "Instance created successfully"}, 201
+
+
+@api_ns_radarr_instances.route("radarr/instances/<int:instance_id>")
+class RadarrInstanceItem(Resource):
+    @authenticate
+    @api_ns_radarr_instances.marshal_with(instance_model)
+    @api_ns_radarr_instances.response(200, "Success")
+    @api_ns_radarr_instances.response(401, "Not Authenticated")
+    @api_ns_radarr_instances.response(404, "Instance not found")
+    def get(self, instance_id):
+        """Get a specific Radarr instance by ID."""
+        row = database.execute(
+            select(TableRadarrInstances).where(TableRadarrInstances.id == instance_id)
+        ).scalar_one_or_none()
+        if not row:
+            api_ns_radarr_instances.abort(404, f"Radarr instance {instance_id} not found")
+        return _row_to_dict(row)
+
+    @authenticate
+    @api_ns_radarr_instances.expect(instance_model, validate=False)
+    @api_ns_radarr_instances.response(200, "Instance updated")
+    @api_ns_radarr_instances.response(400, "Bad request")
+    @api_ns_radarr_instances.response(401, "Not Authenticated")
+    @api_ns_radarr_instances.response(404, "Instance not found")
+    def put(self, instance_id):
+        """Update a Radarr instance."""
+        row = database.execute(
+            select(TableRadarrInstances).where(TableRadarrInstances.id == instance_id)
+        ).scalar_one_or_none()
+        if not row:
+            api_ns_radarr_instances.abort(404, f"Radarr instance {instance_id} not found")
+
+        payload = api_ns_radarr_instances.payload or {}
+        db_dict = _payload_to_db(payload)
+
+        try:
+            database.execute(
+                update(TableRadarrInstances).values(**db_dict)
+                .where(TableRadarrInstances.id == instance_id)
+            )
+        except Exception as e:
+            logging.exception("BAZARR Error updating Radarr instance")
+            return {"message": str(e)}, 400
+
+        # Restart SignalR client for this instance
+        try:
+            from app.signalr_client import radarr_signalr_client
+            from app.config import settings
+            if settings.general.use_radarr:
+                updated_row = database.execute(
+                    select(TableRadarrInstances).where(TableRadarrInstances.id == instance_id)
+                ).scalar_one_or_none()
+                if updated_row:
+                    if updated_row.enabled:
+                        radarr_signalr_client.add_instance(updated_row.to_dict())
+                    else:
+                        radarr_signalr_client.remove_instance(instance_id)
+        except Exception:
+            logging.exception("BAZARR Could not restart SignalR for updated Radarr instance")
+
+        return {"message": "Instance updated successfully"}, 200
+
+    @authenticate
+    @api_ns_radarr_instances.response(200, "Instance deleted")
+    @api_ns_radarr_instances.response(400, "Cannot delete primary instance")
+    @api_ns_radarr_instances.response(401, "Not Authenticated")
+    @api_ns_radarr_instances.response(404, "Instance not found")
+    def delete(self, instance_id):
+        """Delete a Radarr instance (and all its movies from the database)."""
+        if instance_id == 1:
+            return {"message": "Cannot delete the primary Radarr instance (id=1). "
+                               "Disable it instead or reconfigure via Settings."}, 400
+
+        row = database.execute(
+            select(TableRadarrInstances).where(TableRadarrInstances.id == instance_id)
+        ).scalar_one_or_none()
+        if not row:
+            api_ns_radarr_instances.abort(404, f"Radarr instance {instance_id} not found")
+
+        # Stop SignalR client for this instance
+        try:
+            from app.signalr_client import radarr_signalr_client
+            radarr_signalr_client.remove_instance(instance_id)
+        except Exception:
+            logging.exception("BAZARR Could not stop SignalR for deleted Radarr instance")
+
+        # The ON DELETE CASCADE will remove movies from this instance automatically
+        try:
+            database.execute(
+                delete(TableRadarrInstances).where(TableRadarrInstances.id == instance_id)
+            )
+        except Exception as e:
+            logging.exception("BAZARR Error deleting Radarr instance")
+            return {"message": str(e)}, 400
+
+        return {"message": f"Radarr instance {instance_id} deleted successfully"}, 200
+
+
+@api_ns_radarr_instances.route("radarr/instances/<int:instance_id>/test")
+class RadarrInstanceTest(Resource):
+    @authenticate
+    @api_ns_radarr_instances.marshal_with(test_result_model)
+    @api_ns_radarr_instances.response(200, "Test result")
+    @api_ns_radarr_instances.response(401, "Not Authenticated")
+    @api_ns_radarr_instances.response(404, "Instance not found")
+    def get(self, instance_id):
+        """Test connectivity to a Radarr instance."""
+        row = database.execute(
+            select(TableRadarrInstances).where(TableRadarrInstances.id == instance_id)
+        ).scalar_one_or_none()
+        if not row:
+            api_ns_radarr_instances.abort(404, f"Radarr instance {instance_id} not found")
+
+        instance = row.to_dict()
+        legacy = is_radarr_instance_legacy(instance)
+        base_url = url_radarr_from_instance(instance)
+        apikey = instance.get('apikey', '')
+        timeout = int(instance.get('http_timeout', 60))
+
+        try:
+            url = f"{base_url}/api/v3/system/status?apikey={apikey}"
+            r = requests.get(url, timeout=timeout, verify=False, headers=HEADERS)
+            r.raise_for_status()
+            version = r.json().get('version', 'unknown')
+            return {"status": "ok", "version": version, "message": ""}
+        except requests.exceptions.ConnectionError as e:
+            return {"status": "error", "version": "", "message": f"Connection error: {e}"}
+        except requests.exceptions.Timeout:
+            return {"status": "error", "version": "", "message": "Connection timed out"}
+        except Exception as e:
+            return {"status": "error", "version": "", "message": str(e)}

--- a/bazarr/app/database.py
+++ b/bazarr/app/database.py
@@ -10,7 +10,8 @@ import signal
 from dogpile.cache import make_region
 from datetime import datetime
 
-from sqlalchemy import create_engine, inspect, DateTime, ForeignKey, Integer, LargeBinary, Text, func, text, BigInteger
+from sqlalchemy import create_engine, inspect, DateTime, ForeignKey, ForeignKeyConstraint, Integer, LargeBinary, \
+    PrimaryKeyConstraint, Text, UniqueConstraint, func, text, BigInteger
 # importing here to be indirectly imported in other modules later
 from sqlalchemy import update, delete, select, func  # noqa W0611
 from sqlalchemy.orm import scoped_session, sessionmaker, mapped_column, close_all_sessions
@@ -117,6 +118,33 @@ class System(Base):
     updated = mapped_column(Text)
 
 
+class TableRadarrInstances(Base):
+    __tablename__ = 'table_radarr_instances'
+
+    id = mapped_column(Integer, primary_key=True)
+    name = mapped_column(Text, nullable=False)
+    ip = mapped_column(Text, nullable=False)
+    port = mapped_column(Integer, nullable=False)
+    base_url = mapped_column(Text, nullable=False)
+    ssl = mapped_column(Integer, nullable=False, default=0)
+    apikey = mapped_column(Text, nullable=False, default='')
+    http_timeout = mapped_column(Integer, nullable=False, default=60)
+    enabled = mapped_column(Integer, nullable=False, default=1)
+    full_update = mapped_column(Text, nullable=False, default='Daily')
+    full_update_day = mapped_column(Integer, nullable=False, default=6)
+    full_update_hour = mapped_column(Integer, nullable=False, default=4)
+    movies_sync = mapped_column(Integer, nullable=False, default=60)
+    movies_sync_on_live = mapped_column(Integer, nullable=False, default=1)
+    only_monitored = mapped_column(Integer, nullable=False, default=0)
+    excluded_tags = mapped_column(Text, nullable=False, default='[]')
+    sync_only_monitored_movies = mapped_column(Integer, nullable=False, default=0)
+    defer_search_signalr = mapped_column(Integer, nullable=False, default=0)
+    use_ffprobe_cache = mapped_column(Integer, nullable=False, default=1)
+
+    def to_dict(self):
+        return {column.name: getattr(self, column.name) for column in self.__table__.columns}
+
+
 class TableAnnouncements(Base):
     __tablename__ = 'table_announcements'
 
@@ -140,11 +168,20 @@ class TableBlacklist(Base):
 
 class TableBlacklistMovie(Base):
     __tablename__ = 'table_blacklist_movie'
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ['radarr_id', 'radarr_instance_id'],
+            ['table_movies.radarrId', 'table_movies.radarr_instance_id'],
+            ondelete='CASCADE',
+            name='fk_radarrId_blacklist_movie'
+        ),
+    )
 
     id = mapped_column(Integer, primary_key=True)
     language = mapped_column(Text)
     provider = mapped_column(Text)
-    radarr_id = mapped_column(Integer, ForeignKey('table_movies.radarrId', ondelete='CASCADE'))
+    radarr_id = mapped_column(Integer)
+    radarr_instance_id = mapped_column(Integer, nullable=False, default=1)
     subs_id = mapped_column(Text)
     timestamp = mapped_column(DateTime, default=datetime.now)
 
@@ -201,13 +238,22 @@ class TableHistory(Base):
 
 class TableHistoryMovie(Base):
     __tablename__ = 'table_history_movie'
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ['radarrId', 'radarr_instance_id'],
+            ['table_movies.radarrId', 'table_movies.radarr_instance_id'],
+            ondelete='CASCADE',
+            name='fk_radarrId_history_movie'
+        ),
+    )
 
     id = mapped_column(Integer, primary_key=True)
     action = mapped_column(Integer, nullable=False)
     description = mapped_column(Text, nullable=False)
     language = mapped_column(Text)
     provider = mapped_column(Text)
-    radarrId = mapped_column(Integer, ForeignKey('table_movies.radarrId', ondelete='CASCADE'))
+    radarrId = mapped_column(Integer)
+    radarr_instance_id = mapped_column(Integer, nullable=False, default=1)
     score = mapped_column(Integer)
     subs_id = mapped_column(Text)
     subtitles_path = mapped_column(Text)
@@ -233,6 +279,23 @@ class TableLanguagesProfiles(Base):
 
 class TableMovies(Base):
     __tablename__ = 'table_movies'
+    __table_args__ = (
+        PrimaryKeyConstraint('radarrId', 'radarr_instance_id', name='pk_table_movies'),
+        UniqueConstraint('path', name='unique_table_movies_path'),
+        UniqueConstraint('tmdbId', 'radarr_instance_id', name='unique_table_movies_tmdbId_instance'),
+        ForeignKeyConstraint(
+            ['radarr_instance_id'],
+            ['table_radarr_instances.id'],
+            ondelete='CASCADE',
+            name='fk_movies_radarr_instance_id'
+        ),
+        ForeignKeyConstraint(
+            ['profileId'],
+            ['table_languages_profiles.profileId'],
+            ondelete='SET NULL',
+            name='fk_movies_profileId_languages_profiles'
+        ),
+    )
 
     alternativeTitles = mapped_column(Text)
     audio_codec = mapped_column(Text)
@@ -248,17 +311,18 @@ class TableMovies(Base):
     monitored = mapped_column(Text)
     movie_file_id = mapped_column(Integer)
     overview = mapped_column(Text)
-    path = mapped_column(Text, nullable=False, unique=True)
+    path = mapped_column(Text, nullable=False)
     poster = mapped_column(Text)
-    profileId = mapped_column(Integer, ForeignKey('table_languages_profiles.profileId', ondelete='SET NULL'))
-    radarrId = mapped_column(Integer, primary_key=True)
+    profileId = mapped_column(Integer)
+    radarrId = mapped_column(Integer, nullable=False)
+    radarr_instance_id = mapped_column(Integer, nullable=False, default=1)
     resolution = mapped_column(Text)
     sceneName = mapped_column(Text)
     sortTitle = mapped_column(Text)
     subtitles = mapped_column(Text)
     tags = mapped_column(Text)
     title = mapped_column(Text, nullable=False)
-    tmdbId = mapped_column(Text, nullable=False, unique=True)
+    tmdbId = mapped_column(Text, nullable=False)
     updated_at_timestamp = mapped_column(DateTime)
     video_codec = mapped_column(Text)
     year = mapped_column(Text)
@@ -323,6 +387,15 @@ class TableShowsRootfolder(Base):
     error = mapped_column(Text)
     id = mapped_column(Integer, primary_key=True)
     path = mapped_column(Text)
+
+
+def get_radarr_instances():
+    """Return all enabled Radarr instances as a list of dicts."""
+    return [row.to_dict() for row in database.execute(
+        select(TableRadarrInstances)
+        .where(TableRadarrInstances.enabled == 1)
+        .order_by(TableRadarrInstances.id)
+    ).scalars().all()]
 
 
 def init_db():
@@ -498,7 +571,7 @@ def get_audio_profile_languages(audio_languages_list_str):
     return audio_languages
 
 
-def get_profile_id(series_id=None, episode_id=None, movie_id=None):
+def get_profile_id(series_id=None, episode_id=None, movie_id=None, radarr_instance_id=1):
     if series_id:
         data = database.execute(
             select(TableShows.profileId)
@@ -519,7 +592,8 @@ def get_profile_id(series_id=None, episode_id=None, movie_id=None):
     elif movie_id:
         data = database.execute(
             select(TableMovies.profileId)
-            .where(TableMovies.radarrId == movie_id))\
+            .where(TableMovies.radarrId == movie_id)
+            .where(TableMovies.radarr_instance_id == radarr_instance_id))\
             .first()
         if data:
             return data.profileId

--- a/bazarr/app/signalr_client.py
+++ b/bazarr/app/signalr_client.py
@@ -18,8 +18,8 @@ from sonarr.sync.episodes import sync_episodes, sync_one_episode
 from sonarr.sync.series import update_series, update_one_series
 from radarr.sync.movies import update_movies, update_one_movie
 from sonarr.info import get_sonarr_info, url_sonarr
-from radarr.info import url_radarr
-from app.database import TableShows, TableMovies, database, select
+from radarr.info import url_radarr, url_radarr_from_instance
+from app.database import TableShows, TableMovies, TableRadarrInstances, database, select
 from app.jobs_queue import jobs_queue
 
 from .config import settings
@@ -180,15 +180,38 @@ class SonarrSignalrClient:
 
 
 class RadarrSignalrClient:
-    def __init__(self):
+    """SignalR client for a single Radarr instance."""
+
+    def __init__(self, instance=None):
+        """
+        Args:
+            instance: dict from TableRadarrInstances.to_dict(). If None, uses primary settings.
+        """
         super(RadarrSignalrClient, self).__init__()
+        self.instance = instance
+        self.instance_id = instance['id'] if instance else 1
         self.apikey_radarr = None
         self.connection = None
         self.connected = False
 
+    def _get_base_url(self):
+        if self.instance:
+            return url_radarr_from_instance(self.instance)
+        return url_radarr()
+
+    def _get_apikey(self):
+        if self.instance:
+            return self.instance.get('apikey', settings.radarr.apikey)
+        return settings.radarr.apikey
+
+    def _get_movies_sync_on_live(self):
+        if self.instance:
+            return bool(self.instance.get('movies_sync_on_live', 1))
+        return settings.radarr.movies_sync_on_live
+
     def start(self):
         self.configure()
-        logging.info('BAZARR trying to connect to Radarr SignalR feed...')
+        logging.info(f'BAZARR trying to connect to Radarr SignalR feed (instance {self.instance_id})...')
         while self.connection.transport.state.value not in [0, 1, 2]:
             try:
                 self.connection.start()
@@ -196,7 +219,7 @@ class RadarrSignalrClient:
                 time.sleep(5)
 
     def stop(self):
-        logging.info('BAZARR SignalR client for Radarr is now disconnected.')
+        logging.info(f'BAZARR SignalR client for Radarr instance {self.instance_id} is now disconnected.')
         self.connection.stop()
 
     def restart(self):
@@ -210,25 +233,33 @@ class RadarrSignalrClient:
         radarr_queue.clear()
         self.connected = False
         event_stream(type='badges')
-        logging.error("BAZARR connection to Radarr SignalR feed has failed. We'll try to reconnect.")
+        logging.error(f"BAZARR connection to Radarr SignalR feed (instance {self.instance_id}) has failed. "
+                      f"We'll try to reconnect.")
         self.restart()
 
     def on_connect_handler(self):
         self.connected = True
         event_stream(type='badges')
-        logging.info('BAZARR SignalR client for Radarr is connected and waiting for events.')
-        if settings.radarr.movies_sync_on_live:
+        logging.info(f'BAZARR SignalR client for Radarr instance {self.instance_id} is connected and waiting for events.')
+        if self._get_movies_sync_on_live():
             scheduler.execute_job_now(taskid="update_movies")
 
     def on_reconnect_handler(self):
         self.connected = False
         event_stream(type='badges')
-        logging.error('BAZARR SignalR client for Radarr connection as been lost. Trying to reconnect...')
+        logging.error(f'BAZARR SignalR client for Radarr instance {self.instance_id} connection has been lost. '
+                      f'Trying to reconnect...')
 
     def configure(self):
-        self.apikey_radarr = settings.radarr.apikey
+        self.apikey_radarr = self._get_apikey()
+        base_url = self._get_base_url()
+        instance_id = self.instance_id
+
+        def _feed_queue_with_instance(data):
+            feed_queue(data, radarr_instance_id=instance_id)
+
         self.connection = HubConnectionBuilder() \
-            .with_url(f"{url_radarr()}/signalr/messages?access_token={self.apikey_radarr}",
+            .with_url(f"{base_url}/signalr/messages?access_token={self.apikey_radarr}",
                       options={
                           "verify_ssl": False,
                           "headers": HEADERS
@@ -241,16 +272,114 @@ class RadarrSignalrClient:
             }).build()
         self.connection.on_open(self.on_connect_handler)
         self.connection.on_reconnect(self.on_reconnect_handler)
-        self.connection.on_close(lambda: logging.debug('BAZARR SignalR client for Radarr is disconnected.'))
+        self.connection.on_close(lambda: logging.debug(
+            f'BAZARR SignalR client for Radarr instance {self.instance_id} is disconnected.'))
         self.connection.on_error(self.exception_handler)
-        self.connection.on("receiveMessage", feed_queue)
+        self.connection.on("receiveMessage", _feed_queue_with_instance)
+
+
+class RadarrSignalrManager:
+    """Manages multiple RadarrSignalrClient instances (one per Radarr instance).
+
+    Provides a backward-compatible interface with a single .connected property
+    and .start()/.restart() methods.
+    """
+
+    def __init__(self):
+        # dict mapping instance_id -> RadarrSignalrClient
+        self._clients: dict = {}
+
+    @property
+    def connected(self):
+        """True if any Radarr instance is connected."""
+        return any(client.connected for client in self._clients.values())
+
+    def _load_instances(self):
+        """Load all enabled Radarr instances from the database."""
+        try:
+            from app.database import get_radarr_instances
+            return get_radarr_instances()
+        except Exception as e:
+            logging.warning(f"BAZARR Could not load Radarr instances from DB: {e}. "
+                            f"Using primary instance from settings.")
+            return []
+
+    def start(self):
+        """Start SignalR clients for all enabled Radarr instances."""
+        instances = self._load_instances()
+
+        if not instances:
+            # Fallback: start single client using settings
+            client = RadarrSignalrClient(instance=None)
+            self._clients[1] = client
+            client.start()
+            return
+
+        for instance in instances:
+            instance_id = instance['id']
+            if instance_id not in self._clients:
+                client = RadarrSignalrClient(instance=instance)
+                self._clients[instance_id] = client
+                t = threading.Thread(target=client.start, daemon=True)
+                t.start()
+
+    def restart(self):
+        """Restart the primary Radarr SignalR client (called when settings change)."""
+        if settings.general.use_radarr:
+            # Stop and remove existing primary client
+            if 1 in self._clients:
+                try:
+                    self._clients[1].stop()
+                except Exception:
+                    pass
+                del self._clients[1]
+
+            # Reload all instances and restart
+            instances = self._load_instances()
+            if instances:
+                for instance in instances:
+                    instance_id = instance['id']
+                    if instance_id not in self._clients:
+                        client = RadarrSignalrClient(instance=instance)
+                        self._clients[instance_id] = client
+                        t = threading.Thread(target=client.start, daemon=True)
+                        t.start()
+            else:
+                client = RadarrSignalrClient(instance=None)
+                self._clients[1] = client
+                t = threading.Thread(target=client.start, daemon=True)
+                t.start()
+
+    def add_instance(self, instance):
+        """Start a SignalR client for a newly added Radarr instance."""
+        instance_id = instance['id']
+        if instance_id in self._clients:
+            try:
+                self._clients[instance_id].stop()
+            except Exception:
+                pass
+        client = RadarrSignalrClient(instance=instance)
+        self._clients[instance_id] = client
+        t = threading.Thread(target=client.start, daemon=True)
+        t.start()
+
+    def remove_instance(self, instance_id):
+        """Stop the SignalR client for a removed Radarr instance."""
+        if instance_id in self._clients:
+            try:
+                self._clients[instance_id].stop()
+            except Exception:
+                pass
+            del self._clients[instance_id]
 
 
 def dispatcher(data):
     try:
         series_title = series_year = episode_title = season_number = episode_number = movie_title = movie_year = None
 
-        #
+        # Extract the radarr instance id (injected by feed_queue)
+        radarr_instance_id = data.pop('_radarr_instance_id', 1)
+
         try:
             episodesChanged = False
             topic = data['name']
@@ -281,7 +410,8 @@ def dispatcher(data):
                 if action == 'deleted':
                     existing_movie_details = database.execute(
                         select(TableMovies.title, TableMovies.year)
-                        .where(TableMovies.radarrId == media_id)) \
+                        .where(TableMovies.radarrId == media_id)
+                        .where(TableMovies.radarr_instance_id == radarr_instance_id)) \
                         .first()
                     if existing_movie_details:
                         movie_title = existing_movie_details.title
@@ -297,7 +427,6 @@ def dispatcher(data):
         if topic == 'series':
             logging.debug(f'Event received from Sonarr for series: {series_title} ({series_year})')
             if episodesChanged:
-                # this will happen if a season's monitored status is changed.
                 sync_episodes(series_id=media_id, defer_search=settings.sonarr.defer_search_signalr, is_signalr=True)
             else:
                 update_one_series(series_id=media_id, action=action, is_signalr=True)
@@ -306,9 +435,12 @@ def dispatcher(data):
                           f'S{season_number:0>2}E{episode_number:0>2} - {episode_title}')
             sync_one_episode(episode_id=media_id, defer_search=settings.sonarr.defer_search_signalr, is_signalr=True)
         elif topic == 'movie':
-            logging.debug(f'Event received from Radarr for movie: {movie_title} ({movie_year})')
-            update_one_movie(movie_id=media_id, action=action, defer_search=settings.radarr.defer_search_signalr,
-                             is_signalr=True)
+            logging.debug(f'Event received from Radarr instance {radarr_instance_id} for movie: '
+                          f'{movie_title} ({movie_year})')
+            update_one_movie(movie_id=media_id, action=action,
+                             defer_search=settings.radarr.defer_search_signalr,
+                             is_signalr=True,
+                             radarr_instance_id=radarr_instance_id)
     except Exception as e:
         logging.debug(f'BAZARR an exception occurred while parsing SignalR feed: {repr(e)}')
     finally:
@@ -318,22 +450,7 @@ def dispatcher(data):
 
 def filter_nested_dict(data: dict) -> dict:
     """
-    Filters out specific keys from a nested dictionary structure, including any
-    nested dictionaries or lists that may contain dictionaries.
-
-    The function recursively processes the input dictionary to remove any key-value
-    pairs where the key matches the specified keys to exclude. For lists, it will
-    iterate through the items and apply the same filtering logic if the item is a
-    dictionary.
-
-    :param data: A dictionary that may contain nested dictionaries or lists. Values
-                 that are dictionaries will be recursively filtered, and lists
-                 within the dictionary will be traversed to check for and filter
-                 nested dictionaries within them.
-    :type data: dict
-    :return: A dictionary where specified keys are removed, including from any
-             nested dictionaries or dictionaries within lists.
-    :rtype: dict
+    Filters out specific keys from a nested dictionary structure.
     """
     keys_to_remove = ['statistics']
 
@@ -342,29 +459,24 @@ def filter_nested_dict(data: dict) -> dict:
     for key, value in data.items():
         if key not in keys_to_remove:
             if isinstance(value, dict):
-                # Recursively filter nested dictionaries
                 filtered_data[key] = filter_nested_dict(value)
             elif isinstance(value, list):
-                # Handle lists that might contain dictionaries
                 filtered_data[key] = [
                     filter_nested_dict(item) if isinstance(item, dict) else item
                     for item in value
                 ]
             else:
-                # Keep the value as is
                 filtered_data[key] = value
 
     return filtered_data
 
 
-def feed_queue(data):
+def feed_queue(data, radarr_instance_id=1):
     # some sonarr version sends events as a list of a single dict, we make it a dict
     if isinstance(data, list) and len(data):
         data = data[0]
 
     if isinstance(data, dict) and 'name' in data and data['name'] in ['series', 'episode', 'movie']:
-        # filter out some keys to reduce the size of the event data dictionary and prevent similar events from being
-        # added to the queue
         data = filter_nested_dict(data)
 
         # check if event is duplicate from the previous one
@@ -387,16 +499,16 @@ def feed_queue(data):
             else:
                 last_movie_event_data = data
 
-        # if data is a dict and contain an event for series, episode or movie, we add it to the event queue
         if isinstance(data, dict) and 'name' in data:
             if data['name'] in ['series', 'episode']:
                 sonarr_queue.append(data)
             elif data['name'] == 'movie':
+                # Embed the instance_id so dispatcher knows which Radarr sent this
+                data['_radarr_instance_id'] = radarr_instance_id
                 radarr_queue.append(data)
 
 
 def consume_queue(queue):
-    # get events data from queues one at a time and dispatch it
     while True:
         try:
             data = queue.popleft()
@@ -420,4 +532,4 @@ radarr_queue_thread.start()
 # instantiate proper SignalR client
 sonarr_signalr_client = SonarrSignalrClientLegacy() if get_sonarr_info.version().startswith(('0.', '2.', '3.')) else \
     SonarrSignalrClient()
-radarr_signalr_client = RadarrSignalrClient()
+radarr_signalr_client = RadarrSignalrManager()

--- a/bazarr/radarr/info.py
+++ b/bazarr/radarr/info.py
@@ -15,6 +15,28 @@ from constants import HEADERS
 region = make_region().configure('dogpile.cache.memory')
 
 
+def url_radarr_from_instance(instance):
+    """Build base URL for a Radarr instance dict (from TableRadarrInstances.to_dict())."""
+    protocol = "https" if instance.get('ssl') else "http"
+    base_url = instance.get('base_url', '/')
+    if not base_url:
+        base_url = "/"
+    if not base_url.startswith("/"):
+        base_url = f"/{base_url}"
+    if base_url.endswith("/"):
+        base_url = base_url[:-1]
+
+    port = instance.get('port')
+    port_str = f":{port}" if port not in empty_values else ""
+    return f"{protocol}://{instance['ip']}{port_str}{base_url}"
+
+
+def url_api_radarr_from_instance(instance, is_legacy=False):
+    """Build API URL for a Radarr instance dict."""
+    base = url_radarr_from_instance(instance)
+    return base + f'/api{"/v3" if not is_legacy else ""}/'
+
+
 class GetRadarrInfo:
     @staticmethod
     def version():
@@ -82,6 +104,43 @@ class GetRadarrInfo:
             return True
         else:
             return False
+
+
+def get_radarr_version_for_instance(instance):
+    """Return the Radarr version string for a given instance dict."""
+    cache_key = f"radarr_version_instance_{instance['id']}"
+    cached = region.get(cache_key, expiration_time=datetime.timedelta(seconds=60).total_seconds())
+    if cached:
+        return cached
+
+    apikey = instance.get('apikey', '')
+    timeout = int(instance.get('http_timeout', 60))
+    base = url_radarr_from_instance(instance)
+    version = 'unknown'
+
+    try:
+        rv = f"{base}/api/system/status?apikey={apikey}"
+        radarr_json = requests.get(rv, timeout=timeout, verify=False, headers=HEADERS).json()
+        if 'version' in radarr_json:
+            version = radarr_json['version']
+        else:
+            raise JSONDecodeError
+    except JSONDecodeError:
+        try:
+            rv = f"{base}/api/v3/system/status?apikey={apikey}"
+            version = requests.get(rv, timeout=timeout, verify=False, headers=HEADERS).json()['version']
+        except Exception:
+            pass
+    except Exception:
+        pass
+
+    region.set(cache_key, version)
+    return version
+
+
+def is_radarr_instance_legacy(instance):
+    """Return True if the instance is running a legacy version of Radarr."""
+    return get_radarr_version_for_instance(instance).startswith('0.')
 
 
 get_radarr_info = GetRadarrInfo()

--- a/bazarr/radarr/rootfolder.py
+++ b/bazarr/radarr/rootfolder.py
@@ -6,20 +6,33 @@ import logging
 
 from app.config import settings
 from utilities.path_mappings import path_mappings
-from app.database import TableMoviesRootfolder, TableMovies, database, delete, update, insert, select
-from radarr.info import url_api_radarr
+from app.database import (TableMoviesRootfolder, TableMovies, TableRadarrInstances,
+                          database, delete, update, insert, select, get_radarr_instances)
+from radarr.info import url_api_radarr, url_api_radarr_from_instance, is_radarr_instance_legacy
 from constants import HEADERS
 
 
-def get_radarr_rootfolder():
-    apikey_radarr = settings.radarr.apikey
-    radarr_rootfolder = []
+def get_radarr_rootfolder(instance=None):
+    """Fetch and sync root folders for a Radarr instance.
 
-    # Get root folder data from Radarr
-    url_radarr_api_rootfolder = f"{url_api_radarr()}rootfolder?apikey={apikey_radarr}"
+    Args:
+        instance: dict from TableRadarrInstances.to_dict(). If None, uses primary instance from settings.
+    """
+    if instance is not None:
+        legacy = is_radarr_instance_legacy(instance)
+        api_url = url_api_radarr_from_instance(instance, is_legacy=legacy)
+        apikey = instance.get('apikey', '')
+        timeout = int(instance.get('http_timeout', 60))
+    else:
+        api_url = url_api_radarr()
+        apikey = settings.radarr.apikey
+        timeout = int(settings.radarr.http_timeout)
+
+    radarr_rootfolder = []
+    url = f"{api_url}rootfolder?apikey={apikey}"
 
     try:
-        rootfolder = requests.get(url_radarr_api_rootfolder, timeout=int(settings.radarr.http_timeout), verify=False, headers=HEADERS)
+        rootfolder = requests.get(url, timeout=timeout, verify=False, headers=HEADERS)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get rootfolder from Radarr. Connection Error.")
         return []
@@ -61,7 +74,19 @@ def get_radarr_rootfolder():
 
 
 def check_radarr_rootfolder():
-    get_radarr_rootfolder()
+    """Check root folders for all enabled Radarr instances."""
+    instances = get_radarr_instances()
+    if instances:
+        for instance in instances:
+            try:
+                get_radarr_rootfolder(instance=instance)
+            except Exception:
+                logging.exception(
+                    f"BAZARR Error checking root folder for Radarr instance '{instance.get('name', instance['id'])}'")
+    else:
+        # Fallback: use primary instance from settings
+        get_radarr_rootfolder()
+
     rootfolder = database.execute(
         select(TableMoviesRootfolder.id, TableMoviesRootfolder.path))\
         .all()
@@ -79,17 +104,13 @@ def check_radarr_rootfolder():
                                             'Please check path mapping or if directory/drive is online.')
                 .where(TableMoviesRootfolder.id == item.id))
         else:
-            # Try os.access() first (fast, no disk I/O)
-            # Fall back to write test only if os.access() fails (e.g., NFS mounts)
             mapped_path = path_mappings.path_replace_movie(root_path)
             if os.access(mapped_path, os.W_OK):
-                # Path is writable according to os.access()
                 database.execute(
                     update(TableMoviesRootfolder)
                     .values(accessible=1, error='')
                     .where(TableMoviesRootfolder.id == item.id))
             else:
-                # os.access() failed, try actual write test (needed for NFS)
                 try:
                     test_file = os.path.join(mapped_path, '.bazarr_write_test')
                     with open(test_file, 'w') as f:

--- a/bazarr/radarr/sync/movies.py
+++ b/bazarr/radarr/sync/movies.py
@@ -8,7 +8,9 @@ from datetime import datetime
 from functools import reduce
 
 from app.config import settings
-from app.database import TableMovies, TableLanguagesProfiles, database, insert, update, delete, select, get_exclusion_clause
+from app.database import (TableMovies, TableLanguagesProfiles, TableRadarrInstances,
+                          database, insert, update, delete, select, get_exclusion_clause,
+                          get_radarr_instances)
 from app.event_handler import event_stream
 from app.jobs_queue import jobs_queue
 from constants import MINIMUM_VIDEO_SIZE
@@ -52,7 +54,8 @@ def update_movie(updated_movie):
         updated_movie['updated_at_timestamp'] = datetime.now()
         database.execute(
             update(TableMovies).values(updated_movie)
-            .where(TableMovies.radarrId == updated_movie['radarrId']))
+            .where(TableMovies.radarrId == updated_movie['radarrId'])
+            .where(TableMovies.radarr_instance_id == updated_movie['radarr_instance_id']))
     except IntegrityError as e:
         logging.error(f"BAZARR cannot update movie {updated_movie['path']} because of {e}")
     else:
@@ -60,10 +63,11 @@ def update_movie(updated_movie):
         event_stream(type='movie', action='update', payload=updated_movie['radarrId'])
 
 
-def get_movie_monitored_status(movie_id):
+def get_movie_monitored_status(movie_id, radarr_instance_id=1):
     existing_movie_monitored = database.execute(
         select(TableMovies.monitored)
-        .where(TableMovies.radarrId == str(movie_id)))\
+        .where(TableMovies.radarrId == str(movie_id))
+        .where(TableMovies.radarr_instance_id == radarr_instance_id))\
         .first()
     if existing_movie_monitored is None:
         return True
@@ -85,17 +89,130 @@ def add_movie(added_movie):
         event_stream(type='movie', action='update', payload=int(added_movie['radarrId']))
 
 
+def _sync_instance_movies(instance, movie_default_profile):
+    """Sync movies for a single Radarr instance.
+
+    Args:
+        instance: dict from TableRadarrInstances.to_dict()
+        movie_default_profile: default language profile ID (or None)
+    """
+    instance_id = instance['id']
+    instance_name = instance.get('name', f'Instance {instance_id}')
+    apikey = instance.get('apikey', '')
+
+    logging.debug(f'BAZARR Starting movie sync from Radarr instance "{instance_name}" (id={instance_id}).')
+
+    if not apikey:
+        logging.warning(f'BAZARR Skipping Radarr instance "{instance_name}": no API key configured.')
+        return
+
+    audio_profiles = get_profile_list(instance=instance)
+    tagsDict = get_tags(instance=instance)
+    language_profiles = get_language_profiles()
+
+    # Get movies data from radarr
+    movies = get_movies_from_radarr_api(apikey_radarr=apikey, instance=instance)
+    if not isinstance(movies, list):
+        logging.warning(f'BAZARR Could not retrieve movies from Radarr instance "{instance_name}".')
+        return
+
+    movies_count = len(movies)
+
+    # Get current movies in DB for this instance
+    current_movies_id_db = [x.radarrId for x in
+                            database.execute(
+                                select(TableMovies.radarrId)
+                                .where(TableMovies.radarr_instance_id == instance_id))
+                            .all()]
+    current_movies_db_kv = [x.items() for x in [y._asdict()['TableMovies'].__dict__ for y in
+                                                  database.execute(
+                                                      select(TableMovies)
+                                                      .where(TableMovies.radarr_instance_id == instance_id))
+                                                  .all()]]
+
+    current_movies_radarr = [movie['id'] for movie in movies if movie['hasFile'] and
+                             'movieFile' in movie and
+                             (movie['movieFile']['size'] > MINIMUM_VIDEO_SIZE or
+                              get_movie_file_size_from_db(movie['movieFile']['path']) > MINIMUM_VIDEO_SIZE)]
+
+    # Remove movies from DB that no longer exist in Radarr or don't have a movie file
+    movies_to_delete = list(set(current_movies_id_db) - set(current_movies_radarr))
+    movies_deleted = []
+    if len(movies_to_delete):
+        try:
+            database.execute(
+                delete(TableMovies)
+                .where(TableMovies.radarrId.in_(movies_to_delete))
+                .where(TableMovies.radarr_instance_id == instance_id))
+        except IntegrityError as e:
+            logging.error(f"BAZARR cannot delete movies from instance '{instance_name}' because of {e}")
+        else:
+            for removed_movie in movies_to_delete:
+                movies_deleted.append(removed_movie)
+                event_stream(type='movie', action='delete', payload=removed_movie)
+
+    # Instance-specific settings
+    sync_monitored = bool(instance.get('sync_only_monitored_movies', 0))
+    if sync_monitored:
+        skipped_count = 0
+    files_missing = 0
+    movies_added = []
+    movies_updated = []
+
+    for i, movie in enumerate(movies, start=1):
+        if movie['hasFile'] is True:
+            if 'movieFile' in movie:
+                if sync_monitored:
+                    if get_movie_monitored_status(movie['id'], instance_id) != movie['monitored']:
+                        trace(f"{i}: (Monitor Status Mismatch) {movie['title']}")
+                    elif not movie['monitored']:
+                        trace(f"{i}: (Skipped Unmonitored) {movie['title']}")
+                        skipped_count += 1
+                        continue
+
+                if (movie['movieFile']['size'] > MINIMUM_VIDEO_SIZE or
+                        get_movie_file_size_from_db(movie['movieFile']['path']) > MINIMUM_VIDEO_SIZE):
+                    trace(f"{i}: (Processing) {movie['title']}")
+                    if movie['id'] in current_movies_id_db:
+                        parsed_movie = movieParser(movie, action='update',
+                                                   tags_dict=tagsDict,
+                                                   language_profiles=language_profiles,
+                                                   movie_default_profile=movie_default_profile,
+                                                   audio_profiles=audio_profiles,
+                                                   radarr_instance_id=instance_id,
+                                                   instance=instance)
+                        if not any([parsed_movie.items() <= x for x in current_movies_db_kv]):
+                            update_movie(parsed_movie)
+                            movies_updated.append(parsed_movie['title'])
+                    else:
+                        parsed_movie = movieParser(movie, action='insert',
+                                                   tags_dict=tagsDict,
+                                                   language_profiles=language_profiles,
+                                                   movie_default_profile=movie_default_profile,
+                                                   audio_profiles=audio_profiles,
+                                                   radarr_instance_id=instance_id,
+                                                   instance=instance)
+                        add_movie(parsed_movie)
+                        movies_added.append(parsed_movie['title'])
+        else:
+            trace(f"{i}: (Skipped File Missing) {movie['title']}")
+            files_missing += 1
+
+    trace(f"Instance '{instance_name}': Skipped {files_missing} file-missing movies out of {movies_count}")
+    if sync_monitored:
+        trace(f"Instance '{instance_name}': Skipped {skipped_count} unmonitored movies out of {movies_count}")
+    logging.debug(f'BAZARR Synced {len(movies_added)} added, {len(movies_updated)} updated, '
+                  f'{len(movies_deleted)} deleted from Radarr instance "{instance_name}".')
+
+
 def update_movies(job_id=None):
     if not job_id:
         jobs_queue.add_job_from_function("Syncing movies with Radarr", is_progress=True)
         return
 
     check_radarr_rootfolder()
-    logging.debug('BAZARR Starting movie sync from Radarr.')
-    apikey_radarr = settings.radarr.apikey
 
     movie_default_enabled = settings.general.movie_default_enabled
-
     if movie_default_enabled is True:
         movie_default_profile = settings.general.movie_default_profile
         if movie_default_profile == '':
@@ -110,116 +227,61 @@ def update_movies(job_id=None):
             .first()):
         movie_default_profile = None
 
-    if apikey_radarr is None:
-        pass
-    else:
-        audio_profiles = get_profile_list()
-        tagsDict = get_tags()
-        language_profiles = get_language_profiles()
+    # Sync from all enabled Radarr instances
+    instances = get_radarr_instances()
+    if not instances:
+        logging.warning('BAZARR No enabled Radarr instances found. Skipping movie sync.')
+        return
 
-        # Get movies data from radarr
-        movies = get_movies_from_radarr_api(apikey_radarr=apikey_radarr)
-        if not isinstance(movies, list):
-            return
-        else:
-            movies_count = len(movies)
-            jobs_queue.update_job_progress(job_id=job_id, progress_max=movies_count)
-            # Get current movies in DB
-            current_movies_id_db = [x.radarrId for x in
-                                    database.execute(
-                                        select(TableMovies.radarrId))
-                                    .all()]
-            current_movies_db_kv = [x.items() for x in [y._asdict()['TableMovies'].__dict__ for y in
-                                                        database.execute(
-                                                            select(TableMovies))
-                                                        .all()]]
+    movies_count = 0
+    for instance in instances:
+        # Estimate count for progress reporting
+        try:
+            movies_count += len(get_movies_from_radarr_api(
+                apikey_radarr=instance.get('apikey', ''), instance=instance) or [])
+        except Exception:
+            pass
 
-            current_movies_radarr = [movie['id'] for movie in movies if movie['hasFile'] and
-                                     'movieFile' in movie and
-                                     (movie['movieFile']['size'] > MINIMUM_VIDEO_SIZE or
-                                      get_movie_file_size_from_db(movie['movieFile']['path']) > MINIMUM_VIDEO_SIZE)]
+    jobs_queue.update_job_progress(job_id=job_id, progress_max=max(movies_count, 1))
 
-            # Remove movies from DB that either no longer exist in Radarr or exist and Radarr says do not have a movie file
-            movies_to_delete = list(set(current_movies_id_db) - set(current_movies_radarr))
-            movies_deleted = []
-            if len(movies_to_delete):
-                try:
-                    database.execute(delete(TableMovies).where(TableMovies.radarrId.in_(movies_to_delete)))
-                except IntegrityError as e:
-                    logging.error(f"BAZARR cannot delete movies because of {e}")
-                else:
-                    for removed_movie in movies_to_delete:
-                        movies_deleted.append(removed_movie)
-                        event_stream(type='movie', action='delete', payload=removed_movie)
+    for instance in instances:
+        try:
+            _sync_instance_movies(instance, movie_default_profile)
+        except Exception:
+            logging.exception(f'BAZARR Exception syncing Radarr instance "{instance.get("name", instance["id"])}"')
 
-            # Add new movies and update movies that Radarr says have media files
-            # Any new movies added to Radarr that don't have media files yet will not be added to DB
-            sync_monitored = settings.radarr.sync_only_monitored_movies
-            if sync_monitored:
-                skipped_count = 0
-            files_missing = 0
-            movies_added = []
-            movies_updated = []
-            for i, movie in enumerate(movies, start=1):
-                jobs_queue.update_job_progress(job_id=job_id, progress_value=i, progress_message=movie['title'])
-                # Only movies that Radarr says have files downloaded will be kept up to date in the DB
-                if movie['hasFile'] is True:
-                    if 'movieFile' in movie:
-                        if sync_monitored:
-                            if get_movie_monitored_status(movie['id']) != movie['monitored']:
-                                # monitored status is not the same as our DB
-                                trace(f"{i}: (Monitor Status Mismatch) {movie['title']}")
-                            elif not movie['monitored']:
-                                trace(f"{i}: (Skipped Unmonitored) {movie['title']}")
-                                skipped_count += 1
-                                continue
-
-                        if (movie['movieFile']['size'] > MINIMUM_VIDEO_SIZE or
-                                get_movie_file_size_from_db(movie['movieFile']['path']) > MINIMUM_VIDEO_SIZE):
-                            # Add/update movies from Radarr that have a movie file to current movies list
-                            trace(f"{i}: (Processing) {movie['title']}")
-                            if movie['id'] in current_movies_id_db:
-                                parsed_movie = movieParser(movie, action='update',
-                                                           tags_dict=tagsDict,
-                                                           language_profiles=language_profiles,
-                                                           movie_default_profile=movie_default_profile,
-                                                           audio_profiles=audio_profiles)
-                                if not any([parsed_movie.items() <= x for x in current_movies_db_kv]):
-                                    update_movie(parsed_movie)
-                                    movies_updated.append(parsed_movie['title'])
-                            else:
-                                parsed_movie = movieParser(movie, action='insert',
-                                                           tags_dict=tagsDict,
-                                                           language_profiles=language_profiles,
-                                                           movie_default_profile=movie_default_profile,
-                                                           audio_profiles=audio_profiles)
-                                add_movie(parsed_movie)
-                                movies_added.append(parsed_movie['title'])
-                else:
-                    trace(f"{i}: (Skipped File Missing) {movie['title']}")
-                    files_missing += 1
-
-            trace(f"Skipped {files_missing} file missing movies out of {movies_count}")
-            if sync_monitored:
-                trace(f"Skipped {skipped_count} unmonitored movies out of {movies_count}")
-                trace(f"Processed {movies_count - files_missing - skipped_count} movies out of {movies_count} "
-                      f"with {len(movies_added)} added, {len(movies_updated)} updated and "
-                      f"{len(movies_deleted)} deleted")
-            else:
-                trace(f"Processed {movies_count - files_missing} movies out of {movies_count} with {len(movies_added)} added and "
-                      f"{len(movies_updated)} updated")
-
-            logging.debug('BAZARR All movies synced from Radarr into database.')
+    logging.debug('BAZARR All movies synced from all Radarr instances into database.')
     jobs_queue.update_job_name(job_id=job_id, new_job_name="Synced movies with Radarr")
 
 
-def update_one_movie(movie_id, action, defer_search=False, is_signalr=False):
-    logging.debug(f'BAZARR syncing this specific movie from Radarr: {movie_id}')
+def update_one_movie(movie_id, action, defer_search=False, is_signalr=False,
+                     radarr_instance_id=1, instance=None):
+    """Sync a single movie from a specific Radarr instance.
 
-    # Check if there's a row in the database for this movie ID
+    Args:
+        movie_id: Radarr movie ID.
+        action: 'updated' or 'deleted'.
+        defer_search: If True, defer subtitle search to next scheduled run.
+        is_signalr: True if called from SignalR feed.
+        radarr_instance_id: The instance ID (default=1 for primary).
+        instance: Full instance dict. If None, uses primary instance from settings.
+    """
+    logging.debug(f'BAZARR syncing this specific movie from Radarr instance {radarr_instance_id}: {movie_id}')
+
+    # If no instance dict provided, load it from DB
+    if instance is None:
+        inst_row = database.execute(
+            select(TableRadarrInstances)
+            .where(TableRadarrInstances.id == radarr_instance_id)
+        ).scalar_one_or_none()
+        if inst_row:
+            instance = inst_row.to_dict()
+
+    # Check if there's a row in the database for this movie ID + instance
     existing_movie = database.execute(
         select(TableMovies.path)
-        .where(TableMovies.radarrId == movie_id))\
+        .where(TableMovies.radarrId == movie_id)
+        .where(TableMovies.radarr_instance_id == radarr_instance_id))\
         .first()
 
     # Remove movie from DB
@@ -228,7 +290,8 @@ def update_one_movie(movie_id, action, defer_search=False, is_signalr=False):
             try:
                 database.execute(
                     delete(TableMovies)
-                    .where(TableMovies.radarrId == movie_id))
+                    .where(TableMovies.radarrId == movie_id)
+                    .where(TableMovies.radarr_instance_id == radarr_instance_id))
             except IntegrityError as e:
                 logging.error(f"BAZARR cannot delete movie {path_mappings.path_replace_movie(existing_movie.path)} "
                               f"because of {e}")
@@ -240,7 +303,6 @@ def update_one_movie(movie_id, action, defer_search=False, is_signalr=False):
         return
 
     movie_default_enabled = settings.general.movie_default_enabled
-
     if movie_default_enabled is True:
         movie_default_profile = settings.general.movie_default_profile
         if movie_default_profile == '':
@@ -248,23 +310,31 @@ def update_one_movie(movie_id, action, defer_search=False, is_signalr=False):
     else:
         movie_default_profile = None
 
-    audio_profiles = get_profile_list()
-    tagsDict = get_tags()
+    apikey = instance.get('apikey', settings.radarr.apikey) if instance else settings.radarr.apikey
+    audio_profiles = get_profile_list(instance=instance)
+    tagsDict = get_tags(instance=instance)
     language_profiles = get_language_profiles()
 
     try:
-        # Get movie data from radarr api
         movie = None
-        movie_data = get_movies_from_radarr_api(apikey_radarr=settings.radarr.apikey, radarr_id=movie_id)
+        movie_data = get_movies_from_radarr_api(apikey_radarr=apikey, radarr_id=movie_id, instance=instance)
         if not movie_data:
             return
         else:
             if action == 'updated' and existing_movie:
-                movie = movieParser(movie_data, action='update', tags_dict=tagsDict, language_profiles=language_profiles,
-                                    movie_default_profile=movie_default_profile, audio_profiles=audio_profiles)
+                movie = movieParser(movie_data, action='update', tags_dict=tagsDict,
+                                    language_profiles=language_profiles,
+                                    movie_default_profile=movie_default_profile,
+                                    audio_profiles=audio_profiles,
+                                    radarr_instance_id=radarr_instance_id,
+                                    instance=instance)
             elif action == 'updated' and not existing_movie:
-                movie = movieParser(movie_data, action='insert', tags_dict=tagsDict, language_profiles=language_profiles,
-                                    movie_default_profile=movie_default_profile, audio_profiles=audio_profiles)
+                movie = movieParser(movie_data, action='insert', tags_dict=tagsDict,
+                                    language_profiles=language_profiles,
+                                    movie_default_profile=movie_default_profile,
+                                    audio_profiles=audio_profiles,
+                                    radarr_instance_id=radarr_instance_id,
+                                    instance=instance)
     except Exception:
         logging.exception('BAZARR cannot get movie returned by SignalR feed from Radarr API.')
         return
@@ -278,7 +348,8 @@ def update_one_movie(movie_id, action, defer_search=False, is_signalr=False):
         try:
             database.execute(
                 delete(TableMovies)
-                .where(TableMovies.radarrId == movie_id))
+                .where(TableMovies.radarrId == movie_id)
+                .where(TableMovies.radarr_instance_id == radarr_instance_id))
         except IntegrityError as e:
             logging.error(f"BAZARR cannot delete movie {path_mappings.path_replace_movie(existing_movie.path)} because "
                           f"of {e}")
@@ -295,7 +366,8 @@ def update_one_movie(movie_id, action, defer_search=False, is_signalr=False):
             database.execute(
                 update(TableMovies)
                 .values(movie)
-                .where(TableMovies.radarrId == movie['radarrId']))
+                .where(TableMovies.radarrId == movie['radarrId'])
+                .where(TableMovies.radarr_instance_id == radarr_instance_id))
         except IntegrityError as e:
             logging.error(f"BAZARR cannot update movie {path_mappings.path_replace_movie(movie['path'])} because "
                           f"of {e}")
@@ -329,7 +401,7 @@ def update_one_movie(movie_id, action, defer_search=False, is_signalr=False):
     else:
         if os.path.exists(path_mappings.path_replace_movie(movie["path"])):
             logging.debug(f'BAZARR downloading missing subtitles for this movie: {movie["title"]} ({movie["year"]})')
-            if _is_there_missing_subtitles(radarr_id=movie_id):
+            if _is_there_missing_subtitles(radarr_id=movie_id, radarr_instance_id=radarr_instance_id):
                 jobs_queue.feed_jobs_pending_queue(job_name=f'Downloading missing subtitles for {movie["title"]} '
                                                             f'({movie["year"]})',
                                                    module='subtitles.mass_download.movies',
@@ -345,24 +417,14 @@ def update_one_movie(movie_id, action, defer_search=False, is_signalr=False):
                           f'{movie["title"]} ({movie["year"]})')
 
 
-def _is_there_missing_subtitles(radarr_id: int) -> bool:
+def _is_there_missing_subtitles(radarr_id: int, radarr_instance_id: int = 1) -> bool:
     """
     Determines if there are any missing subtitles for a specified movie in the database.
-
-    This function checks a movie identified by its radarr_id within the database to
-    see if there are subtitles flagged as missing. It also considers the search activity
-    status for the missing subtitles to determine whether there are active missing episodes.
-
-    :param radarr_id: The ID of the movie in the Radarr system.
-    :type radarr_id: int
-
-    :return: A boolean indicating whether there are any active missing subtitles
-             for the specified movie.
-    :rtype: bool
     """
     movies_conditions = [(TableMovies.missing_subtitles.is_not(None)),
                          (TableMovies.missing_subtitles != '[]'),
-                         (TableMovies.radarrId == radarr_id)]
+                         (TableMovies.radarrId == radarr_id),
+                         (TableMovies.radarr_instance_id == radarr_instance_id)]
     if not radarr_id:
         return False
     movies_conditions += get_exclusion_clause('movie')

--- a/bazarr/radarr/sync/parser.py
+++ b/bazarr/radarr/sync/parser.py
@@ -4,7 +4,7 @@ import os
 
 from app.config import settings
 from languages.get_languages import audio_language_from_name
-from radarr.info import get_radarr_info
+from radarr.info import get_radarr_info, is_radarr_instance_legacy
 from utilities.video_analyzer import embedded_audio_reader
 from utilities.path_mappings import path_mappings
 
@@ -21,7 +21,25 @@ def get_matching_profile(tags, language_profiles):
     return matching_profile
 
 
-def movieParser(movie, action, tags_dict, language_profiles, movie_default_profile, audio_profiles):
+def movieParser(movie, action, tags_dict, language_profiles, movie_default_profile, audio_profiles,
+                radarr_instance_id=1, instance=None):
+    """Parse a Radarr movie API response into a DB-ready dict.
+
+    Args:
+        movie: Raw movie dict from Radarr API.
+        action: 'insert' or 'update'.
+        tags_dict: Tags from Radarr API.
+        language_profiles: Language profiles from the DB.
+        movie_default_profile: Default profile ID (or None).
+        audio_profiles: Quality profiles from Radarr API.
+        radarr_instance_id: The instance ID this movie belongs to (default=1).
+        instance: instance dict (used to determine legacy status). If None, uses global radarr_info.
+    """
+    if instance is not None:
+        _is_legacy = is_radarr_instance_legacy(instance)
+    else:
+        _is_legacy = get_radarr_info.is_legacy()
+
     if 'movieFile' in movie:
         try:
             overview = str(movie['overview'])
@@ -43,7 +61,7 @@ def movieParser(movie, action, tags_dict, language_profiles, movie_default_profi
             sceneName = None
 
         alternativeTitles = None
-        if get_radarr_info.is_legacy():
+        if _is_legacy:
             if 'alternativeTitles' in movie:
                 alternativeTitles = str([item['title'] for item in movie['alternativeTitles']])
         else:
@@ -66,7 +84,7 @@ def movieParser(movie, action, tags_dict, language_profiles, movie_default_profi
 
         if 'mediaInfo' in movie['movieFile']:
             videoFormat = videoCodecID = videoCodecLibrary = None
-            if get_radarr_info.is_legacy():
+            if _is_legacy:
                 if 'videoFormat' in movie['movieFile']['mediaInfo']:
                     videoFormat = movie['movieFile']['mediaInfo']['videoFormat']
             else:
@@ -79,7 +97,7 @@ def movieParser(movie, action, tags_dict, language_profiles, movie_default_profi
             videoCodec = RadarrFormatVideoCodec(videoFormat, videoCodecID, videoCodecLibrary)
 
             audioFormat = audioCodecID = audioProfile = audioAdditionalFeatures = None
-            if get_radarr_info.is_legacy():
+            if _is_legacy:
                 if 'audioFormat' in movie['movieFile']['mediaInfo']:
                     audioFormat = movie['movieFile']['mediaInfo']['audioFormat']
             else:
@@ -103,7 +121,7 @@ def movieParser(movie, action, tags_dict, language_profiles, movie_default_profi
                                                    use_cache=True)
         else:
             audio_language = []
-            if get_radarr_info.is_legacy():
+            if _is_legacy:
                 if 'mediaInfo' in movie['movieFile']:
                     if 'audioLanguages' in movie['movieFile']['mediaInfo']:
                         audio_languages_list = movie['movieFile']['mediaInfo']['audioLanguages'].split('/')
@@ -122,6 +140,7 @@ def movieParser(movie, action, tags_dict, language_profiles, movie_default_profi
         tags = [d['label'] for d in tags_dict if d['id'] in movie['tags']]
 
         parsed_movie = {'radarrId': int(movie["id"]),
+                        'radarr_instance_id': radarr_instance_id,
                         'title': movie["title"],
                         'path': movie['movieFile']['path'],
                         'tmdbId': str(movie["tmdbId"]),

--- a/bazarr/radarr/sync/utils.py
+++ b/bazarr/radarr/sync/utils.py
@@ -4,20 +4,33 @@ import requests
 import logging
 
 from app.config import settings
-from radarr.info import get_radarr_info, url_api_radarr
+from radarr.info import (get_radarr_info, url_api_radarr,
+                         url_api_radarr_from_instance, is_radarr_instance_legacy)
 from constants import HEADERS
 
 
-def get_profile_list():
-    apikey_radarr = settings.radarr.apikey
+def get_profile_list(instance=None):
+    """Fetch quality profiles from Radarr.
+
+    Args:
+        instance: dict from TableRadarrInstances.to_dict(). If None, uses primary instance from settings.
+    """
+    if instance is not None:
+        apikey = instance.get('apikey', '')
+        timeout = int(instance.get('http_timeout', 60))
+        legacy = is_radarr_instance_legacy(instance)
+        api_url = url_api_radarr_from_instance(instance, is_legacy=legacy)
+    else:
+        apikey = settings.radarr.apikey
+        timeout = int(settings.radarr.http_timeout)
+        api_url = url_api_radarr()
+        legacy = get_radarr_info.is_legacy()
+
     profiles_list = []
-    # Get profiles data from radarr
-    url_radarr_api_movies = (f"{url_api_radarr()}{'quality' if url_api_radarr().endswith('v3/') else ''}profile?"
-                             f"apikey={apikey_radarr}")
+    url = f"{api_url}{'quality' if api_url.endswith('v3/') else ''}profile?apikey={apikey}"
 
     try:
-        profiles_json = requests.get(url_radarr_api_movies, timeout=int(settings.radarr.http_timeout), verify=False,
-                                     headers=HEADERS)
+        profiles_json = requests.get(url, timeout=timeout, verify=False, headers=HEADERS)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get profiles from Radarr. Connection Error.")
     except requests.exceptions.Timeout:
@@ -25,8 +38,7 @@ def get_profile_list():
     except requests.exceptions.RequestException:
         logging.exception("BAZARR Error trying to get profiles from Radarr.")
     else:
-        # Parsing data returned from radarr
-        if get_radarr_info.is_legacy():
+        if legacy:
             for profile in profiles_json.json():
                 if 'language' in profile:
                     profiles_list.append([profile['id'], profile['language'].capitalize()])
@@ -38,15 +50,26 @@ def get_profile_list():
     return profiles_list
 
 
-def get_tags():
-    apikey_radarr = settings.radarr.apikey
-    tagsDict = []
+def get_tags(instance=None):
+    """Fetch tags from Radarr.
 
-    # Get tags data from Radarr
-    url_radarr_api_series = f"{url_api_radarr()}tag?apikey={apikey_radarr}"
+    Args:
+        instance: dict from TableRadarrInstances.to_dict(). If None, uses primary instance from settings.
+    """
+    if instance is not None:
+        apikey = instance.get('apikey', '')
+        timeout = int(instance.get('http_timeout', 60))
+        legacy = is_radarr_instance_legacy(instance)
+        api_url = url_api_radarr_from_instance(instance, is_legacy=legacy)
+    else:
+        apikey = settings.radarr.apikey
+        timeout = int(settings.radarr.http_timeout)
+        api_url = url_api_radarr()
+
+    url = f"{api_url}tag?apikey={apikey}"
 
     try:
-        tagsDict = requests.get(url_radarr_api_series, timeout=int(settings.radarr.http_timeout), verify=False, headers=HEADERS)
+        tagsDict = requests.get(url, timeout=timeout, verify=False, headers=HEADERS)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get tags from Radarr. Connection Error.")
         return []
@@ -66,11 +89,28 @@ def get_tags():
             return []
 
 
-def get_movies_from_radarr_api(apikey_radarr, radarr_id=None):
-    url_radarr_api_movies = f'{url_api_radarr()}movie{f"/{radarr_id}" if radarr_id else ""}?apikey={apikey_radarr}'
+def get_movies_from_radarr_api(apikey_radarr, radarr_id=None, instance=None):
+    """Fetch movie(s) from Radarr API.
+
+    Args:
+        apikey_radarr: Radarr API key (used when instance is None).
+        radarr_id: Optional specific movie ID to fetch.
+        instance: dict from TableRadarrInstances.to_dict(). If None, uses primary instance from settings.
+    """
+    if instance is not None:
+        legacy = is_radarr_instance_legacy(instance)
+        api_url = url_api_radarr_from_instance(instance, is_legacy=legacy)
+        timeout = int(instance.get('http_timeout', 60))
+        apikey = instance.get('apikey', apikey_radarr)
+    else:
+        api_url = url_api_radarr()
+        timeout = int(settings.radarr.http_timeout)
+        apikey = apikey_radarr
+
+    url = f'{api_url}movie{f"/{radarr_id}" if radarr_id else ""}?apikey={apikey}'
 
     try:
-        r = requests.get(url_radarr_api_movies, timeout=int(settings.radarr.http_timeout), verify=False, headers=HEADERS)
+        r = requests.get(url, timeout=timeout, verify=False, headers=HEADERS)
         if r.status_code == 404:
             return
         r.raise_for_status()
@@ -96,12 +136,28 @@ def get_movies_from_radarr_api(apikey_radarr, radarr_id=None):
             return
 
 
-def get_history_from_radarr_api(apikey_radarr, movie_id):
-    url_radarr_api_history = f"{url_api_radarr()}history?eventType=1&movieIds={movie_id}&apikey={apikey_radarr}"
+def get_history_from_radarr_api(apikey_radarr, movie_id, instance=None):
+    """Fetch download history for a movie from Radarr API.
+
+    Args:
+        apikey_radarr: Radarr API key (used when instance is None).
+        movie_id: Radarr movie ID.
+        instance: dict from TableRadarrInstances.to_dict(). If None, uses primary instance from settings.
+    """
+    if instance is not None:
+        legacy = is_radarr_instance_legacy(instance)
+        api_url = url_api_radarr_from_instance(instance, is_legacy=legacy)
+        timeout = int(instance.get('http_timeout', 60))
+        apikey = instance.get('apikey', apikey_radarr)
+    else:
+        api_url = url_api_radarr()
+        timeout = int(settings.sonarr.http_timeout)
+        apikey = apikey_radarr
+
+    url = f"{api_url}history?eventType=1&movieIds={movie_id}&apikey={apikey}"
 
     try:
-        r = requests.get(url_radarr_api_history, timeout=int(settings.sonarr.http_timeout), verify=False,
-                         headers=HEADERS)
+        r = requests.get(url, timeout=timeout, verify=False, headers=HEADERS)
         r.raise_for_status()
     except requests.exceptions.HTTPError:
         logging.exception("BAZARR Error trying to get history from Radarr. Http error.")

--- a/migrations/versions/a3f8b2c1d9e7_.py
+++ b/migrations/versions/a3f8b2c1d9e7_.py
@@ -1,0 +1,206 @@
+"""Add multi-instance Radarr support
+
+Revision ID: a3f8b2c1d9e7
+Revises: df76a4410347
+Create Date: 2026-02-19 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import warnings
+from sqlalchemy import exc as sa_exc
+
+# revision identifiers, used by Alembic.
+revision = 'a3f8b2c1d9e7'
+down_revision = 'df76a4410347'
+branch_labels = None
+depends_on = None
+
+bind = op.get_context().bind
+insp = sa.inspect(bind)
+tables = insp.get_table_names()
+
+should_recreate = 'always' if bind.engine.name == 'sqlite' else 'auto'
+
+
+def column_exists(table_name, column_name):
+    columns = insp.get_columns(table_name)
+    return any(c["name"] == column_name for c in columns)
+
+
+def table_exists(table_name):
+    return table_name in tables
+
+
+def upgrade():
+    warnings.filterwarnings("ignore", category=sa_exc.SAWarning)
+
+    # 1. Create the radarr instances table if it doesn't exist
+    if not table_exists('table_radarr_instances'):
+        op.create_table(
+            'table_radarr_instances',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('name', sa.Text(), nullable=False),
+            sa.Column('ip', sa.Text(), nullable=False),
+            sa.Column('port', sa.Integer(), nullable=False),
+            sa.Column('base_url', sa.Text(), nullable=False),
+            sa.Column('ssl', sa.Integer(), nullable=False, server_default='0'),
+            sa.Column('apikey', sa.Text(), nullable=False, server_default=''),
+            sa.Column('http_timeout', sa.Integer(), nullable=False, server_default='60'),
+            sa.Column('enabled', sa.Integer(), nullable=False, server_default='1'),
+            sa.Column('full_update', sa.Text(), nullable=False, server_default='Daily'),
+            sa.Column('full_update_day', sa.Integer(), nullable=False, server_default='6'),
+            sa.Column('full_update_hour', sa.Integer(), nullable=False, server_default='4'),
+            sa.Column('movies_sync', sa.Integer(), nullable=False, server_default='60'),
+            sa.Column('movies_sync_on_live', sa.Integer(), nullable=False, server_default='1'),
+            sa.Column('only_monitored', sa.Integer(), nullable=False, server_default='0'),
+            sa.Column('excluded_tags', sa.Text(), nullable=False, server_default='[]'),
+            sa.Column('sync_only_monitored_movies', sa.Integer(), nullable=False, server_default='0'),
+            sa.Column('defer_search_signalr', sa.Integer(), nullable=False, server_default='0'),
+            sa.Column('use_ffprobe_cache', sa.Integer(), nullable=False, server_default='1'),
+            sa.PrimaryKeyConstraint('id', name='pk_table_radarr_instances'),
+        )
+
+    # 2. Populate the primary instance from the app's settings
+    # We read from config.yaml via a direct import to avoid circular dependency issues.
+    # This populates instance id=1 from the existing settings.radarr.* config.
+    try:
+        from app.config import settings
+        primary = {
+            'id': 1,
+            'name': 'Radarr',
+            'ip': str(settings.radarr.ip),
+            'port': int(settings.radarr.port),
+            'base_url': str(settings.radarr.base_url),
+            'ssl': 1 if settings.radarr.ssl else 0,
+            'apikey': str(settings.radarr.apikey),
+            'http_timeout': int(settings.radarr.http_timeout),
+            'enabled': 1,
+            'full_update': str(settings.radarr.full_update),
+            'full_update_day': int(settings.radarr.full_update_day),
+            'full_update_hour': int(settings.radarr.full_update_hour),
+            'movies_sync': int(settings.radarr.movies_sync),
+            'movies_sync_on_live': 1 if settings.radarr.movies_sync_on_live else 0,
+            'only_monitored': 1 if settings.radarr.only_monitored else 0,
+            'excluded_tags': str(settings.radarr.excluded_tags),
+            'sync_only_monitored_movies': 1 if settings.radarr.sync_only_monitored_movies else 0,
+            'defer_search_signalr': 1 if settings.radarr.defer_search_signalr else 0,
+            'use_ffprobe_cache': 1 if settings.radarr.use_ffprobe_cache else 0,
+        }
+        instances_table = sa.table(
+            'table_radarr_instances',
+            sa.column('id'), sa.column('name'), sa.column('ip'), sa.column('port'),
+            sa.column('base_url'), sa.column('ssl'), sa.column('apikey'),
+            sa.column('http_timeout'), sa.column('enabled'), sa.column('full_update'),
+            sa.column('full_update_day'), sa.column('full_update_hour'),
+            sa.column('movies_sync'), sa.column('movies_sync_on_live'),
+            sa.column('only_monitored'), sa.column('excluded_tags'),
+            sa.column('sync_only_monitored_movies'), sa.column('defer_search_signalr'),
+            sa.column('use_ffprobe_cache'),
+        )
+        # Only insert if no row with id=1 exists
+        conn = op.get_bind()
+        existing = conn.execute(sa.text("SELECT id FROM table_radarr_instances WHERE id=1")).fetchone()
+        if not existing:
+            conn.execute(instances_table.insert().values(**primary))
+    except Exception as e:
+        import logging
+        logging.warning(f"Could not populate primary Radarr instance from settings: {e}")
+        # Insert a placeholder row so the FK constraint is satisfied
+        conn = op.get_bind()
+        existing = conn.execute(sa.text("SELECT id FROM table_radarr_instances WHERE id=1")).fetchone()
+        if not existing:
+            conn.execute(sa.text(
+                "INSERT INTO table_radarr_instances "
+                "(id, name, ip, port, base_url, ssl, apikey, http_timeout, enabled, "
+                " full_update, full_update_day, full_update_hour, movies_sync, "
+                " movies_sync_on_live, only_monitored, excluded_tags, "
+                " sync_only_monitored_movies, defer_search_signalr, use_ffprobe_cache) "
+                "VALUES (1, 'Radarr', '127.0.0.1', 7878, '/', 0, '', 60, 1, "
+                "        'Daily', 6, 4, 60, 1, 0, '[]', 0, 0, 1)"
+            ))
+
+    # 3. Add radarr_instance_id to table_movies and recreate with composite PK
+    if not column_exists('table_movies', 'radarr_instance_id'):
+        # First add the column as nullable
+        with op.batch_alter_table('table_movies') as batch_op:
+            batch_op.add_column(sa.Column('radarr_instance_id', sa.Integer(), nullable=True,
+                                          server_default='1'))
+
+        # Set all existing rows to instance 1
+        op.get_bind().execute(sa.text("UPDATE table_movies SET radarr_instance_id = 1"))
+
+    # Recreate table_movies with composite PK and updated constraints
+    with op.batch_alter_table('table_movies', recreate=should_recreate) as batch_op:
+        # Drop old single-column PK and recreate as composite
+        batch_op.create_primary_key('pk_table_movies', ['radarrId', 'radarr_instance_id'])
+        # Add FK to radarr_instances
+        batch_op.create_foreign_key(
+            'fk_movies_radarr_instance_id',
+            'table_radarr_instances',
+            ['radarr_instance_id'],
+            ['id'],
+            ondelete='CASCADE'
+        )
+        # Make radarr_instance_id non-nullable now that all rows have a value
+        batch_op.alter_column('radarr_instance_id', nullable=False)
+        # Drop the old global tmdbId unique constraint and recreate per-instance
+        try:
+            batch_op.drop_constraint('unique_table_movies_tmdbId', type_='unique')
+        except Exception:
+            pass
+        batch_op.create_unique_constraint(
+            'unique_table_movies_tmdbId_instance',
+            ['tmdbId', 'radarr_instance_id']
+        )
+
+    # 4. Add radarr_instance_id to table_history_movie
+    if not column_exists('table_history_movie', 'radarr_instance_id'):
+        with op.batch_alter_table('table_history_movie') as batch_op:
+            batch_op.add_column(sa.Column('radarr_instance_id', sa.Integer(), nullable=True,
+                                          server_default='1'))
+        op.get_bind().execute(sa.text("UPDATE table_history_movie SET radarr_instance_id = 1"))
+
+    # Recreate table_history_movie with updated composite FK
+    with op.batch_alter_table('table_history_movie', recreate=should_recreate) as batch_op:
+        # Drop old single-column FK and recreate as composite
+        try:
+            batch_op.drop_constraint('fk_radarrId_history_movie', type_='foreignkey')
+        except Exception:
+            pass
+        batch_op.alter_column('radarr_instance_id', nullable=False)
+        batch_op.create_foreign_key(
+            'fk_radarrId_history_movie',
+            'table_movies',
+            ['radarrId', 'radarr_instance_id'],
+            ['radarrId', 'radarr_instance_id'],
+            ondelete='CASCADE'
+        )
+
+    # 5. Add radarr_instance_id to table_blacklist_movie
+    if not column_exists('table_blacklist_movie', 'radarr_instance_id'):
+        with op.batch_alter_table('table_blacklist_movie') as batch_op:
+            batch_op.add_column(sa.Column('radarr_instance_id', sa.Integer(), nullable=True,
+                                          server_default='1'))
+        op.get_bind().execute(sa.text("UPDATE table_blacklist_movie SET radarr_instance_id = 1"))
+
+    # Recreate table_blacklist_movie with updated composite FK
+    with op.batch_alter_table('table_blacklist_movie', recreate=should_recreate) as batch_op:
+        try:
+            batch_op.drop_constraint('fk_radarrId_blacklist_movie', type_='foreignkey')
+        except Exception:
+            pass
+        batch_op.alter_column('radarr_instance_id', nullable=False)
+        batch_op.create_foreign_key(
+            'fk_radarrId_blacklist_movie',
+            'table_movies',
+            ['radarr_id', 'radarr_instance_id'],
+            ['radarrId', 'radarr_instance_id'],
+            ondelete='CASCADE'
+        )
+
+    warnings.filterwarnings("default", category=sa_exc.SAWarning)
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Allows Bazarr to connect to multiple Radarr instances simultaneously, enabling separate libraries (e.g. anime movies on a dedicated Radarr).

Changes:
- database: Add TableRadarrInstances model; change TableMovies primary key to composite (radarrId, radarr_instance_id); add radarr_instance_id to TableHistoryMovie and TableBlacklistMovie with composite FKs
- migration: New Alembic migration (a3f8b2c1d9e7) to create table_radarr_instances and update existing tables; migrates primary Radarr config from settings to DB instance id=1
- radarr/info: Add url_radarr_from_instance(), url_api_radarr_from_instance(), get_radarr_version_for_instance(), and is_radarr_instance_legacy() for per-instance URL and version building
- radarr/sync/utils: All API functions (get_profile_list, get_tags, get_movies_from_radarr_api, get_history_from_radarr_api) accept an optional instance dict parameter
- radarr/sync/movies: update_movies() loops over all enabled instances; update_one_movie() accepts radarr_instance_id parameter; all DB queries filter by radarr_instance_id
- radarr/sync/parser: movieParser() accepts radarr_instance_id and instance parameters; sets radarr_instance_id in parsed movie dict
- radarr/rootfolder: check_radarr_rootfolder() iterates over all enabled instances
- signalr_client: RadarrSignalrClient accepts instance dict; new RadarrSignalrManager maintains one client per instance with backward-compatible start/restart/connected interface; events carry radarr_instance_id through the queue to the dispatcher
- api/radarr/instances: New REST API for CRUD on Radarr instances with test-connectivity endpoint (GET/POST /api/radarr/instances, GET/PUT/DELETE /api/radarr/instances/<id>, GET /api/radarr/instances/<id>/test)

https://claude.ai/code/session_01F8Fg1kGTh7xX5Vb13dkRKU