### PR TITLE
fix: don't cache unknown sonarr/radarr versions

### DIFF
--- a/bazarr/radarr/info.py
+++ b/bazarr/radarr/info.py
@@ -23,7 +23,7 @@ class GetRadarrInfo:
         @return: str
         """
         radarr_version = region.get("radarr_version", expiration_time=datetime.timedelta(seconds=60).total_seconds())
-        if radarr_version:
+        if radarr_version and radarr_version != 'unknown':
             region.set("radarr_version", radarr_version)
             return radarr_version
         else:

--- a/bazarr/sonarr/info.py
+++ b/bazarr/sonarr/info.py
@@ -23,7 +23,7 @@ class GetSonarrInfo:
         @return: str
         """
         sonarr_version = region.get("sonarr_version", expiration_time=datetime.timedelta(seconds=60).total_seconds())
-        if sonarr_version:
+        if sonarr_version and sonarr_version != 'unknown':
             region.set("sonarr_version", sonarr_version)
             return sonarr_version
         else:


### PR DESCRIPTION
Currently, when the version resolution for Sonarr/Radarr fails for whatever reason (e.g. it is not yet available after startup), the resultant `unknown` value is cached and returned from the cache for subsequent calls of `version()`. Also, because repeated calls to `version()` are refreshing the cache expiration by setting the value again, a stale cache will stay alive forever, as long as there are `version()` calls at least every 60 seconds.

I'm not sure which parts of this behavior are intentional, so my suggested change would have the minimal impact of not caching `unknown` values while keeping everything else the same.