### PR TITLE
Fix missing audio_exclude migration in upgrade_languages_profile_values

### DIFF
--- a/bazarr/app/database.py
+++ b/bazarr/app/database.py
@@ -554,6 +554,9 @@ def upgrade_languages_profile_values():
             elif language['hi'] in ["also", "never"]:
                 language['hi'] = "False"
 
+            if 'audio_exclude' not in language:
+                language['audio_exclude'] = "False"
+
             if 'audio_only_include' not in language:
                 language['audio_only_include'] = "False"
         database.execute(


### PR DESCRIPTION
## Summary

Fixes #3212

The `upgrade_languages_profile_values()` migration function in `bazarr/app/database.py` adds default values for missing keys in language profile items. The `audio_exclude` key was missing from this migration, causing a `KeyError` when processing language profiles that were created before the `audio_exclude` field was introduced.

## Change

Added a single migration block that initializes `audio_exclude` to `"False"` for any language profile item that doesn't already have it, consistent with how `audio_only_include` is handled immediately after.

## Test plan

- Verified the fix is consistent with the existing pattern for `audio_only_include`
- The migration now handles all expected keys, preventing `KeyError` on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)