### PR TITLE
Fixed legendasnet response parsing

### DIFF
--- a/custom_libs/subliminal_patch/providers/legendasnet.py
+++ b/custom_libs/subliminal_patch/providers/legendasnet.py
@@ -11,7 +11,11 @@ from requests import Session
 
 from subzero.language import Language
 from subliminal import Episode, Movie
-from subliminal.exceptions import ConfigurationError, ProviderError, DownloadLimitExceeded
+from subliminal.exceptions import (
+    ConfigurationError,
+    ProviderError,
+    DownloadLimitExceeded,
+)
 from subliminal_patch.exceptions import APIThrottled
 from .mixins import ProviderRetryMixin
 from subliminal_patch.subtitle import Subtitle
@@ -26,18 +30,28 @@ retry_timeout = 5
 
 
 class LegendasNetSubtitle(Subtitle):
-    provider_name = 'legendasnet'
+    provider_name = "legendasnet"
     hash_verifiable = False
 
-    def __init__(self, language, forced, page_link, download_link, file_id, release_names, uploader,
-                 season=None, episode=None):
+    def __init__(
+        self,
+        language,
+        forced,
+        page_link,
+        download_link,
+        file_id,
+        release_names,
+        uploader,
+        season=None,
+        episode=None,
+    ):
         super().__init__(language)
         language = Language.rebuild(language, forced=forced)
 
         self.season = season
         self.episode = episode
         self.releases = release_names
-        self.release_info = ', '.join(release_names)
+        self.release_info = ", ".join(release_names)
         self.language = language
         self.forced = forced
         self.file_id = file_id
@@ -56,20 +70,20 @@ class LegendasNetSubtitle(Subtitle):
         # handle movies and series separately
         if isinstance(video, Episode):
             # series
-            matches.add('series')
+            matches.add("series")
             # season
             if video.season == self.season:
-                matches.add('season')
+                matches.add("season")
             # episode
             if video.episode == self.episode:
-                matches.add('episode')
+                matches.add("episode")
             # imdb
-            matches.add('series_imdb_id')
+            matches.add("series_imdb_id")
         else:
             # title
-            matches.add('title')
+            matches.add("title")
             # imdb
-            matches.add('imdb_id')
+            matches.add("imdb_id")
 
         utils.update_matches(matches, video, self.release_info)
 
@@ -80,14 +94,17 @@ class LegendasNetSubtitle(Subtitle):
 
 class LegendasNetProvider(ProviderRetryMixin, Provider):
     """Legendas.Net Provider"""
-    server_hostname = 'legendas.net/api'
 
-    languages = {Language('por', 'BR')}
+    server_hostname = "legendas.net/api"
+
+    languages = {Language("por", "BR")}
     video_types = (Episode, Movie)
 
     def __init__(self, username, password):
         self.session = Session()
-        self.session.headers = {'User-Agent': os.environ.get("SZ_USER_AGENT", "Sub-Zero/2")}
+        self.session.headers = {
+            "User-Agent": os.environ.get("SZ_USER_AGENT", "Sub-Zero/2")
+        }
         self.username = username
         self.password = password
         self.access_token = None
@@ -98,22 +115,35 @@ class LegendasNetProvider(ProviderRetryMixin, Provider):
     def login(self):
         headersList = {
             "Accept": "*/*",
-            "User-Agent": self.session.headers['User-Agent'],
-            "Content-Type": "application/json"
+            "User-Agent": self.session.headers["User-Agent"],
+            "Content-Type": "application/json",
         }
 
-        payload = json.dumps({
-            "email": self.username,
-            "password": self.password
-        })
+        payload = json.dumps({"email": self.username, "password": self.password})
 
-        response = self.session.request("POST", self.server_url() + 'login', data=payload, headers=headersList)
-        if response.status_code != 200:
-            raise ConfigurationError('Failed to login and retrieve access token')
-        self.access_token = response.json().get('access_token')
+        response = self.retry(
+            lambda: self.session.request(
+                "POST",
+                self.server_url() + "login",
+                data=payload,
+                headers=headersList,
+                timeout=30,
+            ),
+            amount=retry_amount,
+            retry_timeout=retry_timeout,
+        )
+
+        if response.status_code == 429:
+            raise APIThrottled("Too many requests")
+        elif response.status_code == 401 or response.status_code == 403:
+            raise ConfigurationError("Invalid username or password")
+        elif response.status_code != 200:
+            response.raise_for_status()
+
+        self.access_token = response.json().get("access_token")
         if not self.access_token:
-            raise ConfigurationError('Access token not found in login response')
-        self.session.headers.update({'Authorization': f'Bearer {self.access_token}'})
+            raise ConfigurationError("Access token not found in login response")
+        self.session.headers.update({"Authorization": f"Bearer {self.access_token}"})
 
     def initialize(self):
         self._started = time.time()
@@ -122,7 +152,7 @@ class LegendasNetProvider(ProviderRetryMixin, Provider):
         self.session.close()
 
     def server_url(self):
-        return f'https://{self.server_hostname}/v1/'
+        return f"https://{self.server_hostname}/v1/"
 
     def query(self, languages, video):
         self.video = video
@@ -130,33 +160,37 @@ class LegendasNetProvider(ProviderRetryMixin, Provider):
         # query the server
         if isinstance(self.video, Episode):
             res = self.retry(
-                lambda: self.session.get(self.server_url() + 'search/tv',
-                                         json={
-                                             'name': video.series,
-                                             'page': 1,
-                                             'per_page': 25,
-                                             'tv_episode': video.episode,
-                                             'tv_season': video.season,
-                                             'imdb_id': video.series_imdb_id
-                                         },
-                                         headers={'Content-Type': 'application/json'},
-                                         timeout=30),
+                lambda: self.session.get(
+                    self.server_url() + "search/tv",
+                    json={
+                        "name": video.series,
+                        "page": 1,
+                        "per_page": 25,
+                        "tv_episode": video.episode,
+                        "tv_season": video.season,
+                        "imdb_id": video.series_imdb_id,
+                    },
+                    headers={"Content-Type": "application/json"},
+                    timeout=30,
+                ),
                 amount=retry_amount,
-                retry_timeout=retry_timeout
+                retry_timeout=retry_timeout,
             )
         else:
             res = self.retry(
-                lambda: self.session.get(self.server_url() + 'search/movie',
-                                         json={
-                                             'name': video.title,
-                                             'page': 1,
-                                             'per_page': 25,
-                                             'imdb_id': video.imdb_id
-                                         },
-                                         headers={'Content-Type': 'application/json'},
-                                         timeout=30),
+                lambda: self.session.get(
+                    self.server_url() + "search/movie",
+                    json={
+                        "name": video.title,
+                        "page": 1,
+                        "per_page": 25,
+                        "imdb_id": video.imdb_id,
+                    },
+                    headers={"Content-Type": "application/json"},
+                    timeout=30,
+                ),
                 amount=retry_amount,
-                retry_timeout=retry_timeout
+                retry_timeout=retry_timeout,
             )
 
         if res.status_code == 404:
@@ -164,7 +198,7 @@ class LegendasNetProvider(ProviderRetryMixin, Provider):
             raise ProviderError("Endpoint not found")
         elif res.status_code == 429:
             raise APIThrottled("Too many requests")
-        elif res.status_code == 403:
+        elif res.status_code == 401 or res.status_code == 403:
             raise ConfigurationError("Invalid access token")
         elif res.status_code != 200:
             res.raise_for_status()
@@ -173,42 +207,44 @@ class LegendasNetProvider(ProviderRetryMixin, Provider):
 
         result = res.json()
 
-        if ('success' in result and not result['success']) or ('status' in result and not result['status']):
+        if ("success" in result and not result["success"]) or (
+            "status" in result and not result["status"]
+        ):
             logger.debug(result["error"])
             return []
 
         if isinstance(self.video, Episode):
-            if len(result['tv_shows']):
-                for item in result['tv_shows']:
+            if len(result["tv_shows"]):
+                for item in result["tv_shows"]:
                     subtitle = LegendasNetSubtitle(
-                        language=Language('por', 'BR'),
+                        language=Language("por", "BR"),
                         forced=self._is_forced(item),
                         page_link=f"https://legendas.net/tv_legenda?movie_id={result['tv_shows'][0]['tmdb_id']}&"
-                                  f"legenda_id={item['id']}",
-                        download_link=item['path'],
-                        file_id=item['id'],
-                        release_names=[item.get('release_name', '')],
-                        uploader=item['uploader'],
-                        season=item.get('season', ''),
-                        episode=item.get('episode', '')
+                        f"legenda_id={item['id']}",
+                        download_link=item["path"],
+                        file_id=item["id"],
+                        release_names=[item.get("release_name", "")],
+                        uploader=item["uploader"],
+                        season=item.get("season", ""),
+                        episode=item.get("episode", ""),
                     )
                     subtitle.get_matches(self.video)
                     if subtitle.language in languages:
                         subtitles.append(subtitle)
         else:
-            if len(result['movies']):
-                for item in result['movies']:
+            if len(result["movies"]):
+                for item in result["movies"]:
                     subtitle = LegendasNetSubtitle(
-                        language=Language('por', 'BR'),
+                        language=Language("por", "BR"),
                         forced=self._is_forced(item),
                         page_link=f"https://legendas.net/legenda?movie_id={result['movies'][0]['tmdb_id']}&"
-                                  f"legenda_id={item['id']}",
-                        download_link=item['path'],
-                        file_id=item['id'],
-                        release_names=[item.get('release_name', '')],
-                        uploader=item['uploader'],
+                        f"legenda_id={item['id']}",
+                        download_link=item["path"],
+                        file_id=item["id"],
+                        release_names=[item.get("release_name", "")],
+                        uploader=item["uploader"],
                         season=None,
-                        episode=None
+                        episode=None,
                     )
                     subtitle.get_matches(self.video)
                     if subtitle.language in languages:
@@ -218,9 +254,9 @@ class LegendasNetProvider(ProviderRetryMixin, Provider):
 
     @staticmethod
     def _is_forced(item):
-        forced_tags = ['forced', 'foreign']
+        forced_tags = ["forced", "foreign"]
         for tag in forced_tags:
-            if tag in item.get('comment', '').lower():
+            if tag in item.get("comment", "").lower():
                 return True
 
         # nothing match so we consider it as normal subtitles
@@ -230,24 +266,24 @@ class LegendasNetProvider(ProviderRetryMixin, Provider):
         return self.query(languages, video)
 
     def download_subtitle(self, subtitle):
-        logger.debug('Downloading subtitle %r', subtitle)
+        logger.debug("Downloading subtitle %r", subtitle)
         download_link = urljoin("https://legendas.net", subtitle.download_link)
 
         r = self.retry(
             lambda: self.session.get(download_link, timeout=30),
             amount=retry_amount,
-            retry_timeout=retry_timeout
+            retry_timeout=retry_timeout,
         )
 
         if r.status_code == 429:
             raise DownloadLimitExceeded("Daily download limit exceeded")
-        elif r.status_code == 403:
+        elif r.status_code == 401 or r.status_code == 403:
             raise ConfigurationError("Invalid access token")
         elif r.status_code != 200:
             r.raise_for_status()
 
         if not r:
-            logger.error(f'Could not download subtitle from {download_link}')
+            logger.error(f"Could not download subtitle from {download_link}")
             subtitle.content = None
             return
         else:

--- a/custom_libs/subliminal_patch/providers/legendasnet.py
+++ b/custom_libs/subliminal_patch/providers/legendasnet.py
@@ -11,11 +11,7 @@ from requests import Session
 
 from subzero.language import Language
 from subliminal import Episode, Movie
-from subliminal.exceptions import (
-    ConfigurationError,
-    ProviderError,
-    DownloadLimitExceeded,
-)
+from subliminal.exceptions import ConfigurationError, ProviderError, DownloadLimitExceeded
 from subliminal_patch.exceptions import APIThrottled
 from .mixins import ProviderRetryMixin
 from subliminal_patch.subtitle import Subtitle
@@ -30,28 +26,18 @@ retry_timeout = 5
 
 
 class LegendasNetSubtitle(Subtitle):
-    provider_name = "legendasnet"
+    provider_name = 'legendasnet'
     hash_verifiable = False
 
-    def __init__(
-        self,
-        language,
-        forced,
-        page_link,
-        download_link,
-        file_id,
-        release_names,
-        uploader,
-        season=None,
-        episode=None,
-    ):
+    def __init__(self, language, forced, page_link, download_link, file_id, release_names, uploader,
+                 season=None, episode=None):
         super().__init__(language)
         language = Language.rebuild(language, forced=forced)
 
         self.season = season
         self.episode = episode
         self.releases = release_names
-        self.release_info = ", ".join(release_names)
+        self.release_info = ', '.join(release_names)
         self.language = language
         self.forced = forced
         self.file_id = file_id
@@ -70,20 +56,20 @@ class LegendasNetSubtitle(Subtitle):
         # handle movies and series separately
         if isinstance(video, Episode):
             # series
-            matches.add("series")
+            matches.add('series')
             # season
             if video.season == self.season:
-                matches.add("season")
+                matches.add('season')
             # episode
             if video.episode == self.episode:
-                matches.add("episode")
+                matches.add('episode')
             # imdb
-            matches.add("series_imdb_id")
+            matches.add('series_imdb_id')
         else:
             # title
-            matches.add("title")
+            matches.add('title')
             # imdb
-            matches.add("imdb_id")
+            matches.add('imdb_id')
 
         utils.update_matches(matches, video, self.release_info)
 
@@ -94,17 +80,14 @@ class LegendasNetSubtitle(Subtitle):
 
 class LegendasNetProvider(ProviderRetryMixin, Provider):
     """Legendas.Net Provider"""
+    server_hostname = 'legendas.net/api'
 
-    server_hostname = "legendas.net/api"
-
-    languages = {Language("por", "BR")}
+    languages = {Language('por', 'BR')}
     video_types = (Episode, Movie)
 
     def __init__(self, username, password):
         self.session = Session()
-        self.session.headers = {
-            "User-Agent": os.environ.get("SZ_USER_AGENT", "Sub-Zero/2")
-        }
+        self.session.headers = {'User-Agent': os.environ.get("SZ_USER_AGENT", "Sub-Zero/2")}
         self.username = username
         self.password = password
         self.access_token = None
@@ -115,35 +98,32 @@ class LegendasNetProvider(ProviderRetryMixin, Provider):
     def login(self):
         headersList = {
             "Accept": "*/*",
-            "User-Agent": self.session.headers["User-Agent"],
-            "Content-Type": "application/json",
+            "User-Agent": self.session.headers['User-Agent'],
+            "Content-Type": "application/json"
         }
 
-        payload = json.dumps({"email": self.username, "password": self.password})
+        payload = json.dumps({
+            "email": self.username,
+            "password": self.password
+        })
 
         response = self.retry(
-            lambda: self.session.request(
-                "POST",
-                self.server_url() + "login",
-                data=payload,
-                headers=headersList,
-                timeout=30,
-            ),
+            lambda: self.session.request("POST", self.server_url() + 'login', data=payload, headers=headersList, timeout=30),
             amount=retry_amount,
-            retry_timeout=retry_timeout,
+            retry_timeout=retry_timeout
         )
 
         if response.status_code == 429:
-            raise APIThrottled("Too many requests")
-        elif response.status_code == 401 or response.status_code == 403:
-            raise ConfigurationError("Invalid username or password")
+            raise APIThrottled('Too many requests')
+        elif response.status_code in (401, 403):
+            raise ConfigurationError('Invalid username or password')
         elif response.status_code != 200:
             response.raise_for_status()
 
-        self.access_token = response.json().get("access_token")
+        self.access_token = response.json().get('access_token')
         if not self.access_token:
-            raise ConfigurationError("Access token not found in login response")
-        self.session.headers.update({"Authorization": f"Bearer {self.access_token}"})
+            raise ConfigurationError('Access token not found in login response')
+        self.session.headers.update({'Authorization': f'Bearer {self.access_token}'})
 
     def initialize(self):
         self._started = time.time()
@@ -152,7 +132,7 @@ class LegendasNetProvider(ProviderRetryMixin, Provider):
         self.session.close()
 
     def server_url(self):
-        return f"https://{self.server_hostname}/v1/"
+        return f'https://{self.server_hostname}/v1/'
 
     def query(self, languages, video):
         self.video = video
@@ -160,37 +140,33 @@ class LegendasNetProvider(ProviderRetryMixin, Provider):
         # query the server
         if isinstance(self.video, Episode):
             res = self.retry(
-                lambda: self.session.get(
-                    self.server_url() + "search/tv",
-                    json={
-                        "name": video.series,
-                        "page": 1,
-                        "per_page": 25,
-                        "tv_episode": video.episode,
-                        "tv_season": video.season,
-                        "imdb_id": video.series_imdb_id,
-                    },
-                    headers={"Content-Type": "application/json"},
-                    timeout=30,
-                ),
+                lambda: self.session.get(self.server_url() + 'search/tv',
+                                         json={
+                                             'name': video.series,
+                                             'page': 1,
+                                             'per_page': 25,
+                                             'tv_episode': video.episode,
+                                             'tv_season': video.season,
+                                             'imdb_id': video.series_imdb_id
+                                         },
+                                         headers={'Content-Type': 'application/json'},
+                                         timeout=30),
                 amount=retry_amount,
-                retry_timeout=retry_timeout,
+                retry_timeout=retry_timeout
             )
         else:
             res = self.retry(
-                lambda: self.session.get(
-                    self.server_url() + "search/movie",
-                    json={
-                        "name": video.title,
-                        "page": 1,
-                        "per_page": 25,
-                        "imdb_id": video.imdb_id,
-                    },
-                    headers={"Content-Type": "application/json"},
-                    timeout=30,
-                ),
+                lambda: self.session.get(self.server_url() + 'search/movie',
+                                         json={
+                                             'name': video.title,
+                                             'page': 1,
+                                             'per_page': 25,
+                                             'imdb_id': video.imdb_id
+                                         },
+                                         headers={'Content-Type': 'application/json'},
+                                         timeout=30),
                 amount=retry_amount,
-                retry_timeout=retry_timeout,
+                retry_timeout=retry_timeout
             )
 
         if res.status_code == 404:
@@ -198,7 +174,7 @@ class LegendasNetProvider(ProviderRetryMixin, Provider):
             raise ProviderError("Endpoint not found")
         elif res.status_code == 429:
             raise APIThrottled("Too many requests")
-        elif res.status_code == 401 or res.status_code == 403:
+        elif res.status_code in (401, 403):
             raise ConfigurationError("Invalid access token")
         elif res.status_code != 200:
             res.raise_for_status()
@@ -207,44 +183,42 @@ class LegendasNetProvider(ProviderRetryMixin, Provider):
 
         result = res.json()
 
-        if ("success" in result and not result["success"]) or (
-            "status" in result and not result["status"]
-        ):
+        if ('success' in result and not result['success']) or ('status' in result and not result['status']):
             logger.debug(result["error"])
             return []
 
         if isinstance(self.video, Episode):
-            if len(result["tv_shows"]):
-                for item in result["tv_shows"]:
+            if len(result['tv_shows']):
+                for item in result['tv_shows']:
                     subtitle = LegendasNetSubtitle(
-                        language=Language("por", "BR"),
+                        language=Language('por', 'BR'),
                         forced=self._is_forced(item),
                         page_link=f"https://legendas.net/tv_legenda?movie_id={result['tv_shows'][0]['tmdb_id']}&"
-                        f"legenda_id={item['id']}",
-                        download_link=item["path"],
-                        file_id=item["id"],
-                        release_names=[item.get("release_name", "")],
-                        uploader=item["uploader"],
-                        season=item.get("season", ""),
-                        episode=item.get("episode", ""),
+                                  f"legenda_id={item['id']}",
+                        download_link=item['path'],
+                        file_id=item['id'],
+                        release_names=[item.get('release_name', '')],
+                        uploader=item['uploader'],
+                        season=item.get('season', ''),
+                        episode=item.get('episode', '')
                     )
                     subtitle.get_matches(self.video)
                     if subtitle.language in languages:
                         subtitles.append(subtitle)
         else:
-            if len(result["movies"]):
-                for item in result["movies"]:
+            if len(result['movies']):
+                for item in result['movies']:
                     subtitle = LegendasNetSubtitle(
-                        language=Language("por", "BR"),
+                        language=Language('por', 'BR'),
                         forced=self._is_forced(item),
                         page_link=f"https://legendas.net/legenda?movie_id={result['movies'][0]['tmdb_id']}&"
-                        f"legenda_id={item['id']}",
-                        download_link=item["path"],
-                        file_id=item["id"],
-                        release_names=[item.get("release_name", "")],
-                        uploader=item["uploader"],
+                                  f"legenda_id={item['id']}",
+                        download_link=item['path'],
+                        file_id=item['id'],
+                        release_names=[item.get('release_name', '')],
+                        uploader=item['uploader'],
                         season=None,
-                        episode=None,
+                        episode=None
                     )
                     subtitle.get_matches(self.video)
                     if subtitle.language in languages:
@@ -254,9 +228,9 @@ class LegendasNetProvider(ProviderRetryMixin, Provider):
 
     @staticmethod
     def _is_forced(item):
-        forced_tags = ["forced", "foreign"]
+        forced_tags = ['forced', 'foreign']
         for tag in forced_tags:
-            if tag in item.get("comment", "").lower():
+            if tag in item.get('comment', '').lower():
                 return True
 
         # nothing match so we consider it as normal subtitles
@@ -266,24 +240,24 @@ class LegendasNetProvider(ProviderRetryMixin, Provider):
         return self.query(languages, video)
 
     def download_subtitle(self, subtitle):
-        logger.debug("Downloading subtitle %r", subtitle)
+        logger.debug('Downloading subtitle %r', subtitle)
         download_link = urljoin("https://legendas.net", subtitle.download_link)
 
         r = self.retry(
             lambda: self.session.get(download_link, timeout=30),
             amount=retry_amount,
-            retry_timeout=retry_timeout,
+            retry_timeout=retry_timeout
         )
 
         if r.status_code == 429:
             raise DownloadLimitExceeded("Daily download limit exceeded")
-        elif r.status_code == 401 or r.status_code == 403:
+        elif r.status_code in (401, 403):
             raise ConfigurationError("Invalid access token")
         elif r.status_code != 200:
             r.raise_for_status()
 
         if not r:
-            logger.error(f"Could not download subtitle from {download_link}")
+            logger.error(f'Could not download subtitle from {download_link}')
             subtitle.content = None
             return
         else:


### PR DESCRIPTION
# Description

Fix #3234

The original issue was a chain reaction caused by poor error handling in the legendasnet provider when it hit a rate limit.

The legendas.net server (or its Cloudflare protection) returned an HTTP 429 (Too Many Requests) status code during the initial login() request because Bazarr was making requests too quickly. 

# Evidence of Tests

Setup Legendasnet, and search for a movie. Before it was failing 100% of the times during initial setup.

<img width="1396" height="182" alt="Screenshot 2026-03-11 at 21 03 24" src="https://github.com/user-attachments/assets/011980e2-1493-4c7b-8802-56234855795c" />

<img width="1716" height="502" alt="Screenshot 2026-03-11 at 21 03 06" src="https://github.com/user-attachments/assets/e2a00f86-fd57-441a-8aaf-3f3700d82a24" />
