### PR TITLE
feat: gemini translation batch size config & multiple api keys

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -196,7 +196,7 @@ validators = [
 
     # translating section
     Validator('translator.default_score', must_exist=True, default=50, is_type_of=int, gte=0),
-    Validator('translator.gemini_key', must_exist=True, default='', is_type_of=str, cast=str),
+    Validator('translator.gemini_keys', must_exist=True, default=[], is_type_of=list),
     Validator('translator.gemini_model', must_exist=True, default='gemini-2.0-flash', is_type_of=str, cast=str),
     Validator('translator.gemini_batch_size', must_exist=True, default=300, is_type_of=int, gte=1),
     Validator('translator.translator_info', must_exist=True, default=True, is_type_of=bool),
@@ -539,6 +539,7 @@ array_keys = ['excluded_tags',
               'excluded_series_types',
               'enabled_providers',
               'enabled_integrations',
+              'gemini_keys',
               'path_mappings',
               'path_mappings_movie',
               'remove_profile_tags',
@@ -583,6 +584,13 @@ if hasattr(settings, 'series_scores'):
     settings.unset('SERIES_SCORES')
 if hasattr(settings, 'movie_scores'):
     settings.unset('MOVIE_SCORES')
+
+# backward compatibility: migrate gemini_key to gemini_keys
+if hasattr(settings.translator, 'gemini_key'):
+    legacy_key = str(settings.translator.gemini_key).strip()
+    if legacy_key and not settings.translator.gemini_keys:
+        settings.translator.gemini_keys = [legacy_key]
+    del settings.translator.gemini_key
 
 # save updated settings to file
 write_config()

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -198,6 +198,7 @@ validators = [
     Validator('translator.default_score', must_exist=True, default=50, is_type_of=int, gte=0),
     Validator('translator.gemini_key', must_exist=True, default='', is_type_of=str, cast=str),
     Validator('translator.gemini_model', must_exist=True, default='gemini-2.0-flash', is_type_of=str, cast=str),
+    Validator('translator.gemini_batch_size', must_exist=True, default=300, is_type_of=int, gte=1),
     Validator('translator.translator_info', must_exist=True, default=True, is_type_of=bool),
     Validator('translator.translator_type', must_exist=True, default='google_translate', is_type_of=str, cast=str),
     Validator('translator.lingarr_url', must_exist=True, default='http://lingarr:9876', is_type_of=str),

--- a/bazarr/subtitles/tools/translate/main.py
+++ b/bazarr/subtitles/tools/translate/main.py
@@ -69,6 +69,8 @@ def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, fo
 
         logging.debug(f'Created translator instance: {translator.__class__.__name__}')
         result = translator.translate(job_id=job_id)
+        if result is False:
+            raise RuntimeError(f'{translator.__class__.__name__} returned a failed translation result')
         logging.debug(f'BAZARR saved translated subtitles to {dest_srt_file}')
         from api.subtitles.subtitles import postprocess_subtitles
         # Call postprocess_subtitles after translation
@@ -77,7 +79,7 @@ def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, fo
 
     except Exception as e:
         logging.error(f'Translation failed: {str(e)}', exc_info=True)
-        return False
+        raise
 
     finally:
         jobs_queue.update_job_name(job_id=job_id,

--- a/bazarr/subtitles/tools/translate/services/gemini_translator.py
+++ b/bazarr/subtitles/tools/translate/services/gemini_translator.py
@@ -29,6 +29,9 @@ from ..core.translator_utils import add_translator_info, get_description, create
 
 logger = logging.getLogger(__name__)
 DEFAULT_GEMINI_BATCH_SIZE = 300
+DEFAULT_GEMINI_KEY_COOLDOWN_SECONDS = 60
+_GEMINI_KEY_COOLDOWNS = {}
+_GEMINI_KEY_COOLDOWNS_LOCK = threading.Lock()
 
 
 class SubtitleObject(typing.TypedDict):
@@ -59,7 +62,9 @@ class GeminiTranslatorService:
         self.orig_to_lang = orig_to_lang
 
         self.gemini_api_key = None
+        self.api_keys = []
         self.current_api_key = None
+        self.current_api_index = -1
         self.current_api_number = 1
         self.backup_api_number = 2
         self.target_language = None
@@ -85,8 +90,9 @@ class GeminiTranslatorService:
             logger.debug(f'BAZARR is sending subtitle file to Gemini for translation')
             logger.info(f"BAZARR is sending subtitle file to Gemini for translation " + self.source_srt_file)
 
-            self.gemini_api_key = settings.translator.gemini_key
-            self.current_api_key = self.gemini_api_key
+            self.api_keys = self._get_configured_api_keys()
+            self.current_api_key = self._select_next_api_key()
+            self.gemini_api_key = self.current_api_key
             self.target_language = language_from_alpha3(self.to_lang)
             self.input_file = self.source_srt_file
             self.output_file = self.dest_srt_file
@@ -212,6 +218,104 @@ class GeminiTranslatorService:
             batch_size = DEFAULT_GEMINI_BATCH_SIZE
         return max(1, batch_size)
 
+    def _get_configured_api_keys(self) -> List[str]:
+        keys = []
+        seen_keys = set()
+        configured_keys = getattr(settings.translator, "gemini_keys", [])
+
+        if not isinstance(configured_keys, list):
+            configured_keys = [configured_keys]
+
+        for raw_key in configured_keys:
+            key = str(raw_key).strip()
+            if key and key not in seen_keys:
+                keys.append(key)
+                seen_keys.add(key)
+
+        return keys
+
+    @staticmethod
+    def _is_key_on_cooldown(api_key: str) -> bool:
+        now = time.time()
+        with _GEMINI_KEY_COOLDOWNS_LOCK:
+            expires_at = _GEMINI_KEY_COOLDOWNS.get(api_key)
+            if expires_at is None:
+                return False
+            if expires_at <= now:
+                _GEMINI_KEY_COOLDOWNS.pop(api_key, None)
+                return False
+            return True
+
+    def _select_next_api_key(self):
+        if not self.api_keys:
+            self.current_api_key = None
+            return None
+
+        total_keys = len(self.api_keys)
+        start_index = self.current_api_index if self.current_api_index >= 0 else -1
+
+        for offset in range(1, total_keys + 1):
+            candidate_index = (start_index + offset) % total_keys
+            candidate_key = self.api_keys[candidate_index]
+            if not self._is_key_on_cooldown(candidate_key):
+                self.current_api_index = candidate_index
+                self.current_api_key = candidate_key
+                return candidate_key
+
+        self.current_api_key = None
+        return None
+
+    @staticmethod
+    def _is_rate_limited_response(response) -> bool:
+        if response is None:
+            return False
+
+        if response.status_code == 429:
+            return True
+
+        try:
+            error_body = response.json().get("error", {})
+        except Exception:
+            return False
+
+        error_status = str(error_body.get("status", "")).upper()
+        error_message = str(error_body.get("message", "")).lower()
+        return error_status == "RESOURCE_EXHAUSTED" or "rate limit" in error_message or "quota" in error_message
+
+    @staticmethod
+    def _get_retry_after_seconds(response) -> int:
+        if response is not None:
+            retry_after = response.headers.get("Retry-After")
+            if retry_after:
+                try:
+                    return max(1, int(float(retry_after)))
+                except (TypeError, ValueError):
+                    pass
+
+        return DEFAULT_GEMINI_KEY_COOLDOWN_SECONDS
+
+    @staticmethod
+    def _set_key_cooldown(api_key: str, cooldown_seconds: int):
+        with _GEMINI_KEY_COOLDOWNS_LOCK:
+            _GEMINI_KEY_COOLDOWNS[api_key] = time.time() + max(1, cooldown_seconds)
+
+    def _handle_rate_limited_key(self, response):
+        if not self.current_api_key:
+            raise RuntimeError("All Gemini API keys are currently rate limited. Please wait before retrying.")
+
+        cooldown_seconds = self._get_retry_after_seconds(response)
+        self._set_key_cooldown(self.current_api_key, cooldown_seconds)
+
+        rotated_key = self._select_next_api_key()
+        if not rotated_key:
+            raise RuntimeError("All Gemini API keys are currently rate limited. Please wait before retrying.")
+
+        if self.job_id is not None:
+            jobs_queue.update_job_progress(
+                job_id=self.job_id,
+                progress_message="Gemini key rate limited. Rotating to another configured key.",
+            )
+
     def _build_generate_payload(self, batch: List[SubtitleObject]) -> dict:
         return {
             "system_instruction": {
@@ -296,6 +400,12 @@ class GeminiTranslatorService:
             return self.current_progress
 
         except Exception as e:
+            response = getattr(e, "response", None)
+            if self._is_rate_limited_response(response):
+                self._handle_rate_limited_key(response)
+                if retry_num > 0:
+                    return self._process_batch(batch, translated_subtitle, total, retry_num - 1)
+
             if retry_num > 0:
                 return self._process_batch(batch, translated_subtitle, total, retry_num - 1)
             else:
@@ -343,8 +453,18 @@ class GeminiTranslatorService:
                 translated_subtitle[int(line["index"])].content = line["content"]
 
     def _translate_with_gemini(self):
+        if not self.api_keys:
+            jobs_queue.update_job_progress(
+                job_id=self.job_id,
+                progress_message="Please provide at least one valid Gemini API key.",
+            )
+            return
+
         if not self.current_api_key:
-            jobs_queue.update_job_progress(job_id=self.job_id, progress_message="Please provide a valid Gemini API key.")
+            jobs_queue.update_job_progress(
+                job_id=self.job_id,
+                progress_message="All Gemini API keys are currently rate limited. Please wait before retrying.",
+            )
             return
 
         if not self.target_language:
@@ -407,7 +527,8 @@ class GeminiTranslatorService:
                             raise e
 
                     # Check if we exited the loop due to an interrupt
-                    jobs_queue.update_job_progress(job_id=self.job_id, progress_value=total)
+                    jobs_queue.update_job_progress(job_id=self.job_id, progress_value=total,
+                                                   progress_message=self.source_srt_file)
                     if self.interrupt_flag:
                         # File will be automatically closed by the with statement
                         self._clear_progress()

--- a/bazarr/subtitles/tools/translate/services/gemini_translator.py
+++ b/bazarr/subtitles/tools/translate/services/gemini_translator.py
@@ -544,4 +544,10 @@ class GeminiTranslatorService:
             jobs_queue.update_job_progress(job_id=self.job_id, progress_value=total,
                                            progress_message=f'Gemini translation failed: {str(e)}')
             self._clear_progress()
+            if self.output_file and os.path.exists(self.output_file):
+                try:
+                    if os.path.getsize(self.output_file) == 0:
+                        os.remove(self.output_file)
+                except OSError:
+                    pass
             raise e

--- a/bazarr/subtitles/tools/translate/services/gemini_translator.py
+++ b/bazarr/subtitles/tools/translate/services/gemini_translator.py
@@ -110,10 +110,11 @@ class GeminiTranslatorService:
                 add_translator_info(self.dest_srt_file, f"# Subtitles translated with {settings.translator.gemini_model} # ")
             except Exception as e:
                 jobs_queue.update_job_progress(job_id=job_id, progress_message=f'Gemini translation error: {str(e)}')
+                raise
 
         except Exception as e:
             logger.error(f'BAZARR encountered an error translating with Gemini: {str(e)}')
-            return False
+            raise
 
         else:
             message = (f"{language_from_alpha2(self.from_lang)} subtitles translated to "

--- a/bazarr/subtitles/tools/translate/services/gemini_translator.py
+++ b/bazarr/subtitles/tools/translate/services/gemini_translator.py
@@ -28,6 +28,7 @@ from languages.get_languages import alpha3_from_alpha2, language_from_alpha2, la
 from ..core.translator_utils import add_translator_info, get_description, create_process_result
 
 logger = logging.getLogger(__name__)
+DEFAULT_GEMINI_BATCH_SIZE = 300
 
 
 class SubtitleObject(typing.TypedDict):
@@ -67,11 +68,9 @@ class GeminiTranslatorService:
         self.start_line = 1
         self.description = None
         self.model_name = "gemini-2.0-flash"
-        self.batch_size = 100
+        self.batch_size = DEFAULT_GEMINI_BATCH_SIZE
         self.free_quota = True
         self.error_log = False
-        self.token_limit = 0
-        self.token_count = 0
         self.interrupt_flag = False
         self.progress_file = None
         self.current_progress = 0
@@ -92,10 +91,8 @@ class GeminiTranslatorService:
             self.input_file = self.source_srt_file
             self.output_file = self.dest_srt_file
             self.model_name = settings.translator.gemini_model
+            self.batch_size = self._get_batch_size()
             self.description = get_description(self.media_type, self.radarr_id, self.sonarr_series_id)
-
-            if "2.5-flash" in self.model_name or "pro" in self.model_name:
-                self.batch_size = 300
 
             if self.input_file:
                 self.progress_file = os.path.join(os.path.dirname(self.input_file), f".{os.path.basename(self.input_file)}.progress")
@@ -208,31 +205,33 @@ class GeminiTranslatorService:
             return True
         return False
 
-    def _get_token_limit(self) -> int:
-        """
-        Get the token limit for the current model.
+    def _get_batch_size(self) -> int:
+        try:
+            batch_size = int(settings.translator.gemini_batch_size)
+        except (AttributeError, TypeError, ValueError):
+            batch_size = DEFAULT_GEMINI_BATCH_SIZE
+        return max(1, batch_size)
 
-        Returns:
-            int: Token limit for the current model according to https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash
-        """
-        if "2.0-flash" in self.model_name:
-            return 7000
-        elif "2.5-flash" in self.model_name or "pro" in self.model_name:
-            return 50000
-        else:
-            return 7000
-
-    def _validate_token_size(self, contents: str) -> bool:
-        """
-        Validate the token size of the input contents.
-
-        Args:
-            contents (str): Input contents to validate
-
-        Returns:
-            bool: True if token size is valid, False otherwise
-        """
-        return True
+    def _build_generate_payload(self, batch: List[SubtitleObject]) -> dict:
+        return {
+            "system_instruction": {
+                "parts": [
+                    {
+                        "text": self.get_instruction(self.target_language, self.description)
+                    }
+                ]
+            },
+            "contents": [
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "text": json.dumps(batch, ensure_ascii=False)
+                        }
+                    ]
+                }
+            ]
+        }
 
     current_progress = 0
 
@@ -254,25 +253,7 @@ class GeminiTranslatorService:
 
         url = f"https://generativelanguage.googleapis.com/v1beta/models/{self.model_name}:generateContent?key={self.current_api_key}"
 
-        payload = json.dumps({
-            "system_instruction": {
-                "parts": [
-                    {
-                        "text": self.get_instruction(self.target_language, self.description)
-                    }
-                ]
-            },
-            "contents": [
-                {
-                    "role": "user",
-                    "parts": [
-                        {
-                            "text": json.dumps(batch, ensure_ascii=False)
-                        }
-                    ]
-                }
-            ]
-        })
+        payload = json.dumps(self._build_generate_payload(batch), ensure_ascii=False)
         headers = {
             'Content-Type': 'application/json'
         }
@@ -374,8 +355,6 @@ class GeminiTranslatorService:
             jobs_queue.update_job_progress(job_id=self.job_id, progress_message="Please provide a subtitle file.")
             return
 
-        self.token_limit = self._get_token_limit()
-
         try:
             with open(self.input_file, "r", encoding="utf-8") as original_file:
                 original_text = original_file.read()
@@ -397,7 +376,6 @@ class GeminiTranslatorService:
                     i = self.start_line - 1
                     total = len(original_subtitle)
                     batch = [SubtitleObject(index=str(i), content=original_subtitle[i].content)]
-
                     i += 1
 
                     # Save initial progress
@@ -413,35 +391,6 @@ class GeminiTranslatorService:
                             continue
 
                         try:
-                            if not self._validate_token_size(json.dumps(batch, ensure_ascii=False)):
-                                jobs_queue.update_job_progress(
-                                    job_id=self.job_id,
-                                    progress_message=f"Token size ({int(self.token_count / 0.9)}) exceeds limit ("
-                                                     f"{self.token_limit}) for {self.model_name}."
-                                )
-                                user_prompt = "0"
-                                while not user_prompt.isdigit() or int(user_prompt) <= 0:
-                                    user_prompt = jobs_queue.update_job_progress(
-                                        job_id=self.job_id,
-                                        progress_message=f"Please enter a new batch size (current: {self.batch_size}): "
-                                    )
-                                    if user_prompt.isdigit() and int(user_prompt) > 0:
-                                        new_batch_size = int(user_prompt)
-                                        decrement = self.batch_size - new_batch_size
-                                        if decrement > 0:
-                                            for _ in range(decrement):
-                                                i -= 1
-                                                batch.pop()
-                                        self.batch_size = new_batch_size
-                                        jobs_queue.update_job_progress(job_id=self.job_id,
-                                                                       progress_message=f"Batch size updated to "
-                                                                                        f"{self.batch_size}.")
-                                    else:
-                                        jobs_queue.update_job_progress(job_id=self.job_id,
-                                                                       progress_message="Invalid input. Batch size must"
-                                                                                        " be a positive integer.")
-                                continue
-
                             start_time = time.time()
                             self._process_batch(batch, translated_subtitle, total)
                             end_time = time.time()

--- a/bazarr/subtitles/tools/translate/services/google_translator.py
+++ b/bazarr/subtitles/tools/translate/services/google_translator.py
@@ -95,7 +95,7 @@ class GoogleTranslatorService:
                     jobs_queue.update_job_progress(job_id=job_id,
                                                    progress_message=f'Translation failed: Unable to translate '
                                                                     f'malformed subtitles for {self.source_srt_file}')
-                    return False
+                    raise
 
             try:
                 subs.save(self.dest_srt_file)
@@ -121,7 +121,7 @@ class GoogleTranslatorService:
             logger.error(f'BAZARR encountered an error during translation: {str(e)}')
             jobs_queue.update_job_progress(job_id=job_id,
                                            progress_message=f'Google translation failed: {str(e)}')
-            return False
+            raise
 
     @retry(exceptions=(TooManyRequests, RequestError), tries=6, delay=1, backoff=2, jitter=(0, 1))
     def _translate_text(self, text, job_id):

--- a/bazarr/subtitles/tools/translate/services/lingarr_translator.py
+++ b/bazarr/subtitles/tools/translate/services/lingarr_translator.py
@@ -64,7 +64,7 @@ class LingarrTranslatorService:
                 logger.error(f'Translation failed for {self.source_srt_file}')
                 jobs_queue.update_job_progress(job_id=job_id,
                                                progress_message=f'Translation failed for {self.source_srt_file}')
-                return False
+                raise RuntimeError(f'Translation failed for {self.source_srt_file}')
 
             logger.debug(f'BAZARR saving Lingarr translated subtitles to {self.dest_srt_file}')
             translation_map = {}
@@ -108,7 +108,7 @@ class LingarrTranslatorService:
         except Exception as e:
             logger.error(f'BAZARR encountered an error during Lingarr translation: {str(e)}')
             jobs_queue.update_job_progress(job_id=job_id, progress_message=f'Lingarr translation failed: {str(e)}')
-            return False
+            raise
 
     @retry(exceptions=(TooManyRequests, RequestError, requests.exceptions.RequestException), tries=3, delay=1,
            backoff=2, jitter=(0, 1))

--- a/frontend/src/pages/Settings/Subtitles/index.tsx
+++ b/frontend/src/pages/Settings/Subtitles/index.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent } from "react";
 import { Code, Space, Table, Text as MantineText } from "@mantine/core";
 import {
   Check,
+  Chips,
   CollapseBox,
   Layout,
   Message,
@@ -561,12 +562,19 @@ const SettingsSubtitlesView: FunctionComponent = () => {
             then lower it if requests fail or raise it gradually if your model
             handles larger batches reliably.
           </Message>
-          <Text
-            label="Gemini API key"
-            settingKey="settings-translator-gemini_key"
-          ></Text>
+          <Chips
+            label="Gemini API keys"
+            settingKey="settings-translator-gemini_keys"
+            sanitizeFn={(values) => {
+              const uniqueKeys = new Set(
+                (values ?? []).map((value) => value.trim()).filter(Boolean),
+              );
+              return Array.from(uniqueKeys);
+            }}
+          ></Chips>
           <Message>
-            You can generate it here: https://aistudio.google.com/apikey
+            You can generate keys here: https://aistudio.google.com/apikey. Add
+            as many keys as needed; Bazarr rotates across available keys.
           </Message>
         </CollapseBox>
         <CollapseBox

--- a/frontend/src/pages/Settings/Subtitles/index.tsx
+++ b/frontend/src/pages/Settings/Subtitles/index.tsx
@@ -6,6 +6,7 @@ import {
   Layout,
   Message,
   MultiSelector,
+  Number,
   Section,
   Selector,
   Slider,
@@ -548,6 +549,18 @@ const SettingsSubtitlesView: FunctionComponent = () => {
             label="Gemini model"
             settingKey="settings-translator-gemini_model"
           />
+          <Number
+            label="Gemini batch size"
+            settingKey="settings-translator-gemini_batch_size"
+            min={1}
+          />
+          <Message>
+            Number of subtitle lines sent in each Gemini request. Higher values
+            reduce the number of API calls and can speed up translation, but may
+            increase timeout or response-size errors. Start with 300 (default),
+            then lower it if requests fail or raise it gradually if your model
+            handles larger batches reliably.
+          </Message>
           <Text
             label="Gemini API key"
             settingKey="settings-translator-gemini_key"

--- a/frontend/src/types/settings.d.ts
+++ b/frontend/src/types/settings.d.ts
@@ -182,6 +182,7 @@ declare namespace Settings {
     default_score: number;
     gemini_key: string;
     gemini_model: string;
+    gemini_batch_size: number;
     lingarr_url: string;
     lingarr_token: string;
     translator_info: boolean;

--- a/frontend/src/types/settings.d.ts
+++ b/frontend/src/types/settings.d.ts
@@ -180,7 +180,7 @@ declare namespace Settings {
 
   interface Translator {
     default_score: number;
-    gemini_key: string;
+    gemini_keys: string[];
     gemini_model: string;
     gemini_batch_size: number;
     lingarr_url: string;

--- a/tests/bazarr/test_gemini_translator.py
+++ b/tests/bazarr/test_gemini_translator.py
@@ -129,3 +129,34 @@ def test_handle_rate_limited_key_raises_when_all_keys_unavailable():
 
     with pytest.raises(RuntimeError, match="All Gemini API keys are currently rate limited"):
         service._handle_rate_limited_key(_RateLimitedResponse())
+
+
+def test_translate_with_gemini_does_not_leave_output_file_on_failure(tmp_path, mocker):
+    input_file = tmp_path / "input.srt"
+    output_file = tmp_path / "output.srt"
+    input_file.write_text(
+        "1\n00:00:00,000 --> 00:00:02,000\nHello world\n\n",
+        encoding="utf-8",
+    )
+
+    service = _build_service()
+    service.input_file = str(input_file)
+    service.output_file = str(output_file)
+    service.api_keys = ["key-1"]
+    service.current_api_key = "key-1"
+    service.target_language = "English"
+    service.batch_size = 1
+    service.job_id = "job-1"
+
+    def _fail_after_output_file_created(*args, **kwargs):
+        # Translation output file should be opened before batch processing starts.
+        assert output_file.exists()
+        raise RuntimeError("boom")
+
+    mocker.patch.object(service, "_process_batch", side_effect=_fail_after_output_file_created)
+    mocker.patch.object(gemini_translator.jobs_queue, "update_job_progress")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        service._translate_with_gemini()
+
+    assert not output_file.exists()

--- a/tests/bazarr/test_gemini_translator.py
+++ b/tests/bazarr/test_gemini_translator.py
@@ -1,0 +1,51 @@
+from bazarr.subtitles.tools.translate.services import gemini_translator
+
+
+def _build_service():
+    return gemini_translator.GeminiTranslatorService(
+        source_srt_file="input.srt",
+        dest_srt_file="output.srt",
+        to_lang="eng",
+        media_type="series",
+        sonarr_series_id=1,
+        sonarr_episode_id=1,
+        radarr_id=1,
+        forced=False,
+        hi=False,
+        video_path="/tmp/video.mkv",
+        from_lang="en",
+        orig_to_lang="eng",
+    )
+
+
+def test_get_batch_size_uses_configured_value(mocker):
+    service = _build_service()
+    mocker.patch.object(
+        gemini_translator.settings.translator,
+        "gemini_batch_size",
+        450,
+        create=True,
+    )
+    assert service._get_batch_size() == 450
+
+
+def test_get_batch_size_falls_back_to_default_for_invalid_value(mocker):
+    service = _build_service()
+    mocker.patch.object(
+        gemini_translator.settings.translator,
+        "gemini_batch_size",
+        "invalid",
+        create=True,
+    )
+    assert service._get_batch_size() == gemini_translator.DEFAULT_GEMINI_BATCH_SIZE
+
+
+def test_get_batch_size_is_clamped_to_minimum_of_one(mocker):
+    service = _build_service()
+    mocker.patch.object(
+        gemini_translator.settings.translator,
+        "gemini_batch_size",
+        0,
+        create=True,
+    )
+    assert service._get_batch_size() == 1

--- a/tests/bazarr/test_gemini_translator.py
+++ b/tests/bazarr/test_gemini_translator.py
@@ -1,3 +1,7 @@
+import time
+
+import pytest
+
 from bazarr.subtitles.tools.translate.services import gemini_translator
 
 
@@ -49,3 +53,79 @@ def test_get_batch_size_is_clamped_to_minimum_of_one(mocker):
         create=True,
     )
     assert service._get_batch_size() == 1
+
+
+@pytest.fixture(autouse=True)
+def _clear_gemini_key_cooldowns():
+    cooldowns = getattr(gemini_translator, "_GEMINI_KEY_COOLDOWNS", None)
+    if cooldowns is not None:
+        cooldowns.clear()
+    yield
+    cooldowns = getattr(gemini_translator, "_GEMINI_KEY_COOLDOWNS", None)
+    if cooldowns is not None:
+        cooldowns.clear()
+
+
+def test_get_configured_api_keys_trims_and_deduplicates(mocker):
+    service = _build_service()
+    mocker.patch.object(
+        gemini_translator.settings.translator,
+        "gemini_keys",
+        [" key-1 ", "", "key-2", "key-1"],
+        create=True,
+    )
+
+    assert service._get_configured_api_keys() == ["key-1", "key-2"]
+
+
+def test_get_configured_api_keys_returns_empty_when_no_keys(mocker):
+    service = _build_service()
+    mocker.patch.object(
+        gemini_translator.settings.translator,
+        "gemini_keys",
+        [],
+        create=True,
+    )
+
+    assert service._get_configured_api_keys() == []
+
+
+def test_select_next_api_key_skips_keys_on_cooldown():
+    service = _build_service()
+    service.api_keys = ["key-1", "key-2"]
+    service.current_api_index = -1
+    gemini_translator._GEMINI_KEY_COOLDOWNS["key-1"] = time.time() + 60
+
+    selected_key = service._select_next_api_key()
+
+    assert selected_key == "key-2"
+
+
+def test_handle_rate_limited_key_applies_cooldown_and_rotates_key():
+    class _RateLimitedResponse:
+        status_code = 429
+        headers = {"Retry-After": "7"}
+
+    service = _build_service()
+    service.api_keys = ["key-1", "key-2"]
+    service.current_api_index = 0
+    service.current_api_key = "key-1"
+
+    service._handle_rate_limited_key(_RateLimitedResponse())
+
+    assert gemini_translator._GEMINI_KEY_COOLDOWNS["key-1"] > time.time() + 6
+    assert service.current_api_key == "key-2"
+
+
+def test_handle_rate_limited_key_raises_when_all_keys_unavailable():
+    class _RateLimitedResponse:
+        status_code = 429
+        headers = {"Retry-After": "3"}
+
+    service = _build_service()
+    service.api_keys = ["key-1"]
+    service.current_api_index = 0
+    service.current_api_key = "key-1"
+
+    with pytest.raises(RuntimeError, match="All Gemini API keys are currently rate limited"):
+        service._handle_rate_limited_key(_RateLimitedResponse())


### PR DESCRIPTION
This PR introduces 2 features:

1. Instead of using hardcoded logic for batch size of translation requests, Bazarr now lets users configure this in settings. This allows for easier use of different models and maximum efficiency of free tier limits. I removed token validation since it was doing nothing (validate token always returned true) and sending such big context will always result in bad response format, so there is no point.

2. Google API keys are issued per project, and as a user, you can create an unlimited amount of projects. With this change, we can provide Bazarr with a set of keys, allowing for API key rotation.

I've also introduced a few fixes:

1. Remove the empty file created when translation fails completely. If it fails partially (some part of the subtitles is translated), the file remains on the disk.
2. If translation fails, the job is now marked as Failed, not Completed with an error.
3. ~~If translation succeeds, bazarr is now made aware of the new subtitle file to index.~~

PS. I realize that it would be better to create 3-5 separate PRs for this, but since they all touched the same files, in order to save time, I decided to create just one. I've keep the git history clean so it could be merged without squashing.