### PR TITLE
feat(providers): add Subsarr subtitle provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ If you need something that is not already part of Bazarr, feel free to create a 
 - Subs.sab.bz
 - Subs4Free
 - Subs4Series
+- Subsarr (self-hosted, requires [slimcdk/subsarr](https://github.com/slimcdk/subsarr))
 - Subscene
 - Subscenter
 - SubsRo

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -93,7 +93,7 @@ validators = [
     Validator('general.path_mappings', must_exist=True, default=[], is_type_of=list),
     Validator('general.debug', must_exist=True, default=False, is_type_of=bool),
     Validator('general.branch', must_exist=True, default='master', is_type_of=str,
-              is_in=['master', 'development']),
+              is_in=['master', 'development', 'provider-subsarr']),
     Validator('general.auto_update', must_exist=True, default=True, is_type_of=bool),
     Validator('general.single_language', must_exist=True, default=False, is_type_of=bool),
     Validator('general.minimum_score', must_exist=True, default=90, is_type_of=int, gte=0, lte=100),

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -445,8 +445,6 @@ validators = [
 
     # subsarr section
     Validator('subsarr.base_url', must_exist=True, default='', is_type_of=str),
-    Validator('subsarr.email', must_exist=True, default='', is_type_of=str),
-    Validator('subsarr.password', must_exist=True, default='', is_type_of=str),
 
     # subx section
     Validator('subx.api_key', must_exist=True, default='', is_type_of=str),
@@ -578,7 +576,7 @@ if settings.general.wanted_search_frequency_movie == 3:
 # initialize subsarr section as a proper nested dict if absent
 # (validators only set flat dotted keys which don't create a top-level section)
 if not settings.get('subsarr'):
-    settings.set('SUBSARR', {'base_url': '', 'email': '', 'password': ''})
+    settings.set('SUBSARR', {'base_url': ''})
 
 # backward compatibility embeddedsubtitles provider
 if hasattr(settings.embeddedsubtitles, 'unknown_as_english'):

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -443,6 +443,11 @@ validators = [
     # subsource section
     Validator('subsource.apikey', must_exist=True, default='', is_type_of=str),
 
+    # subsarr section
+    Validator('subsarr.base_url', must_exist=True, default='', is_type_of=str),
+    Validator('subsarr.email', must_exist=True, default='', is_type_of=str),
+    Validator('subsarr.password', must_exist=True, default='', is_type_of=str),
+
     # subx section
     Validator('subx.api_key', must_exist=True, default='', is_type_of=str),
 ]
@@ -569,6 +574,11 @@ if settings.general.wanted_search_frequency == 3:
     settings.general.wanted_search_frequency = 6
 if settings.general.wanted_search_frequency_movie == 3:
     settings.general.wanted_search_frequency_movie = 6
+
+# initialize subsarr section as a proper nested dict if absent
+# (validators only set flat dotted keys which don't create a top-level section)
+if not settings.get('subsarr'):
+    settings.set('SUBSARR', {'base_url': '', 'email': '', 'password': ''})
 
 # backward compatibility embeddedsubtitles provider
 if hasattr(settings.embeddedsubtitles, 'unknown_as_english'):

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -93,7 +93,7 @@ validators = [
     Validator('general.path_mappings', must_exist=True, default=[], is_type_of=list),
     Validator('general.debug', must_exist=True, default=False, is_type_of=bool),
     Validator('general.branch', must_exist=True, default='master', is_type_of=str,
-              is_in=['master', 'development', 'provider-subsarr']),
+              is_in=['master', 'development']),
     Validator('general.auto_update', must_exist=True, default=True, is_type_of=bool),
     Validator('general.single_language', must_exist=True, default=False, is_type_of=bool),
     Validator('general.minimum_score', must_exist=True, default=90, is_type_of=int, gte=0, lte=100),
@@ -572,11 +572,6 @@ if settings.general.wanted_search_frequency == 3:
     settings.general.wanted_search_frequency = 6
 if settings.general.wanted_search_frequency_movie == 3:
     settings.general.wanted_search_frequency_movie = 6
-
-# initialize subsarr section as a proper nested dict if absent
-# (validators only set flat dotted keys which don't create a top-level section)
-if not settings.get('subsarr'):
-    settings.set('SUBSARR', {'base_url': ''})
 
 # backward compatibility embeddedsubtitles provider
 if hasattr(settings.embeddedsubtitles, 'unknown_as_english'):

--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -345,8 +345,6 @@ def get_providers_auth():
         },
         'subsarr': {
             'base_url': settings.subsarr.base_url,
-            'email': settings.subsarr.email,
-            'password': settings.subsarr.password,
         },
         'animesubinfo': {},
         'subx':

--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -343,6 +343,11 @@ def get_providers_auth():
         'subsource': {
             'api_key': settings.subsource.apikey,
         },
+        'subsarr': {
+            'base_url': settings.subsarr.base_url,
+            'email': settings.subsarr.email,
+            'password': settings.subsarr.password,
+        },
         'animesubinfo': {},
         'subx':
             {

--- a/custom_libs/subliminal_patch/converters/subsarr.py
+++ b/custom_libs/subliminal_patch/converters/subsarr.py
@@ -1,6 +1,105 @@
 # coding=utf-8
-# Subsarr uses the same Subscene language names as Subsource.
-# Registering under a separate name avoids duplicate-registration conflicts.
-from subliminal_patch.converters.subsource import SubsourceConverter
+from __future__ import absolute_import
+import logging
 
-SubsarrConverter = SubsourceConverter
+from babelfish import LanguageReverseConverter
+from subliminal.exceptions import ConfigurationError
+
+logger = logging.getLogger(__name__)
+
+
+class SubsarrConverter(LanguageReverseConverter):
+    """Language converter for subsarr's lowercase/slugified language names."""
+
+    def __init__(self):
+        self.from_subsarr = {
+            'english': ('eng',),
+            'arabic': ('ara',),
+            'farsi_persian': ('fas',),
+            'indonesian': ('ind',),
+            'french': ('fra',),
+            'vietnamese': ('vie',),
+            'danish': ('dan',),
+            'italian': ('ita',),
+            'spanish': ('spa',),
+            'brazillian-portuguese': ('por', 'BR'),
+            'swedish': ('swe',),
+            'norwegian': ('nor',),
+            'korean': ('kor',),
+            'turkish': ('tur',),
+            'dutch': ('nld',),
+            'finnish': ('fin',),
+            'malay': ('msa',),
+            'hebrew': ('heb',),
+            'thai': ('tha',),
+            'chinese-bg-code': ('zho',),
+            'portuguese': ('por',),
+            'greek': ('ell',),
+            'romanian': ('ron',),
+            'german': ('deu',),
+            'czech': ('ces',),
+            'polish': ('pol',),
+            'japanese': ('jpn',),
+            'bengali': ('ben',),
+            'russian': ('rus',),
+            'bulgarian': ('bul',),
+            'croatian': ('hrv',),
+            'hungarian': ('hun',),
+            'serbian': ('srp',),
+            'sinhala': ('sin',),
+            'slovak': ('slk',),
+            'ukranian': ('ukr',),
+            'burmese': ('mya',),
+            'slovenian': ('slv',),
+            'hindi': ('hin',),
+            'icelandic': ('isl',),
+            'estonian': ('est',),
+            'malayalam': ('mal',),
+            'urdu': ('urd',),
+            'tamil': ('tam',),
+            'telugu': ('tel',),
+            'lithuanian': ('lit',),
+            'tagalog': ('tgl',),
+            'albanian': ('sqi',),
+            'cambodian-khmer': ('khm',),
+            'latvian': ('lav',),
+            'kurdish': ('kur',),
+            'macedonian': ('mkd',),
+            'bosnian': ('bos',),
+            'catalan': ('cat',),
+            'nepali': ('nep',),
+            'basque': ('eus',),
+            'swahili': ('swa',),
+            'pashto': ('pus',),
+            'kannada': ('kan',),
+            'mongolian': ('mon',),
+            'azerbaijani': ('aze',),
+            'armenian': ('hye',),
+            'esperanto': ('epo',),
+            'belarusian': ('bel',),
+            'georgian': ('kat',),
+            'somali': ('som',),
+            'punjabi': ('pan',),
+            'kinyarwanda': ('kin',),
+            'yoruba': ('yor',),
+            'sundanese': ('sun',),
+            'afrikaans': ('afr',),
+        }
+        self.to_subsarr = {v: k for k, v in self.from_subsarr.items()}
+        self.codes = set(self.from_subsarr.keys())
+
+    def convert(self, alpha3, country=None, script=None):
+        if (alpha3, country, script) in self.to_subsarr:
+            return self.to_subsarr[(alpha3, country, script)]
+        if country and (alpha3, country) in self.to_subsarr:
+            return self.to_subsarr[(alpha3, country)]
+        if (alpha3,) in self.to_subsarr:
+            return self.to_subsarr[(alpha3,)]
+
+        raise ConfigurationError('Unsupported language code for subsarr: %s, %s, %s' % (alpha3, country, script))
+
+    def reverse(self, subsarr):
+        if subsarr in self.from_subsarr:
+            return self.from_subsarr[subsarr]
+
+        raise ConfigurationError('Unsupported language name for subsarr: %s' % subsarr)

--- a/custom_libs/subliminal_patch/converters/subsarr.py
+++ b/custom_libs/subliminal_patch/converters/subsarr.py
@@ -1,90 +1,36 @@
 # coding=utf-8
-from __future__ import absolute_import
-import logging
-
-from babelfish import LanguageReverseConverter
 from subliminal.exceptions import ConfigurationError
+from subliminal_patch.converters.subsource import SubsourceConverter
 
-logger = logging.getLogger(__name__)
+# Subsarr stores Subscene language names as lowercase slugs (spaces become hyphens).
+# A few names differ from what SubsourceConverter uses.
+_NAME_OVERRIDES = {
+    'Khmer': 'cambodian-khmer',
+    'Pushto': 'pashto',
+    'Espranto': 'esperanto',
+    'Ukrainian': 'ukranian',  # Subscene's original misspelling
+}
 
 
-class SubsarrConverter(LanguageReverseConverter):
-    """Language converter for subsarr's lowercase/slugified language names."""
+def _to_subsarr_name(subscene_name):
+    return _NAME_OVERRIDES.get(subscene_name, subscene_name.lower().replace(' ', '-'))
+
+
+class SubsarrConverter(SubsourceConverter):
+    """Derives from SubsourceConverter, transforming names to subsarr's lowercase/slugified format."""
+
+    # Languages present in subsarr but missing from SubsourceConverter
+    _EXTRA_LANGUAGES = {
+        'kinyarwanda': ('kin',),
+        'punjabi': ('pan',),
+        'sundanese': ('sun',),
+        'yoruba': ('yor',),
+    }
 
     def __init__(self):
-        self.from_subsarr = {
-            'english': ('eng',),
-            'arabic': ('ara',),
-            'farsi_persian': ('fas',),
-            'indonesian': ('ind',),
-            'french': ('fra',),
-            'vietnamese': ('vie',),
-            'danish': ('dan',),
-            'italian': ('ita',),
-            'spanish': ('spa',),
-            'brazillian-portuguese': ('por', 'BR'),
-            'swedish': ('swe',),
-            'norwegian': ('nor',),
-            'korean': ('kor',),
-            'turkish': ('tur',),
-            'dutch': ('nld',),
-            'finnish': ('fin',),
-            'malay': ('msa',),
-            'hebrew': ('heb',),
-            'thai': ('tha',),
-            'chinese-bg-code': ('zho',),
-            'portuguese': ('por',),
-            'greek': ('ell',),
-            'romanian': ('ron',),
-            'german': ('deu',),
-            'czech': ('ces',),
-            'polish': ('pol',),
-            'japanese': ('jpn',),
-            'bengali': ('ben',),
-            'russian': ('rus',),
-            'bulgarian': ('bul',),
-            'croatian': ('hrv',),
-            'hungarian': ('hun',),
-            'serbian': ('srp',),
-            'sinhala': ('sin',),
-            'slovak': ('slk',),
-            'ukranian': ('ukr',),
-            'burmese': ('mya',),
-            'slovenian': ('slv',),
-            'hindi': ('hin',),
-            'icelandic': ('isl',),
-            'estonian': ('est',),
-            'malayalam': ('mal',),
-            'urdu': ('urd',),
-            'tamil': ('tam',),
-            'telugu': ('tel',),
-            'lithuanian': ('lit',),
-            'tagalog': ('tgl',),
-            'albanian': ('sqi',),
-            'cambodian-khmer': ('khm',),
-            'latvian': ('lav',),
-            'kurdish': ('kur',),
-            'macedonian': ('mkd',),
-            'bosnian': ('bos',),
-            'catalan': ('cat',),
-            'nepali': ('nep',),
-            'basque': ('eus',),
-            'swahili': ('swa',),
-            'pashto': ('pus',),
-            'kannada': ('kan',),
-            'mongolian': ('mon',),
-            'azerbaijani': ('aze',),
-            'armenian': ('hye',),
-            'esperanto': ('epo',),
-            'belarusian': ('bel',),
-            'georgian': ('kat',),
-            'somali': ('som',),
-            'punjabi': ('pan',),
-            'kinyarwanda': ('kin',),
-            'yoruba': ('yor',),
-            'sundanese': ('sun',),
-            'afrikaans': ('afr',),
-        }
+        super().__init__()
+        self.from_subsarr = {_to_subsarr_name(k): v for k, v in self.from_subsource.items()}
+        self.from_subsarr.update(self._EXTRA_LANGUAGES)
         self.to_subsarr = {v: k for k, v in self.from_subsarr.items()}
         self.codes = set(self.from_subsarr.keys())
 

--- a/custom_libs/subliminal_patch/converters/subsarr.py
+++ b/custom_libs/subliminal_patch/converters/subsarr.py
@@ -1,0 +1,6 @@
+# coding=utf-8
+# Subsarr uses the same Subscene language names as Subsource.
+# Registering under a separate name avoids duplicate-registration conflicts.
+from subliminal_patch.converters.subsource import SubsourceConverter
+
+SubsarrConverter = SubsourceConverter

--- a/custom_libs/subliminal_patch/providers/subsarr.py
+++ b/custom_libs/subliminal_patch/providers/subsarr.py
@@ -3,7 +3,6 @@ import logging
 
 from babelfish import language_converters
 from requests import Session
-from requests.auth import HTTPBasicAuth
 from subzero.language import Language
 from subliminal import Episode, Movie
 from subliminal.exceptions import ConfigurationError, ProviderError
@@ -15,9 +14,6 @@ from .mixins import ProviderRetryMixin
 logger = logging.getLogger(__name__)
 
 language_converters.register('subsarr = subliminal_patch.converters.subsarr:SubsarrConverter')
-
-# Case-insensitive reverse lookup for subsarr language names
-_LANG_LOWER = {k.lower(): k for k in language_converters['subsarr'].from_subsource.keys()}
 
 
 class SubsarrSubtitle(Subtitle):
@@ -70,13 +66,13 @@ class SubsarrProvider(ProviderRetryMixin, Provider):
     """Subsarr Provider — self-hosted Subscene subtitle provider."""
     provider_name = 'subsarr'
 
-    languages = {Language(*lang) for lang in list(language_converters['subsarr'].to_subsource.keys())}
+    languages = {Language(*lang) for lang in list(language_converters['subsarr'].to_subsarr.keys())}
     languages.update(set(Language.rebuild(lang, hi=True) for lang in languages))
 
     video_types = (Episode, Movie)
     subtitle_class = SubsarrSubtitle
 
-    def __init__(self, base_url=None, email=None, password=None):
+    def __init__(self, base_url=None):
         if not base_url:
             raise ConfigurationError('Base URL must be specified')
 
@@ -84,21 +80,17 @@ class SubsarrProvider(ProviderRetryMixin, Provider):
             raise ConfigurationError('Base URL must include scheme (http:// or https://)')
 
         self.base_url = base_url.rstrip('/')
-        self.email = email
-        self.password = password
         self.session = None
 
     def initialize(self):
         self.session = Session()
         self.session.headers['User-Agent'] = 'Subliminal/2 Bazarr/1'
-        if self.email and self.password:
-            self.session.auth = HTTPBasicAuth(self.email, self.password)
 
     def terminate(self):
         self.session.close()
 
     def _url(self, path):
-        return f'{self.base_url}{path}'
+        return f'{self.base_url}/api/v1{path}'
 
     def ping(self):
         try:
@@ -121,6 +113,7 @@ class SubsarrProvider(ProviderRetryMixin, Provider):
         imdb_id = None
         season = None
         episode = None
+        year = None
 
         if isinstance(video, Episode):
             title = video.series
@@ -130,6 +123,7 @@ class SubsarrProvider(ProviderRetryMixin, Provider):
         else:
             title = video.title
             imdb_id = video.imdb_id
+            year = getattr(video, 'year', None)
 
         subtitles = []
         lang_names = set()
@@ -146,25 +140,26 @@ class SubsarrProvider(ProviderRetryMixin, Provider):
             lang_names.add(lang_name)
 
         for lang_name in lang_names:
+            params = {'language': lang_name, 'per_page': 100}
+            if season is not None:
+                params['season'] = season
+            if episode is not None:
+                params['episode'] = episode
+
+            items = []
             if imdb_id:
-                params = {'imdb_id': imdb_id, 'language': lang_name, 'per_page': 100}
-                if season is not None:
-                    params['season'] = season
-                if episode is not None:
-                    params['episode'] = episode
-                items = self._search(params)
-            else:
-                params = {'query': title, 'language': lang_name, 'per_page': 100}
-                if season is not None:
-                    params['season'] = season
-                if episode is not None:
-                    params['episode'] = episode
-                items = self._search(params)
+                imdb_params = {**params, 'imdb_id': imdb_id}
+                if year is not None:
+                    imdb_params['year'] = year
+                items = self._search(imdb_params)
+
+            # Fall back to title query if IMDB search returned nothing
+            if not items and title:
+                items = self._search({**params, 'query': title})
 
             for item in items:
                 try:
-                    lang_name = _LANG_LOWER.get(item['language'].lower(), item['language'])
-                    lang_obj = Language(*language_converters['subsarr'].reverse(lang_name))
+                    lang_obj = Language(*language_converters['subsarr'].reverse(item['language']))
                 except (ConfigurationError, KeyError):
                     logger.debug('Skipping unsupported language: %s', item.get('language'))
                     continue
@@ -176,13 +171,16 @@ class SubsarrProvider(ProviderRetryMixin, Provider):
                 if lang_obj not in languages:
                     continue
 
+                raw_releases = item.get('releases')
+                releases = raw_releases if isinstance(raw_releases, list) else []
+
                 subtitle = SubsarrSubtitle(
                     language=lang_obj,
                     hearing_impaired=hi,
                     record_id=item['id'],
                     download_url=item['download_url'],
                     title=item.get('title', ''),
-                    releases=item.get('releases', []),
+                    releases=releases,
                     filename=item.get('filename', ''),
                     season=season,
                     episode=episode,

--- a/custom_libs/subliminal_patch/providers/subsarr.py
+++ b/custom_libs/subliminal_patch/providers/subsarr.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import logging
-
 from babelfish import language_converters
 from requests import Session
 from subzero.language import Language
@@ -43,23 +42,22 @@ class SubsarrSubtitle(Subtitle):
         return self.record_id
 
     def get_matches(self, video):
-        matches = set()
+        self.matches = set()
 
         if isinstance(video, Episode):
             if video.series and self.title and video.series.lower() == self.title.lower():
-                matches.add('series')
+                self.matches.add('series')
             if video.season and self.season == video.season:
-                matches.add('season')
+                self.matches.add('season')
             if video.episode and self.episode == video.episode:
-                matches.add('episode')
+                self.matches.add('episode')
         else:
             if video.title and self.title and video.title.lower() == self.title.lower():
-                matches.add('title')
+                self.matches.add('title')
 
-        utils.update_matches(matches, video, self.release_info)
+        utils.update_matches(self.matches, video, self.release_info)
 
-        self.matches = matches
-        return matches
+        return self.matches
 
 
 class SubsarrProvider(ProviderRetryMixin, Provider):

--- a/custom_libs/subliminal_patch/providers/subsarr.py
+++ b/custom_libs/subliminal_patch/providers/subsarr.py
@@ -1,0 +1,201 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from babelfish import language_converters
+from requests import Session
+from requests.auth import HTTPBasicAuth
+from subzero.language import Language
+from subliminal import Episode, Movie
+from subliminal.exceptions import ConfigurationError, ProviderError
+from subliminal.subtitle import fix_line_ending
+from subliminal_patch.subtitle import Subtitle
+from subliminal_patch.providers import Provider, utils
+from .mixins import ProviderRetryMixin
+
+logger = logging.getLogger(__name__)
+
+language_converters.register('subsarr = subliminal_patch.converters.subsarr:SubsarrConverter')
+
+
+class SubsarrSubtitle(Subtitle):
+    provider_name = 'subsarr'
+    hash_verifiable = False
+    hearing_impaired_verifiable = True
+
+    def __init__(self, language, hearing_impaired, record_id, download_url, title,
+                 releases, filename, season=None, episode=None):
+        super().__init__(language)
+        language = Language.rebuild(language, hi=hearing_impaired)
+
+        self.language = language
+        self.hearing_impaired = hearing_impaired
+        self.record_id = record_id
+        self.download_url = download_url
+        self.title = title
+        self.releases = releases
+        self.release_info = ', '.join(releases) if releases else filename
+        self.filename = filename
+        self.season = season
+        self.episode = episode
+        self.matches = set()
+
+    @property
+    def id(self):
+        return self.record_id
+
+    def get_matches(self, video):
+        matches = set()
+
+        if isinstance(video, Episode):
+            if video.series and self.title and video.series.lower() == self.title.lower():
+                matches.add('series')
+            if video.season and self.season == video.season:
+                matches.add('season')
+            if video.episode and self.episode == video.episode:
+                matches.add('episode')
+        else:
+            if video.title and self.title and video.title.lower() == self.title.lower():
+                matches.add('title')
+
+        utils.update_matches(matches, video, self.release_info)
+
+        self.matches = matches
+        return matches
+
+
+class SubsarrProvider(ProviderRetryMixin, Provider):
+    """Subsarr Provider — self-hosted Subscene subtitle provider."""
+    provider_name = 'subsarr'
+
+    languages = {Language(*lang) for lang in list(language_converters['subsarr'].to_subsource.keys())}
+    languages.update(set(Language.rebuild(lang, hi=True) for lang in languages))
+
+    video_types = (Episode, Movie)
+    subtitle_class = SubsarrSubtitle
+
+    def __init__(self, base_url=None, email=None, password=None):
+        if not base_url:
+            raise ConfigurationError('Base URL must be specified')
+
+        self.base_url = base_url.rstrip('/')
+        self.email = email
+        self.password = password
+        self.session = None
+
+    def initialize(self):
+        self.session = Session()
+        self.session.headers['User-Agent'] = 'Subliminal/2 Bazarr/1'
+        if self.email and self.password:
+            self.session.auth = HTTPBasicAuth(self.email, self.password)
+
+    def terminate(self):
+        self.session.close()
+
+    def _url(self, path):
+        return f'{self.base_url}{path}'
+
+    def ping(self):
+        try:
+            r = self.session.get(self._url('/info'), timeout=10)
+            return r.status_code == 200
+        except Exception:
+            return False
+
+    def _search(self, params):
+        r = self.retry(
+            lambda: self.session.get(self._url('/subtitles/search'), params=params, timeout=30),
+            amount=3,
+            retry_timeout=5,
+        )
+        if r.status_code != 200:
+            r.raise_for_status()
+        return r.json().get('items', [])
+
+    def query(self, languages, video):
+        imdb_id = None
+        season = None
+        episode = None
+
+        if isinstance(video, Episode):
+            title = video.series
+            imdb_id = video.series_imdb_id
+            season = video.season
+            episode = video.episode
+        else:
+            title = video.title
+            imdb_id = video.imdb_id
+
+        subtitles = []
+        lang_names = set()
+
+        for lang in languages:
+            base_lang = Language.rebuild(lang, hi=False, forced=False)
+            try:
+                lang_name = language_converters['subsarr'].convert(
+                    base_lang.alpha3, base_lang.country, base_lang.script
+                )
+            except ConfigurationError:
+                logger.debug('Language %s not supported by subsarr', lang)
+                continue
+            lang_names.add(lang_name)
+
+        for lang_name in lang_names:
+            if imdb_id:
+                params = {'imdb_id': imdb_id, 'language': lang_name, 'per_page': 100}
+                if season is not None:
+                    params['season'] = season
+                if episode is not None:
+                    params['episode'] = episode
+                items = self._search(params)
+            else:
+                params = {'query': title, 'language': lang_name, 'per_page': 100}
+                if season is not None:
+                    params['season'] = season
+                if episode is not None:
+                    params['episode'] = episode
+                items = self._search(params)
+
+            for item in items:
+                try:
+                    lang_obj = Language(*language_converters['subsarr'].reverse(item['language']))
+                except (ConfigurationError, KeyError):
+                    logger.debug('Skipping unsupported language: %s', item.get('language'))
+                    continue
+
+                hi = item.get('hi', False)
+                if hi:
+                    lang_obj = Language.rebuild(lang_obj, hi=True)
+
+                if lang_obj not in languages:
+                    continue
+
+                subtitle = SubsarrSubtitle(
+                    language=lang_obj,
+                    hearing_impaired=hi,
+                    record_id=item['id'],
+                    download_url=item['download_url'],
+                    title=item.get('title', ''),
+                    releases=item.get('releases', []),
+                    filename=item.get('filename', ''),
+                    season=season,
+                    episode=episode,
+                )
+                subtitle.get_matches(video)
+                subtitles.append(subtitle)
+
+        return subtitles
+
+    def list_subtitles(self, video, languages):
+        return self.query(languages, video)
+
+    def download_subtitle(self, subtitle):
+        logger.debug('Downloading subtitle %r from %s', subtitle, subtitle.download_url)
+        r = self.retry(
+            lambda: self.session.get(subtitle.download_url, timeout=30, allow_redirects=True),
+            amount=3,
+            retry_timeout=5,
+        )
+        if r.status_code != 200:
+            raise ProviderError(f'Download failed with status {r.status_code}')
+
+        subtitle.content = fix_line_ending(r.content)

--- a/custom_libs/subliminal_patch/providers/subsarr.py
+++ b/custom_libs/subliminal_patch/providers/subsarr.py
@@ -16,6 +16,9 @@ logger = logging.getLogger(__name__)
 
 language_converters.register('subsarr = subliminal_patch.converters.subsarr:SubsarrConverter')
 
+# Case-insensitive reverse lookup for subsarr language names
+_LANG_LOWER = {k.lower(): k for k in language_converters['subsarr'].from_subsource.keys()}
+
 
 class SubsarrSubtitle(Subtitle):
     provider_name = 'subsarr'
@@ -76,6 +79,9 @@ class SubsarrProvider(ProviderRetryMixin, Provider):
     def __init__(self, base_url=None, email=None, password=None):
         if not base_url:
             raise ConfigurationError('Base URL must be specified')
+
+        if not base_url.startswith(('http://', 'https://')):
+            raise ConfigurationError('Base URL must include scheme (http:// or https://)')
 
         self.base_url = base_url.rstrip('/')
         self.email = email
@@ -157,7 +163,8 @@ class SubsarrProvider(ProviderRetryMixin, Provider):
 
             for item in items:
                 try:
-                    lang_obj = Language(*language_converters['subsarr'].reverse(item['language']))
+                    lang_name = _LANG_LOWER.get(item['language'].lower(), item['language'])
+                    lang_obj = Language(*language_converters['subsarr'].reverse(lang_name))
                 except (ConfigurationError, KeyError):
                     logger.debug('Skipping unsupported language: %s', item.get('language'))
                     continue

--- a/frontend/src/pages/Settings/Providers/list.ts
+++ b/frontend/src/pages/Settings/Providers/list.ts
@@ -463,7 +463,7 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
   {
     key: "subsarr",
     name: "Subsarr",
-    description: "Self-hosted Subscene subtitle provider",
+    description: "Self-hosted Subscene subtitle provider. (requires slimcdk/subsarr https://github.com/slimcdk/subsarr)",
     inputs: [
       {
         type: "text",

--- a/frontend/src/pages/Settings/Providers/list.ts
+++ b/frontend/src/pages/Settings/Providers/list.ts
@@ -470,14 +470,6 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
         key: "base_url",
         name: "Base URL",
       },
-      {
-        type: "text",
-        key: "email",
-      },
-      {
-        type: "password",
-        key: "password",
-      },
     ],
   },
   {

--- a/frontend/src/pages/Settings/Providers/list.ts
+++ b/frontend/src/pages/Settings/Providers/list.ts
@@ -463,7 +463,8 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
   {
     key: "subsarr",
     name: "Subsarr",
-    description: "Self-hosted Subscene subtitle provider. (requires slimcdk/subsarr https://github.com/slimcdk/subsarr)",
+    description:
+      "Self-hosted Subscene subtitle provider. (requires slimcdk/subsarr https://github.com/slimcdk/subsarr)",
     inputs: [
       {
         type: "text",

--- a/frontend/src/pages/Settings/Providers/list.ts
+++ b/frontend/src/pages/Settings/Providers/list.ts
@@ -461,6 +461,26 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
     ],
   },
   {
+    key: "subsarr",
+    name: "Subsarr",
+    description: "Self-hosted Subscene subtitle provider",
+    inputs: [
+      {
+        type: "text",
+        key: "base_url",
+        name: "Base URL",
+      },
+      {
+        type: "text",
+        key: "email",
+      },
+      {
+        type: "password",
+        key: "password",
+      },
+    ],
+  },
+  {
     key: "subssabbz",
     name: "Subs.sab.bz",
     description: "Bulgarian Subtitles Provider",


### PR DESCRIPTION
This is a provider integration for a local, self-hosted solution to serve subtitles from the Subscene archive. The codebase is MIT-licensed and available at: https://github.com/slimcdk/subsarr

<img width="657" height="294" alt="image" src="https://github.com/user-attachments/assets/f10aca36-fdf0-4e34-a6e4-57f6d9adc5d8" />

> [!NOTE]  
> Note: Users must obtain the Subscene archive themselves - this service does not include any archive data. Reddit user subscene_V2 has a guide on how to obtain it here: https://www.reddit.com/r/DataHoarder/comments/1b5rxc2/subscenecom_full_dump

---
### Hosting of Subsarr
The service can be hosted using a container runtime: 
```yaml
services:
  subsarr:
    image: ghcr.io/slimcdk/subsarr:latest
    volumes:
      - subsarr-db:/app/db            # fast reads - Must go on SSD
      - subsarr-storage:/app/storage  # bulk file storage - can go on HDDs
      - /path/to/subscene/archive:/tmp/subscene-archive:ro
    ports:
      - 8090:8090
    restart: unless-stopped
```

```bash
# Import (one-time)
docker compose run --rm subsarr import-dump --archive "/tmp/subscene-archive/Subscene V2.7z.001"

# Start the server
docker compose up -d
```
---
Disclaimer: This service and integration were largely created with the help of Claude.