### PR TITLE
fix: catch all exceptions in Sonarr/Radarr v3 API version fallback

### DIFF
--- a/bazarr/radarr/info.py
+++ b/bazarr/radarr/info.py
@@ -5,7 +5,7 @@ import requests
 import datetime
 import semver
 
-from requests.exceptions import JSONDecodeError
+from requests.exceptions import JSONDecodeError, RequestException
 
 from dogpile.cache import make_region
 
@@ -42,7 +42,7 @@ class GetRadarrInfo:
                     rv = f"{url_radarr()}/api/v3/system/status?apikey={settings.radarr.apikey}"
                     radarr_version = requests.get(rv, timeout=int(settings.radarr.http_timeout), verify=False,
                                                   headers=HEADERS).json()['version']
-                except JSONDecodeError:
+                except (RequestException, JSONDecodeError, KeyError):
                     logging.debug('BAZARR cannot get Radarr version')
                     radarr_version = 'unknown'
             except Exception:

--- a/bazarr/sonarr/info.py
+++ b/bazarr/sonarr/info.py
@@ -5,7 +5,7 @@ import requests
 import datetime
 import semver
 
-from requests.exceptions import JSONDecodeError
+from requests.exceptions import JSONDecodeError, RequestException
 
 from dogpile.cache import make_region
 
@@ -42,7 +42,7 @@ class GetSonarrInfo:
                     sv = f"{url_sonarr()}/api/v3/system/status?apikey={settings.sonarr.apikey}"
                     sonarr_version = requests.get(sv, timeout=int(settings.sonarr.http_timeout), verify=False,
                                                   headers=HEADERS).json()['version']
-                except JSONDecodeError:
+                except (RequestException, JSONDecodeError, KeyError):
                     logging.debug('BAZARR cannot get Sonarr version')
                     sonarr_version = 'unknown'
             except Exception:


### PR DESCRIPTION
## What broke and why

`GET /api/badges` crashed with an unhandled exception when Radarr (or Sonarr)
was temporarily unreachable. The call chain was:

```
badges GET
  → get_all_announcements()
  → get_radarr_info.is_deprecated()
  → version()  ← exception escaped here
```

`version()` tries the legacy v1 API first, then falls back to v3 if the
response doesn't look right. The outer `except JSONDecodeError` correctly
triggers the v3 fallback, but the inner handler only caught `JSONDecodeError`.
This left two failure modes unhandled in the v3 attempt:

- `RequestException` — Radarr/Sonarr unreachable (ConnectionError, Timeout, etc.)
- `KeyError` — response was valid JSON but contained no `version` key

Either of these propagated uncaught all the way up to the badges endpoint.

## Fix

In both `radarr/info.py` and `sonarr/info.py`, the inner `except JSONDecodeError`
is replaced with `except (RequestException, JSONDecodeError, KeyError)` —
explicitly enumerating the three ways the single line
`requests.get(...).json()['version']` can fail. `RequestException` is added
to the import alongside the existing `JSONDecodeError`.

The same latent bug existed in `sonarr/info.py` and is fixed here proactively.

Fixes #3253