### PR TITLE
feat: set outcome message on completed subtitle search jobs

### DIFF
--- a/bazarr/subtitles/mass_download/movies.py
+++ b/bazarr/subtitles/mass_download/movies.py
@@ -84,6 +84,7 @@ def movies_download_subtitles(no, job_id=None, job_sub_function=False):
 
     providers_list = get_providers()
 
+    downloaded_count = 0
     if providers_list:
         for language in ast.literal_eval(movie.missing_subtitles):
             if language is not None:
@@ -107,10 +108,15 @@ def movies_download_subtitles(no, job_id=None, job_sub_function=False):
                     store_subtitles_movie(movie.path, moviePath)
                     history_log_movie(1, no, result)
                     send_notifications_movie(no, result.message)
+                    downloaded_count += 1
+        outcome_msg = (f"{downloaded_count} subtitle(s) downloaded"
+                       if downloaded_count else "No subtitles found")
     else:
         logging.info("BAZARR All providers are throttled")
+        outcome_msg = "All providers throttled"
 
-    jobs_queue.update_job_progress(job_id=job_id, progress_value="max")
+    jobs_queue.update_job_progress(job_id=job_id, progress_value="max",
+                                   progress_message=outcome_msg)
     jobs_queue.update_job_name(job_id=job_id, new_job_name=f"Downloaded missing subtitles for {movie.title} ({movie.year})")
 
 

--- a/bazarr/subtitles/mass_download/series.py
+++ b/bazarr/subtitles/mass_download/series.py
@@ -50,6 +50,7 @@ def series_download_subtitles(no, job_id=None, job_sub_function=False):
         .join(TableShows)
         .where(reduce(operator.and_, conditions))) \
         .all()
+    throttled = False
     if not episodes_details:
         logging.debug(f"BAZARR no episode for that sonarrSeriesId have been found in database or they have all been "
                       f"ignored because of monitored status, series type or series tags: {no}")
@@ -70,8 +71,12 @@ def series_download_subtitles(no, job_id=None, job_sub_function=False):
             else:
                 jobs_queue.update_job_progress(job_id=job_id, progress_value=count_episodes_details)
                 logging.info("BAZARR All providers are throttled")
+                throttled = True
                 break
 
+    outcome_msg = ("All providers throttled" if throttled
+                   else "Search completed")
+    jobs_queue.update_job_progress(job_id=job_id, progress_message=outcome_msg)
     jobs_queue.update_job_name(job_id=job_id, new_job_name=f"Downloaded missing subtitles for {series_row.title}")
 
 
@@ -126,6 +131,7 @@ def episode_download_subtitles(no, job_id=None, job_sub_function=False, provider
     if not providers_list:
         providers_list = get_providers()
 
+    downloaded_count = 0
     if providers_list:
         audio_language_list = get_audio_profile_languages(episode.audio_language)
         if len(audio_language_list) > 0:
@@ -162,11 +168,16 @@ def episode_download_subtitles(no, job_id=None, job_sub_function=False, provider
                     store_subtitles(episode.path, path_mappings.path_replace(episode.path))
                     history_log(1, episode.sonarrSeriesId, episode.sonarrEpisodeId, result)
                     send_notifications(episode.sonarrSeriesId, episode.sonarrEpisodeId, result.message)
+                    downloaded_count += 1
+        outcome_msg = (f"{downloaded_count} subtitle(s) downloaded"
+                       if downloaded_count else "No subtitles found")
     else:
         logging.info("BAZARR All providers are throttled")
+        outcome_msg = "All providers throttled"
 
     if not job_sub_function and job_id:
-        jobs_queue.update_job_progress(job_id=job_id, progress_value='max')
+        jobs_queue.update_job_progress(job_id=job_id, progress_value='max',
+                                       progress_message=outcome_msg)
         jobs_queue.update_job_name(job_id=job_id, new_job_name=f"Downloaded missing subtitles for {episode.title}")
 
 

--- a/bazarr/subtitles/wanted/movies.py
+++ b/bazarr/subtitles/wanted/movies.py
@@ -119,6 +119,7 @@ def wanted_search_missing_subtitles_movies(job_id=None):
     if count_movies == 0:
         jobs_queue.update_job_progress(job_id=job_id, progress_value='max')
 
+    throttled = False
     for i, movie in enumerate(movies, start=1):
         jobs_queue.update_job_progress(job_id=job_id, progress_value=i, progress_message=movie.title)
 
@@ -130,7 +131,11 @@ def wanted_search_missing_subtitles_movies(job_id=None):
             jobs_queue.update_job_progress(job_id=job_id, progress_value=i, progress_max=count_movies)
         else:
             logging.info("BAZARR All providers are throttled")
+            throttled = True
             break
 
+    outcome_msg = ("All providers throttled" if throttled
+                   else "Search completed")
+    jobs_queue.update_job_progress(job_id=job_id, progress_message=outcome_msg)
     jobs_queue.update_job_name(job_id=job_id, new_job_name="Searched for missing movies subtitles")
     logging.info('BAZARR Finished searching for missing Movies Subtitles. Check History for more information.')

--- a/bazarr/subtitles/wanted/series.py
+++ b/bazarr/subtitles/wanted/series.py
@@ -132,6 +132,7 @@ def wanted_search_missing_subtitles_series(job_id=None):
     if count_episodes == 0:
         jobs_queue.update_job_progress(job_id=job_id, progress_value='max')
 
+    throttled = False
     for i, episode in enumerate(episodes, start=1):
         jobs_queue.update_job_progress(job_id=job_id, progress_value=i,
                                        progress_message=f'{episode.title} - S{episode.season:02d}E{episode.episode:02d}'
@@ -145,8 +146,12 @@ def wanted_search_missing_subtitles_series(job_id=None):
             jobs_queue.update_job_progress(job_id=job_id, progress_value=i, progress_max=count_episodes)
         else:
             logging.info("BAZARR All providers are throttled")
+            throttled = True
             break
 
+    outcome_msg = ("All providers throttled" if throttled
+                   else "Search completed")
+    jobs_queue.update_job_progress(job_id=job_id, progress_message=outcome_msg)
     jobs_queue.update_job_name(job_id=job_id, new_job_name="Searched for missing series subtitles")
     logging.info('BAZARR Finished searching for missing Series Subtitles. Check History for more information.')
 


### PR DESCRIPTION
## Summary

Closes #3256

Completed subtitle search jobs previously showed no outcome information in the Jobs queue — all appeared as "Completed" with no indication of whether subtitles were actually downloaded, not found, or skipped due to throttled providers.

This change sets a `progress_message` at job completion that reflects the actual result:
- `"X subtitle(s) downloaded"` — when at least one subtitle was saved
- `"No subtitles found"` — when a search ran but providers returned nothing
- `"All providers throttled"` — when no providers were available to search
- `"Search completed"` — for series-level searches (episode-level outcome is tracked per-episode in the progress message during the run)

The `progress_message` field is already rendered in the Jobs queue UI; this change ensures it carries meaningful information after the job finishes rather than retaining the last mid-run progress message.

## Files changed

- `bazarr/subtitles/mass_download/movies.py` — track download count, set outcome message
- `bazarr/subtitles/mass_download/series.py` — track throttled state and download count, set outcome messages for series and single-episode searches

## Test plan

- [ ] Trigger a subtitle search for a movie; confirm Jobs queue shows "X subtitle(s) downloaded" or "No subtitles found" after completion
- [ ] Trigger a subtitle search for an episode; confirm same outcome message appears
- [ ] Trigger a search while all providers are throttled; confirm "All providers throttled" appears
- [ ] Verify pre-existing progress messages still work correctly during job execution (not affected by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)