### PR TITLE
feat: show loading state and toast feedback when saving Languages Profile

### DIFF
--- a/frontend/src/components/forms/ItemEditForm.tsx
+++ b/frontend/src/components/forms/ItemEditForm.tsx
@@ -1,10 +1,12 @@
 import { FunctionComponent, useMemo } from "react";
 import { Button, Divider, Group, LoadingOverlay, Stack } from "@mantine/core";
 import { useForm } from "@mantine/form";
+import { showNotification } from "@mantine/notifications";
 import { UseMutationResult } from "@tanstack/react-query";
 import { useLanguageProfiles } from "@/apis/hooks";
 import { MultiSelector, Selector } from "@/components/inputs";
 import { useModals, withModal } from "@/modules/modals";
+import { notification } from "@/modules/task";
 import { GetItemId, useSelectorOptions } from "@/utilities";
 
 interface Props {
@@ -56,9 +58,29 @@ const ItemEditForm: FunctionComponent<Props> = ({
         if (item) {
           const itemId = GetItemId(item);
           if (itemId) {
-            mutate({ id: [itemId], profileid: [profile?.profileId ?? null] });
-            onComplete?.();
-            modals.closeSelf();
+            mutate(
+              { id: [itemId], profileid: [profile?.profileId ?? null] },
+              {
+                onSuccess: () => {
+                  showNotification(
+                    notification.info(
+                      "Profile Saved",
+                      "Languages profile updated successfully",
+                    ),
+                  );
+                  onComplete?.();
+                  modals.closeSelf();
+                },
+                onError: () => {
+                  showNotification(
+                    notification.error(
+                      "Save Failed",
+                      "Could not update languages profile",
+                    ),
+                  );
+                },
+              },
+            );
             return;
           }
         }


### PR DESCRIPTION
## Summary

Closes #3255

When editing a series or movie and saving a new Languages Profile, the editor modal previously closed immediately on form submit — before the mutation completed. This meant:

- The `LoadingOverlay` (which shows while `isPending`) was never visible
- There was no indication of whether the save succeeded or failed
- The missing subtitle count appeared not to update (the data *did* refresh via query invalidation, but with no feedback the user couldn't tell)

## Change

Move `modals.closeSelf()` and `onComplete()` from the synchronous submit handler into the mutation's `onSuccess` callback, so:

- The modal stays open with a loading overlay visible while the request is in flight
- A toast notification confirms success ("Languages profile updated successfully") or failure ("Could not update languages profile")
- The modal only closes after the save is confirmed

## Files changed

- `frontend/src/components/forms/ItemEditForm.tsx` — single file, frontend only

Both new imports (`showNotification` from `@mantine/notifications`, `notification` from `@/modules/task`) are pre-existing in the project and already used in the Episodes and Movies detail pages.

## Test plan

- [ ] Edit a series, change the Languages Profile, click Save — confirm modal stays open briefly with overlay, then closes with a success toast
- [ ] Confirm missing subtitle count updates after the modal closes (query invalidation was already working; this makes it visible)
- [ ] Simulate a network error during save — confirm modal stays open and error toast appears
- [ ] Confirm Cancel still closes the modal immediately without any toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)