### PR TITLE
fix: await subtitle tool mutations before closing modal; add UI feedback

### DIFF
--- a/frontend/src/apis/hooks/system.ts
+++ b/frontend/src/apis/hooks/system.ts
@@ -1,7 +1,9 @@
 import { useMemo } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { showNotification } from "@mantine/notifications";
 import { QueryKeys } from "@/apis/queries/keys";
 import api from "@/apis/raw";
+import { notification } from "@/modules/task";
 import { Environment } from "@/utilities";
 import { setAuthenticated } from "@/utilities/event";
 
@@ -90,6 +92,19 @@ export function useSettingsMutation() {
       void client.invalidateQueries({
         queryKey: [QueryKeys.Plex, "libraries"],
       });
+
+      showNotification(
+        notification.info("Settings saved", "Your changes have been saved"),
+      );
+    },
+
+    onError: () => {
+      showNotification(
+        notification.error(
+          "Save failed",
+          "An error occurred while saving settings",
+        ),
+      );
     },
   });
 }

--- a/frontend/src/apis/hooks/system.ts
+++ b/frontend/src/apis/hooks/system.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { showNotification } from "@mantine/notifications";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { QueryKeys } from "@/apis/queries/keys";
 import api from "@/apis/raw";
 import { notification } from "@/modules/task";

--- a/frontend/src/components/forms/SyncSubtitleForm.tsx
+++ b/frontend/src/components/forms/SyncSubtitleForm.tsx
@@ -1,7 +1,16 @@
 /* eslint-disable camelcase */
 import { FunctionComponent } from "react";
-import { Alert, Button, Checkbox, Divider, Stack, Text } from "@mantine/core";
+import {
+  Alert,
+  Button,
+  Checkbox,
+  Divider,
+  LoadingOverlay,
+  Stack,
+  Text,
+} from "@mantine/core";
 import { useForm } from "@mantine/form";
+import { showNotification } from "@mantine/notifications";
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -15,6 +24,7 @@ import {
   Selector,
 } from "@/components/inputs";
 import { useModals, withModal } from "@/modules/modals";
+import { notification } from "@/modules/task";
 import { syncMaxOffsetSecondsOptions } from "@/pages/Settings/Subtitles/options";
 import { fromPython, toPython } from "@/utilities";
 
@@ -118,7 +128,7 @@ const SyncSubtitleForm: FunctionComponent<Props> = ({
     throw new Error("You need to select at least 1 media to sync");
   }
 
-  const { mutateAsync } = useSubtitleAction();
+  const { mutateAsync, isPending } = useSubtitleAction();
   const modals = useModals();
 
   const subtitle = selections[0];
@@ -140,24 +150,40 @@ const SyncSubtitleForm: FunctionComponent<Props> = ({
 
   return (
     <form
-      onSubmit={form.onSubmit((parameters) => {
-        selections.forEach(async (s) => {
-          const form: FormType.ModifySubtitle = {
-            ...s,
-            reference: parameters.reference,
-            max_offset_seconds: parameters.maxOffsetSeconds,
-            no_fix_framerate: toPython(parameters.noFixFramerate),
-            gss: toPython(parameters.gss),
-          };
-
-          await mutateAsync({ action: "sync", form });
-        });
-
-        onSubmit?.();
-        modals.closeSelf();
+      onSubmit={form.onSubmit(async (parameters) => {
+        try {
+          await Promise.all(
+            selections.map((s) => {
+              const form: FormType.ModifySubtitle = {
+                ...s,
+                reference: parameters.reference,
+                max_offset_seconds: parameters.maxOffsetSeconds,
+                no_fix_framerate: toPython(parameters.noFixFramerate),
+                gss: toPython(parameters.gss),
+              };
+              return mutateAsync({ action: "sync", form });
+            }),
+          );
+          showNotification(
+            notification.info(
+              "Subtitles synced",
+              `${selections.length} subtitle(s) synced successfully`,
+            ),
+          );
+          onSubmit?.();
+          modals.closeSelf();
+        } catch {
+          showNotification(
+            notification.error(
+              "Sync failed",
+              "An error occurred while syncing subtitles",
+            ),
+          );
+        }
       })}
     >
-      <Stack>
+      <Stack pos="relative">
+        <LoadingOverlay visible={isPending} />
         <Alert
           title="Subtitles"
           color="gray"
@@ -189,7 +215,9 @@ const SyncSubtitleForm: FunctionComponent<Props> = ({
           {...form.getInputProps("gss")}
         ></Checkbox>
         <Divider></Divider>
-        <Button type="submit">Sync</Button>
+        <Button type="submit" loading={isPending}>
+          Sync
+        </Button>
       </Stack>
     </form>
   );

--- a/frontend/src/components/forms/TranslationForm.tsx
+++ b/frontend/src/components/forms/TranslationForm.tsx
@@ -1,13 +1,12 @@
 import { FunctionComponent, useMemo } from "react";
 import { Alert, Button, Divider, LoadingOverlay, Stack } from "@mantine/core";
 import { useForm } from "@mantine/form";
+import { showNotification } from "@mantine/notifications";
 import { isObject } from "lodash";
-import { useSubtitleAction } from "@/apis/hooks";
-import { useSystemSettings } from "@/apis/hooks";
+import { useSubtitleAction, useSystemSettings } from "@/apis/hooks";
 import { Selector } from "@/components/inputs";
 import { useModals, withModal } from "@/modules/modals";
 import { notification } from "@/modules/task";
-import { showNotification } from "@mantine/notifications";
 import { useSelectorOptions } from "@/utilities";
 import FormUtils from "@/utilities/form";
 import { useEnabledLanguages } from "@/utilities/languages";

--- a/frontend/src/components/forms/TranslationForm.tsx
+++ b/frontend/src/components/forms/TranslationForm.tsx
@@ -1,11 +1,13 @@
 import { FunctionComponent, useMemo } from "react";
-import { Alert, Button, Divider, Stack } from "@mantine/core";
+import { Alert, Button, Divider, LoadingOverlay, Stack } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { isObject } from "lodash";
 import { useSubtitleAction } from "@/apis/hooks";
 import { useSystemSettings } from "@/apis/hooks";
 import { Selector } from "@/components/inputs";
 import { useModals, withModal } from "@/modules/modals";
+import { notification } from "@/modules/task";
+import { showNotification } from "@mantine/notifications";
 import { useSelectorOptions } from "@/utilities";
 import FormUtils from "@/utilities/form";
 import { useEnabledLanguages } from "@/utilities/languages";
@@ -134,7 +136,7 @@ const TranslationForm: FunctionComponent<Props> = ({
   onSubmit,
 }) => {
   const settings = useSystemSettings();
-  const { mutateAsync } = useSubtitleAction();
+  const { mutateAsync, isPending } = useSubtitleAction();
   const modals = useModals();
 
   const { data: languages } = useEnabledLanguages();
@@ -199,25 +201,38 @@ const TranslationForm: FunctionComponent<Props> = ({
 
   return (
     <form
-      onSubmit={form.onSubmit(({ language }) => {
+      onSubmit={form.onSubmit(async ({ language }) => {
         if (language) {
-          selections.forEach(
-            async (s) =>
-              await mutateAsync({
-                action: "translate",
-                form: {
-                  ...s,
-                  language: language.code2,
-                },
-              }),
-          );
-
-          onSubmit?.();
-          modals.closeSelf();
+          try {
+            await Promise.all(
+              selections.map((s) =>
+                mutateAsync({
+                  action: "translate",
+                  form: { ...s, language: language.code2 },
+                }),
+              ),
+            );
+            showNotification(
+              notification.info(
+                "Translation started",
+                `${selections.length} subtitle(s) submitted for translation`,
+              ),
+            );
+            onSubmit?.();
+            modals.closeSelf();
+          } catch {
+            showNotification(
+              notification.error(
+                "Translation failed",
+                "An error occurred while translating subtitles",
+              ),
+            );
+          }
         }
       })}
     >
-      <Stack>
+      <Stack pos="relative">
+        <LoadingOverlay visible={isPending} />
         <Alert>
           <div>
             {translatorService}
@@ -235,7 +250,9 @@ const TranslationForm: FunctionComponent<Props> = ({
         )}
         <Selector {...options} {...form.getInputProps("language")}></Selector>
         <Divider></Divider>
-        <Button type="submit">Start</Button>
+        <Button type="submit" loading={isPending}>
+          Start
+        </Button>
       </Stack>
     </form>
   );


### PR DESCRIPTION
## Summary

- **Fix async forEach bug in SyncSubtitleForm and TranslationForm** — `await` inside `forEach` is a no-op; subtitles were being submitted in parallel without waiting for completion, so the modal closed immediately with no feedback regardless of outcome. Changed to `Promise.all(selections.map(...))` with `await`.
- **Add loading state and toast feedback to subtitle tool forms** — `SyncSubtitleForm` and `TranslationForm` now show a `LoadingOverlay` and a loading spinner on the submit button while mutations are in flight, and display success/error toast notifications on completion.
- **Add success/error toasts to Settings save** — `useSettingsMutation` now shows a success notification after settings are saved and an error notification if the save fails.

## Motivation

Following maintainer feedback on #3259 ("I'd accept more UI feedback help"), extended the async feedback pattern to the subtitle tool forms and the Settings save hook.

## Test plan

- [ ] **SyncSubtitleForm — success path:** Select subtitle(s), open Sync tool, submit → overlay appears, button shows spinner, modal holds open until complete, modal closes, success toast appears
- [ ] **SyncSubtitleForm — error path:** Block the API endpoint, submit → error toast appears, modal stays open
- [ ] **TranslationForm — success path:** Select subtitle(s), open Translate tool, submit → same loading/toast behavior as above
- [ ] **Settings save — success path:** Change a setting, click Save → success toast appears
- [ ] **Settings save — error path:** With backend unreachable, attempt save → error toast appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)