### PR TITLE
docs: add Development Setup section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,47 @@
 - Git.
 - UI testing must be done using Chrome latest version.
 
+## Development Setup
+
+### Option 1: Full local environment (Docker)
+
+The recommended path for backend or full-stack changes. Runs both the Python backend
+and the Vite frontend in Docker containers with live reloading — no local Node.js or
+Python required on your host.
+
+See **[dev-setup/README.md](dev-setup/README.md)** for setup instructions.
+
+### Option 2: Local frontend against a running Bazarr instance
+
+Useful when you're making frontend-only changes and already have Bazarr running
+elsewhere (a home server, NAS, etc.). Runs the Vite dev server locally and proxies
+API calls to your existing instance.
+
+**Prerequisites:** Node.js 20.x
+
+1. Create `frontend/.env.local` (this file is gitignored):
+
+   ```
+   VITE_PROXY_URL=http://<your-bazarr-host>:<port>
+   VITE_PROXY_SECURE=false
+   VITE_ALLOW_WEBSOCKET=true
+   VITE_API_KEY=<your API key from Settings > General > Security>
+   ```
+
+2. Start the dev server:
+
+   ```bash
+   cd frontend
+   npm install
+   npm start
+   ```
+
+   The Vite server opens at `http://localhost:5173` by default. All `/api/*`
+   requests are proxied to `VITE_PROXY_URL`.
+
+> **Note:** `VITE_API_KEY` is required. Without it, the frontend attempts to read
+> a local `config.yaml` that doesn't exist in a dev checkout and will fail to load.
+
 ## Warning
 
 As we're using Git in the development process, you better disable automatic update of Bazarr in UI or you may get your changes overwritten. Alternatively, you can completely disable the update module by running Bazarr with `--no-update` command line argument.


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` currently has no guidance on how to run Bazarr locally for development — not even a pointer to the existing `dev-setup/README.md`. This adds a "Development Setup" section covering two workflows:

- **Option 1 (Docker):** Defers to `dev-setup/README.md` rather than duplicating it — that doc is already comprehensive.
- **Option 2 (local Vite + remote backend):** Documents running the Vite dev server locally, proxied via `.env.local` to an existing Bazarr instance. Useful for frontend-only contributors who already run Bazarr on a home server or NAS.

The `VITE_API_KEY` gotcha gets a callout — without it, the frontend silently fails to load in a dev checkout because it can't find a local `config.yaml`.

## Test plan

- [ ] Verify `dev-setup/README.md` link resolves correctly on GitHub
- [ ] Follow Option 2 steps against a running Bazarr instance and confirm Vite dev server loads


## Commentary

I thought I'd offer this up to assist other contributors like myself, after noticing that one of my Claude Code sessions hadn't tested the full workflows of the UI-only changes it had made. 

I wanted a lightweight way of running the UI branch/build against an existing backend, so I could manually test each of the happy-path and failure mode cases. Seemed only right to make sure these more complicated UI changes actually did what was intended, before bothering the project with yet another PR.

Happy to make any revisions that would better fit the project team's needs or style
