### PR TITLE
fix: correct 410 handling for opensubtitlescom provider

### DIFF
--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -80,6 +80,7 @@ def provider_throttle_map():
         "opensubtitlescom": {
             TooManyRequests: (datetime.timedelta(minutes=1), "1 minute"),
             DownloadLimitExceeded: (datetime.timedelta(hours=6), "6 hours"),
+            ProviderError: (datetime.timedelta(minutes=1), "1 minute"),
         },
         "addic7ed": {
             DownloadLimitExceeded: (datetime.timedelta(hours=3), "3 hours"),

--- a/custom_libs/subliminal_patch/providers/opensubtitlescom.py
+++ b/custom_libs/subliminal_patch/providers/opensubtitlescom.py
@@ -571,7 +571,7 @@ class OpenSubtitlesComProvider(ProviderRetryMixin, Provider):
                                                 f"downloaded. Quota will be reset in {quota_reset_time}.")
             elif status_code == 410:
                 log_request_response(response)
-                raise ProviderError("Download as expired")
+                raise ProviderError("Download link has expired")
             elif status_code == 429:
                 log_request_response(response)
                 raise TooManyRequests()


### PR DESCRIPTION
## Summary

Two fixes for how Bazarr handles HTTP 410 responses from the opensubtitlescom provider:

- **Typo fix:** `"Download as expired"` → `"Download link has expired"` (`opensubtitlescom.py:574`)
- **Throttle fix:** Add `ProviderError` to the `opensubtitlescom` entry in `provider_throttle_map()` with a 1-minute duration

### Why the throttle fix matters

When a 410 is received, `ProviderError` is raised. Because `ProviderError` had no entry in the `opensubtitlescom`-specific throttle map, it fell through to the generic catch-all at the bottom of `provider_throttle()`:

```python
throttle_delta, throttle_description = datetime.timedelta(minutes=10), "10 minutes"
```

This 10-minute default is intended for truly unknown/unexpected errors. A 410 ("Download link has expired") is a known, transient condition — the provider is working fine and will succeed on the next attempt. A 1-minute throttle is more appropriate and matches the existing `TooManyRequests` duration for this provider.

## Known follow-on issue

The root cause of the 410 appears to be that the retry loop in `download_subtitle()` reuses the same one-time-use download URL on retry attempts. If the initial download request fails for any reason (network hiccup, timeout), the URL is already consumed, and the retry receives 410. A proper fix would re-fetch a fresh URL from the `/download` endpoint before retrying, but that's a larger change and out of scope here.

## Test plan

- [ ] Trigger a subtitle download from opensubtitlescom that receives a 410 response
- [ ] Confirm provider is throttled for ~1 minute rather than 10
- [ ] Confirm log message reads "Download link has expired" (not "as")

🤖 Generated with [Claude Code](https://claude.com/claude-code)