### PR TITLE
feat: Send notification when embedded subtitles satisfy profile requirements

### DIFF
--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -19,6 +19,7 @@ from utilities.video_analyzer import embedded_subs_reader
 from app.event_handler import event_stream
 from subtitles.indexer.utils import guess_external_subtitles, get_external_subtitles_path
 from app.jobs_queue import jobs_queue
+from app.notifier import send_notifications_movie
 
 gc.enable()
 
@@ -143,6 +144,27 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True):
             if movie:
                 logging.debug(f"BAZARR storing those languages to DB: {actual_subtitles}")
                 list_missing_subtitles_movies(no=movie.radarrId)
+
+                item = database.execute(
+                    select(TableMovies.missing_subtitles, TableMovies.radarrId)
+                    .where(TableMovies.path == original_path)
+                ).first()
+
+                missing = []
+                movie_id = None
+
+                if item:
+                    movie_id = item.radarrId
+                    if item.missing_subtitles:
+                        missing = ast.literal_eval(item.missing_subtitles)
+
+                if missing == [] and settings.general.use_embedded_subs:
+                    if not settings.general.dont_notify_manual_actions:
+                        send_notifications_movie(
+                            movie_id,
+                            "Embedded subtitles satisfy profile... no download needed"
+                        )
+
             else:
                 logging.debug(f"BAZARR haven't been able to update existing subtitles to DB: {actual_subtitles}")
     else:

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -18,6 +18,7 @@ from utilities.video_analyzer import embedded_subs_reader
 from app.event_handler import event_stream
 from subtitles.indexer.utils import guess_external_subtitles, get_external_subtitles_path
 from app.jobs_queue import jobs_queue
+from app.notifier import send_notifications
 
 gc.enable()
 
@@ -141,6 +142,32 @@ def store_subtitles(original_path, reversed_path, use_cache=True):
             if episode:
                 logging.debug(f"BAZARR storing those languages to DB: {actual_subtitles}")
                 list_missing_subtitles(epno=episode.sonarrEpisodeId)
+
+                item = database.execute(
+                    select(TableEpisodes.missing_subtitles, TableEpisodes.sonarrSeriesId)
+                    .where(TableEpisodes.sonarrEpisodeId == episode.sonarrEpisodeId)
+                ).first()
+
+                missing = []
+                series_id = None
+
+                if item:
+                    series_id = item.sonarrSeriesId
+                    if item.missing_subtitles:
+                        missing = ast.literal_eval(item.missing_subtitles)
+
+                logging.debug(f"BAZARR DEBUG: missing={missing}")
+
+                if missing == [] and settings.general.use_embedded_subs:
+                    if not settings.general.dont_notify_manual_actions:
+                        logging.debug("BAZARR DEBUG: sending notification")
+
+                        send_notifications(
+                            series_id,
+                            episode.sonarrEpisodeId,
+                            "Embedded subtitles satisfy profile... no download needed"
+                        )
+
             else:
                 logging.debug(f"BAZARR haven't been able to update existing subtitles to DB: {actual_subtitles}")
     else:


### PR DESCRIPTION
Bazarr do not notify the user if embedded subtitles already satisfied the
required subtitle profile for a movie or episode. 

This update adds a notification when all required subtitles are already embedded.