### PR TITLE
fix: skip audio tracks where knowit returns a string language in ffprobe refiner

### DIFF
--- a/bazarr/subtitles/refiners/ffprobe.py
+++ b/bazarr/subtitles/refiners/ffprobe.py
@@ -76,6 +76,11 @@ def refine_from_ffprobe(path, video):
                 video.audio_codec = parser_data['audio'][0]['codec']
         for track in parser_data['audio']:
             if 'language' in track:
+                if isinstance(track['language'], str):
+                    logging.debug(
+                        'BAZARR ffprobe returned a string for audio language,'
+                        ' skipping: %s', track['language'])
+                    continue
                 video.audio_languages.add(track['language'].alpha3)
 
     return video


### PR DESCRIPTION
## Problem

When `knowit` cannot resolve an audio track's language tag (e.g. an unrecognized or malformed tag), it returns a raw string instead of a `babelfish.Language` object. The ffprobe refiner then calls `.alpha3` on that string, raising:

```
AttributeError: 'str' object has no attribute 'alpha3'
```

This exception propagates up through `get_video()` in `subtitles/utils.py`, causing the entire video object construction to fail for that file. The result is that subtitle matching cannot run for any file with an unresolvable audio track language tag.

## Fix

Added an `isinstance(track['language'], str)` guard before the `.alpha3` call, consistent with the identical guard already present in `utilities/video_analyzer.py` (see `embedded_audio_reader`).

Unresolvable audio language tracks are skipped with a debug log entry rather than crashing the refiner.

## Test plan

- [ ] Verify files previously producing `'str' object has no attribute 'alpha3'` log errors no longer error
- [ ] Verify subtitle search proceeds normally for affected files
- [ ] Verify files with valid audio language tags are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)