### PR TITLE
Improved subdl provider anime and pack subtitle support

### DIFF
--- a/bazarr/subtitles/utils.py
+++ b/bazarr/subtitles/utils.py
@@ -76,8 +76,8 @@ def _get_scores(media_type, min_movie=None, min_ep=None):
 
     max_score = MAX_SCORES['episode' if series else 'movie']
 
-    min_movie = (max_score / 2) if min_movie is None else min_movie
-    min_ep = (2/3 * max_score) if min_ep is None else min_ep
+    min_movie = min_movie or (max_score / 2)
+    min_ep = min_ep or (2/3 * max_score)
     min_score = int(min_ep if series else min_movie)
 
     return (

--- a/bazarr/subtitles/utils.py
+++ b/bazarr/subtitles/utils.py
@@ -76,8 +76,8 @@ def _get_scores(media_type, min_movie=None, min_ep=None):
 
     max_score = MAX_SCORES['episode' if series else 'movie']
 
-    min_movie = min_movie or (max_score / 2)
-    min_ep = min_ep or (2/3 * max_score)
+    min_movie = (max_score / 2) if min_movie is None else min_movie
+    min_ep = (2/3 * max_score) if min_ep is None else min_ep
     min_score = int(min_ep if series else min_movie)
 
     return (

--- a/custom_libs/subliminal_patch/providers/subdl.py
+++ b/custom_libs/subliminal_patch/providers/subdl.py
@@ -33,12 +33,13 @@ class SubdlSubtitle(Subtitle):
     hearing_impaired_verifiable = True
 
     def __init__(self, language, forced, hearing_impaired, page_link, download_link, file_id, release_names, uploader,
-                 season=None, episode=None):
+                 season=None, episode=None, absolute_episode=None):
         super().__init__(language)
         language = Language.rebuild(language, hi=hearing_impaired, forced=forced)
 
         self.season = season
         self.episode = episode
+        self.absolute_episode = absolute_episode
         self.releases = release_names
         self.release_info = ', '.join(release_names)
         self.language = language
@@ -64,8 +65,11 @@ class SubdlSubtitle(Subtitle):
             # season
             if video.season == self.season:
                 matches.add('season')
-            # episode
+            # episode — match by standard episode or absolute episode number
             if video.episode == self.episode:
+                matches.add('episode')
+            elif (getattr(video, 'absolute_episode', None) and
+                  video.absolute_episode == self.episode):
                 matches.add('episode')
             # imdb — IMDB match also confirms the year
             matches.add('series_imdb_id')
@@ -159,7 +163,32 @@ class SubdlProvider(ProviderRetryMixin, Provider):
                 amount=retry_amount,
                 retry_timeout=retry_timeout
             )
+
+            # For anime with absolute episode numbering, also search by absolute episode number
+            # so we can find subtitles that are only indexed by absolute number on subdl
+            absolute_episode = getattr(self.video, 'absolute_episode', None)
+            if absolute_episode and absolute_episode != self.video.episode:
+                logger.debug(f'Also searching by absolute episode number: {absolute_episode}')
+                res_absolute = self.retry(
+                    lambda: self.session.get(self.server_url() + 'subtitles',
+                                             params=(('api_key', self.api_key),
+                                                     ('episode_number', absolute_episode),
+                                                     ('film_name', title if not imdb_id else None),
+                                                     ('imdb_id', imdb_id if imdb_id else None),
+                                                     ('languages', langs),
+                                                     ('subs_per_page', 30),
+                                                     ('type', 'tv'),
+                                                     ('comment', 1),
+                                                     ('releases', 1),
+                                                     ('bazarr', 1)),
+                                             timeout=30),
+                    amount=retry_amount,
+                    retry_timeout=retry_timeout
+                )
+            else:
+                res_absolute = None
         else:
+            res_absolute = None
             params = {
                        'api_key': self.api_key,
                        'film_name': title if not imdb_id else None,
@@ -228,30 +257,46 @@ class SubdlProvider(ProviderRetryMixin, Provider):
                     return subtitles
                 raise ProviderError(error_msg)
 
-        logger.debug(f"Query returned {len(result['subtitles'])} subtitles")
+        # Merge absolute episode search results if available
+        all_items = list(result.get('subtitles', []))
+        seen_ids = {item['name'] for item in all_items}
 
-        if len(result['subtitles']):
-            for item in result['subtitles']:
+        if res_absolute and res_absolute.status_code == 200:
+            abs_result = res_absolute.json()
+            if ('success' in abs_result and abs_result['success']) or ('status' in abs_result and abs_result['status']):
+                for item in abs_result.get('subtitles', []):
+                    if item['name'] not in seen_ids:
+                        all_items.append(item)
+                        seen_ids.add(item['name'])
+                logger.debug(f'Absolute episode search added {len(abs_result.get("subtitles", []))} more subtitles')
+
+        logger.debug(f"Query returned {len(all_items)} subtitles")
+
+        absolute_episode = getattr(self.video, 'absolute_episode', None)
+
+        if len(all_items):
+            for item in all_items:
                 if (isinstance(self.video, Episode) and
                         item.get('episode_from', False) != item.get('episode_end', False)):
                     # ignore season packs
                     continue
-                else:
-                    subtitle = SubdlSubtitle(
-                        language=Language.fromsubdl(item['language']),
-                        forced=self._is_forced(item),
-                        hearing_impaired=item.get('hi', False) or self._is_hi(item),
-                        page_link=urljoin("https://subdl.com", item.get('subtitlePage', '')),
-                        download_link=item['url'],
-                        file_id=item['name'],
-                        release_names=item.get('releases', []),
-                        uploader=item.get('author', ''),
-                        season=item.get('season', None),
-                        episode=item.get('episode', None),
-                    )
-                    subtitle.get_matches(self.video)
-                    if subtitle.language in languages:  # make sure only desired subtitles variants are returned
-                        subtitles.append(subtitle)
+
+                subtitle = SubdlSubtitle(
+                    language=Language.fromsubdl(item['language']),
+                    forced=self._is_forced(item),
+                    hearing_impaired=item.get('hi', False) or self._is_hi(item),
+                    page_link=urljoin("https://subdl.com", item.get('subtitlePage', '')),
+                    download_link=item['url'],
+                    file_id=item['name'],
+                    release_names=item.get('releases', []),
+                    uploader=item.get('author', ''),
+                    season=item.get('season', None),
+                    episode=item.get('episode', None),
+                    absolute_episode=absolute_episode,
+                )
+                subtitle.get_matches(self.video)
+                if subtitle.language in languages:  # make sure only desired subtitles variants are returned
+                    subtitles.append(subtitle)
 
         return subtitles
 

--- a/custom_libs/subliminal_patch/providers/subdl.py
+++ b/custom_libs/subliminal_patch/providers/subdl.py
@@ -7,6 +7,7 @@ import io
 from zipfile import ZipFile, is_zipfile
 from urllib.parse import urljoin
 from requests import Session
+from guessit import guessit
 
 from babelfish import language_converters
 from subzero.language import Language
@@ -65,6 +66,11 @@ class SubdlSubtitle(Subtitle):
             matches.add('series')
             # season
             if video.season == self.season:
+                matches.add('season')
+            elif self.is_pack and self.absolute_episode:
+                # Arc-based season numbering (e.g. subdl's Enies Lobby = S09) differs from
+                # Sonarr's sequential numbering (S11). When a pack is validated via absolute
+                # episode range, trust the match regardless of season number discrepancy.
                 matches.add('season')
             # episode — match by standard episode, absolute episode, or pack range
             if video.episode == self.episode:
@@ -318,6 +324,18 @@ class SubdlProvider(ProviderRetryMixin, Provider):
                 if isinstance(self.video, Episode):
                     ep_from = item.get('episode_from')
                     ep_end = item.get('episode_end')
+                    # Fallback: parse episode range from release names when the API
+                    # does not provide episode_from/episode_end fields.
+                    if not (ep_from and ep_end and ep_from != ep_end):
+                        ep_from_parsed, ep_end_parsed = self._parse_episode_range_from_releases(
+                            item.get('releases', [])
+                        )
+                        if ep_from_parsed and ep_end_parsed and ep_from_parsed != ep_end_parsed:
+                            ep_from = ep_from_parsed
+                            ep_end = ep_end_parsed
+                            logger.debug(
+                                f'Parsed episode range {ep_from}-{ep_end} from release names'
+                            )
                     if ep_from and ep_end and ep_from != ep_end:
                         # Multi-episode pack: allow if target episode is within range
                         target_ep = self.video.episode
@@ -383,6 +401,23 @@ class SubdlProvider(ProviderRetryMixin, Provider):
 
         # nothing match so we consider it as normal subtitles
         return False
+
+    @staticmethod
+    def _parse_episode_range_from_releases(release_names):
+        """Parse episode range (ep_from, ep_end) from release name strings.
+
+        Used as a fallback when the subdl API does not populate episode_from/
+        episode_end for a pack. Guessit expands patterns like 'EP0264-0336'
+        into a list of integers; we extract the first and last as the range.
+
+        Returns (ep_from, ep_end) as ints, or (None, None) if not found.
+        """
+        for name in release_names:
+            guess = guessit(name, {'type': 'episode'})
+            ep = guess.get('episode')
+            if isinstance(ep, list) and len(ep) >= 2:
+                return ep[0], ep[-1]
+        return None, None
 
     def list_subtitles(self, video, languages):
         return self.query(languages, video)

--- a/custom_libs/subliminal_patch/providers/subdl.py
+++ b/custom_libs/subliminal_patch/providers/subdl.py
@@ -33,13 +33,14 @@ class SubdlSubtitle(Subtitle):
     hearing_impaired_verifiable = True
 
     def __init__(self, language, forced, hearing_impaired, page_link, download_link, file_id, release_names, uploader,
-                 season=None, episode=None, absolute_episode=None):
+                 season=None, episode=None, absolute_episode=None, is_pack=False):
         super().__init__(language)
         language = Language.rebuild(language, hi=hearing_impaired, forced=forced)
 
         self.season = season
         self.episode = episode
         self.absolute_episode = absolute_episode
+        self.is_pack = is_pack
         self.releases = release_names
         self.release_info = ', '.join(release_names)
         self.language = language
@@ -65,11 +66,14 @@ class SubdlSubtitle(Subtitle):
             # season
             if video.season == self.season:
                 matches.add('season')
-            # episode — match by standard episode or absolute episode number
+            # episode — match by standard episode, absolute episode, or pack range
             if video.episode == self.episode:
                 matches.add('episode')
             elif (getattr(video, 'absolute_episode', None) and
                   video.absolute_episode == self.episode):
+                matches.add('episode')
+            elif self.is_pack:
+                # Pack was already validated to contain the target episode
                 matches.add('episode')
             # imdb — IMDB match also confirms the year
             matches.add('series_imdb_id')
@@ -310,10 +314,22 @@ class SubdlProvider(ProviderRetryMixin, Provider):
 
         if len(all_items):
             for item in all_items:
-                if (isinstance(self.video, Episode) and
-                        item.get('episode_from', False) != item.get('episode_end', False)):
-                    # ignore season packs
-                    continue
+                is_pack = False
+                if isinstance(self.video, Episode):
+                    ep_from = item.get('episode_from')
+                    ep_end = item.get('episode_end')
+                    if ep_from and ep_end and ep_from != ep_end:
+                        # Multi-episode pack: allow if target episode is within range
+                        target_ep = self.video.episode
+                        if absolute_episode:
+                            # Check both standard and absolute episode against the range
+                            if not ((ep_from <= target_ep <= ep_end) or
+                                    (ep_from <= absolute_episode <= ep_end)):
+                                continue
+                        else:
+                            if not (ep_from <= target_ep <= ep_end):
+                                continue
+                        is_pack = True
 
                 subtitle = SubdlSubtitle(
                     language=Language.fromsubdl(item['language']),
@@ -327,6 +343,7 @@ class SubdlProvider(ProviderRetryMixin, Provider):
                     season=item.get('season', None),
                     episode=item.get('episode', None),
                     absolute_episode=absolute_episode,
+                    is_pack=is_pack,
                 )
                 subtitle.get_matches(self.video)
                 if subtitle.language in languages:  # make sure only desired subtitles variants are returned
@@ -395,11 +412,35 @@ class SubdlProvider(ProviderRetryMixin, Provider):
             archive_stream = io.BytesIO(r.content)
             if is_zipfile(archive_stream):
                 archive = ZipFile(archive_stream)
-                for name in archive.namelist():
-                    # TODO when possible, deal with season pack / multiple files archive
-                    subtitle_content = archive.read(name)
-                    subtitle.content = fix_line_ending(subtitle_content)
-                    return
+                if subtitle.is_pack and self.video and isinstance(self.video, Episode):
+                    # Use smart extraction for packs: match by episode number
+                    target_episode = self.video.episode
+                    absolute_episode = getattr(self.video, 'absolute_episode', None)
+                    content = utils.get_subtitle_from_archive(
+                        archive,
+                        episode=target_episode,
+                        episode_title=getattr(self.video, 'title', None),
+                    )
+                    # Fallback: try absolute episode number
+                    if content is None and absolute_episode:
+                        content = utils.get_subtitle_from_archive(
+                            archive,
+                            episode=absolute_episode,
+                        )
+                    if content is not None:
+                        subtitle.content = content
+                    else:
+                        logger.warning(f'Could not find episode {target_episode} in pack archive {download_link}')
+                        subtitle.content = None
+                else:
+                    # Single episode: prefer subtitle file extensions, fallback to first file
+                    for name in archive.namelist():
+                        if name.endswith(('.srt', '.sub', '.ssa', '.ass')):
+                            subtitle.content = fix_line_ending(archive.read(name))
+                            return
+                    for name in archive.namelist():
+                        subtitle.content = fix_line_ending(archive.read(name))
+                        return
             else:
                 logger.error(f'Could not unzip subtitle from {download_link}')
                 subtitle.content = None

--- a/custom_libs/subliminal_patch/providers/subdl.py
+++ b/custom_libs/subliminal_patch/providers/subdl.py
@@ -187,8 +187,31 @@ class SubdlProvider(ProviderRetryMixin, Provider):
                 )
             else:
                 res_absolute = None
+
+            # Fallback: search by season only (no episode filter) to catch subtitles that use
+            # split-season / cour-based internal numbering (e.g. Fire Force S3 split into two cours
+            # where episode 25 is stored internally as cour-2 episode 13).
+            # The release name matching in get_matches() will identify the correct episode.
+            logger.debug(f'Also searching by season only (no episode filter) for season {self.video.season}')
+            res_season = self.retry(
+                lambda: self.session.get(self.server_url() + 'subtitles',
+                                         params=(('api_key', self.api_key),
+                                                 ('film_name', title if not imdb_id else None),
+                                                 ('imdb_id', imdb_id if imdb_id else None),
+                                                 ('languages', langs),
+                                                 ('season_number', self.video.season),
+                                                 ('subs_per_page', 30),
+                                                 ('type', 'tv'),
+                                                 ('comment', 1),
+                                                 ('releases', 1),
+                                                 ('bazarr', 1)),
+                                         timeout=30),
+                amount=retry_amount,
+                retry_timeout=retry_timeout
+            )
         else:
             res_absolute = None
+            res_season = None
             params = {
                        'api_key': self.api_key,
                        'film_name': title if not imdb_id else None,
@@ -269,6 +292,17 @@ class SubdlProvider(ProviderRetryMixin, Provider):
                         all_items.append(item)
                         seen_ids.add(item['name'])
                 logger.debug(f'Absolute episode search added {len(abs_result.get("subtitles", []))} more subtitles')
+
+        if res_season and res_season.status_code == 200:
+            season_result = res_season.json()
+            if ('success' in season_result and season_result['success']) or ('status' in season_result and season_result['status']):
+                added = 0
+                for item in season_result.get('subtitles', []):
+                    if item['name'] not in seen_ids:
+                        all_items.append(item)
+                        seen_ids.add(item['name'])
+                        added += 1
+                logger.debug(f'Season-only search added {added} more subtitles')
 
         logger.debug(f"Query returned {len(all_items)} subtitles")
 

--- a/custom_libs/subliminal_patch/providers/subdl.py
+++ b/custom_libs/subliminal_patch/providers/subdl.py
@@ -77,7 +77,7 @@ class SubdlSubtitle(Subtitle):
             # tmdb 
             matches.add('tmdb_id')
 
-        utils.update_matches(matches, video, self.release_info)
+        utils.update_matches(matches, video, self.releases)
 
         self.matches = matches
 

--- a/custom_libs/subliminal_patch/providers/subdl.py
+++ b/custom_libs/subliminal_patch/providers/subdl.py
@@ -67,8 +67,10 @@ class SubdlSubtitle(Subtitle):
             # episode
             if video.episode == self.episode:
                 matches.add('episode')
-            # imdb
+            # imdb — IMDB match also confirms the year
             matches.add('series_imdb_id')
+            if video.year:
+                matches.add('year')
         else:
             # title
             matches.add('title')

--- a/custom_libs/subliminal_patch/providers/subdl.py
+++ b/custom_libs/subliminal_patch/providers/subdl.py
@@ -314,6 +314,38 @@ class SubdlProvider(ProviderRetryMixin, Provider):
                         added += 1
                 logger.debug(f'Season-only search added {added} more subtitles')
 
+        # Last resort: if all season-filtered searches returned nothing, search by title only
+        # (no season/episode filter). This catches anime stored as season 0 on subdl (full series
+        # blocks) where season_number filtering silently excludes all results.
+        if not all_items and isinstance(self.video, Episode):
+            logger.debug('All season-filtered searches returned 0 results, falling back to title-only search')
+            res_title = self.retry(
+                lambda: self.session.get(self.server_url() + 'subtitles',
+                                         params=(('api_key', self.api_key),
+                                                 ('film_name', title if not imdb_id else None),
+                                                 ('imdb_id', imdb_id if imdb_id else None),
+                                                 ('languages', langs),
+                                                 ('subs_per_page', 30),
+                                                 ('type', 'tv'),
+                                                 ('comment', 1),
+                                                 ('releases', 1),
+                                                 ('bazarr', 1)),
+                                         timeout=30),
+                amount=retry_amount,
+                retry_timeout=retry_timeout
+            )
+            if res_title.status_code == 200:
+                title_result = res_title.json()
+                if ('success' in title_result and title_result['success']) or \
+                        ('status' in title_result and title_result['status']):
+                    added = 0
+                    for item in title_result.get('subtitles', []):
+                        if item['name'] not in seen_ids:
+                            all_items.append(item)
+                            seen_ids.add(item['name'])
+                            added += 1
+                    logger.debug(f'Title-only fallback search added {added} subtitles')
+
         logger.debug(f"Query returned {len(all_items)} subtitles")
 
         absolute_episode = getattr(self.video, 'absolute_episode', None)


### PR DESCRIPTION
## Summary

This PR improves the subdl provider with several fixes and new features targeting anime subtitle matching and multi-episode pack support.

### Bug Fixes

- **Fixed `update_matches` receiving joined string instead of releases list** — `update_matches` expects a list so guessit can parse each release name individually. Passing the pre-joined `release_info` string caused guessit to treat the entire comma-separated value as one release name, resulting in missed matches.

- **Fixed year not being scored when series IMDB ID is present** — When a series IMDB ID is matched, the year is implicitly confirmed. Adding a year match improves subtitle scores and aligns with how other providers handle IMDB-confirmed metadata.

### New Features

- **Absolute episode number support for anime** — Some anime on subdl are indexed by absolute episode number rather than season/episode (e.g. One Piece episode 1155 instead of S22E70). Adds absolute episode matching in `get_matches()` and a supplemental API search by absolute episode number when it differs from the standard episode number.

- **Season-only fallback search for split-cour anime** — Some anime use cour-internal episode numbering on subdl (e.g. Fire Force S3 stores episode 25 as cour-2 episode 13). A supplemental season-only search (no episode filter) is merged with main results, allowing release name matching to identify the correct episode.

- **Multi-episode pack support** — Previously all season packs were unconditionally skipped. Packs are now allowed when the target episode falls within the pack's `episode_from`/`episode_end` range (checking both standard and absolute episode numbers for anime). `download_subtitle()` uses `utils.get_subtitle_from_archive()` for smart file extraction from pack archives.

- **Episode range parsing from release names for anime packs** — The subdl API does not always populate `episode_from`/`episode_end` for packs. When these fields are absent, the episode range is now parsed from the release name string using guessit (e.g. `EP0264-0336` → range 264–336). Additionally, when a pack is validated via absolute episode range, arc-based season number discrepancies (subdl S09 vs Sonarr S11 for the same anime) are tolerated. This enables subtitles like `One Piece S09 CR [EP0264-0336][Enies Lobby]` to be correctly matched for One Piece S11E80 (absolute_episode=306).

## Test plan

- [ ] Single-episode subtitle search still works for standard series
- [ ] Anime with absolute episode numbering (e.g. One Piece) returns correct subtitles
- [ ] Split-cour anime (e.g. Fire Force S3E25) returns the correct subtitle via season-only fallback
- [ ] Multi-episode pack archives are correctly filtered to the target episode range
- [ ] Correct subtitle file is extracted from pack archives
- [ ] Packs whose range is only in the release name (not in API fields) are correctly detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)