### PR TITLE
Fix WebSocket file descriptor leak in signalrcore transport

### DIFF
--- a/libs/signalrcore/transport/websockets/websocket_transport.py
+++ b/libs/signalrcore/transport/websockets/websocket_transport.py
@@ -55,9 +55,10 @@ class WebsocketTransport(BaseTransport):
     def stop(self):
         if self.state == ConnectionState.connected:
             self.connection_checker.stop()
+        if self._ws is not None:
             self._ws.close()
-            self.state = ConnectionState.disconnected
-            self.handshake_received = False
+        self.state = ConnectionState.disconnected
+        self.handshake_received = False
 
     def start(self):
         if not self.skip_negotiation:


### PR DESCRIPTION
## Problem

`WebsocketTransport.stop()` guards the `_ws.close()` call behind `if self.state == ConnectionState.connected`, which means the underlying WebSocket is never closed when `stop()` is called after a connection error (state is already `disconnected`).

When `handle_reconnect()` calls `stop()` then `start()`, a new `WebSocketApp` and thread are created while the old socket FD is orphaned. Each failed reconnect cycle leaks one socket file descriptor.

With the default configuration (`reconnect_interval=180`, `max_attempts=None`), this leaks ~20 FDs/day. After ~49 days, Bazarr hits the 1024 FD soft limit, causing all file/socket operations to fail with EMFILE.

In my case this caused a cascading failure where the s6 process supervisor entered a tight retry loop burning ~750% system CPU on the host for 13 minutes.

## Fix

- Move `_ws.close()` outside the `state == connected` guard so the WebSocket is always closed if it exists
- `connection_checker.stop()` remains guarded (it is only started when connected)
- `state` and `handshake_received` are always reset, making `stop()` idempotent

## Notes

- The upstream signalrcore library (`mandrewcito/signalrcore`) has since been refactored and no longer has this bug, but Bazarr vendors a copy of the old v0.9.5
- Related upstream issue: mandrewcito/signalrcore#97
- Minimal 3-line change, no behavior change for the normal (connected → stop) path