### PR TITLE
Fix Subtitle Tools mass edit not allowing selection of non-SRT subtitles

### DIFF
--- a/frontend/src/components/modals/SubtitleToolsModal.tsx
+++ b/frontend/src/components/modals/SubtitleToolsModal.tsx
@@ -56,10 +56,6 @@ function getLocalisedValues(item: SupportType): LocalisedType {
   }
 }
 
-const CanSelectSubtitle = (item: TableColumnType) => {
-  return item.path.endsWith(".srt");
-};
-
 interface SubtitleToolViewProps {
   payload: SupportType[];
 }
@@ -171,7 +167,7 @@ const SubtitleToolView: FunctionComponent<SubtitleToolViewProps> = ({
     <Stack>
       <SimpleTable
         tableStyles={{ emptyText: "No external subtitles found" }}
-        enableRowSelection={(row) => CanSelectSubtitle(row.original)}
+        enableRowSelection={true}
         onRowSelectionChanged={(rows) =>
           setSelections(rows.map((r) => r.original))
         }


### PR DESCRIPTION
## Summary
- Removed the `CanSelectSubtitle` function that hardcoded a `.srt` extension check, preventing selection of `.ass`, `.ssa`, `.sub`, `.vtt` and other subtitle formats in the Subtitle Tools mass edit modal
- The backend (pysubs2) already supports all these formats and the per-episode context menu already works on them — only the mass edit checkboxes were restricted
- Fixes #3285

## Test plan
- [ ] Open a series with `.ass` (or `.ssa`/`.sub`/`.vtt`) subtitle files
- [ ] Go to Subtitle Tools (mass edit)
- [ ] Verify checkboxes are now clickable for all subtitle formats
- [ ] Select multiple non-SRT subtitles and run a tool (e.g. Remove HI Tags, Adjust Times)
- [ ] Verify the tool completes successfully
- [ ] Verify `.srt` subtitles still work as before

## Screenshots

<img width="1577" height="1512" alt="image" src="https://github.com/user-attachments/assets/04b8dff0-f541-472b-a900-9d3c37cf17be" />

<img width="1585" height="1524" alt="image" src="https://github.com/user-attachments/assets/91eb29ab-d530-463e-ad6b-bc59f894a3de" />

<img width="1582" height="1519" alt="image" src="https://github.com/user-attachments/assets/99d59283-7001-43e7-83dc-2b5c7136969a" />
