### PR TITLE
feat(notifications): Custom notifications with variable expansion

### DIFF
--- a/bazarr/app/database.py
+++ b/bazarr/app/database.py
@@ -268,6 +268,9 @@ class TableMovies(Base):
     video_codec = mapped_column(Text)
     year = mapped_column(Text)
 
+    def to_dict(self):
+        return {column.name: getattr(self, column.name) for column in self.__table__.columns}
+
 
 class TableMoviesRootfolder(Base):
     __tablename__ = 'table_movies_rootfolder'
@@ -319,6 +322,9 @@ class TableShows(Base):
     title = mapped_column(Text, nullable=False)
     updated_at_timestamp = mapped_column(DateTime)
     year = mapped_column(Text)
+
+    def to_dict(self):
+        return {column.name: getattr(self, column.name) for column in self.__table__.columns}
 
 
 class TableShowsRootfolder(Base):

--- a/bazarr/app/notifier.py
+++ b/bazarr/app/notifier.py
@@ -60,9 +60,7 @@ def update_notifier():
 def get_notifier_providers():
     return database.execute(
         select(TableSettingsNotifier.name, TableSettingsNotifier.url)
-        .where(
-            TableSettingsNotifier.enabled == 1
-        )
+        .where(TableSettingsNotifier.enabled == 1)
     ).all()
 
 
@@ -171,4 +169,18 @@ def _expand_notifier_url(url, media_variables):
     if url is None or not media_variables:
         return url
 
-    # TODO: add substitutions
+    # Looks for {bazarr_*} placeholders in the URL string
+    placeholder_pattern = re.compile(r'\{(bazarr_[A-Za-z0-9_]+)\}')
+
+    def replace(match):
+        key = match.group(1)
+        if key not in media_variables:
+            return match.group(0)
+
+        value = media_variables[key]
+        if value is None:
+            return ''
+
+        return quote(str(value), safe='')
+
+    return placeholder_pattern.sub(replace, url)

--- a/bazarr/app/notifier.py
+++ b/bazarr/app/notifier.py
@@ -167,14 +167,14 @@ def _build_media_variables(record, prefix):
 def _expand_notifier_url(url, media_variables):
     if url is None or not media_variables:
         return url
-    
+
     # Looks for {bazarr_*} placeholders in the URL string
     placeholder_pattern = re.compile(r'\{(bazarr_[A-Za-z0-9_]+)\}')
 
     def replace(match):
         key = match.group(1)
         if key not in media_variables:
-            return match.group(0)
+            return ''
 
         value = media_variables[key]
         if value is None:

--- a/bazarr/app/notifier.py
+++ b/bazarr/app/notifier.py
@@ -68,6 +68,7 @@ def send_notifications(sonarr_series_id, sonarr_episode_id, message):
     providers = get_notifier_providers()
     if not len(providers):
         return
+
     series = (
         database.execute(
             select(TableShows)
@@ -86,6 +87,7 @@ def send_notifications(sonarr_series_id, sonarr_episode_id, message):
         series_year = f' ({series_year})'
     else:
         series_year = ''
+
     episode = (
         database.execute(
             select(TableEpisodes)
@@ -119,6 +121,7 @@ def send_notifications_movie(radarr_id, message):
     providers = get_notifier_providers()
     if not len(providers):
         return
+
     movie = (
         database.execute(
             select(TableMovies)
@@ -155,20 +158,16 @@ def send_notifications_movie(radarr_id, message):
 
 
 def _build_media_variables(record, prefix):
-    media_variables = {}
-    if record is None:
-        return media_variables
+    if record is None or not prefix:
+        return {}
 
-    for column in record.__table__.columns:
-        media_variables[f'bazarr_{prefix}_{column.name}'] = getattr(record, column.name)
-
-    return media_variables
+    return {f'bazarr_{prefix}_{key}': value for key, value in record.to_dict().items()}
 
 
 def _expand_notifier_url(url, media_variables):
     if url is None or not media_variables:
         return url
-
+    
     # Looks for {bazarr_*} placeholders in the URL string
     placeholder_pattern = re.compile(r'\{(bazarr_[A-Za-z0-9_]+)\}')
 

--- a/bazarr/app/notifier.py
+++ b/bazarr/app/notifier.py
@@ -2,6 +2,8 @@
 
 from apprise import Apprise, AppriseAsset
 import logging
+import re
+from urllib.parse import quote
 
 from .database import (
     TableSettingsNotifier,
@@ -68,28 +70,38 @@ def send_notifications(sonarr_series_id, sonarr_episode_id, message):
     providers = get_notifier_providers()
     if not len(providers):
         return
-    series = database.execute(
-        select(TableShows.title, TableShows.year)
-        .where(
-            TableShows.sonarrSeriesId == sonarr_series_id
+    series = (
+        database.execute(
+            select(TableShows)
+            .where(TableShows.sonarrSeriesId == sonarr_series_id)
         )
-    ).first()
+        .scalars()
+        .first()
+    )
     if not series:
         return
+
     series_title = series.title
     series_year = series.year
+
     if series_year not in [None, '', '0']:
         series_year = f' ({series_year})'
     else:
         series_year = ''
-    episode = database.execute(
-        select(TableEpisodes.title, TableEpisodes.season, TableEpisodes.episode)
-        .where(
-            TableEpisodes.sonarrEpisodeId == sonarr_episode_id
+    episode = (
+        database.execute(
+            select(TableEpisodes)
+            .where(TableEpisodes.sonarrEpisodeId == sonarr_episode_id)
         )
-    ).first()
+        .scalars()
+        .first()
+    )
     if not episode:
         return
+
+    media_variables = {}
+    media_variables.update(_build_media_variables(series, 'series'))
+    media_variables.update(_build_media_variables(episode, 'episode'))
 
     asset = AppriseAsset(async_mode=False)
 
@@ -97,7 +109,7 @@ def send_notifications(sonarr_series_id, sonarr_episode_id, message):
 
     for provider in providers:
         if provider.url is not None:
-            apobj.add(provider.url)
+            apobj.add(_expand_notifier_url(provider.url, media_variables))
 
     apobj.notify(
         title='Bazarr notification',
@@ -109,20 +121,26 @@ def send_notifications_movie(radarr_id, message):
     providers = get_notifier_providers()
     if not len(providers):
         return
-    movie = database.execute(
-        select(TableMovies.title, TableMovies.year)
-        .where(
-            TableMovies.radarrId == radarr_id
+    movie = (
+        database.execute(
+            select(TableMovies)
+            .where(TableMovies.radarrId == radarr_id)
         )
-    ).first()
+        .scalars()
+        .first()
+    )
     if not movie:
         return
+
     movie_title = movie.title
     movie_year = movie.year
+
     if movie_year not in [None, '', '0']:
         movie_year = f' ({movie_year})'
     else:
         movie_year = ''
+
+    media_variables = _build_media_variables(movie, 'movie')
 
     asset = AppriseAsset(async_mode=False)
 
@@ -130,9 +148,27 @@ def send_notifications_movie(radarr_id, message):
 
     for provider in providers:
         if provider.url is not None:
-            apobj.add(provider.url)
+            apobj.add(_expand_notifier_url(provider.url, media_variables))
 
     apobj.notify(
         title='Bazarr notification',
         body=f'{movie_title}{movie_year} : {message}',
     )
+
+
+def _build_media_variables(record, prefix):
+    media_variables = {}
+    if record is None:
+        return media_variables
+
+    for column in record.__table__.columns:
+        media_variables[f'bazarr_{prefix}_{column.name}'] = getattr(record, column.name)
+
+    return media_variables
+
+
+def _expand_notifier_url(url, media_variables):
+    if url is None or not media_variables:
+        return url
+
+    # TODO: add substitutions

--- a/bazarr/app/notifier.py
+++ b/bazarr/app/notifier.py
@@ -46,7 +46,10 @@ def update_notifier():
 def get_notifier_providers():
     return database.execute(
         select(TableSettingsNotifier.name, TableSettingsNotifier.url)
-        .where(TableSettingsNotifier.enabled == 1))\
+        .where(
+            TableSettingsNotifier.enabled == 1,
+            TableSettingsNotifier.url.is_not(None),
+        ))\
         .all()
 
 
@@ -84,8 +87,10 @@ def send_notifications(sonarr_series_id, sonarr_episode_id, message):
     apobj = Apprise(asset=asset)
 
     for provider in providers:
-        if provider.url is not None:
+        if provider.name in {"Form", "XML", "JSON"}:
             apobj.add(_expand_notifier_url(provider.url, media_variables))
+        else:
+            apobj.add(provider.url)
 
     apobj.notify(
         title='Bazarr notification',
@@ -118,8 +123,10 @@ def send_notifications_movie(radarr_id, message):
     apobj = Apprise(asset=asset)
 
     for provider in providers:
-        if provider.url is not None:
+        if provider.name in {"Form", "XML", "JSON"}:
             apobj.add(_expand_notifier_url(provider.url, media_variables))
+        else:
+            apobj.add(provider.url)
 
     apobj.notify(
         title='Bazarr notification',

--- a/bazarr/app/notifier.py
+++ b/bazarr/app/notifier.py
@@ -27,11 +27,10 @@ def update_notifier():
     notifiers_added = []
     notifiers_kept = []
 
-    notifiers_in_db = [
-        row.name for row in database.execute(
-            select(TableSettingsNotifier.name)
-        ).all()
-    ]
+    notifiers_in_db = [row.name for row in
+                       database.execute(
+                           select(TableSettingsNotifier.name))
+                       .all()]
 
     for x in results['schemas']:
         if x['service_name'] not in notifiers_in_db:
@@ -40,28 +39,24 @@ def update_notifier():
         else:
             notifiers_kept.append(x['service_name'])
 
-    notifiers_to_delete = [
-        item for item in notifiers_in_db if item not in notifiers_kept
-    ]
+    notifiers_to_delete = [item for item in notifiers_in_db if item not in notifiers_kept]
 
     for item in notifiers_to_delete:
         database.execute(
             delete(TableSettingsNotifier)
-            .where(TableSettingsNotifier.name == item)
-        )
+            .where(TableSettingsNotifier.name == item))
 
     database.execute(
         insert(TableSettingsNotifier)
         .values(notifiers_added)
-        .on_conflict_do_nothing()
-    )
+        .on_conflict_do_nothing())
 
 
 def get_notifier_providers():
     return database.execute(
         select(TableSettingsNotifier.name, TableSettingsNotifier.url)
-        .where(TableSettingsNotifier.enabled == 1)
-    ).all()
+        .where(TableSettingsNotifier.enabled == 1))\
+        .all()
 
 
 def send_notifications(sonarr_series_id, sonarr_episode_id, message):
@@ -69,14 +64,11 @@ def send_notifications(sonarr_series_id, sonarr_episode_id, message):
     if not len(providers):
         return
 
-    series = (
-        database.execute(
-            select(TableShows)
-            .where(TableShows.sonarrSeriesId == sonarr_series_id)
-        )
-        .scalars()
+    series = database.execute(
+        select(TableShows)
+        .where(TableShows.sonarrSeriesId == sonarr_series_id))\
+        .scalars()\
         .first()
-    )
     if not series:
         return
 
@@ -88,14 +80,11 @@ def send_notifications(sonarr_series_id, sonarr_episode_id, message):
     else:
         series_year = ''
 
-    episode = (
-        database.execute(
-            select(TableEpisodes)
-            .where(TableEpisodes.sonarrEpisodeId == sonarr_episode_id)
-        )
-        .scalars()
+    episode = database.execute(
+        select(TableEpisodes)
+        .where(TableEpisodes.sonarrEpisodeId == sonarr_episode_id))\
+        .scalars()\
         .first()
-    )
     if not episode:
         return
 
@@ -122,14 +111,11 @@ def send_notifications_movie(radarr_id, message):
     if not len(providers):
         return
 
-    movie = (
-        database.execute(
-            select(TableMovies)
-            .where(TableMovies.radarrId == radarr_id)
-        )
-        .scalars()
+    movie = database.execute(
+        select(TableMovies)
+        .where(TableMovies.radarrId == radarr_id))\
+        .scalars()\
         .first()
-    )
     if not movie:
         return
 

--- a/bazarr/app/notifier.py
+++ b/bazarr/app/notifier.py
@@ -63,7 +63,6 @@ def send_notifications(sonarr_series_id, sonarr_episode_id, message):
         return
     series_title = series.title
     series_year = series.year
-
     if series_year not in [None, '', '0']:
         series_year = f' ({series_year})'
     else:

--- a/bazarr/app/notifier.py
+++ b/bazarr/app/notifier.py
@@ -5,16 +5,7 @@ import logging
 import re
 from urllib.parse import quote
 
-from .database import (
-    TableSettingsNotifier,
-    TableEpisodes,
-    TableShows,
-    TableMovies,
-    database,
-    insert,
-    delete,
-    select,
-)
+from .database import TableSettingsNotifier, TableEpisodes, TableShows, TableMovies, database, insert, delete, select
 
 
 def update_notifier():
@@ -63,7 +54,6 @@ def send_notifications(sonarr_series_id, sonarr_episode_id, message):
     providers = get_notifier_providers()
     if not len(providers):
         return
-
     series = database.execute(
         select(TableShows)
         .where(TableShows.sonarrSeriesId == sonarr_series_id))\
@@ -71,7 +61,6 @@ def send_notifications(sonarr_series_id, sonarr_episode_id, message):
         .first()
     if not series:
         return
-
     series_title = series.title
     series_year = series.year
 
@@ -79,7 +68,6 @@ def send_notifications(sonarr_series_id, sonarr_episode_id, message):
         series_year = f' ({series_year})'
     else:
         series_year = ''
-
     episode = database.execute(
         select(TableEpisodes)
         .where(TableEpisodes.sonarrEpisodeId == sonarr_episode_id))\
@@ -102,7 +90,7 @@ def send_notifications(sonarr_series_id, sonarr_episode_id, message):
 
     apobj.notify(
         title='Bazarr notification',
-        body=f'{series_title}{series_year} - S{episode.season:02d}E{episode.episode:02d} - {episode.title} : {message}',
+        body=f"{series_title}{series_year} - S{episode.season:02d}E{episode.episode:02d} - {episode.title} : {message}",
     )
 
 
@@ -110,7 +98,6 @@ def send_notifications_movie(radarr_id, message):
     providers = get_notifier_providers()
     if not len(providers):
         return
-
     movie = database.execute(
         select(TableMovies)
         .where(TableMovies.radarrId == radarr_id))\
@@ -118,10 +105,8 @@ def send_notifications_movie(radarr_id, message):
         .first()
     if not movie:
         return
-
     movie_title = movie.title
     movie_year = movie.year
-
     if movie_year not in [None, '', '0']:
         movie_year = f' ({movie_year})'
     else:
@@ -139,7 +124,7 @@ def send_notifications_movie(radarr_id, message):
 
     apobj.notify(
         title='Bazarr notification',
-        body=f'{movie_title}{movie_year} : {message}',
+        body=f"{movie_title}{movie_year} : {message}",
     )
 
 

--- a/bazarr/app/notifier.py
+++ b/bazarr/app/notifier.py
@@ -3,7 +3,16 @@
 from apprise import Apprise, AppriseAsset
 import logging
 
-from .database import TableSettingsNotifier, TableEpisodes, TableShows, TableMovies, database, insert, delete, select
+from .database import (
+    TableSettingsNotifier,
+    TableEpisodes,
+    TableShows,
+    TableMovies,
+    database,
+    insert,
+    delete,
+    select,
+)
 
 
 def update_notifier():
@@ -16,10 +25,11 @@ def update_notifier():
     notifiers_added = []
     notifiers_kept = []
 
-    notifiers_in_db = [row.name for row in
-                       database.execute(
-                           select(TableSettingsNotifier.name))
-                       .all()]
+    notifiers_in_db = [
+        row.name for row in database.execute(
+            select(TableSettingsNotifier.name)
+        ).all()
+    ]
 
     for x in results['schemas']:
         if x['service_name'] not in notifiers_in_db:
@@ -28,24 +38,30 @@ def update_notifier():
         else:
             notifiers_kept.append(x['service_name'])
 
-    notifiers_to_delete = [item for item in notifiers_in_db if item not in notifiers_kept]
+    notifiers_to_delete = [
+        item for item in notifiers_in_db if item not in notifiers_kept
+    ]
 
     for item in notifiers_to_delete:
         database.execute(
             delete(TableSettingsNotifier)
-            .where(TableSettingsNotifier.name == item))
+            .where(TableSettingsNotifier.name == item)
+        )
 
     database.execute(
         insert(TableSettingsNotifier)
         .values(notifiers_added)
-        .on_conflict_do_nothing())
+        .on_conflict_do_nothing()
+    )
 
 
 def get_notifier_providers():
     return database.execute(
         select(TableSettingsNotifier.name, TableSettingsNotifier.url)
-        .where(TableSettingsNotifier.enabled == 1))\
-        .all()
+        .where(
+            TableSettingsNotifier.enabled == 1
+        )
+    ).all()
 
 
 def send_notifications(sonarr_series_id, sonarr_episode_id, message):
@@ -54,8 +70,10 @@ def send_notifications(sonarr_series_id, sonarr_episode_id, message):
         return
     series = database.execute(
         select(TableShows.title, TableShows.year)
-        .where(TableShows.sonarrSeriesId == sonarr_series_id))\
-        .first()
+        .where(
+            TableShows.sonarrSeriesId == sonarr_series_id
+        )
+    ).first()
     if not series:
         return
     series_title = series.title
@@ -66,8 +84,10 @@ def send_notifications(sonarr_series_id, sonarr_episode_id, message):
         series_year = ''
     episode = database.execute(
         select(TableEpisodes.title, TableEpisodes.season, TableEpisodes.episode)
-        .where(TableEpisodes.sonarrEpisodeId == sonarr_episode_id))\
-        .first()
+        .where(
+            TableEpisodes.sonarrEpisodeId == sonarr_episode_id
+        )
+    ).first()
     if not episode:
         return
 
@@ -81,7 +101,7 @@ def send_notifications(sonarr_series_id, sonarr_episode_id, message):
 
     apobj.notify(
         title='Bazarr notification',
-        body=f"{series_title}{series_year} - S{episode.season:02d}E{episode.episode:02d} - {episode.title} : {message}",
+        body=f'{series_title}{series_year} - S{episode.season:02d}E{episode.episode:02d} - {episode.title} : {message}',
     )
 
 
@@ -91,8 +111,10 @@ def send_notifications_movie(radarr_id, message):
         return
     movie = database.execute(
         select(TableMovies.title, TableMovies.year)
-        .where(TableMovies.radarrId == radarr_id))\
-        .first()
+        .where(
+            TableMovies.radarrId == radarr_id
+        )
+    ).first()
     if not movie:
         return
     movie_title = movie.title
@@ -112,5 +134,5 @@ def send_notifications_movie(radarr_id, message):
 
     apobj.notify(
         title='Bazarr notification',
-        body=f"{movie_title}{movie_year} : {message}",
+        body=f'{movie_title}{movie_year} : {message}',
     )

--- a/frontend/src/pages/Settings/Notifications/components.tsx
+++ b/frontend/src/pages/Settings/Notifications/components.tsx
@@ -1,11 +1,13 @@
 import { FunctionComponent, useCallback, useMemo } from "react";
 import {
+  Anchor,
   Button,
   Divider,
   Group,
   SimpleGrid,
   Stack,
   Textarea,
+  Text,
 } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { useMutation } from "@tanstack/react-query";
@@ -63,6 +65,10 @@ const NotificationForm: FunctionComponent<Props> = ({
     },
   });
 
+  const isCustomNotificationProvider =
+    form.values.selection &&
+    ["JSON", "XML", "Form"].includes(form.values.selection.name);
+
   const test = useMutation({
     mutationFn: (url: string) => api.system.testNotification(url),
   });
@@ -94,6 +100,21 @@ const NotificationForm: FunctionComponent<Props> = ({
             {...form.getInputProps("url")}
           ></Textarea>
         </div>
+        {isCustomNotificationProvider && (
+          <div>
+            <Text size="sm" c="dimmed">
+              Customize the notification payload with{" "}
+              <Anchor
+                href="https://wiki.bazarr.media/Additional-Configuration/Custom-Notifications/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                media variables
+              </Anchor>
+              .
+            </Text>
+          </div>
+        )}
         <Divider></Divider>
         <Group justify="right">
           <MutateButton mutation={test} args={() => form.values.url}>

--- a/frontend/src/pages/Settings/Notifications/components.tsx
+++ b/frontend/src/pages/Settings/Notifications/components.tsx
@@ -6,8 +6,8 @@ import {
   Group,
   SimpleGrid,
   Stack,
-  Textarea,
   Text,
+  Textarea,
 } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { useMutation } from "@tanstack/react-query";

--- a/tests/bazarr/test_app_notifier.py
+++ b/tests/bazarr/test_app_notifier.py
@@ -46,14 +46,15 @@ def test_expand_notifier_url_replaces_multiple_placeholders():
     assert 'path=%2Fmedia%2FMovies%2FMy%20Movie%20%282024%29.mkv' in result
 
 
-def test_expand_notifier_url_leaves_unknown_or_non_bazarr_placeholders():
+def test_expand_notifier_url_blanks_unknown_bazarr_placeholders_and_keeps_non_bazarr():
     url = 'json://localhost/?:known={bazarr_movie_title}&:unknown={bazarr_missing}&:other={title}'
     media_variables = {'bazarr_movie_title': 'Known'}
 
     result = notifier._expand_notifier_url(url, media_variables)
 
     assert 'known=Known' in result
-    assert '{bazarr_missing}' in result
+    assert 'unknown=' in result
+    assert '{bazarr_missing}' not in result
     assert '{title}' in result
 
 
@@ -64,3 +65,13 @@ def test_expand_notifier_url_none_values_become_empty_string():
     result = notifier._expand_notifier_url(url, media_variables)
 
     assert result.endswith('?:path=')
+
+
+def test_expand_notifier_url_concatenation_blanks_missing_bazarr_key():
+    url = 'json://localhost/?:path={bazarr_movie_path}{bazarr_episode_path}'
+    media_variables = {'bazarr_movie_path': '/media/Movies/My Movie (2024).mkv'}
+
+    result = notifier._expand_notifier_url(url, media_variables)
+
+    assert 'path=%2Fmedia%2FMovies%2FMy%20Movie%20%282024%29.mkv' in result
+    assert '{bazarr_episode_path}' not in result

--- a/tests/bazarr/test_app_notifier.py
+++ b/tests/bazarr/test_app_notifier.py
@@ -1,0 +1,66 @@
+from bazarr.app import notifier
+
+
+class DummyRecord:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def to_dict(self):
+        return self._payload
+
+
+def test_build_media_variables_empty_on_missing_inputs():
+    assert notifier._build_media_variables(None, 'movie') == {}
+    assert notifier._build_media_variables(DummyRecord({'title': 'Foo'}), '') == {}
+
+
+def test_build_media_variables_prefixes_keys():
+    record = DummyRecord({'title': 'Foo', 'radarrId': 42})
+
+    result = notifier._build_media_variables(record, 'movie')
+
+    assert result == {
+        'bazarr_movie_title': 'Foo',
+        'bazarr_movie_radarrId': 42,
+    }
+
+
+def test_expand_notifier_url_replaces_multiple_placeholders():
+    url = (
+        'json://localhost/?:title={bazarr_movie_title}'
+        '&:id={bazarr_movie_radarrId}&:path={bazarr_movie_path}'
+    )
+    media_variables = {
+        'bazarr_movie_title': 'My Movie',
+        'bazarr_movie_radarrId': 42,
+        'bazarr_movie_path': '/media/Movies/My Movie (2024).mkv',
+    }
+
+    result = notifier._expand_notifier_url(url, media_variables)
+
+    assert '{bazarr_movie_title}' not in result
+    assert '{bazarr_movie_radarrId}' not in result
+    assert '{bazarr_movie_path}' not in result
+    assert 'title=My%20Movie' in result
+    assert 'id=42' in result
+    assert 'path=%2Fmedia%2FMovies%2FMy%20Movie%20%282024%29.mkv' in result
+
+
+def test_expand_notifier_url_leaves_unknown_or_non_bazarr_placeholders():
+    url = 'json://localhost/?:known={bazarr_movie_title}&:unknown={bazarr_missing}&:other={title}'
+    media_variables = {'bazarr_movie_title': 'Known'}
+
+    result = notifier._expand_notifier_url(url, media_variables)
+
+    assert 'known=Known' in result
+    assert '{bazarr_missing}' in result
+    assert '{title}' in result
+
+
+def test_expand_notifier_url_none_values_become_empty_string():
+    url = 'json://localhost/?:path={bazarr_movie_path}'
+    media_variables = {'bazarr_movie_path': None}
+
+    result = notifier._expand_notifier_url(url, media_variables)
+
+    assert result.endswith('?:path=')


### PR DESCRIPTION
Disclaimer: This PR was created with the help of GPT-5.3 Codex.

# What it does
This PR adds the ability to use variables within notification URLs that take advantage of Apprise's ability to customise notification payloads such as described in [https://appriseit.com/services/json/#payload-manipulation](https://appriseit.com/services/json/#payload-manipulation).

Specifically, those variables are in the format `{bazarr_movie_*}`, `{bazarr_series_*}`, and `{bazarr_episode_*}` where the wildcard is the database field name for the relevant table. ie. `{bazarr_movie_path}` will expand to the movie's `path` as stored in the Bazarr `TableMovies` table.

With this PR, the following JSON notification is possible:

```
// json://localhost:8000?:static=foo&:path={bazarr_movie_path}{bazarr_episode_path}

{
  version: "1.0",
  title: "Bazarr notification",
  message: "Back to the Future (1985) : English subtitles downloaded from opensubtitlescom with a score of 90.56%.",
  attachments: [],
  type: "info",
  static: "foo",
  path: "/movies/Back to the Future (1985)/Back to the Future (1985) - Bluray-1080p [EAC3 5.1] [EN].mkv"
}
```

Note that the new fields `static` and `path` are added to the notification's JSON payload, and that the `{bazarr_movie_path}` placeholder/variable is expanded to the actual value. The `{bazarr_episode_path}` variable doesn't expand to a value, and so returns an empty string (enabling this to work for both movies and tv shows simultaneously).

# Motivation
In my case, I want to be able to use a custom JSON notification to send events from Bazarr to an event bus I have running to coordinate various actions between apps. I do know that there's a dedicated webhook feature, but I was ideally wanting to be able to craft the payload myself.

Also, looking at the feature requests board, this new feature would enable self-service of the following by being able to edit the notification payload:
[https://bazarr.featureupvote.com/suggestions/308381/add-webhooks-support-in-notifications](https://bazarr.featureupvote.com/suggestions/308381/add-webhooks-support-in-notifications)

[https://bazarr.featureupvote.com/suggestions/301964/notification-add-filename-or-release-group](https://bazarr.featureupvote.com/suggestions/301964/notification-add-filename-or-release-group)

[https://bazarr.featureupvote.com/suggestions/182870/add-the-movie-year-to-the-notification-text](https://bazarr.featureupvote.com/suggestions/182870/add-the-movie-year-to-the-notification-text) (can be marked as closed already)

# Testing
* Unit tests have been added in `test_app_notifier.py` for the variable expansion logic.
* I end-to-end tested the feature by connecting a Radarr instance and triggering a notification (the output of which is included above).