### PR TITLE
fix: sections would not hide themselves

### DIFF
--- a/frontend/src/pages/Settings/components/Section.tsx
+++ b/frontend/src/pages/Settings/components/Section.tsx
@@ -14,7 +14,7 @@ export const Section: FunctionComponent<Props> = ({
   children,
 }) => {
   return (
-    <Stack hidden={hidden} gap="xs" my="lg">
+    <Stack style={hidden ? { display: "none" } : undefined} gap="xs" my="lg">
       <Title order={4}>{header}</Title>
       <Divider></Divider>
       {children}


### PR DESCRIPTION
Fixes an issue which causes the `Updates` section settings to be displayed even though the `--no-update` flag is being passed to the Bazarr.

Explanation: the `hidden` attribute gets ignored if, for whatever reason, the `display` css attribute is set to something else than `none`.