### PR TITLE
fix: update section should be hidden when auto updates are disabled

### DIFF
--- a/frontend/src/pages/Settings/components/Section.tsx
+++ b/frontend/src/pages/Settings/components/Section.tsx
@@ -14,7 +14,7 @@ export const Section: FunctionComponent<Props> = ({
   children,
 }) => {
   return (
-    <Stack hidden={hidden} gap="xs" my="lg">
+    <Stack style={hidden ? { display: "none" } : undefined} gap="xs" my="lg">
       <Title order={4}>{header}</Title>
       <Divider></Divider>
       {children}

--- a/frontend/src/pages/Settings/components/Section.tsx
+++ b/frontend/src/pages/Settings/components/Section.tsx
@@ -14,7 +14,7 @@ export const Section: FunctionComponent<Props> = ({
   children,
 }) => {
   return (
-    <Stack style={hidden ? { display: "none" } : undefined} gap="xs" my="lg">
+    <Stack display={hidden ? "none" : undefined} gap="xs" my="lg">
       <Title order={4}>{header}</Title>
       <Divider></Divider>
       {children}


### PR DESCRIPTION
Fixes an issue which causes the `Updates` section settings to be displayed even though the `--no-update` flag is being passed to the Bazarr.

**Explanation**: the `hidden` attribute gets ignored if, for whatever reason, the `display` css attribute is set to something else than `none` (cf https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/hidden#the_hidden_state). Unfortunately it would seem that due to some css wizardry (not an expert on this topic, I must confess), the display attribute **is** set, causing the `hidden` attribute to be ignored.

Fixes #3296

Note: in theory this could have impacted other references in the codebase and it turns out it was the only usage of the `hidden` property