### PR TITLE
Improve Sonarr and Radarr sync performance

### DIFF
--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -202,7 +202,7 @@ def get_providers():
                 providers_list.remove(provider)
             else:
                 logging.info("Using %s again after %s, (disabled because: %s)", provider, throttle_desc, reason)
-                del tp[provider]
+                tp.pop(provider, None)
                 set_throttled_providers(str(tp))
         # if forced only is enabled: # fixme: Prepared for forced only implementation to remove providers with don't support forced only subtitles
         #     for provider in providers_list:
@@ -471,7 +471,7 @@ def update_throttled_provider():
 
     for provider in list(tp):
         if provider not in providers_list:
-            del tp[provider]
+            tp.pop(provider, None)
             set_throttled_providers(str(tp))
 
         reason, until, throttle_desc = tp.get(provider, (None, None, None))
@@ -482,7 +482,7 @@ def update_throttled_provider():
                 pass
             else:
                 logging.info("Using %s again after %s, (disabled because: %s)", provider, throttle_desc, reason)
-                del tp[provider]
+                tp.pop(provider, None)
                 set_throttled_providers(str(tp))
 
             reason, until, throttle_desc = tp.get(provider, (None, None, None))
@@ -491,7 +491,7 @@ def update_throttled_provider():
                 now = datetime.datetime.now()
                 if now >= until:
                     logging.info("Using %s again after %s, (disabled because: %s)", provider, throttle_desc, reason)
-                    del tp[provider]
+                    tp.pop(provider, None)
                     set_throttled_providers(str(tp))
 
     event_stream(type='badges')
@@ -513,7 +513,7 @@ def reset_throttled_providers(only_auth_or_conf_error=False):
         if only_auth_or_conf_error and tp[provider][0] not in ['AuthenticationError', 'ConfigurationError',
                                                                'PaymentRequired']:
             continue
-        del tp[provider]
+        tp.pop(provider, None)
     set_throttled_providers(str(tp))
     update_throttled_provider()
     if only_auth_or_conf_error:

--- a/bazarr/radarr/sync/movies.py
+++ b/bazarr/radarr/sync/movies.py
@@ -144,14 +144,14 @@ def update_movies(job_id=None, wait_for_completion=False):
             movies_count = len(movies)
             jobs_queue.update_job_progress(job_id=job_id, progress_max=movies_count)
             # Get current movies in DB
-            current_movies_id_db = [x.radarrId for x in
-                                    database.execute(
-                                        select(TableMovies.radarrId))
-                                    .all()]
-            current_movies_db_kv = [x.items() for x in [y._asdict()['TableMovies'].__dict__ for y in
-                                                        database.execute(
-                                                            select(TableMovies))
-                                                        .all()]]
+            current_movies_in_db = {
+                row[0].radarrId: {
+                    column.name: getattr(row[0], column.name)
+                    for column in row[0].__table__.columns
+                }
+                for row in database.execute(select(TableMovies)).all()
+            }
+            current_movies_id_db = set(current_movies_in_db)
 
             current_movies_radarr = [movie['id'] for movie in movies if movie['hasFile'] and
                                      'movieFile' in movie and
@@ -205,7 +205,7 @@ def update_movies(job_id=None, wait_for_completion=False):
                                                            language_profiles=language_profiles,
                                                            movie_default_profile=movie_default_profile,
                                                            audio_profiles=audio_profiles)
-                                if not any([parsed_movie.items() <= x for x in current_movies_db_kv]):
+                                if not parsed_movie.items() <= current_movies_in_db[movie['id']].items():
                                     update_movie(parsed_movie)
                                     movies_updated.append(parsed_movie['title'])
                             else:

--- a/bazarr/sonarr/sync/episodes.py
+++ b/bazarr/sonarr/sync/episodes.py
@@ -72,6 +72,7 @@ def sync_episodes(series_id, defer_search=False, is_signalr=False):
     current_episodes_sonarr = []
     episodes_to_update = []
     episodes_to_add = []
+    parse_embedded_audio_track = settings.general.parse_embedded_audio_track
 
     # Get episodes data for a series from Sonarr
     episodes = get_episodes_from_sonarr_api(apikey_sonarr=apikey_sonarr, series_id=series_id)
@@ -127,11 +128,14 @@ def sync_episodes(series_id, defer_search=False, is_signalr=False):
 
                     # Parse episode data
                     if episode['id'] in current_episodes_in_db_row_as_dict:
-                        parsed_episode = episodeParser(episode)
+                        parsed_episode = episodeParser(
+                            episode, parse_embedded_audio_track=parse_embedded_audio_track)
                         if not set(parsed_episode.items()).issubset(set(current_episodes_in_db_row_as_dict[episode['id']].items())):
                             episodes_to_update.append(parsed_episode)
                     else:
-                        episodes_to_add.append(episodeParser(episode))
+                        episodes_to_add.append(
+                            episodeParser(
+                                episode, parse_embedded_audio_track=parse_embedded_audio_track))
     else:
         return
 

--- a/bazarr/sonarr/sync/episodes.py
+++ b/bazarr/sonarr/sync/episodes.py
@@ -60,17 +60,12 @@ def sync_episodes(series_id, defer_search=False, is_signalr=False):
 
     # Get current episodes id in DB
     if series_id:
-        current_episodes_id_db_list = [row.sonarrEpisodeId for row in
-                                       database.execute(
-                                           select(TableEpisodes.sonarrEpisodeId,
-                                                  TableEpisodes.path,
-                                                  TableEpisodes.sonarrSeriesId)
-                                           .where(TableEpisodes.sonarrSeriesId == series_id)).all()]
         current_episodes_in_db_row_as_dict = {row[0].sonarrEpisodeId: row[0].to_dict() for row in
                                               database.execute(
                                                   select(TableEpisodes)
                                                   .where(TableEpisodes.sonarrSeriesId == series_id))
                                               .all()}
+        current_episodes_id_db_list = list(current_episodes_in_db_row_as_dict)
     else:
         return
 

--- a/bazarr/sonarr/sync/parser.py
+++ b/bazarr/sonarr/sync/parser.py
@@ -107,7 +107,10 @@ def profile_id_to_language(id_, profiles):
     return profiles_to_return
 
 
-def episodeParser(episode):
+def episodeParser(episode, parse_embedded_audio_track=None):
+    if parse_embedded_audio_track is None:
+        parse_embedded_audio_track = settings.general.parse_embedded_audio_track
+
     if 'hasFile' in episode:
         if episode['hasFile'] is True:
             if 'episodeFile' in episode:
@@ -124,7 +127,7 @@ def episodeParser(episode):
                     else:
                         sceneName = None
 
-                    if settings.general.parse_embedded_audio_track:
+                    if parse_embedded_audio_track:
                         audio_language = embedded_audio_reader(path_mappings.path_replace(episode['episodeFile']
                                                                                           ['path']),
                                                                file_size=episode['episodeFile']['size'],

--- a/bazarr/sonarr/sync/parser.py
+++ b/bazarr/sonarr/sync/parser.py
@@ -111,10 +111,12 @@ def episodeParser(episode):
     if 'hasFile' in episode:
         if episode['hasFile'] is True:
             if 'episodeFile' in episode:
-                try:
-                    bazarr_file_size = os.path.getsize(path_mappings.path_replace(episode['episodeFile']['path']))
-                except OSError:
-                    bazarr_file_size = 0
+                bazarr_file_size = episode['episodeFile']['size']
+                if bazarr_file_size <= MINIMUM_VIDEO_SIZE:
+                    try:
+                        bazarr_file_size = os.path.getsize(path_mappings.path_replace(episode['episodeFile']['path']))
+                    except OSError:
+                        bazarr_file_size = 0
                 if (episode['episodeFile']['size'] > MINIMUM_VIDEO_SIZE or bazarr_file_size > MINIMUM_VIDEO_SIZE or
                         (settings.general.enable_strm_support and episode['episodeFile']['path'].lower().endswith('.strm'))):
                     if 'sceneName' in episode['episodeFile']:

--- a/bazarr/sonarr/sync/series.py
+++ b/bazarr/sonarr/sync/series.py
@@ -74,6 +74,10 @@ def update_series(job_id=None, wait_for_completion=False):
             # Get current series monitored status in DB
             series_monitored = get_series_monitored_table()
 
+        audio_profiles = get_profile_list()
+        tagsDict = get_tags()
+        language_profiles = get_language_profiles()
+
         trace(f"Starting sync for {series_count} shows")
 
         jobs_queue.update_job_progress(job_id=job_id, progress_max=series_count)
@@ -105,7 +109,9 @@ def update_series(job_id=None, wait_for_completion=False):
             current_shows_sonarr.append(show['id'])
 
             # Update series in DB
-            update_one_series(show['id'], action='updated', sync_episodes_after_update=False)
+            update_one_series(show['id'], action='updated', sync_episodes_after_update=False,
+                              series_data=[show], audio_profiles=audio_profiles, tagsDict=tagsDict,
+                              language_profiles=language_profiles)
 
             # Update episodes in DB
             sync_episodes(series_id=show['id'])
@@ -127,7 +133,8 @@ def update_series(job_id=None, wait_for_completion=False):
     gc.collect()
 
 
-def update_one_series(series_id, action, is_signalr=False, sync_episodes_after_update=True):
+def update_one_series(series_id, action, is_signalr=False, sync_episodes_after_update=True, series_data=None,
+                      audio_profiles=None, tagsDict=None, language_profiles=None):
     logging.debug(f'BAZARR syncing this specific series from Sonarr: {series_id}')
 
     # Check if there's a row in database for this series ID
@@ -152,59 +159,63 @@ def update_one_series(series_id, action, is_signalr=False, sync_episodes_after_u
     else:
         serie_default_profile = None
 
-    audio_profiles = get_profile_list()
-    tagsDict = get_tags()
-    language_profiles = get_language_profiles()
+    if audio_profiles is None:
+        audio_profiles = get_profile_list()
+    if tagsDict is None:
+        tagsDict = get_tags()
+    if language_profiles is None:
+        language_profiles = get_language_profiles()
 
-    try:
-        # Get series data from sonarr api
-        series_data = get_series_from_sonarr_api(apikey_sonarr=settings.sonarr.apikey, sonarr_series_id=int(series_id))
-    except Exception:
-        logging.exception(f'BAZARR cannot get series with ID {series_id} from Sonarr API.')
-        return
-    else:
-        if not series_data:
+    if series_data is None:
+        try:
+            # Get series data from sonarr api
+            series_data = get_series_from_sonarr_api(apikey_sonarr=settings.sonarr.apikey, sonarr_series_id=int(series_id))
+        except Exception:
+            logging.exception(f'BAZARR cannot get series with ID {series_id} from Sonarr API.')
             return
-        else:
-            if action == 'updated' and existing_series:
-                # Update existing series in DB
-                series = seriesParser(series_data[0], action='update', tags_dict=tagsDict,
-                                      language_profiles=language_profiles,
-                                      serie_default_profile=serie_default_profile,
-                                      audio_profiles=audio_profiles)
-                try:
-                    series['updated_at_timestamp'] = datetime.now()
-                    database.execute(
-                        update(TableShows)
-                        .values(series)
-                        .where(TableShows.sonarrSeriesId == series['sonarrSeriesId']))
-                except IntegrityError as e:
-                    logging.error(f"BAZARR cannot update series {series['path']} because of {e}")
-                else:
-                    if sync_episodes_after_update and not is_signalr:
-                        # Sonarr emit two SignalR events when episodes must be refreshed.
-                        # The one that gets there doesn't include the episodeChanged flag.
-                        # The episodes are synced only when this function is called from the
-                        # frontend sync button in the episodes' page.
-                        sync_episodes(series_id=int(series_id))
-                    event_stream(type='series', action='update', payload=int(series_id))
-                    logging.debug(
-                        f'BAZARR updated this series into the database:{path_mappings.path_replace(series["path"])}')
-            elif action == 'updated' and not existing_series:
-                # Insert new series in DB
-                series = seriesParser(series_data[0], action='insert', tags_dict=tagsDict,
-                                      language_profiles=language_profiles,
-                                      serie_default_profile=serie_default_profile,
-                                      audio_profiles=audio_profiles)
 
-                try:
-                    series['created_at_timestamp'] = datetime.now()
-                    database.execute(
-                        insert(TableShows)
-                        .values(series))
-                except IntegrityError as e:
-                    logging.error(f"BAZARR cannot insert series {series['path']} because of {e}")
-                else:
-                    event_stream(type='series', action='update', payload=int(series_id))
-                    logging.debug(
-                        f'BAZARR inserted this series into the database:{path_mappings.path_replace(series["path"])}')
+    if not series_data:
+        return
+
+    if action == 'updated' and existing_series:
+        # Update existing series in DB
+        series = seriesParser(series_data[0], action='update', tags_dict=tagsDict,
+                              language_profiles=language_profiles,
+                              serie_default_profile=serie_default_profile,
+                              audio_profiles=audio_profiles)
+        try:
+            series['updated_at_timestamp'] = datetime.now()
+            database.execute(
+                update(TableShows)
+                .values(series)
+                .where(TableShows.sonarrSeriesId == series['sonarrSeriesId']))
+        except IntegrityError as e:
+            logging.error(f"BAZARR cannot update series {series['path']} because of {e}")
+        else:
+            if sync_episodes_after_update and not is_signalr:
+                # Sonarr emit two SignalR events when episodes must be refreshed.
+                # The one that gets there doesn't include the episodeChanged flag.
+                # The episodes are synced only when this function is called from the
+                # frontend sync button in the episodes' page.
+                sync_episodes(series_id=int(series_id))
+            event_stream(type='series', action='update', payload=int(series_id))
+            logging.debug(
+                f'BAZARR updated this series into the database:{path_mappings.path_replace(series["path"])}')
+    elif action == 'updated' and not existing_series:
+        # Insert new series in DB
+        series = seriesParser(series_data[0], action='insert', tags_dict=tagsDict,
+                              language_profiles=language_profiles,
+                              serie_default_profile=serie_default_profile,
+                              audio_profiles=audio_profiles)
+
+        try:
+            series['created_at_timestamp'] = datetime.now()
+            database.execute(
+                insert(TableShows)
+                .values(series))
+        except IntegrityError as e:
+            logging.error(f"BAZARR cannot insert series {series['path']} because of {e}")
+        else:
+            event_stream(type='series', action='update', payload=int(series_id))
+            logging.debug(
+                f'BAZARR inserted this series into the database:{path_mappings.path_replace(series["path"])}')

--- a/bazarr/sonarr/sync/series.py
+++ b/bazarr/sonarr/sync/series.py
@@ -105,7 +105,7 @@ def update_series(job_id=None, wait_for_completion=False):
             current_shows_sonarr.append(show['id'])
 
             # Update series in DB
-            update_one_series(show['id'], action='updated')
+            update_one_series(show['id'], action='updated', sync_episodes_after_update=False)
 
             # Update episodes in DB
             sync_episodes(series_id=show['id'])
@@ -127,7 +127,7 @@ def update_series(job_id=None, wait_for_completion=False):
     gc.collect()
 
 
-def update_one_series(series_id, action, is_signalr=False):
+def update_one_series(series_id, action, is_signalr=False, sync_episodes_after_update=True):
     logging.debug(f'BAZARR syncing this specific series from Sonarr: {series_id}')
 
     # Check if there's a row in database for this series ID
@@ -181,7 +181,7 @@ def update_one_series(series_id, action, is_signalr=False):
                 except IntegrityError as e:
                     logging.error(f"BAZARR cannot update series {series['path']} because of {e}")
                 else:
-                    if not is_signalr:
+                    if sync_episodes_after_update and not is_signalr:
                         # Sonarr emit two SignalR events when episodes must be refreshed.
                         # The one that gets there doesn't include the episodeChanged flag.
                         # The episodes are synced only when this function is called from the

--- a/bazarr/sonarr/sync/series.py
+++ b/bazarr/sonarr/sync/series.py
@@ -183,6 +183,16 @@ def update_one_series(series_id, action, is_signalr=False, sync_episodes_after_u
                               language_profiles=language_profiles,
                               serie_default_profile=serie_default_profile,
                               audio_profiles=audio_profiles)
+        existing_series_model = existing_series[0]
+        existing_series_values = {
+            column.name: getattr(existing_series_model, column.name)
+            for column in existing_series_model.__table__.columns
+        }
+        if series.items() <= existing_series_values.items():
+            if sync_episodes_after_update and not is_signalr:
+                sync_episodes(series_id=int(series_id))
+            return
+
         try:
             series['updated_at_timestamp'] = datetime.now()
             database.execute(

--- a/tests/bazarr/test_sync_performance_paths.py
+++ b/tests/bazarr/test_sync_performance_paths.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import datetime
+
 from types import SimpleNamespace
 
 import pytest
@@ -263,3 +265,29 @@ def test_update_movies_compares_against_matching_radarr_id(monkeypatch):
     movies_sync.update_movies(job_id="job")
 
     assert updated_movies == [{"radarrId": 2, "title": "New Movie 2", "path": "/movies/two.mkv"}]
+
+
+def test_get_providers_expired_throttle_cleanup_is_idempotent(monkeypatch):
+    from app import get_providers as providers
+
+    provider = "opensubtitlescom"
+    providers.tp.clear()
+    providers.tp[provider] = ("TooManyRequests", datetime.datetime.now(), "1 minute")
+
+    removed_once = {"done": False}
+
+    class _RacingThrottle(dict):
+        def __delitem__(self, key):
+            if not removed_once["done"]:
+                removed_once["done"] = True
+                super().__delitem__(key)
+                raise KeyError(key)
+            super().__delitem__(key)
+
+    racing_tp = _RacingThrottle(providers.tp)
+    monkeypatch.setattr(providers, "tp", racing_tp)
+    monkeypatch.setattr(providers.provider_registry, "names", lambda: [provider])
+    monkeypatch.setattr(providers, "settings", SimpleNamespace(general=SimpleNamespace(enabled_providers=[provider])))
+    monkeypatch.setattr(providers, "set_throttled_providers", lambda data: None)
+
+    assert providers.get_providers() == [provider]

--- a/tests/bazarr/test_sync_performance_paths.py
+++ b/tests/bazarr/test_sync_performance_paths.py
@@ -1,0 +1,265 @@
+# -*- coding: utf-8 -*-
+from types import SimpleNamespace
+
+import pytest
+
+
+class _Result:
+    def __init__(self, first_value=None, all_value=None):
+        self._first_value = first_value
+        self._all_value = [] if all_value is None else all_value
+
+    def first(self):
+        return self._first_value
+
+    def all(self):
+        return self._all_value
+
+
+class _Column:
+    def __init__(self, name):
+        self.name = name
+
+
+def _model(**values):
+    return SimpleNamespace(
+        __table__=SimpleNamespace(columns=[_Column(name) for name in values]),
+        **values,
+    )
+
+
+def test_update_one_series_fetches_and_inserts_for_standalone_call(monkeypatch):
+    from sonarr.sync import series as series_sync
+
+    execute_calls = []
+
+    class _Database:
+        def execute(self, statement):
+            execute_calls.append(statement)
+            if len(execute_calls) == 1:
+                return _Result(first_value=None)
+            return _Result()
+
+    events = []
+    monkeypatch.setattr(series_sync, "database", _Database())
+    monkeypatch.setattr(
+        series_sync,
+        "settings",
+        SimpleNamespace(
+            general=SimpleNamespace(serie_default_enabled=False),
+            sonarr=SimpleNamespace(apikey="sonarr-key"),
+        ),
+    )
+    monkeypatch.setattr(series_sync, "get_profile_list", lambda: [])
+    monkeypatch.setattr(series_sync, "get_tags", lambda: {})
+    monkeypatch.setattr(series_sync, "get_language_profiles", lambda: [])
+    monkeypatch.setattr(series_sync, "get_series_from_sonarr_api", lambda **kwargs: [{"id": 123}])
+    monkeypatch.setattr(
+        series_sync,
+        "seriesParser",
+        lambda *args, **kwargs: {"sonarrSeriesId": 123, "path": "/series/path"},
+    )
+    monkeypatch.setattr(series_sync, "event_stream", lambda **kwargs: events.append(kwargs))
+    monkeypatch.setattr(series_sync.path_mappings, "path_replace", lambda path: path)
+
+    series_sync.update_one_series(123, action="updated")
+
+    assert len(execute_calls) == 2
+    assert events == [{"type": "series", "action": "update", "payload": 123}]
+
+
+def test_update_series_runs_one_explicit_episode_sync(monkeypatch):
+    from sonarr.sync import series as series_sync
+
+    update_calls = []
+    episode_sync_calls = []
+
+    class _Database:
+        def execute(self, statement):
+            return _Result(all_value=[])
+
+    monkeypatch.setattr(series_sync, "database", _Database())
+    monkeypatch.setattr(
+        series_sync,
+        "settings",
+        SimpleNamespace(
+            general=SimpleNamespace(debug=False),
+            sonarr=SimpleNamespace(apikey="sonarr-key", sync_only_monitored_series=False),
+        ),
+    )
+    monkeypatch.setattr(series_sync, "check_sonarr_rootfolder", lambda: None)
+    monkeypatch.setattr(series_sync, "get_series_from_sonarr_api", lambda **kwargs: [{"id": 123, "title": "Series"}])
+    monkeypatch.setattr(series_sync, "get_profile_list", lambda: [])
+    monkeypatch.setattr(series_sync, "get_tags", lambda: {})
+    monkeypatch.setattr(series_sync, "get_language_profiles", lambda: [])
+    monkeypatch.setattr(
+        series_sync,
+        "update_one_series",
+        lambda *args, **kwargs: update_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(series_sync, "sync_episodes", lambda series_id: episode_sync_calls.append(series_id))
+    monkeypatch.setattr(
+        series_sync,
+        "jobs_queue",
+        SimpleNamespace(
+            add_job_from_function=lambda *args, **kwargs: None,
+            update_job_progress=lambda *args, **kwargs: None,
+            update_job_name=lambda *args, **kwargs: None,
+        ),
+    )
+
+    series_sync.update_series(job_id="job")
+
+    assert episode_sync_calls == [123]
+    assert len(update_calls) == 1
+    assert update_calls[0][1]["sync_episodes_after_update"] is False
+
+
+def test_unchanged_series_skips_update_but_manual_call_syncs_episodes(monkeypatch):
+    from sonarr.sync import series as series_sync
+
+    existing_series = _model(sonarrSeriesId=123, path="/series/path")
+    execute_calls = []
+    episode_sync_calls = []
+
+    class _Database:
+        def execute(self, statement):
+            execute_calls.append(statement)
+            return _Result(first_value=(existing_series,))
+
+    monkeypatch.setattr(series_sync, "database", _Database())
+    monkeypatch.setattr(
+        series_sync,
+        "settings",
+        SimpleNamespace(
+            general=SimpleNamespace(serie_default_enabled=False),
+            sonarr=SimpleNamespace(apikey="sonarr-key"),
+        ),
+    )
+    monkeypatch.setattr(series_sync, "get_profile_list", lambda: [])
+    monkeypatch.setattr(series_sync, "get_tags", lambda: {})
+    monkeypatch.setattr(series_sync, "get_language_profiles", lambda: [])
+    monkeypatch.setattr(
+        series_sync,
+        "seriesParser",
+        lambda *args, **kwargs: {"sonarrSeriesId": 123, "path": "/series/path"},
+    )
+    monkeypatch.setattr(series_sync, "sync_episodes", lambda series_id: episode_sync_calls.append(series_id))
+
+    series_sync.update_one_series(
+        123,
+        action="updated",
+        series_data=[{"id": 123}],
+        sync_episodes_after_update=True,
+    )
+
+    assert len(execute_calls) == 1
+    assert episode_sync_calls == [123]
+
+
+def test_episode_parser_uses_reported_size_before_filesystem_stat(monkeypatch):
+    from constants import MINIMUM_VIDEO_SIZE
+    from sonarr.sync import parser
+
+    monkeypatch.setattr(
+        parser.os.path,
+        "getsize",
+        lambda path: pytest.fail("episodeParser should not stat files when Sonarr size is already valid"),
+    )
+    monkeypatch.setattr(parser, "audio_language_from_name", lambda name: name)
+
+    parsed = parser.episodeParser(
+        {
+            "hasFile": True,
+            "seriesId": 123,
+            "id": 456,
+            "title": "Episode",
+            "seasonNumber": 1,
+            "episodeNumber": 2,
+            "monitored": True,
+            "episodeFile": {
+                "id": 789,
+                "path": "/series/path/episode.mkv",
+                "size": MINIMUM_VIDEO_SIZE + 1,
+                "language": {"name": "English"},
+                "mediaInfo": {},
+                "quality": {"quality": {"name": "HDTV-1080p"}},
+            },
+        },
+        parse_embedded_audio_track=False,
+    )
+
+    assert parsed["sonarrEpisodeId"] == 456
+    assert parsed["file_size"] == MINIMUM_VIDEO_SIZE + 1
+
+
+def test_update_movies_compares_against_matching_radarr_id(monkeypatch):
+    from constants import MINIMUM_VIDEO_SIZE
+    from radarr.sync import movies as movies_sync
+
+    movie_rows = [
+        (_model(radarrId=1, title="Movie 1", path="/movies/one.mkv"),),
+        (_model(radarrId=2, title="Old Movie 2", path="/movies/two.mkv"),),
+    ]
+    updated_movies = []
+
+    class _Database:
+        def execute(self, statement):
+            return _Result(all_value=movie_rows)
+
+    def _movie_parser(movie, **kwargs):
+        return {
+            "radarrId": movie["id"],
+            "title": movie["title"],
+            "path": movie["movieFile"]["path"],
+        }
+
+    monkeypatch.setattr(movies_sync, "database", _Database())
+    monkeypatch.setattr(
+        movies_sync,
+        "settings",
+        SimpleNamespace(
+            general=SimpleNamespace(movie_default_enabled=False, debug=False),
+            radarr=SimpleNamespace(apikey="radarr-key", sync_only_monitored_movies=False),
+        ),
+    )
+    monkeypatch.setattr(movies_sync, "check_radarr_rootfolder", lambda: None)
+    monkeypatch.setattr(movies_sync, "get_profile_list", lambda: [])
+    monkeypatch.setattr(movies_sync, "get_tags", lambda: {})
+    monkeypatch.setattr(movies_sync, "get_language_profiles", lambda: [])
+    monkeypatch.setattr(movies_sync, "movieParser", _movie_parser)
+    monkeypatch.setattr(movies_sync, "update_movie", lambda movie: updated_movies.append(movie))
+    monkeypatch.setattr(movies_sync, "event_stream", lambda **kwargs: None)
+    monkeypatch.setattr(
+        movies_sync,
+        "jobs_queue",
+        SimpleNamespace(
+            add_job_from_function=lambda *args, **kwargs: None,
+            update_job_progress=lambda *args, **kwargs: None,
+            update_job_name=lambda *args, **kwargs: None,
+        ),
+    )
+    monkeypatch.setattr(
+        movies_sync,
+        "get_movies_from_radarr_api",
+        lambda apikey_radarr: [
+            {
+                "id": 1,
+                "title": "Movie 1",
+                "hasFile": True,
+                "monitored": True,
+                "movieFile": {"path": "/movies/one.mkv", "size": MINIMUM_VIDEO_SIZE + 1},
+            },
+            {
+                "id": 2,
+                "title": "New Movie 2",
+                "hasFile": True,
+                "monitored": True,
+                "movieFile": {"path": "/movies/two.mkv", "size": MINIMUM_VIDEO_SIZE + 1},
+            },
+        ],
+    )
+
+    movies_sync.update_movies(job_id="job")
+
+    assert updated_movies == [{"radarrId": 2, "title": "New Movie 2", "path": "/movies/two.mkv"}]


### PR DESCRIPTION
## Summary

This PR improves Sonarr and Radarr sync performance by removing repeated work from large sync loops.

No database index changes are included.

Main changes:

- Avoid duplicate Sonarr episode syncs during full-series sync
- Reuse Sonarr profile/tag/language context across full Sonarr sync
- Skip unchanged Sonarr series row updates
- Collapse duplicate per-series episode DB queries
- Avoid filesystem size checks when Sonarr already reports a valid episode size
- Cache episode parser settings during Sonarr episode sync
- Compare Radarr movies by `radarrId` instead of scanning every DB movie row

## Performance Notes

Benchmarks were run with `pyperf` against current `upstream/development`, using copied Bazarr databases derived from a DB with `4,274` movies, `2,452` shows, `76,112` episodes.

The sync benchmarks keep Bazarr's database/SQLAlchemy read path in use, while mocking external or side-effect work such as Sonarr/Radarr API input, job progress updates, event emission, filesystem fallback checks, and database writes.

### Sonarr

- `sync.sonarr.update_one_series.cached_context`: `112 ms` -> `42.7 ms`, `2.63x` faster
- `sync.sonarr.update_one_series.skip_unchanged`: `110 ms` -> `43.2 ms`, `2.55x` faster
- `sync.sonarr.update_series.single_episode_sync`: `37.5 ms` -> `35.6 ms`, `1.05x` faster
- `sync.sonarr.episode_parser.cached_settings`: `9.97 ms` -> `9.50 ms`, `1.05x` faster
- `sync.sonarr.episode_parser.filesize_fastpath`: `10.3 ms` -> `9.51 ms`, `1.08x` faster
- Geometric mean for the measured Sonarr set: `1.41x` faster

### Radarr

- `radarr.update_movies.db_controlled`, `--movie-count 2000`: `564 ms +- 33 ms` -> `65.9 ms +- 6.3 ms`, `8.56x` faster

## Test Plan

- [x] Added regression coverage for standalone Sonarr series refreshes
- [x] Added regression coverage that full-series Sonarr sync only performs one explicit episode sync per processed series
- [x] Added regression coverage that unchanged Sonarr series rows skip `UPDATE` while manual callers still sync episodes
- [x] Added regression coverage that `episodeParser()` avoids filesystem stat calls when Sonarr's reported size is already valid
- [x] Added regression coverage that Radarr movie comparison checks the matching `radarrId` row rather than scanning every movie row

Validation:

```bash
nix shell --impure --expr 'with import <nixpkgs> {}; python312.withPackages (ps: with ps; [ pytest setuptools pillow ])' -c bash -lc 'python -m pytest tests/bazarr/test_sync_performance_paths.py'
```

