### PR TITLE
Added Whisper fallback implementation

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -145,6 +145,8 @@ validators = [
     Validator('general.chmod', must_exist=True, default='0640', is_type_of=str),
     Validator('general.subfolder', must_exist=True, default='current', is_type_of=str),
     Validator('general.subfolder_custom', must_exist=True, default='', is_type_of=str),
+    Validator('general.use_whisper_fallback', must_exist=True, default=False, is_type_of=bool),
+    Validator('general.use_whisper_fallback_series', must_exist=True, default=False, is_type_of=bool),
     Validator('general.upgrade_subs', must_exist=True, default=True, is_type_of=bool),
     Validator('general.upgrade_frequency', must_exist=True, default=12, is_type_of=int,
               is_in=[6, 12, 24, 168, ONE_HUNDRED_YEARS_IN_HOURS]),

--- a/bazarr/subtitles/download.py
+++ b/bazarr/subtitles/download.py
@@ -25,7 +25,7 @@ from .processing import process_subtitle
 @update_pools
 def generate_subtitles(path, languages, audio_language, sceneName, title, media_type, profile_id,
                        forced_minimum_score=None, is_upgrade=False, check_if_still_required=False,
-                       previous_subtitles_to_delete=None, job_id=None):
+                       previous_subtitles_to_delete=None, job_id=None, fallback_allowed=False):
     if not languages:
         return None
 
@@ -78,7 +78,8 @@ def generate_subtitles(path, languages, audio_language, sceneName, title, media_
                                                                        pool_instance=pool,
                                                                        min_score=int(min_score),
                                                                        hearing_impaired=hi_required,
-                                                                       use_original_format=original_format in (1, "1", "True", True))
+                                                                       use_original_format=original_format in (1, "1", "True", True),
+                                                                       fallback_allowed=fallback_allowed)
                     except Exception as e:
                         logging.exception(f'BAZARR Error downloading Subtitles for this file {path}: {repr(e)}')
                         return None

--- a/bazarr/subtitles/mass_download/series.py
+++ b/bazarr/subtitles/mass_download/series.py
@@ -17,6 +17,7 @@ from app.database import (get_exclusion_clause, get_audio_profile_languages, Tab
                           select, get_profile_id)
 from app.jobs_queue import jobs_queue
 from app.event_handler import event_stream
+from app.config import settings
 
 from ..download import generate_subtitles
 
@@ -64,10 +65,10 @@ def series_download_subtitles(no, job_id=None, job_sub_function=False):
                                                             f'{episode.episode:02d} - {episode.episodeTitle}')
 
             providers_list = get_providers()
-
+            fallback_allowed = settings.general.use_whisper_fallback and settings.general.use_whisper_fallback_series
             if providers_list:
                 episode_download_subtitles(no=episode.sonarrEpisodeId, job_id=job_id, job_sub_function=True,
-                                           providers_list=providers_list)
+                                           providers_list=providers_list, fallback_allowed=fallback_allowed)
             else:
                 jobs_queue.update_job_progress(job_id=job_id, progress_value=count_episodes_details)
                 logging.info("BAZARR All providers are throttled")
@@ -80,7 +81,7 @@ def series_download_subtitles(no, job_id=None, job_sub_function=False):
     jobs_queue.update_job_name(job_id=job_id, new_job_name=f"Downloaded missing subtitles for {series_row.title}")
 
 
-def episode_download_subtitles(no, job_id=None, job_sub_function=False, providers_list=None):
+def episode_download_subtitles(no, job_id=None, job_sub_function=False, providers_list=None, fallback_allowed=False):
     if not job_sub_function and not job_id:
         jobs_queue.add_job_from_function(f"""Downloading missing subtitles for {database.scalar(
             select(TableShows.title).where(TableShows.sonarrSeriesId == no)) or 'Unknown Series'}""", is_progress=True)
@@ -161,7 +162,8 @@ def episode_download_subtitles(no, job_id=None, job_sub_function=False, provider
                                              'series',
                                              episode.profileId,
                                              check_if_still_required=True,
-                                             job_id=job_id):
+                                             job_id=job_id,
+                                             fallback_allowed=fallback_allowed):
                 if result:
                     if isinstance(result, tuple) and len(result):
                         result = result[0]

--- a/bazarr/subtitles/wanted/movies.py
+++ b/bazarr/subtitles/wanted/movies.py
@@ -15,6 +15,7 @@ from app.get_providers import get_providers
 from app.database import get_exclusion_clause, get_audio_profile_languages, TableMovies, database, update, select
 from app.event_handler import event_stream
 from app.jobs_queue import jobs_queue
+from app.config import settings
 
 from ..adaptive_searching import is_search_active, updateFailedAttempts
 from ..download import generate_subtitles
@@ -50,7 +51,8 @@ def _wanted_movie(movie, providers_list, job_id=None):
                                      'movie',
                                      movie.profileId,
                                      check_if_still_required=True,
-                                     job_id=job_id):
+                                     job_id=job_id,
+                                     fallback_allowed=settings.general.use_whisper_fallback):
 
         if result:
             found_any = True

--- a/bazarr/subtitles/wanted/series.py
+++ b/bazarr/subtitles/wanted/series.py
@@ -18,6 +18,7 @@ from app.database import get_exclusion_clause, get_audio_profile_languages, Tabl
     update, select
 from app.event_handler import event_stream
 from app.jobs_queue import jobs_queue
+from app.config import settings
 
 from ..adaptive_searching import is_search_active, updateFailedAttempts
 from ..download import generate_subtitles
@@ -53,7 +54,8 @@ def _wanted_episode(episode, providers_list, job_id=None):
                                      'series',
                                      episode.profileId,
                                      check_if_still_required=True,
-                                     job_id=job_id):
+                                     job_id=job_id,
+                                     fallback_allowed=settings.general.use_whisper_fallback):
         if result:
             found_any = True
             if isinstance(result, tuple) and len(result):

--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -524,7 +524,7 @@ class SZProviderPool(ProviderPool):
         return True
 
     def download_best_subtitles(self, subtitles, video, languages, min_score=0, hearing_impaired=False, only_one=False,
-                                use_original_format=False):
+                                use_original_format=False, fallback_allowed=False):
         """Download the best matching subtitles.
 
         patch:
@@ -634,6 +634,24 @@ class SZProviderPool(ProviderPool):
             if only_one:
                 logger.debug('Only one subtitle downloaded')
                 break
+
+        # --- WHISPER FALLBACK PRECONDITIONS ---
+        # 1. No regular provider results with at least minimum score
+        # 2. We are in a Bulk Task or Single Series search
+        # 3. User enabled the Whisper fallback setting
+        # 4. Whisper is actually in the active providers list
+        if (not downloaded_subtitles and 
+            fallback_allowed and 
+            'whisperai' in self.providers):
+            
+            for subtitle, score, score_without_hash, matches, orig_matches in scored_subtitles:
+                if subtitle.provider_name == 'whisperai':
+                    logger.info('BAZARR Bulk Task: Falling back to Whisper for %r', video.name)
+                    subtitle.use_original_format = use_original_format
+                    if self.download_subtitle(subtitle):
+                        subtitle.score = score
+                        downloaded_subtitles.append(subtitle)
+                        break
 
         return downloaded_subtitles
 

--- a/custom_libs/subliminal_patch/core_persistent.py
+++ b/custom_libs/subliminal_patch/core_persistent.py
@@ -50,6 +50,7 @@ def download_best_subtitles(
     hearing_impaired=False,
     only_one=False,
     use_original_format=False,
+    fallback_allowed=False,
     **kwargs
 ):
     downloaded_subtitles = defaultdict(list)
@@ -77,6 +78,7 @@ def download_best_subtitles(
             hearing_impaired=hearing_impaired,
             only_one=only_one,
             use_original_format=use_original_format,
+            fallback_allowed=fallback_allowed,
         )
         logger.info("Downloaded %d subtitle(s)", len(subtitles))
         downloaded_subtitles[video].extend(subtitles)

--- a/frontend/src/pages/Settings/Subtitles/index.tsx
+++ b/frontend/src/pages/Settings/Subtitles/index.tsx
@@ -228,6 +228,39 @@ const SettingsSubtitlesView: FunctionComponent = () => {
           </Message>
         </CollapseBox>
       </Section>
+      <Section header="Whisper As Fallback">
+        <Check
+          label="Use Whisper as Fallback for Automated Searches"
+          settingKey="settings-general-use_whisper_fallback"
+        ></Check>
+        <CollapseBox settingKey={"settings-general-use_whisper_fallback"}>
+          <Message>
+            When enabled, Bazarr will ignore the Radarr/Sonarr minimum score and
+            fall back to a Whisper generated subtitle when no provider reaches
+            that minimum score. To avoid overloading Whisper, this fallback is
+            used only during automated tasks like Search for Missing Movie
+            Subtitles and Search for Missing Series Subtitles, or by invoking
+            Search from the Wanted menu. You are responsible for ensuring that
+            only one Whisper transcription or translation runs at a time, unless
+            your hardware can handle more.
+          </Message>
+        </CollapseBox>
+        <CollapseBox settingKey={"settings-general-use_whisper_fallback"}>
+          <Check
+            label="Use Whisper as Fallback for Single Series Searches"
+            settingKey="settings-general-use_whisper_fallback_series"
+          ></Check>
+          <CollapseBox
+            settingKey={"settings-general-use_whisper_fallback_series"}
+          >
+            <Message>
+              When enabled, Bazarr will also use Whisper fallback for single
+              series subtitle searches. All of the warnings about overloading
+              Whisper from the previous setting also apply to this one.
+            </Message>
+          </CollapseBox>
+        </CollapseBox>
+      </Section>
       <Section header="Upgrading Subtitles">
         <Check
           label="Upgrade Previously Downloaded Subtitles"


### PR DESCRIPTION
The whisper fallback occurs when no provider matches the minimum score, but a whisper subtitle is available. 
Added two switches, one for all bulk automated / wanted tasks and the other sub-switch for single series.