### PR TITLE
Fixed test_check_login_form_auth_failure abort mock assertion

### DIFF
--- a/tests/bazarr/test_ui.py
+++ b/tests/bazarr/test_ui.py
@@ -177,7 +177,7 @@ def test_check_login_form_auth_failure():
             result = decorated_function()
 
             # Should call abort
-            mock_abort.assert_called_once_with(401, message="Unauthorized")
+            mock_abort.assert_called_once_with(401)
 
 
 def test_check_login_preserves_function_arguments():


### PR DESCRIPTION
`test_check_login_form_auth_failure` asserted `abort` was called with `abort(401, message="Unauthorized")`, but the actual `check_login` decorator in `bazarr/app/ui.py` calls `abort(401)` (Flask's `flask.abort` doesn't accept a `message` keyword). The assertion is corrected to match the real call.