### PR TITLE
Improved password verification to use constant-time comparison

### DIFF
--- a/bazarr/utilities/helper.py
+++ b/bazarr/utilities/helper.py
@@ -3,6 +3,7 @@
 import os
 import logging
 import hashlib
+import hmac
 
 from charset_normalizer import detect
 from bs4 import UnicodeDammit
@@ -16,7 +17,8 @@ def check_credentials(user, pw, request, log_success=True):
     ip_addr = forwarded_for_ip_addr or real_ip_addr or request.remote_addr
     username = settings.auth.username
     password = settings.auth.password
-    if hashlib.md5(f"{pw}".encode('utf-8')).hexdigest() == password and user == username:
+    submitted_hash = hashlib.md5(f"{pw}".encode('utf-8')).hexdigest()
+    if hmac.compare_digest(submitted_hash, str(password or '')) and user == username:
         if log_success:
             logging.info(f'Successful authentication from {ip_addr} for user {user}')
         return True


### PR DESCRIPTION
`check_credentials()` in `bazarr/utilities/helper.py` compares the MD5 hash of the supplied password with the stored hash using Python's `==` operator, which short-circuits on the first differing byte and is therefore vulnerable to timing attacks against the stored hash.

This change uses `hmac.compare_digest()`, which compares in constant time. No change to the stored password format or migration is required: this is a drop-in hardening of the comparison itself.

A more thorough overhaul of the password storage (e.g. moving from MD5 to PBKDF2/Argon2 with per-user salt) is a separate effort and out of scope for this PR.