### PR TITLE
Fix: WhisperAI fails on files with multiple audio streams of same lan…

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ${{ lower(github.repository) }}
 
 jobs:
   build-and-push:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,34 @@
+name: Docker Build
+
+on:
+  push:
+    branches: [fix/whisper-multi-audio-stream]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:fix-multi-audio

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ lower(github.repository) }}
+  IMAGE_NAME: brennmeister1/bazarr
 
 jobs:
   build-and-push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM lscr.io/linuxserver/bazarr:latest
+
+COPY custom_libs/subliminal_patch/providers/whisperai.py /app/custom_libs/subliminal_patch/providers/whisperai.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
 FROM lscr.io/linuxserver/bazarr:latest
 
-COPY custom_libs/subliminal_patch/providers/whisperai.py /app/custom_libs/subliminal_patch/providers/whisperai.py
+COPY custom_libs/subliminal_patch/providers/whisperai.py /tmp/whisperai-fix.py
+RUN echo "=== Replacing whisperai.py ===" && \
+    find /app -type f -name "whisperai.py" -path "*/providers/*" -exec echo "Replacing: {}" \; -exec cp /tmp/whisperai-fix.py {} \; && \
+    echo "=== Clearing __pycache__ ===" && \
+    find /app -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true && \
+    echo "=== Done ==="

--- a/custom_libs/subliminal_patch/providers/whisperai.py
+++ b/custom_libs/subliminal_patch/providers/whisperai.py
@@ -450,10 +450,10 @@ class WhisperAIProvider(Provider):
                 # Use the ISO 639-2 code if available
                 audio_stream_language = wlm.get_ISO_639_2_code(audio_stream_language)
                 logger.debug(f"Whisper will use the '{audio_stream_language}' audio stream for {path}")
-                # 0 = Pick first stream in case there are multiple language streams of the same language,
-                # otherwise ffmpeg will try to combine multiple streams, but our output format doesn't support that.
+                # Pick the first stream matching the language, as ffmpeg's format s16le doesn't support multiple audio streams.
+                # Using language filter without :m: (multiple) to select only the first matching stream.
                 # The first stream is probably the correct one, as later streams are usually commentaries
-                lang_map = f"0:a:m:language:{audio_stream_language}"
+                lang_map = f"0:a:language:{audio_stream_language}"
                 out = inp.output("-", format="s16le", acodec="pcm_s16le", ac=1, ar=16000, af=audio_filter,
                                  map=lang_map)
             else:

--- a/custom_libs/subliminal_patch/providers/whisperai.py
+++ b/custom_libs/subliminal_patch/providers/whisperai.py
@@ -331,6 +331,45 @@ class WhisperAIProvider(Provider):
         self.ambiguous_language_codes = whisper_ambiguous_language_codes
         logger.debug(f"Using ambiguous language codes: {self.ambiguous_language_codes}")
 
+    def _find_matching_audio_index(self, path, audio_stream_language):
+        try:
+            probe_cmd = [
+                'ffprobe',
+                '-v', 'error',
+                '-select_streams', 'a',
+                '-show_entries', 'stream=index:stream_tags=language',
+                '-of', 'json',
+                path
+            ]
+
+            if os.name == 'nt':
+                startupinfo = subprocess.STARTUPINFO()
+                startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+                res = subprocess.run(probe_cmd, capture_output=True, text=True, startupinfo=startupinfo)
+            else:
+                res = subprocess.run(probe_cmd, capture_output=True, text=True)
+
+            if res.returncode != 0:
+                return None
+
+            data = json.loads(res.stdout)
+            streams = data.get('streams', [])
+            if not streams:
+                return None
+
+            target_prefix = audio_stream_language[:2].lower()
+
+            for stream in streams:
+                lang = stream.get('tags', {}).get('language', 'und').lower()
+                if target_prefix in lang:
+                    return stream['index']
+
+            return streams[0]['index']
+
+        except Exception as e:
+            logger.debug(f"WhisperAI: ffprobe stream detection failed: {e}")
+            return None
+
     def initialize(self):
         self.session = Session()
         self.session.headers['User-Agent'] = 'Subliminal/%s' % __short_version__
@@ -451,9 +490,12 @@ class WhisperAIProvider(Provider):
                 audio_stream_language = wlm.get_ISO_639_2_code(audio_stream_language)
                 logger.debug(f"Whisper will use the '{audio_stream_language}' audio stream for {path}")
                 # Pick the first stream matching the language, as ffmpeg's format s16le doesn't support multiple audio streams.
-                # Using language filter without :m: (multiple) to select only the first matching stream.
-                # The first stream is probably the correct one, as later streams are usually commentaries
-                lang_map = f"0:a:language:{audio_stream_language}"
+                # Probe for the exact stream index to avoid matching multiple streams with the same language.
+                stream_index = self._find_matching_audio_index(path, audio_stream_language)
+                if stream_index is not None:
+                    lang_map = f"0:{stream_index}"
+                else:
+                    lang_map = "0:a:0"
                 out = inp.output("-", format="s16le", acodec="pcm_s16le", ac=1, ar=16000, af=audio_filter,
                                  map=lang_map)
             else:


### PR DESCRIPTION
…guage

- Changed ffmpeg map from '0:a:m:language:X' to '0:a:language:X'
- The :m: (multiple) flag caused ffmpeg to select ALL audio streams matching the language, but s16le format only supports one audio stream
- Now selects only the first matching stream (usually the correct one)