### PR TITLE
Fixed: fese failing to detect ISO 639-2/T language codes like 'fra'

### DIFF
--- a/libs/fese/tags.py
+++ b/libs/fese/tags.py
@@ -136,7 +136,10 @@ def _get_language(tags) -> Language:
 
         try:
             if len(og_lang) == 3:
-                lang = Language.fromalpha3b(og_lang)
+                try:
+                    lang = Language.fromalpha3b(og_lang)
+                except LanguageError:
+                    lang = Language.fromalpha3t(og_lang)
             else:
                 lang = Language.fromalpha2(og_lang[:2])
 
@@ -144,7 +147,7 @@ def _get_language(tags) -> Language:
             assert lang.alpha2
 
             return lang
-        except LanguageError as error:
+        except (LanguageError, AssertionError) as error:
             last_exc = error
             logger.debug("Error with '%s' language: %s", og_lang, error)
 


### PR DESCRIPTION
## What does this PR fix?

Fixes #3184

`fese`'s `_get_language()` only tried `Language.fromalpha3b()` for 3-character language codes. ISO 639-2 has two sets of codes for some languages:

| Language | ISO 639-2/B (bibliographic) | ISO 639-2/T (terminological) |
|---|---|---|
| French | `fre` | `fra` |
| German | `ger` | `deu` |
| Chinese | `chi` | `zho` |
| Czech | `cze` | `ces` |

ffprobe can return either variant. When it returns a `/T` code like `fra`, the existing code threw a `LanguageError` and silently dropped the subtitle stream, leaving `audio_language` empty and keeping items stuck in the "unknown audio" set.

## The fix

Fall back to `Language.fromalpha3t()` when `fromalpha3b()` fails, so both variants are accepted.

```python
# Before — only handles ISO 639-2/B codes
lang = Language.fromalpha3b(og_lang)

# After — handles both /B and /T codes
try:
    lang = Language.fromalpha3b(og_lang)
except LanguageError:
    lang = Language.fromalpha3t(og_lang)
```

## Verified

Tested locally against both code sets — `fra`, `deu`, `zho`, `ces` (ISO 639-2/T) and `fre`, `ger`, `chi`, `cze` (ISO 639-2/B) all resolve correctly after the fix.