### PR TITLE
feat(settings): add provider-specific minimum score exceptions

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -55,6 +55,50 @@ def validate_tags(tags):
     return all(re.match( r'^[a-z0-9_-]+$', item) for item in tags)
 
 
+def validate_provider_score_exceptions(exceptions):
+    if not exceptions:
+        return True
+
+    for exception in exceptions:
+        if not isinstance(exception, str):
+            return False
+
+        provider, separator, score = exception.partition(':')
+        if separator != ':':
+            return False
+
+        if not re.match(r'^[a-z0-9_-]+$', provider):
+            return False
+
+        if not score.isdigit():
+            return False
+
+        if not 0 <= int(score) <= 100:
+            return False
+
+    return True
+
+
+def filter_provider_score_exceptions(exceptions, providers):
+    if not exceptions or not isinstance(exceptions, list):
+        return []
+
+    active_providers = set(providers)
+    filtered_exceptions = []
+    filtered_providers = set()
+
+    for exception in exceptions:
+        if not isinstance(exception, str):
+            continue
+
+        provider = exception.partition(':')[0]
+        if provider in active_providers and provider not in filtered_providers:
+            filtered_exceptions.append(exception)
+            filtered_providers.add(provider)
+
+    return filtered_exceptions
+
+
 ONE_HUNDRED_YEARS_IN_MINUTES = 52560000
 ONE_HUNDRED_YEARS_IN_HOURS = 876000
 
@@ -97,6 +141,8 @@ validators = [
     Validator('general.auto_update', must_exist=True, default=True, is_type_of=bool),
     Validator('general.single_language', must_exist=True, default=False, is_type_of=bool),
     Validator('general.minimum_score', must_exist=True, default=90, is_type_of=int, gte=0, lte=100),
+    Validator('general.minimum_score_provider_exceptions', must_exist=True, default=[], is_type_of=list,
+              condition=validate_provider_score_exceptions),
     Validator('general.use_scenename', must_exist=True, default=True, is_type_of=bool),
     Validator('general.use_postprocessing', must_exist=True, default=False, is_type_of=bool),
     Validator('general.postprocessing_cmd', must_exist=True, default='', is_type_of=str),
@@ -126,6 +172,8 @@ validators = [
     Validator('general.theme', must_exist=True, default='auto', is_type_of=str,
               is_in=['auto', 'light', 'dark']),
     Validator('general.minimum_score_movie', must_exist=True, default=70, is_type_of=int, gte=0, lte=100),
+    Validator('general.minimum_score_movie_provider_exceptions', must_exist=True, default=[], is_type_of=list,
+              condition=validate_provider_score_exceptions),
     Validator('general.use_embedded_subs', must_exist=True, default=True, is_type_of=bool),
     Validator('general.embedded_subs_show_desired', must_exist=True, default=True, is_type_of=bool),
     Validator('general.utf8_encode', must_exist=True, default=True, is_type_of=bool),
@@ -565,6 +613,8 @@ array_keys = ['excluded_tags',
               'excluded_series_types',
               'enabled_providers',
               'enabled_integrations',
+              'minimum_score_provider_exceptions',
+              'minimum_score_movie_provider_exceptions',
               'path_mappings',
               'path_mappings_movie',
               'remove_profile_tags',
@@ -688,7 +738,7 @@ def save_settings(settings_items):
                 pass
 
         # Make sure empty language list are stored correctly
-        if settings_keys[-1] in array_keys and value[0] in empty_values:
+        if settings_keys[-1] in array_keys and value and value[0] in empty_values:
             value = []
 
         # Handle path mappings settings since they are array in array
@@ -870,6 +920,20 @@ def save_settings(settings_items):
 
     if update_subzero:
         settings.general.subzero_mods = ','.join(subzero_mods)
+
+    active_providers = settings.general.enabled_providers
+    try:
+        from subliminal_patch.extensions import provider_registry
+        existing_providers = provider_registry.names()
+        active_providers = [provider for provider in active_providers if provider in existing_providers]
+    except Exception:
+        pass
+    settings.general.minimum_score_provider_exceptions = filter_provider_score_exceptions(
+        settings.general.minimum_score_provider_exceptions,
+        active_providers)
+    settings.general.minimum_score_movie_provider_exceptions = filter_provider_score_exceptions(
+        settings.general.minimum_score_movie_provider_exceptions,
+        active_providers)
 
     try:
         settings.validators.validate()

--- a/bazarr/init.py
+++ b/bazarr/init.py
@@ -10,7 +10,7 @@ import rarfile
 
 from dogpile.cache.region import register_backend as register_cache_backend
 
-from app.config import settings, configure_captcha_func, write_config
+from app.config import settings, configure_captcha_func, filter_provider_score_exceptions, write_config
 from app.get_args import args
 from app.logger import configure_logging
 from utilities.binaries import get_binary, BinaryNotFound
@@ -178,6 +178,12 @@ from subliminal_patch.extensions import provider_registry  # noqa E401
 existing_providers = provider_registry.names()
 enabled_providers = settings.general.enabled_providers
 settings.general.enabled_providers = [x for x in enabled_providers if x in existing_providers]
+settings.general.minimum_score_provider_exceptions = filter_provider_score_exceptions(
+    settings.general.minimum_score_provider_exceptions,
+    settings.general.enabled_providers)
+settings.general.minimum_score_movie_provider_exceptions = filter_provider_score_exceptions(
+    settings.general.minimum_score_movie_provider_exceptions,
+    settings.general.enabled_providers)
 write_config()
 
 

--- a/bazarr/subtitles/download.py
+++ b/bazarr/subtitles/download.py
@@ -19,7 +19,7 @@ from utilities.helper import get_target_folder, force_unicode
 from languages.get_languages import alpha3_from_alpha2
 
 from .pool import update_pools, _get_pool
-from .utils import get_video, _get_lang_obj, _get_scores, _set_forced_providers
+from .utils import get_video, _get_lang_obj, _get_provider_min_scores, _get_scores, _set_forced_providers
 from .processing import process_subtitle
 
 
@@ -58,6 +58,7 @@ def generate_subtitles(path, languages, audio_language, sceneName, title, media_
         minimum_score = settings.general.minimum_score
         minimum_score_movie = settings.general.minimum_score_movie
         min_score, max_score, scores = _get_scores(media_type, minimum_score_movie, minimum_score)
+        provider_min_scores = _get_provider_min_scores(media_type, max_score)
 
         subz_mods = get_array_from(settings.general.subzero_mods)
         saved_any = False
@@ -65,6 +66,7 @@ def generate_subtitles(path, languages, audio_language, sceneName, title, media_
         if providers:
             if forced_minimum_score:
                 min_score = int(forced_minimum_score) + 1
+                provider_min_scores = None
             for language in language_set:
                 # confirm if language is still missing or if cutoff has been reached
                 if check_if_still_required and language not in check_missing_languages(path, media_type):
@@ -78,6 +80,7 @@ def generate_subtitles(path, languages, audio_language, sceneName, title, media_
                                                                        languages={language},
                                                                        pool_instance=pool,
                                                                        min_score=int(min_score),
+                                                                       provider_min_scores=provider_min_scores,
                                                                        hearing_impaired=hi_required,
                                                                        compute_score=ComputeScore(get_scores()),
                                                                        use_original_format=original_format in (1, "1", "True", True))

--- a/bazarr/subtitles/utils.py
+++ b/bazarr/subtitles/utils.py
@@ -79,6 +79,18 @@ def _get_scores(media_type, min_movie=None, min_ep=None):
     return handler.get_scores(min_score_)
 
 
+def _get_provider_min_scores(media_type, max_score):
+    exceptions = settings.general.minimum_score_provider_exceptions if media_type == "series" else \
+        settings.general.minimum_score_movie_provider_exceptions
+    provider_min_scores = {}
+
+    for exception in exceptions:
+        provider, _, score = exception.partition(':')
+        provider_min_scores[provider] = int(int(score) * max_score / 100)
+
+    return provider_min_scores
+
+
 def get_ban_list(profile_id):
     if profile_id:
         profile = get_profiles_list(profile_id)

--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -524,7 +524,7 @@ class SZProviderPool(ProviderPool):
         return True
 
     def download_best_subtitles(self, subtitles, video, languages, min_score=0, hearing_impaired=False, only_one=False,
-                                compute_score=None, use_original_format=False):
+                                compute_score=None, use_original_format=False, provider_min_scores=None):
         """Download the best matching subtitles.
 
         patch:
@@ -583,10 +583,16 @@ class SZProviderPool(ProviderPool):
         downloaded_subtitles = []
         for subtitle, score, score_without_hash, matches, orig_matches in scored_subtitles:
             # check score
-            if score < min_score:
-                min_score_in_percent = round(min_score * 100 / max_score, 2) if min_score > 0 else 0
+            subtitle_min_score = provider_min_scores.get(subtitle.provider_name, min_score) if provider_min_scores \
+                else min_score
+
+            if score < subtitle_min_score:
+                min_score_in_percent = round(subtitle_min_score * 100 / max_score, 2) if subtitle_min_score > 0 else 0
                 logger.info('%r: Score %d is below min_score: %d out of %d (or %r%%)',
-                            subtitle, score, min_score, max_score, min_score_in_percent)
+                            subtitle, score, subtitle_min_score, max_score, min_score_in_percent)
+                if provider_min_scores:
+                    # A later subtitle can still match a provider-specific minimum score.
+                    continue
                 break
 
             # stop when all languages are downloaded
@@ -1086,7 +1092,7 @@ def download_subtitles(subtitles, pool_class=ProviderPool, **kwargs):
 
 
 def download_best_subtitles(videos, languages, min_score=0, hearing_impaired=False, only_one=False, compute_score=None,
-                            pool_class=ProviderPool, throttle_time=0, **kwargs):
+                            pool_class=ProviderPool, throttle_time=0, provider_min_scores=None, **kwargs):
     r"""List and download the best matching subtitles.
 
     The `videos` must pass the `languages` and `undefined` (`only_one`) checks of :func:`check_video`.
@@ -1130,7 +1136,8 @@ def download_best_subtitles(videos, languages, min_score=0, hearing_impaired=Fal
             subtitles = pool.download_best_subtitles(pool.list_subtitles(video, languages - video.subtitle_languages),
                                                      video, languages, min_score=min_score,
                                                      hearing_impaired=hearing_impaired, only_one=only_one,
-                                                     compute_score=compute_score)
+                                                     compute_score=compute_score,
+                                                     provider_min_scores=provider_min_scores)
             logger.info('Downloaded %d subtitle(s)', len(subtitles))
             downloaded_subtitles[video].extend(subtitles)
 

--- a/custom_libs/subliminal_patch/core_persistent.py
+++ b/custom_libs/subliminal_patch/core_persistent.py
@@ -51,6 +51,7 @@ def download_best_subtitles(
     only_one=False,
     compute_score=None,
     use_original_format=False,
+    provider_min_scores=None,
     **kwargs
 ):
     downloaded_subtitles = defaultdict(list)
@@ -79,6 +80,7 @@ def download_best_subtitles(
             only_one=only_one,
             compute_score=compute_score,
             use_original_format=use_original_format,
+            provider_min_scores=provider_min_scores,
         )
         logger.info("Downloaded %d subtitle(s)", len(subtitles))
         downloaded_subtitles[video].extend(subtitles)

--- a/frontend/src/pages/Settings/Radarr/index.tsx
+++ b/frontend/src/pages/Settings/Radarr/index.tsx
@@ -8,6 +8,7 @@ import {
   Message,
   Number,
   PathMappingTable,
+  ProviderScoreExceptions,
   Section,
   Selector,
   Slider,
@@ -59,6 +60,14 @@ const SettingsRadarrView: FunctionComponent = () => {
             label="Minimum Score For Movies"
             settingKey="settings-general-minimum_score_movie"
           ></Slider>
+          <ProviderScoreExceptions
+            label="Minimum Score Exceptions"
+            settingKey="settings-general-minimum_score_movie_provider_exceptions"
+            defaultScoreKey="settings-general-minimum_score_movie"
+          ></ProviderScoreExceptions>
+          <Message>
+            Provider exceptions are removed when a provider is disabled.
+          </Message>
           <Chips
             label="Excluded Tags"
             settingKey="settings-radarr-excluded_tags"

--- a/frontend/src/pages/Settings/Sonarr/index.tsx
+++ b/frontend/src/pages/Settings/Sonarr/index.tsx
@@ -9,6 +9,7 @@ import {
   MultiSelector,
   Number,
   PathMappingTable,
+  ProviderScoreExceptions,
   Section,
   Selector,
   Slider,
@@ -61,6 +62,14 @@ const SettingsSonarrView: FunctionComponent = () => {
             label="Minimum Score For Episodes"
             settingKey="settings-general-minimum_score"
           ></Slider>
+          <ProviderScoreExceptions
+            label="Minimum Score Exceptions"
+            settingKey="settings-general-minimum_score_provider_exceptions"
+            defaultScoreKey="settings-general-minimum_score"
+          ></ProviderScoreExceptions>
+          <Message>
+            Provider exceptions are removed when a provider is disabled.
+          </Message>
           <Chips
             label="Excluded Tags"
             settingKey="settings-sonarr-excluded_tags"

--- a/frontend/src/pages/Settings/components/ProviderScoreExceptions.tsx
+++ b/frontend/src/pages/Settings/components/ProviderScoreExceptions.tsx
@@ -1,0 +1,273 @@
+import {
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import {
+  Button,
+  Group,
+  Slider as MantineSlider,
+  Table,
+  Text,
+} from "@mantine/core";
+import { faTrash } from "@fortawesome/free-solid-svg-icons";
+import { capitalize } from "lodash";
+import { Action, Selector } from "@/components";
+import { ProviderList } from "@/pages/Settings/Providers/list";
+import { useFormActions } from "@/pages/Settings/utilities/FormValues";
+import { useSettingValue } from "@/pages/Settings/utilities/hooks";
+import { useSliderMarks } from "@/utilities";
+
+const emptyList: string[] = [];
+
+type ProviderScoreException = {
+  provider: string;
+  score: number;
+};
+
+type Props = {
+  label: string;
+  settingKey: string;
+  defaultScoreKey: string;
+};
+
+type SliderProps = {
+  marks: ReturnType<typeof useSliderMarks>;
+  provider: string;
+  score: number;
+  onChange: (provider: string, score: number) => void;
+};
+
+function decodeProviderScoreException(
+  value: string,
+): ProviderScoreException | null {
+  const parts = value.split(":");
+
+  if (parts.length !== 2) {
+    return null;
+  }
+
+  const [provider, rawScore] = parts;
+  const score = Number(rawScore);
+
+  if (!provider || !Number.isInteger(score) || score < 0 || score > 100) {
+    return null;
+  }
+
+  return {
+    provider,
+    score,
+  };
+}
+
+function encodeProviderScoreException({
+  provider,
+  score,
+}: ProviderScoreException) {
+  return `${provider}:${score}`;
+}
+
+function getProviderLabel(provider: string) {
+  const info = ProviderList.find((item) => item.key === provider);
+  return info?.name ?? capitalize(provider);
+}
+
+const ProviderScoreSlider: FunctionComponent<SliderProps> = ({
+  marks,
+  provider,
+  score,
+  onChange,
+}) => {
+  const [value, setValue] = useState(score);
+
+  useEffect(() => {
+    setValue(score);
+  }, [score]);
+
+  return (
+    <MantineSlider
+      labelAlwaysOn
+      marks={marks}
+      max={100}
+      min={0}
+      style={{ minWidth: "12rem" }}
+      value={value}
+      onChange={setValue}
+      onChangeEnd={(newValue) => onChange(provider, newValue)}
+    ></MantineSlider>
+  );
+};
+
+export const ProviderScoreExceptions: FunctionComponent<Props> = ({
+  label,
+  settingKey,
+  defaultScoreKey,
+}) => {
+  const { setValue } = useFormActions();
+  const marks = useSliderMarks([0, 100]);
+
+  const defaultScore = useSettingValue<number>(defaultScoreKey) ?? 0;
+  const enabledProviders =
+    useSettingValue<string[]>("settings-general-enabled_providers") ??
+    emptyList;
+  const value = useSettingValue<string[]>(settingKey) ?? emptyList;
+  const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
+
+  const activeProviders = useMemo(
+    () =>
+      enabledProviders.filter((provider) =>
+        ProviderList.some((item) => item.key === provider),
+      ),
+    [enabledProviders],
+  );
+
+  const exceptions = useMemo(
+    () =>
+      value
+        .map(decodeProviderScoreException)
+        .filter((item): item is ProviderScoreException => item !== null)
+        .filter((item) => activeProviders.includes(item.provider))
+        .filter(
+          (item, index, items) =>
+            items.findIndex((other) => other.provider === item.provider) ===
+            index,
+        ),
+    [activeProviders, value],
+  );
+
+  useEffect(() => {
+    const cleanValue = exceptions.map(encodeProviderScoreException);
+    const changed =
+      cleanValue.length !== value.length ||
+      cleanValue.some((item, index) => item !== value[index]);
+
+    if (changed) {
+      setValue(cleanValue, settingKey);
+    }
+  }, [exceptions, setValue, settingKey, value]);
+
+  const updateExceptions = useCallback(
+    (nextExceptions: ProviderScoreException[]) => {
+      setValue(nextExceptions.map(encodeProviderScoreException), settingKey);
+    },
+    [setValue, settingKey],
+  );
+
+  const addException = useCallback(() => {
+    if (!selectedProvider) {
+      return;
+    }
+
+    updateExceptions([
+      ...exceptions,
+      {
+        provider: selectedProvider,
+        score: defaultScore,
+      },
+    ]);
+    setSelectedProvider(null);
+  }, [defaultScore, exceptions, selectedProvider, updateExceptions]);
+
+  const updateScore = useCallback(
+    (provider: string, score: number) => {
+      updateExceptions(
+        exceptions.map((item) =>
+          item.provider === provider ? { ...item, score } : item,
+        ),
+      );
+    },
+    [exceptions, updateExceptions],
+  );
+
+  const removeException = useCallback(
+    (provider: string) => {
+      updateExceptions(exceptions.filter((item) => item.provider !== provider));
+    },
+    [exceptions, updateExceptions],
+  );
+
+  const providerOptions = useMemo(
+    () =>
+      activeProviders
+        .filter(
+          (provider) =>
+            !exceptions.some((exception) => exception.provider === provider),
+        )
+        .map((provider) => ({
+          label: getProviderLabel(provider),
+          value: provider,
+        })),
+    [activeProviders, exceptions],
+  );
+  const canAdd =
+    selectedProvider !== null &&
+    providerOptions.some((option) => option.value === selectedProvider);
+
+  return (
+    <>
+      <Group align="end" gap="xs">
+        <Selector
+          clearable
+          label={label}
+          placeholder="Select provider"
+          options={providerOptions}
+          value={selectedProvider}
+          onChange={setSelectedProvider}
+          searchable
+        ></Selector>
+        <Button disabled={!canAdd} onClick={addException}>
+          Add
+        </Button>
+      </Group>
+      <Table tableLayout="fixed">
+        <colgroup>
+          <col style={{ width: "14rem" }} />
+          <col />
+          <col style={{ width: "3rem" }} />
+        </colgroup>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>Provider</Table.Th>
+            <Table.Th>Minimum Score</Table.Th>
+            <Table.Th></Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {exceptions.length === 0 ? (
+            <Table.Tr>
+              <Table.Td colSpan={3}>
+                <Text ta="center">No provider exceptions configured</Text>
+              </Table.Td>
+            </Table.Tr>
+          ) : (
+            exceptions.map((exception) => (
+              <Table.Tr key={exception.provider}>
+                <Table.Td>
+                  <Text truncate>{getProviderLabel(exception.provider)}</Text>
+                </Table.Td>
+                <Table.Td>
+                  <ProviderScoreSlider
+                    marks={marks}
+                    provider={exception.provider}
+                    score={exception.score}
+                    onChange={updateScore}
+                  ></ProviderScoreSlider>
+                </Table.Td>
+                <Table.Td>
+                  <Action
+                    label="Remove"
+                    icon={faTrash}
+                    c="red"
+                    onClick={() => removeException(exception.provider)}
+                  ></Action>
+                </Table.Td>
+              </Table.Tr>
+            ))
+          )}
+        </Table.Tbody>
+      </Table>
+    </>
+  );
+};

--- a/frontend/src/pages/Settings/components/index.tsx
+++ b/frontend/src/pages/Settings/components/index.tsx
@@ -118,6 +118,7 @@ export * from "./Layout";
 export { default as Layout } from "./Layout";
 export { default as LayoutModal } from "./LayoutModal";
 export * from "./Message";
+export * from "./ProviderScoreExceptions";
 export * from "./Section";
 export * from "./collapse";
 export { default as CollapseBox } from "./collapse";

--- a/frontend/src/types/settings.d.ts
+++ b/frontend/src/types/settings.d.ts
@@ -50,7 +50,9 @@ declare namespace Settings {
     ip: string;
     multithreading: boolean;
     minimum_score: number;
+    minimum_score_provider_exceptions: string[];
     minimum_score_movie: number;
+    minimum_score_movie_provider_exceptions: string[];
     movie_default_enabled: boolean;
     movie_default_profile?: number;
     serie_default_enabled: boolean;


### PR DESCRIPTION
added some kind of per-provider score threshold setting. maybe not the best implementation design.
Added whisperai provider to my bazarr install, but I wanted to grab subtitles generated automatically without impacting my score threshold for other providers so I thought it was a nice feature.