### PR TITLE
Fix Mantine v9 API breakage in Collapse, Grid and modal types

### DIFF
--- a/frontend/src/App/Navbar.tsx
+++ b/frontend/src/App/Navbar.tsx
@@ -209,9 +209,9 @@ const RouteItem: FunctionComponent<{
               }
             }}
           ></NavbarItem>
-          <Collapse hidden={children.length === 0} expanded={isOpen}>
-            {elements}
-          </Collapse>
+          {children.length > 0 && (
+            <Collapse in={isOpen}>{elements}</Collapse>
+          )}
         </Stack>
       );
     } else {

--- a/frontend/src/App/NotificationDrawer.tsx
+++ b/frontend/src/App/NotificationDrawer.tsx
@@ -233,7 +233,7 @@ const NotificationDrawer: FunctionComponent<NotificationDrawerProps> = ({
                         </Text>
                       </Group>
 
-                      <Collapse expanded={!collapsedSections[status]}>
+                      <Collapse in={!collapsedSections[status]}>
                         <Stack>
                           {grouped[status as string]
                             .slice()

--- a/frontend/src/components/modals/ManualSearchModal.tsx
+++ b/frontend/src/components/modals/ManualSearchModal.tsx
@@ -76,7 +76,7 @@ function ManualSearchView<T extends SupportType>(props: Props<T>) {
               ></FontAwesomeIcon>
             )}
           </Text>
-          <Collapse expanded={open}>
+          <Collapse in={open}>
             <>{items}</>
           </Collapse>
         </Stack>
@@ -230,7 +230,7 @@ function ManualSearchView<T extends SupportType>(props: Props<T>) {
         <Divider hidden={!bSceneNameAvailable} my="xs"></Divider>
         <Code hidden={!bSceneNameAvailable}>{item?.sceneName}</Code>
       </Alert>
-      <Collapse expanded={haveResult && !results.isFetching}>
+      <Collapse in={haveResult && !results.isFetching}>
         <PageTable
           autoScroll={false}
           tableStyles={{ emptyText: "No result", placeholder: 10 }}

--- a/frontend/src/modules/modals/WithModal.tsx
+++ b/frontend/src/modules/modals/WithModal.tsx
@@ -1,6 +1,7 @@
 import { createContext, FunctionComponent } from "react";
-import { ContextModalProps } from "@mantine/modals";
-import { ModalSettings } from "@mantine/modals";
+import { ContextModalProps, openModal } from "@mantine/modals";
+
+type ModalSettings = Parameters<typeof openModal>[0];
 
 export type ModalComponent<P extends Record<string, unknown> = {}> =
   FunctionComponent<ContextModalProps<P>> & {

--- a/frontend/src/modules/modals/hooks.ts
+++ b/frontend/src/modules/modals/hooks.ts
@@ -1,7 +1,8 @@
 import { useCallback, useContext, useMemo } from "react";
-import { useModals as useMantineModals } from "@mantine/modals";
-import { ModalSettings } from "@mantine/modals";
+import { openModal, useModals as useMantineModals } from "@mantine/modals";
 import { ModalComponent, ModalIdContext } from "./WithModal";
+
+type ModalSettings = Parameters<typeof openModal>[0];
 
 export function useModals() {
   const { openContextModal: openMantineContextModal, ...rest } =

--- a/frontend/src/pages/Settings/components/collapse.tsx
+++ b/frontend/src/pages/Settings/components/collapse.tsx
@@ -31,7 +31,7 @@ const CollapseBox: FunctionComponent<Props> = ({
 
   return (
     <Collapse
-      expanded={open}
+      in={open}
       pl={indent ? "md" : undefined}
       transitionDuration={0}
     >

--- a/frontend/src/pages/views/ItemOverview.tsx
+++ b/frontend/src/pages/views/ItemOverview.tsx
@@ -141,7 +141,7 @@ const ItemOverview: FunctionComponent<Props> = (props) => {
       <Grid
         align="flex-start"
         grow
-        gap="xs"
+        gutter="xs"
         p={24}
         m={0}
         style={{


### PR DESCRIPTION
## Summary

Follow-up fixes for [#3333](https://github.com/morpheus65535/bazarr/pull/3333) (Bump mantine to v9). Several pages — `Settings`, `System`, `Wanted`, `History`, `Blacklist` — render as blank because navbar dropdowns can't expand. The browser console shows:

```
Received `false` for a non-boolean attribute `expanded`
Matched leaf route at location "/system/" does not have an element or Component.
```

The TypeScript output lists 8 errors from the same v9 API changes. Runtime tolerates the unknown props as no-ops, but `Collapse` then defaults to closed and child route links are never rendered.

## Changes

Three Mantine v9 API breaks:

1. **`Collapse` prop renamed** — v9 uses `in` (boolean) instead of `hidden`/`expanded`. Fixed in 4 call sites:
   - `App/Navbar.tsx` — the user-facing blocker: dropdowns wouldn't open. Replaced with a conditional render so the empty-children case is handled in JSX rather than a removed `hidden` prop.
   - `App/NotificationDrawer.tsx`
   - `components/modals/ManualSearchModal.tsx` (×2)
   - `pages/Settings/components/collapse.tsx`

2. **`ModalSettings` no longer re-exported** from `@mantine/modals` root in v9. Switched to a locally-derived `Parameters<typeof openModal>[0]` alias in `modules/modals/hooks.ts` and `modules/modals/WithModal.tsx` — avoids depending on the internal `lib/context` path.

3. **`Grid` prop renamed** — `gap` → `gutter`. Fixed in `pages/views/ItemOverview.tsx`.

## Test plan

- [x] `yarn tsc` / Vite reports `Found 0 errors` after the fixes (was `Found 8 errors`)
- [x] Navbar dropdowns (Settings, System, Wanted, History, Blacklist) expand on click and reveal child links
- [x] Navigating to `/settings/general`, `/system/tasks`, etc. via the now-visible links renders the actual page content
- [x] `ItemOverview` (series/movie detail header) renders without prop warnings
- [x] Notification drawer collapsible sections still toggle
- [x] Manual search modal release-info cells still expand/collapse