### PR TITLE
fix(subsync): read automatic sync settings at runtime

### DIFF
--- a/bazarr/subtitles/sync.py
+++ b/bazarr/subtitles/sync.py
@@ -19,9 +19,9 @@ def sync_subtitles(video_path,
                    sonarr_episode_id=None,
                    radarr_id=None,
                    job_id=None,
-                   max_offset_seconds=str(settings.subsync.max_offset_seconds),
-                   gss=settings.subsync.gss,
-                   no_fix_framerate=settings.subsync.no_fix_framerate,
+                   max_offset_seconds=None,
+                   gss=None,
+                   no_fix_framerate=None,
                    reference=None,
                    force_sync=False):
     if not settings.subsync.use_subsync and not force_sync:
@@ -47,6 +47,13 @@ def sync_subtitles(video_path,
             subsync_threshold = settings.subsync.subsync_movie_threshold
 
         if not use_subsync_threshold or (use_subsync_threshold and percent_score <= float(subsync_threshold)):
+            if max_offset_seconds is None:
+                max_offset_seconds = str(settings.subsync.max_offset_seconds)
+            if no_fix_framerate is None:
+                no_fix_framerate = settings.subsync.no_fix_framerate
+            if gss is None:
+                gss = settings.subsync.gss
+
             subsync = SubSyncer()
             sync_kwargs = {
                 'video_path': video_path,

--- a/tests/bazarr/test_subtitles_sync.py
+++ b/tests/bazarr/test_subtitles_sync.py
@@ -1,0 +1,73 @@
+from subtitles import sync as sync_module
+
+
+class FakeSubSyncer:
+    calls = []
+
+    def sync(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+def test_sync_subtitles_reads_default_settings_at_runtime(monkeypatch):
+    monkeypatch.setattr(sync_module, "SubSyncer", FakeSubSyncer)
+    monkeypatch.setattr(sync_module.jobs_queue, "update_job_name", lambda **kwargs: None)
+    monkeypatch.setattr(sync_module.gc, "collect", lambda: None)
+    monkeypatch.setattr(sync_module.settings.subsync, "use_subsync", True)
+    monkeypatch.setattr(sync_module.settings.subsync, "use_subsync_threshold", False)
+    monkeypatch.setattr(sync_module.settings.subsync, "max_offset_seconds", 300)
+    monkeypatch.setattr(sync_module.settings.subsync, "no_fix_framerate", False)
+    monkeypatch.setattr(sync_module.settings.subsync, "gss", False)
+    FakeSubSyncer.calls = []
+
+    result = sync_module.sync_subtitles(
+        video_path="/media/show/episode.mkv",
+        srt_path="/media/show/episode.en.srt",
+        srt_lang="en",
+        forced=False,
+        hi=False,
+        percent_score=100,
+        sonarr_series_id=1,
+        sonarr_episode_id=2,
+        job_id=3,
+    )
+
+    assert result is True
+    assert FakeSubSyncer.calls[0]["max_offset_seconds"] == "300"
+    assert FakeSubSyncer.calls[0]["no_fix_framerate"] is False
+    assert FakeSubSyncer.calls[0]["gss"] is False
+
+
+def test_sync_subtitles_preserves_explicit_sync_options(monkeypatch):
+    monkeypatch.setattr(sync_module, "SubSyncer", FakeSubSyncer)
+    monkeypatch.setattr(sync_module.jobs_queue, "update_job_name", lambda **kwargs: None)
+    monkeypatch.setattr(sync_module.gc, "collect", lambda: None)
+    monkeypatch.setattr(sync_module.settings.subsync, "use_subsync", True)
+    monkeypatch.setattr(sync_module.settings.subsync, "use_subsync_threshold", False)
+    monkeypatch.setattr(sync_module.settings.subsync, "max_offset_seconds", 600)
+    monkeypatch.setattr(sync_module.settings.subsync, "no_fix_framerate", True)
+    monkeypatch.setattr(sync_module.settings.subsync, "gss", True)
+    FakeSubSyncer.calls = []
+
+    result = sync_module.sync_subtitles(
+        video_path="/media/show/episode.mkv",
+        srt_path="/media/show/episode.en.srt",
+        srt_lang="en",
+        forced=False,
+        hi=False,
+        percent_score=100,
+        sonarr_series_id=1,
+        sonarr_episode_id=2,
+        job_id=3,
+        max_offset_seconds="120",
+        no_fix_framerate=False,
+        gss=False,
+        reference="a:0",
+        force_sync=True,
+    )
+
+    assert result is True
+    assert FakeSubSyncer.calls[0]["max_offset_seconds"] == "120"
+    assert FakeSubSyncer.calls[0]["no_fix_framerate"] is False
+    assert FakeSubSyncer.calls[0]["gss"] is False
+    assert FakeSubSyncer.calls[0]["reference"] == "a:0"
+    assert FakeSubSyncer.calls[0]["force_sync"] is True


### PR DESCRIPTION
## Summary

Automatic subtitle sync was using `max_offset_seconds`, `gss`, and `no_fix_framerate` values captured when `sync.py` was imported. If those settings were changed later, automatic sync would keep using the old values, needing a restart of Bazarr to get picked up.

This moves those defaults back into the function body so automatic sync reads the current settings when it runs. Explicit values passed by manual sync are left unchanged.

This fixes the automatic sync settings affected by this import-time default issue:

- Max Offset Seconds
- Golden-Section Search
- Do Not Fix Framerate Mismatch

This does not change every sync-related option. For example, `force_audio` ("Always use Audio Track as Reference for Syncing") is already read later in `SubSyncer.sync()`, so it is not part of this fix.

This is the same class of bug fixed by #2414 for #2413. It appears to have been reintroduced in f5d6721409bd1bf1f5661674a286ba4f21f41dfd when job manager support was added to subtitle sync.

#2449 is related because the reported behaviour there, automatic sync ignoring the configured Golden-Section Search value while manual sync works, follows from the same import-time default issue.

## Test plan

```
$ uv run --python 3.10 --with pytest --with 'setuptools<81' --with pillow --with numpy python -m pytest tests/bazarr/test_subtitles_sync.py
================================================= test session starts =================================================
platform linux -- Python 3.10.20, pytest-9.0.3, pluggy-1.6.0
Conflicting packages detected:
['pygments', 'tomli', 'zipp', 'platformdirs']
rootdir: <repo>
collected 2 items

tests/bazarr/test_subtitles_sync.py ..                                                                          [100%]

================================================== warnings summary ===================================================
tests/conftest.py:6
  <repo>/tests/conftest.py:6: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
    import pkg_resources

bazarr/app/database.py:114
  <repo>/tests/../bazarr/app/database.py:114: MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    Base = declarative_base()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================ 2 passed, 2 warnings in 1.88s ============================================

$ uv run --python 3.11 --with pytest --with 'setuptools<81' --with pillow --with numpy python -m pytest tests/bazarr/test_subtitles_sync.py
Installed 8 packages in 17ms
================================================= test session starts =================================================
platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
Conflicting packages detected:
['tomli', 'platformdirs', 'zipp', 'pygments']
rootdir: <repo>
collected 2 items

tests/bazarr/test_subtitles_sync.py ..                                                                          [100%]

================================================== warnings summary ===================================================
tests/conftest.py:6
  <repo>/tests/conftest.py:6: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
    import pkg_resources

bazarr/app/database.py:114
  <repo>/tests/../bazarr/app/database.py:114: MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    Base = declarative_base()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================ 2 passed, 2 warnings in 3.58s ============================================

$ uv run --python 3.12 --with pytest --with 'setuptools<81' --with pillow --with numpy python -m pytest tests/bazarr/test_subtitles_sync.py
Installed 8 packages in 10ms
================================================= test session starts =================================================
platform linux -- Python 3.12.9, pytest-9.0.3, pluggy-1.6.0
Conflicting packages detected:
['tomli', 'platformdirs', 'zipp', 'pygments']
rootdir: <repo>
collected 2 items

tests/bazarr/test_subtitles_sync.py ..                                                                          [100%]

================================================== warnings summary ===================================================
tests/conftest.py:6
  <repo>/tests/conftest.py:6: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
    import pkg_resources

custom_libs/subliminal/refiners/tvdb.py:66
  <repo>/tests/../custom_libs/subliminal/refiners/tvdb.py:66: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    self.token_date = datetime.utcnow() - self.token_lifespan

bazarr/app/database.py:114
  <repo>/tests/../bazarr/app/database.py:114: MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    Base = declarative_base()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================ 2 passed, 3 warnings in 3.73s ============================================

$ uv run --python 3.13 --with pytest --with 'setuptools<81' --with pillow --with numpy python -m pytest tests/bazarr/test_subtitles_sync.py
================================================= test session starts =================================================
platform linux -- Python 3.13.13, pytest-9.0.3, pluggy-1.6.0
Conflicting packages detected:
['pygments', 'zipp', 'tomli', 'platformdirs']
rootdir: <repo>
collected 2 items

tests/bazarr/test_subtitles_sync.py ..                                                                          [100%]

================================================== warnings summary ===================================================
tests/conftest.py:6
  <repo>/tests/conftest.py:6: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
    import pkg_resources

custom_libs/subliminal/refiners/tvdb.py:66
  <repo>/tests/../custom_libs/subliminal/refiners/tvdb.py:66: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    self.token_date = datetime.utcnow() - self.token_lifespan

bazarr/app/database.py:114
  <repo>/tests/../bazarr/app/database.py:114: MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    Base = declarative_base()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================ 2 passed, 3 warnings in 1.42s ============================================
```

Note: I installed `setuptools<81` in the disposable test container because the current test harness imports  `pkg_resources` from `tests/conftest.py`, and it looks like the dev container has setuptools 82.0.1 where that import doesn't seem to work.

### Manual testing
Tested inside the provided Dev docker container (which is Python 3.12)
