### PR TITLE
fix: restore base64 integrity of subtitle payload in manual download

### DIFF
--- a/bazarr/subtitles/manual.py
+++ b/bazarr/subtitles/manual.py
@@ -153,7 +153,8 @@ def manual_download_subtitle(path, audio_language, hi, forced, subtitle, provide
     else:
         os.environ["SZ_KEEP_ENCODING"] = "True"
 
-    subtitle = pickle.loads(codecs.decode(subtitle.encode(), "base64"))
+    subtitle = subtitle.replace(' ', '+')
+    subtitle = pickle.loads(codecs.decode((subtitle + '=' * ((-len(subtitle)) % 4)).encode(), "base64"))
     if hi == 'True':
         subtitle.language.hi = True
     else:


### PR DESCRIPTION
## Problem

Some iOS/mobile clients (confirmed: Helmarr 2.4.0) corrupt the `subtitle` base64 payload before POSTing to the manual download endpoint (`/api/episodes/subtitles` and `/api/movies/subtitles`).

Two distinct corruptions observed in server logs:

**1. Trailing `=` padding stripped:**
```
binascii.Error: Invalid base64-encoded string: number of data characters (3789) cannot be 1 more than a multiple of 4
```

**2. `+` characters passed as spaces (URL encoding not applied to the payload):**
```
_pickle.UnpicklingError: pickle data was truncated
```

Both hit `manual.py` line 156:
```python
subtitle = pickle.loads(codecs.decode(subtitle.encode(), "base64"))
```

Bazarr returns HTTP 204 immediately on job queue, so the client sees a false success banner while the background decode fails silently.

## Fix

Two defensive lines prepended before the decode — no-op for well-formed payloads:

```python
subtitle = subtitle.replace(' ', '+')
subtitle = pickle.loads(codecs.decode((subtitle + '=' * ((-len(subtitle)) % 4)).encode(), "base64"))
```

## Testing

Confirmed working on Bazarr 1.5.6 with Helmarr 2.4.0 (iOS). Bulgarian subtitles via Yavka.net provider now download correctly for TV show episodes via Helmarr manual search. Previously failed 100% of the time with the errors above.

The root bug is in Helmarr (already reported to the Helmarr developer via Discord). This PR makes Bazarr robust against any client that sends a marginally malformed base64 string.