### PR TITLE
Fix: select first matching audio stream to avoid s16le multi-stream failure

### DIFF
--- a/custom_libs/subliminal_patch/providers/whisperai.py
+++ b/custom_libs/subliminal_patch/providers/whisperai.py
@@ -446,18 +446,23 @@ class WhisperAIProvider(Provider):
             # This launches a subprocess to decode audio while down-mixing and resampling as necessary.
             inp = ffmpeg.input(path, threads=0)
             if audio_stream_language:
-                # There is more than one audio stream, so pick the requested one by name
-                # Use the ISO 639-2 code if available
                 audio_stream_language = wlm.get_ISO_639_2_code(audio_stream_language)
                 logger.debug(f"Whisper will use the '{audio_stream_language}' audio stream for {path}")
-                # 0 = Pick first stream in case there are multiple language streams of the same language,
-                # otherwise ffmpeg will try to combine multiple streams, but our output format doesn't support that.
-                # The first stream is probably the correct one, as later streams are usually commentaries
-                lang_map = f"0:a:m:language:{audio_stream_language}"
-                out = inp.output("-", format="s16le", acodec="pcm_s16le", ac=1, ar=16000, af=audio_filter,
-                                 map=lang_map)
-            else:
-                out = inp.output("-", format="s16le", acodec="pcm_s16le", ac=1, ar=16000, af=audio_filter)
+
+            # Probe for the first audio stream matching the requested language.
+            # Mapping by language tag alone (0:a:m:language:X) selects all streams sharing
+            # that tag — s16le only supports one audio stream, so files with duplicate-language
+            # tracks (e.g. stereo + 5.1 both tagged eng) would fail.
+            probe = ffmpeg.probe(path)
+            stream_index = next(
+                (s['index'] for s in probe['streams']
+                 if s['codec_type'] == 'audio'
+                 and s.get('tags', {}).get('language') == audio_stream_language),
+                None
+            ) if audio_stream_language else None
+            map_arg = f"0:{stream_index}" if stream_index is not None else "0:a:0"  # 0:a:0 = first audio stream, avoids mapping all streams if no language matched
+
+            out = inp.output("-", format="s16le", acodec="pcm_s16le", ac=1, ar=16000, af=audio_filter, map=map_arg)
 
             start_time = time.time()
             out, _ = out.run(cmd=[ffmpeg_path, "-nostdin"], capture_stdout=True, capture_stderr=True) 


### PR DESCRIPTION
Files with duplicate-language audio tracks (e.g. stereo + 5.1 both tagged eng) cause ffmpeg to map both streams into the s16le muxer, which only supports a single audio stream, resulting in:

`s16le muxer does not support more than one stream of type audio
`

The existing code uses `0:a:m:language:{lang}` as the ffmpeg map argument, intending to pick the first matching stream. The `0:` is the input file index, not a stream limiter, so ffmpeg maps all streams matching the language tag regardless.

Fixed by using ffmpeg.probe() to find the index of the first matching audio stream and mapping by absolute stream index (0:{index}) instead, falling back to `0:a:0` when no language is specified.

Used Claude to wade through ffmpeg argument creation for repdocution of the issue and testing.  

To reproduce in a Bazarr container:

```
ffmpeg -f lavfi -i sine=frequency=440:duration=10 -f lavfi -i sine=frequency=880:duration=10 -f lavfi -i sine=frequency=220:duration=10 -map 0:a -map 1:a -map 2:a -metadata:s:a:0 language=eng -metadata:s:a:1 language=eng -metadata:s:a:2 language=spa test_eng_eng_spa.mkv
```

```
python3 -c "
import sys; sys.path.insert(0,'/app/bazarr/bin/libs'); import ffmpeg
try:
    out=ffmpeg.input('test_eng_eng_spa.mkv',threads=0).output('-',format='s16le',acodec='pcm_s16le',ac=1,ar=16000,af='aresample=async=1',map='0:a:m:language:eng')
    out.run(cmd=['ffmpeg','-nostdin'],capture_stdout=True,capture_stderr=True)
    print('success')
except ffmpeg.Error as e:
    print(e.stderr.decode())
"
```
```
Stream mapping:
  Stream #0:0 -> #0:0 (vorbis (native) -> pcm_s16le (native))
  Stream #0:1 -> #0:1 (vorbis (native) -> pcm_s16le (native))
[s16le @ 0x14f5e8587640] s16le muxer does not support more than one stream of type audio
[out#0/s16le @ 0x14f5e852e680] Could not write header (incorrect codec parameters ?): Invalid argument
[af#0:0 @ 0x14f5e4ac4580] Error sending frames to consumers: Invalid argument
[af#0:0 @ 0x14f5e4ac4580] Task finished with error code: -22 (Invalid argument)
[af#0:0 @ 0x14f5e4ac4580] Terminating thread with return code -22 (Invalid argument)
[out#0/s16le @ 0x14f5e852e680] Nothing was written into output file, because at least one of its streams received no packets.
size=       0KiB time=N/A bitrate=N/A speed=N/A elapsed=0:00:00.00    
Conversion failed!
```

And the sample fix that was implemented in the PR:
```
python3 -c "
import sys; sys.path.insert(0,'/app/bazarr/bin/libs'); import ffmpeg
probe = ffmpeg.probe('test_eng_eng_spa.mkv')
idx = next((s['index'] for s in probe['streams'] if s['codec_type']=='audio' and s.get('tags',{}).get('language')=='eng'), None)
map_arg = f'0:{idx}' if idx is not None else '0:a:0'
try:
    out=ffmpeg.input('test_eng_eng_spa.mkv',threads=0).output('-',format='s16le',acodec='pcm_s16le',ac=1,ar=16000,af='aresample=async=1',map=map_arg)
    out.run(cmd=['ffmpeg','-nostdin'],capture_stdout=True,capture_stderr=True)
    print('success')
except ffmpeg.Error as e:
    print(e.stderr.decode())
"
```