### PR TITLE
fix(event_handler): skip emit when socketio not yet initialized

### DIFF
--- a/bazarr/app/event_handler.py
+++ b/bazarr/app/event_handler.py
@@ -16,4 +16,5 @@ def event_stream(type, action="update", payload=None):
         payload = int(payload)
     except (ValueError, TypeError):
         pass
-    socketio.emit("data", {"type": type, "action": action, "payload": payload})
+    if socketio.server is not None:
+        socketio.emit("data", {"type": type, "action": action, "payload": payload})


### PR DESCRIPTION
## What

Guards `socketio.emit()` in `event_handler.py` against being called before `socketio.init_app()` has run.

## Why

`socketio = SocketIO()` in `app/app.py` creates the object with `server = None`. `init_app()` only runs when the webserver module is imported (`main.py:49`). If `event_stream()` is called before that point - e.g. via the APScheduler-triggered update check on a fast boot - it crashes:

```
AttributeError: 'NoneType' object has no attribute 'emit'
```

This is the crash reported in #3264.

## Why not the previous approach

A prior attempt (commit `243f6830`) guarded the callers by adding a `startup=True` parameter to `check_if_new_update()`. That was reverted in `04cd4743` because it changed the execution context for `apply_update()` -> `webserver.restart()`, breaking restart after update.

Guarding `event_stream` itself avoids touching the job queue or update logic entirely. Events emitted before the frontend connects are meaningless anyway, so dropping them is safe.

## Change

```python
# event_handler.py
if socketio.server is not None:
    socketio.emit("data", {"type": type, "action": action, "payload": payload})
```

One-line guard. No behavioral change once the server is running.

Fixes #3264