### PR TITLE
Supersubtitles Provider - Normalized series title match

### DIFF
--- a/custom_libs/subliminal_patch/providers/supersubtitles.py
+++ b/custom_libs/subliminal_patch/providers/supersubtitles.py
@@ -540,7 +540,8 @@ class SuperSubtitlesProvider(Provider, ProviderSubtitleArchiveMixin):
                     else:
                         fixed_title = fix_movie_naming(item.series)
                     # Check for the original and the fixed titles too
-                    if any(x in (fixed_title.strip(), item.series) for x in titles):
+                    normalized_titles = {x.lower() for x in titles}
+                    if fixed_title.strip().lower() in normalized_titles or (item.series or "").lower() in normalized_titles:
                         subtitles.append(item)
 
             time.sleep(self.multi_result_throttle)


### PR DESCRIPTION
In some series the title differs in case on Supersubtitles. Ex.: 'From' <> 'FROM'. 
The propesed PR makes the series title match case insensitve.