### PR TITLE
Fix: Job timestamp timezone offset

### DIFF
--- a/bazarr/app/jobs_queue.py
+++ b/bazarr/app/jobs_queue.py
@@ -7,7 +7,7 @@ import os
 import time
 
 from time import sleep
-from datetime import datetime
+from datetime import datetime, timezone
 from collections import deque
 from typing import Union
 from threading import Thread, Lock, RLock
@@ -42,7 +42,7 @@ class Job:
     :ivar status: Current status of the job, initialized to 'pending'.
     :type status: str
     :ivar last_run_time: Last time the job was run, initialized to None.
-    :type last_run_time: datetime
+    :type last_run_time: str
     :ivar is_progress: Indicates whether the job is a progress job, defaults to False.
     :type is_progress: bool
     :ivar is_signalr: Indicates whether the job as been initiated by a SignalR event, defaults to False.
@@ -65,7 +65,7 @@ class Job:
         self.args = args
         self.kwargs = kwargs
         self.status = 'pending'
-        self.last_run_time = datetime.now()
+        self.last_run_time = datetime.now(timezone.utc).isoformat()
         self.is_progress = is_progress
         self.is_signalr = is_signalr
         self.progress_value = 0
@@ -557,7 +557,7 @@ class JobsQueue:
             return False
         try:
             job.status = 'running'
-            job.last_run_time = datetime.now()
+            job.last_run_time = datetime.now(timezone.utc).isoformat()
             if 'job_id' not in job.kwargs or not job.kwargs['job_id']:
                 job.kwargs['job_id'] = job.job_id
             self.jobs_running_queue.append(job)
@@ -581,13 +581,13 @@ class JobsQueue:
         except Exception as e:
             logging.exception(f"Exception raised while running function: {e}")
             job.status = 'failed'
-            job.last_run_time = datetime.now()
+            job.last_run_time = datetime.now(timezone.utc).isoformat()
             self.jobs_running_queue.remove(job)
             self.jobs_failed_queue.append(job)
             return False
         else:
             job.status = 'completed'
-            job.last_run_time = datetime.now()
+            job.last_run_time = datetime.now(timezone.utc).isoformat()
             self.jobs_running_queue.remove(job)
             self.jobs_completed_queue.append(job)
             return True


### PR DESCRIPTION
When Bazarr's server timezone differs from the browser's, last_run_time was set using datetime.now() (server local time), causing react-timeago to compute incorrect relative timestamps.  For example, "7 hours ago" when the job just ran.

Replaced datetime.now() with datetime.now(timezone.utc).isoformat() for all last_run_time assignments, which produces an UTC ISO 8601 string (`'2026-06-18T08:13:11.232442+00:00'`) that browsers parse regardless of server timezone.