### PR TITLE
subf2m: fall back to IMDB id search when localized movie title finds nothing

### DIFF
--- a/custom_libs/subliminal_patch/providers/subf2m.py
+++ b/custom_libs/subliminal_patch/providers/subf2m.py
@@ -376,6 +376,16 @@ class Subf2mProvider(Provider):
             paths = self._search_tv_show_season(video.series, video.season, video.year)
         else:
             paths = self._search_movie(video.title, video.year)
+            if not paths and video.imdb_id:
+                # video.title may be a localized title that subf2m doesn't index
+                # (e.g. Radarr providing a non-English title). subf2m's
+                # searchbytitle also accepts an IMDB id, so fall back to it.
+                logger.debug(
+                    "No results for title %r; retrying search with IMDB id %s",
+                    video.title,
+                    video.imdb_id,
+                )
+                paths = self._search_movie(video.imdb_id, video.year)
 
         if not paths:
             logger.debug("No results")

--- a/tests/subliminal_patch/test_subf2m.py
+++ b/tests/subliminal_patch/test_subf2m.py
@@ -1,5 +1,6 @@
 import pytest
 from subliminal_patch.core import Episode
+from subliminal_patch.core import Movie
 from subliminal_patch.providers import subf2m
 from subliminal_patch.providers.subf2m import ConfigurationError
 from subliminal_patch.providers.subf2m import Subf2mProvider
@@ -30,6 +31,20 @@ def provider():
 def test_search_movie(provider, title, year, expected_url):
     result = provider._search_movie(title, year)
     assert expected_url in result
+
+
+def test_list_subtitles_movie_falls_back_to_imdb_id(provider):
+    # Radarr may provide a localized movie title that subf2m doesn't index
+    # (here the Danish title for "The Goonies"). The provider should fall back
+    # to searching by IMDB id rather than finding nothing. Regression for #2896.
+    movie = Movie(
+        "Goonierne.1985.1080p.BluRay.x264-GROUP",
+        "Goonierne",
+        year=1985,
+        imdb_id="tt0089218",
+    )
+    subtitles = provider.list_subtitles(movie, {Language.fromalpha2("en")})
+    assert subtitles
 
 
 def test_init_empty_user_agent_raises_configurationerror():


### PR DESCRIPTION
### Problem
The subf2m provider searches for movies using `video.title` only. Radarr can provide a *localized* movie title, which subf2m does not index, so `list_subtitles` returns nothing. Reported in #2896.

### Root cause
The movie branch of `list_subtitles` calls `self._search_movie(video.title, video.year)` and nothing else. When `video.title` is localized, `searchbytitle?query=<localized>` yields no usable result. subf2m's `searchbytitle` endpoint also accepts an IMDB id (e.g. `?query=tt0089218`), which resolves to the exact film regardless of language.

### Fix
When the title search yields no results and `video.imdb_id` is set, fall back to `self._search_movie(video.imdb_id, video.year)`. No behaviour change when the title search already succeeds — `_search_movie` already filters by year, so the IMDB-query result matches correctly without further changes.

### Verification (live, against subf2m.co)
Using the Danish title "Goonierne" for *The Goonies* (imdb `tt0089218`):

```
_search_movie("Goonierne", 1985)        -> []                          # the bug
_search_movie("tt0089218", 1985)        -> {'/subtitles/the-goonies'}  # the fallback
list_subtitles(<localized movie>, {en}) -> 30 EN subtitles             # with the fix
```

Added a regression test `test_list_subtitles_movie_falls_back_to_imdb_id` in `tests/subliminal_patch/test_subf2m.py`, matching the existing live-network test style.

Fixes #2896
