### PR TITLE
Fix embedded Chinese subtitle language detection

### DIFF
--- a/custom_libs/subliminal_patch/providers/embeddedsubtitles.py
+++ b/custom_libs/subliminal_patch/providers/embeddedsubtitles.py
@@ -61,6 +61,29 @@ class EmbeddedSubtitle(Subtitle):
 
 
 _ALLOWED_CODECS = ("ass", "subrip", "webvtt", "mov_text")
+_CHINESE_TRADITIONAL_IETF_MARKERS = ("zh-hant", "zh-tw", "zh-hk", "zh-mo", "hant")
+_CHINESE_SIMPLIFIED_IETF_MARKERS = ("zh-hans", "zh-cn", "zh-sg", "hans")
+_CHINESE_TRADITIONAL_TITLE_MARKERS = (
+    "zh-tw",
+    "zht",
+    "zh-hant",
+    "zhhant",
+    "hant",
+    "big5",
+    "traditional",
+    "繁體",
+    "繁体",
+)
+_CHINESE_SIMPLIFIED_TITLE_MARKERS = (
+    "zh-cn",
+    "zhs",
+    "zh-hans",
+    "zhhans",
+    "hans",
+    "simplified",
+    "簡體",
+    "简体",
+)
 
 
 class EmbeddedSubtitlesProvider(Provider):
@@ -215,6 +238,7 @@ class EmbeddedSubtitlesProvider(Provider):
             # Extract all subittle streams to avoid reading the entire
             # container over and over
             subs = list(_filter_subtitles(container.get_subtitles()))
+            _rebuild_langs(subs)
 
             extracted = container.copy_subtitles(
                 subs,
@@ -308,9 +332,38 @@ def _check_hi_fallback(streams, languages):
 def _rebuild_langs(streams):
     for stream in streams:
         kwargs = stream.disposition.language_kwargs()
-        stream.language = Language.rebuild(stream.language, **kwargs)
+        language = _get_chinese_language_from_tags(stream) or stream.language
+        stream.language = Language.rebuild(language, **kwargs)
 
         logger.debug("Rebuild language: %r", stream.language)
+
+
+def _get_chinese_language_from_tags(stream):
+    if stream.language.alpha3 != "zho":
+        return None
+
+    data = getattr(stream.tags, "_data", {}) or {}
+    language_ietf = data.get("language_ietf")
+    if language_ietf:
+        language_ietf = language_ietf.lower().replace("_", "-")
+        if any(
+            marker in language_ietf
+            for marker in _CHINESE_TRADITIONAL_IETF_MARKERS
+        ):
+            return Language("zho", "TW")
+        if any(
+            marker in language_ietf
+            for marker in _CHINESE_SIMPLIFIED_IETF_MARKERS
+        ):
+            return Language("zho")
+
+    title = data.get("title", "").lower()
+    if any(marker in title for marker in _CHINESE_TRADITIONAL_TITLE_MARKERS):
+        return Language("zho", "TW")
+    if any(marker in title for marker in _CHINESE_SIMPLIFIED_TITLE_MARKERS):
+        return Language("zho")
+
+    return None
 
 
 def _discard_possible_incomplete_subtitles(streams):

--- a/tests/subliminal_patch/test_embeddedsubtitles.py
+++ b/tests/subliminal_patch/test_embeddedsubtitles.py
@@ -13,6 +13,8 @@ from subliminal_patch.providers.embeddedsubtitles import (
 )
 from subliminal_patch.providers.embeddedsubtitles import _get_pretty_release_name
 from subliminal_patch.providers.embeddedsubtitles import _MemoizedFFprobeVideoContainer
+from subliminal_patch.providers.embeddedsubtitles import _rebuild_langs
+from subliminal_patch.providers.embeddedsubtitles import EmbeddedSubtitle
 from subliminal_patch.providers.embeddedsubtitles import EmbeddedSubtitlesProvider
 from subzero.language import Language
 
@@ -347,6 +349,105 @@ def test_get_pretty_release_name():
     )
     container = FFprobeVideoContainer("foo.mkv")
     assert _get_pretty_release_name(stream, container) == "foo.en.forced.srt"
+
+
+@pytest.mark.parametrize(
+    "language_ietf,title,expected_language",
+    [
+        ("zh-Hans", "中文（繁體）", Language("zho")),
+        ("zh-Hant", "中文（简体）", Language("zho", "TW")),
+    ],
+)
+def test_rebuild_langs_prefers_chinese_language_ietf_over_title_markers(
+    language_ietf, title, expected_language
+):
+    stream = FFprobeSubtitleStream(
+        {
+            "index": 1,
+            "codec_name": "subrip",
+            "tags": {
+                "language": "chi",
+                "language_ietf": language_ietf,
+                "title": title,
+            },
+        }
+    )
+
+    _rebuild_langs([stream])
+
+    assert stream.language == expected_language
+
+
+@pytest.mark.parametrize(
+    "title,expected_language",
+    [
+        ("中文（简体）", Language("zho")),
+        ("中文（繁體）", Language("zho", "TW")),
+        ("中文（繁体）", Language("zho", "TW")),
+    ],
+)
+def test_rebuild_langs_detects_chinese_script_from_title(title, expected_language):
+    stream = FFprobeSubtitleStream(
+        {
+            "index": 1,
+            "codec_name": "subrip",
+            "tags": {"language": "chi", "title": title},
+        }
+    )
+
+    _rebuild_langs([stream])
+
+    assert stream.language == expected_language
+
+
+def test_get_subtitle_path_rebuilds_chinese_streams_before_cache_extraction(
+    tmpdir, mocker
+):
+    container = FFprobeVideoContainer("foo.mkv")
+    selected_stream = FFprobeSubtitleStream(
+        {
+            "index": 1,
+            "codec_name": "subrip",
+            "tags": {"language": "chi", "title": "中文（简体）"},
+        }
+    )
+    _rebuild_langs([selected_stream])
+    subtitle = EmbeddedSubtitle(selected_stream, container, {"hash"}, "series")
+    cache_streams = [
+        FFprobeSubtitleStream(
+            {
+                "index": 1,
+                "codec_name": "subrip",
+                "tags": {"language": "chi", "title": "中文（简体）"},
+            }
+        ),
+        FFprobeSubtitleStream(
+            {
+                "index": 2,
+                "codec_name": "subrip",
+                "tags": {"language": "chi", "title": "中文（繁體）"},
+            }
+        ),
+    ]
+    extracted_suffixes = {}
+
+    def copy_subtitles(subtitles, *args, **kwargs):
+        extracted_suffixes.update(
+            {stream.index: stream.suffix for stream in subtitles}
+        )
+        return {
+            stream.index: tmpdir.join(stream.suffix).strpath
+            for stream in subtitles
+        }
+
+    mocker.patch.object(container, "get_subtitles", return_value=cache_streams)
+    mocker.patch.object(container, "copy_subtitles", side_effect=copy_subtitles)
+
+    with EmbeddedSubtitlesProvider(cache_dir=tmpdir) as provider:
+        provider._get_subtitle_path(subtitle)
+
+    assert extracted_suffixes[1] == "zh.srt"
+    assert extracted_suffixes[2] == "zh-TW.srt"
 
 
 def test_download_subtitle_multiple(video_multiple_languages):


### PR DESCRIPTION
## Summary

- Fix Simplified/Traditional Chinese detection inside Bazarr's `embeddedsubtitles` provider, without modifying vendored `libs/fese/*`.
- Prefer embedded ffprobe `language_ietf` tags such as `zh-Hans` and `zh-Hant` when present.
- Fall back to embedded subtitle title markers such as `中文（繁體）` / `中文（繁体）` when ffprobe only provides `language=chi` plus a title.
- Rebuild the same stream languages before cache extraction, so download uses the same Simplified/Traditional decision as provider selection.

## Context

Related to #2914.

In my real sample MKVs, `mkvmerge -J` shows both Chinese tracks with BCP 47 data:

- `language_ietf=zh-Hans`, title `中文（简体）`
- `language_ietf=zh-Hant`, title `中文（繁體）`

The Bazarr embedded subtitle path currently receives these streams from ffprobe as generic Chinese (`language=chi`) with the titles above. Before this provider fallback, Simplified and Traditional Chinese both collapsed to generic `zho`. With this change, the Simplified stream remains `zho` / `zh.srt`, and the Traditional stream becomes `zho-TW` / `zh-TW.srt`.

The same rebuild is also applied before embedded subtitles are copied into the provider cache. Without that, provider selection can choose the Simplified stream, but cache extraction may still collapse both Chinese tracks to the same generic suffix and return the wrong content.

I also noticed the existing upstream fese PR for Traditional Chinese detection is still open: vitiko98/fese#4 (`Added traditional Chinese detection`, opened 2025-04-19). Since that has not been merged yet, this PR keeps the workaround limited to Bazarr's `embeddedsubtitles` provider instead of waiting for a vendored fese update.

## Test plan

- [x] Added and ran targeted embedded subtitle regression tests for `language_ietf`, Chinese title fallback, and cache extraction suffixes.
- [x] Ran `py_compile` on the changed Python files.
- [x] Validated against real MKV samples: requesting `zho` selects the Simplified stream and downloads Simplified subtitle content, while the Traditional stream is rebuilt as `zho-TW`.

## AI transparency

I used AI assistance to help investigate the issue and draft this patch/regression tests. I reviewed the behavior, verified it locally, and own the submission.