### PR TITLE
no log: Remove redundant profile language code

### DIFF
--- a/frontend/src/components/forms/ProfileEditForm.tsx
+++ b/frontend/src/components/forms/ProfileEditForm.tsx
@@ -188,7 +188,6 @@ const ProfileEditForm: FunctionComponent<Props> = ({
           value={code}
           onChange={(value) => {
             if (value) {
-              item.language = value.code2;
               action.mutate(index, { ...item, language: value.code2 });
             }
           }}


### PR DESCRIPTION
The removed line `item.language = value.code2` was a direct mutation of the original object from the table row (row.original). The very next line `action.mutate(index, { ...item, language: value.code2 })` creates a brand new object via spread and immediately overrides language with the same value, making the prior mutation completely redundant.

Worse, the mutation was a side effect on React state, it directly mutated form.values.items[ index ] in-place before the state update, which could break React.memo on LanguageCell and cause subtle render bugs. ESLint's no-param-reassign rule (or similar) correctly flagged this.

The action.mutate call alone does everything needed: it replaces the item at that index with a new object containing the updated language, which is the proper React-idiomatic way to update state.