### PR TITLE
Add legendei.net as a Brazilian Portuguese subtitle provider

### DIFF
--- a/custom_libs/subliminal_patch/providers/legendei.py
+++ b/custom_libs/subliminal_patch/providers/legendei.py
@@ -1,0 +1,368 @@
+# -*- coding: utf-8 -*-
+"""Legendei.net subtitle provider (Brazilian Portuguese).
+
+Site mechanics:
+    * Search:   GET https://legendei.net/?s=<query>  (WordPress search)
+    * Detail:   each result links to https://legendei.net/<slug>/, which holds the release
+                name in its <h1> and a download anchor ending in ``?download=<id>``.
+    * Download: GET <detail_url>?download=<id> 302-redirects to a ``.zip`` under
+                ``wp-content/uploads/`` that contains a single ``.srt``.
+    * Inline JS rewrites the download anchor through ``btoa()`` into an ad-gate; since we read
+                the raw href without running JS, we always get the direct link.
+"""
+import io
+import logging
+import os
+import re
+import zipfile
+from time import sleep
+from urllib.parse import quote
+
+from guessit import guessit
+from requests.exceptions import RequestException
+
+from subliminal.subtitle import fix_line_ending
+from subliminal.utils import sanitize, sanitize_release_group
+from subliminal.video import Episode, Movie
+from subliminal_patch.http import RetryingCFSession
+from subliminal_patch.providers import Provider
+from subliminal_patch.providers import utils
+from subliminal_patch.score import get_scores
+from subliminal_patch.subtitle import Subtitle, guess_matches
+from subzero.language import Language
+
+logger = logging.getLogger(__name__)
+
+# Cap on detail-page fetches per search; each is an extra request to the site.
+MAX_DETAIL_FETCHES = 5
+# Seconds between requests.
+REQUEST_DELAY = 1
+BROWSER_HEADERS = {
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
+                  '(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+    'Accept-Language': 'pt-BR,pt;q=0.9,en;q=0.8',
+}
+
+# href markers for the real download link (before JS rewrites it into an ad-gate).
+DOWNLOAD_HREF_MARKERS = ('?download=', '?dl_', '/zip-attachments.php')
+
+# Flag and pictograph emojis that decorate titles.
+EMOJI_RE = re.compile(
+    "["
+    "\U0001F1E6-\U0001F1FF"  # regional indicator symbols (flags)
+    "\U0001F300-\U0001F5FF"
+    "\U0001F600-\U0001F64F"
+    "\U0001F680-\U0001F6FF"
+    "\U0001F900-\U0001F9FF"
+    "\U0001FA70-\U0001FAFF"
+    "\U00002600-\U000027BF"
+    "]+",
+    flags=re.UNICODE,
+)
+
+# Matches a result anchor pointing to a detail page.
+# e.g. <a href="https://legendei.net/oppenheimer-2023-1080p-bluray/" title="Oppenheimer 2023 1080p Bluray">
+RESULT_RE = re.compile(
+    r'<a[^>]+href="(https?://(?:www\.)?legendei\.net/(?!category/|tag/|page/|author/|feed/)'
+    r'[^"?#]+/)"[^>]*?title="([^"]+)"',
+    re.IGNORECASE | re.DOTALL,
+)
+DOWNLOAD_ID_RE = re.compile(r'\?download=(\d+)', re.IGNORECASE)
+H1_RE = re.compile(r'<h1[^>]*>(.*?)</h1>', re.IGNORECASE | re.DOTALL)
+
+
+class LegendeiSubtitle(Subtitle):
+    """Legendei.net Subtitle."""
+    provider_name = 'legendei'
+
+    def __init__(self, language, release_name, page_link, download_link, file_id,
+                 video=None, uploader=None):
+        super(LegendeiSubtitle, self).__init__(language, page_link=page_link)
+        self.release_name = release_name
+        self.release_info = release_name
+        self.page_link = page_link
+        self.download_link = download_link
+        self.file_id = file_id
+        self.video = video
+        self.uploader = uploader
+        self.matches = set()
+        # season packs ("Temporada Completa") bundle several episodes in one archive
+        self.is_pack = isinstance(video, Episode) and bool(
+            re.search(r'temporada\s+completa|complete\s+season|season\s+pack', release_name or '',
+                      re.IGNORECASE))
+
+    @property
+    def id(self):
+        # attachment id when available, otherwise the (unique) download link
+        return self.file_id or self.download_link
+
+    def get_matches(self, video):
+        matches = set()
+
+        release = sanitize(self.release_name)
+        type_ = 'episode' if isinstance(video, Episode) else 'movie'
+
+        if isinstance(video, Episode):
+            for series_name in [video.series] + video.alternative_series:
+                if sanitize(series_name) in release:
+                    matches.update(['series'])
+                    break
+            if video.season and 's{:02d}'.format(video.season) in release:
+                matches.update(['season'])
+            if video.episode and 'e{:02d}'.format(video.episode) in release:
+                matches.update(['episode'])
+            if video.title and sanitize(video.title) in release:
+                matches.update(['title'])
+        else:
+            for movie_name in [video.title] + video.alternative_titles:
+                if sanitize(movie_name) in release:
+                    matches.update(['title'])
+                    break
+            if video.year and '{:04d}'.format(video.year) in release:
+                matches.update(['year'])
+
+        if video.release_group and \
+                sanitize_release_group(video.release_group) in sanitize_release_group(release):
+            matches.update(['release_group'])
+
+        utils.update_matches(matches, video, self.release_name, split="\n")
+
+        self.matches = matches
+        return matches
+
+
+class LegendeiProvider(Provider):
+    """Legendei.net Provider."""
+    languages = {Language('por', 'BR')}
+    video_types = (Episode, Movie)
+
+    site = 'https://legendei.net'
+    search_url = site + '/?s={query}'
+
+    def __init__(self):
+        self.session = None
+
+    def initialize(self):
+        logger.debug("Legendei :: Creating session for requests")
+        self.session = RetryingCFSession()
+        self.session.headers.update(BROWSER_HEADERS)
+
+    def terminate(self):
+        if self.session:
+            self.session.close()
+
+    # ------------------------------------------------------------------ helpers
+
+    def _fetch_html(self, url):
+        """GET *url* and return its HTML body, or None on failure."""
+        try:
+            resp = self.session.get(url, timeout=30)
+        except RequestException as e:
+            logger.warning("Legendei :: Request to %s failed: %r", url, e)
+            return None
+        if resp.status_code != 200:
+            logger.warning("Legendei :: Unexpected status %s for %s", resp.status_code, url)
+            return None
+        return resp.text
+
+    @staticmethod
+    def _clean_release_name(raw):
+        """Normalise an <h1>/title string into a clean release name."""
+        if not raw:
+            return ''
+        text = re.sub(r'<[^>]+>', ' ', raw)
+        text = re.sub(r'\s+', ' ', text).strip()
+        text = re.sub(r'^legenda\s+', '', text, flags=re.IGNORECASE)
+        text = EMOJI_RE.sub('', text).strip()
+        return text
+
+    @staticmethod
+    def _parse_search_results(html):
+        """Yield (detail_url, title) tuples from a search results page."""
+        seen = set()
+        for match in RESULT_RE.finditer(html or ''):
+            detail_url = match.group(1).strip()
+            title = match.group(2).strip()
+            if detail_url in seen:
+                continue
+            seen.add(detail_url)
+            yield detail_url, title
+
+    @staticmethod
+    def _parse_detail_page(html, fallback_title):
+        """Extract (release_name, download_link, file_id) from a detail page, or None."""
+        if not html:
+            return None
+
+        release_name = ''
+        h1 = H1_RE.search(html)
+        if h1:
+            release_name = LegendeiProvider._clean_release_name(h1.group(1))
+        if not release_name:
+            release_name = LegendeiProvider._clean_release_name(fallback_title or '')
+
+        # the WordPress attachment anchor with ?download=<id>
+        dl_match = re.search(r'href="([^"]*\?download=\d+)"', html, re.IGNORECASE)
+        if not dl_match:
+            for marker in DOWNLOAD_HREF_MARKERS:
+                m = re.search(r'href="([^"]*%s[^"]*)"' % re.escape(marker), html, re.IGNORECASE)
+                if m:
+                    dl_match = m
+                    break
+        if not dl_match:
+            return None
+
+        download_link = dl_match.group(1).strip()
+        file_id_match = DOWNLOAD_ID_RE.search(download_link)
+        file_id = file_id_match.group(1) if file_id_match else None
+
+        return release_name, download_link, file_id
+
+    # ------------------------------------------------------------------ provider API
+
+    def list_subtitles(self, video, languages):
+        return self.query(video, languages)
+
+    def _search_queries(self, video):
+        """Yield search queries to try for *video*, in priority order.
+
+        For episodes, search the exact episode first; if only a season pack is available, the
+        caller falls back to the broader ``series + season`` query.
+        """
+        if isinstance(video, Episode):
+            yield quote('{series} S{season:02d}E{episode:02d}'.format(
+                series=video.series, season=video.season, episode=video.episode))
+            yield quote('{series} S{season:02d}'.format(series=video.series, season=video.season))
+            return
+        query = video.title
+        if video.year:
+            query = '{} {:04d}'.format(query, video.year)
+        yield quote(query)
+
+    def query(self, video, languages):
+        # legendei only serves pt-BR; nothing to do unless it was requested
+        wanted = self.languages & set(languages)
+        if not wanted:
+            return []
+        language = next(iter(wanted))
+
+        subtitles = []
+        seen_detail_urls = set()
+        fetched = 0
+
+        for query_text in self._search_queries(video):
+            if fetched >= MAX_DETAIL_FETCHES:
+                break
+
+            search_url = self.search_url.format(query=query_text)
+            logger.debug("Legendei :: Searching %s", search_url)
+            sleep(REQUEST_DELAY)
+            html = self._fetch_html(search_url)
+            if not html:
+                logger.warning("Legendei :: Could not retrieve search results for %r",
+                               getattr(video, 'name', video))
+                continue
+
+            results = list(self._parse_search_results(html))
+            logger.debug("Legendei :: Found %d result(s) for %r", len(results), query_text)
+            if not results:
+                continue
+
+            for detail_url, title in results:
+                if fetched >= MAX_DETAIL_FETCHES:
+                    break
+                if detail_url in seen_detail_urls:
+                    continue
+                seen_detail_urls.add(detail_url)
+                sleep(REQUEST_DELAY)
+                detail_html = self._fetch_html(detail_url)
+                # count every fetch attempt so a run of unparseable pages cannot exceed the cap
+                fetched += 1
+                parsed = self._parse_detail_page(detail_html, title)
+                if not parsed:
+                    continue
+                release_name, download_link, file_id = parsed
+
+                subtitle = LegendeiSubtitle(
+                    language=language,
+                    release_name=release_name,
+                    page_link=detail_url,
+                    download_link=download_link,
+                    file_id=file_id,
+                    video=video,
+                )
+                subtitle.get_matches(video)
+                subtitles.append(subtitle)
+
+            # stop as soon as one query produced results
+            if subtitles:
+                break
+
+        return subtitles
+
+    def download_subtitle(self, subtitle):
+        logger.debug("Legendei :: Downloading subtitle %r", subtitle)
+        try:
+            sleep(REQUEST_DELAY)
+            # follow the redirect to the actual archive
+            res = self.session.get(subtitle.download_link, timeout=30)
+            res.raise_for_status()
+        except RequestException as e:
+            logger.error("Legendei :: Download request failed: %r", e)
+            return
+
+        content = res.content
+        archive_stream = io.BytesIO(content)
+        if zipfile.is_zipfile(archive_stream):
+            logger.debug("Legendei :: Identified zip archive")
+            archive = zipfile.ZipFile(archive_stream)
+            subtitle_content = self._pick_from_archive(archive, subtitle)
+            if subtitle_content is None:
+                logger.error("Legendei :: No subtitle file inside archive for %r", subtitle)
+                return
+            subtitle.content = fix_line_ending(subtitle_content)
+            subtitle.normalize()
+            return subtitle
+
+        # not a zip: maybe a raw .srt (rare) or an error page
+        head = content.lstrip(b'\xef\xbb\xbf')[:6].lower()
+        if head[:1] == b'1' or content[:6].lower() == b'webvtt':
+            logger.debug("Legendei :: Treating response as a raw subtitle file")
+            subtitle.content = fix_line_ending(content)
+            subtitle.normalize()
+            return subtitle
+
+        logger.error("Legendei :: Unexpected download payload (%d bytes) from %s",
+                     len(content), subtitle.download_link)
+
+    @staticmethod
+    def _pick_from_archive(archive, subtitle):
+        """Return the best subtitle bytes from *archive* (single-file fast path + scoring)."""
+        names = [n for n in archive.namelist()
+                 if not os.path.split(n)[-1].startswith('.') and
+                 n.lower().endswith(('.srt', '.sub', '.ssa', '.ass'))]
+        if not names:
+            return None
+        if len(names) == 1:
+            return archive.read(names[0])
+
+        # several candidates: score each with guessit against the video
+        video = getattr(subtitle, 'video', None)
+        best_name, best_score = names[0], -1
+        for name in names:
+            try:
+                score = 0
+                if video is not None:
+                    scores = get_scores(video)
+                    matches = guess_matches(video, guessit(name))
+                    score = sum(scores.get(m, 0) for m in matches)
+                if subtitle.release_name and \
+                        sanitize_release_group(subtitle.release_name).lower() in \
+                        sanitize_release_group(name).lower():
+                    score += 1
+            except Exception:
+                score = 0
+            if score > best_score:
+                best_name, best_score = name, score
+        return archive.read(best_name)

--- a/frontend/src/pages/Settings/Providers/list.ts
+++ b/frontend/src/pages/Settings/Providers/list.ts
@@ -354,6 +354,11 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
     ],
   },
   {
+    key: "legendei",
+    name: "Legendei.net",
+    description: "Brazilian Subtitles Provider",
+  },
+  {
     key: "napiprojekt",
     description: "Polish Subtitles Provider",
     inputs: [

--- a/frontend/src/types/settings.d.ts
+++ b/frontend/src/types/settings.d.ts
@@ -17,6 +17,7 @@ interface Settings {
   opensubtitlescom: Settings.OpenSubtitlesCom;
   addic7ed: Settings.Addic7ed;
   legendasdivx: Settings.Legandasdivx;
+  legendei: Settings.Legendei;
   xsubs: Settings.XSubs;
   assrt: Settings.Assrt;
   napisy24: Settings.Napisy24;
@@ -237,6 +238,8 @@ declare namespace Settings {
   interface Legandasdivx extends BaseProvider {
     skip_wrong_fps: boolean;
   }
+
+  interface Legendei extends BaseProvider {}
 
   interface XSubs extends BaseProvider {}
 

--- a/tests/subliminal_patch/cassettes/test_legendei/test_download_subtitle_episode.yaml
+++ b/tests/subliminal_patch/cassettes/test_legendei/test_download_subtitle_episode.yaml
@@ -1,0 +1,5644 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - pt-BR,pt;q=0.9,en;q=0.8
+      User-Agent:
+      - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like
+        Gecko) Chrome/131.0.0.0 Safari/537.36
+    method: GET
+    uri: https://legendei.net/?s=Breaking%20Bad%20S01E01
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html dir=\"ltr\" lang=\"pt-BR\" prefix=\"og: https://ogp.me/ns#\"\
+        >\n<head>\n<meta charset=\"UTF-8\">\n<meta name=\"viewport\" content=\"width=device-width,\
+        \ initial-scale=1.0\">\n\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css\"\
+        >\n\t\n<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">\n<link\
+        \ rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>\n<link\
+        \ href=\"https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap\"\
+        \ rel=\"stylesheet\">\n\t\n<title>breaking bad s01e01 - Legendei - Aqui Sai\
+        \ Primeiro</title>\n\t<style>img:is([sizes=\"auto\" i], [sizes^=\"auto,\"\
+        \ i]) { contain-intrinsic-size: 3000px 1500px }</style>\n\t\n\t\t<!-- All\
+        \ in One SEO Pro 4.6.0 - aioseo.com -->\n\t\t<meta name=\"robots\" content=\"\
+        max-image-preview:large\" />\n\t\t<meta name=\"google-site-verification\"\
+        \ content=\"JSMIV3rTOC3Y-WjaQzmU3KvW7aWHceTxBFYsJYpm-1k\" />\n\t\t<meta name=\"\
+        generator\" content=\"All in One SEO Pro (AIOSEO) 4.6.0\" />\n\t\t<script\
+        \ type=\"application/ld+json\" class=\"aioseo-schema\">\n\t\t\t{\"@context\"\
+        :\"https:\\/\\/schema.org\",\"@graph\":[{\"@type\":\"BreadcrumbList\",\"@id\"\
+        :\"https:\\/\\/legendei.net\\/#breadcrumblist\",\"itemListElement\":[{\"@type\"\
+        :\"ListItem\",\"@id\":\"https:\\/\\/legendei.net\\/#listItem\",\"position\"\
+        :1,\"name\":\"Home\",\"item\":\"https:\\/\\/legendei.net\\/\",\"nextItem\"\
+        :\"https:\\/\\/legendei.net\\/#listItem\"},{\"@type\":\"ListItem\",\"@id\"\
+        :\"https:\\/\\/legendei.net\\/#listItem\",\"position\":2,\"name\":\"breaking\
+        \ bad s01e01\",\"previousItem\":\"https:\\/\\/legendei.net\\/#listItem\"}]},{\"\
+        @type\":\"Organization\",\"@id\":\"https:\\/\\/legendei.net\\/#organization\"\
+        ,\"name\":\"Legendei\",\"url\":\"https:\\/\\/legendei.net\\/\",\"logo\":{\"\
+        @type\":\"ImageObject\",\"url\":\"https:\\/\\/legendei.net\\/wp-content\\\
+        /uploads\\/2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /#organizationLogo\",\"width\":150,\"height\":150},\"image\":{\"@id\":\"https:\\\
+        /\\/legendei.net\\/#organizationLogo\"}},{\"@type\":\"SearchResultsPage\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/#searchresultspage\",\"url\":\"https:\\\
+        /\\/legendei.net\\/\",\"name\":\"breaking bad s01e01 - Legendei - Aqui Sai\
+        \ Primeiro\",\"inLanguage\":\"pt-BR\",\"isPartOf\":{\"@id\":\"https:\\/\\\
+        /legendei.net\\/#website\"},\"breadcrumb\":{\"@id\":\"https:\\/\\/legendei.net\\\
+        /#breadcrumblist\"}},{\"@type\":\"WebSite\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /#website\",\"url\":\"https:\\/\\/legendei.net\\/\",\"name\":\"Legendei\"\
+        ,\"description\":\"Baixar Legendas de S\\u00e9ries e Filmes\",\"inLanguage\"\
+        :\"pt-BR\",\"publisher\":{\"@id\":\"https:\\/\\/legendei.net\\/#organization\"\
+        }}]}\n\t\t</script>\n\t\t<!-- All in One SEO Pro -->\n\n<link rel='dns-prefetch'\
+        \ href='//fonts.googleapis.com' />\n<link rel=\"alternate\" type=\"application/rss+xml\"\
+        \ title=\"Feed para Legendei &raquo;\" href=\"https://legendei.net/feed/\"\
+        \ />\n<link rel=\"alternate\" type=\"application/rss+xml\" title=\"Feed de\
+        \ coment\xE1rios para Legendei &raquo;\" href=\"https://legendei.net/comments/feed/\"\
+        \ />\n<link rel=\"alternate\" type=\"application/rss+xml\" title=\"Legendei\
+        \ &raquo; Feed do resultado da busca por &#8220;breaking bad s01e01&#8221;\"\
+        \ href=\"https://legendei.net/search/breaking+bad+s01e01/feed/rss2/\" />\n\
+        <script type=\"text/javascript\">\n/* <![CDATA[ */\nwindow._wpemojiSettings\
+        \ = {\"baseUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\/emoji\\/16.0.1\\\
+        /72x72\\/\",\"ext\":\".png\",\"svgUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\\
+        /emoji\\/16.0.1\\/svg\\/\",\"svgExt\":\".svg\",\"source\":{\"concatemoji\"\
+        :\"https:\\/\\/legendei.net\\/wp-includes\\/js\\/wp-emoji-release.min.js?ver=6.8.3\"\
+        }};\n/*! This file is auto-generated */\n!function(s,n){var o,i,e;function\
+        \ c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function\
+        \ p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var\
+        \ t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),a=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new\
+        \ Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return\
+        \ t.every(function(e,t){return e===a[t]})}function u(e,t){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);for(var\
+        \ n=e.getImageData(16,16,1,1),a=0;a<n.data.length;a++)if(0!==n.data[a])return!1;return!0}function\
+        \ f(e,t,n,a){switch(t){case\"flag\":return n(e,\"\\ud83c\\udff3\\ufe0f\\u200d\\\
+        u26a7\\ufe0f\",\"\\ud83c\\udff3\\ufe0f\\u200b\\u26a7\\ufe0f\")?!1:!n(e,\"\\\
+        ud83c\\udde8\\ud83c\\uddf6\",\"\\ud83c\\udde8\\u200b\\ud83c\\uddf6\")&&!n(e,\"\
+        \\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc65\\udb40\\udc6e\\udb40\\\
+        udc67\\udb40\\udc7f\",\"\\ud83c\\udff4\\u200b\\udb40\\udc67\\u200b\\udb40\\\
+        udc62\\u200b\\udb40\\udc65\\u200b\\udb40\\udc6e\\u200b\\udb40\\udc67\\u200b\\\
+        udb40\\udc7f\");case\"emoji\":return!a(e,\"\\ud83e\\udedf\")}return!1}function\
+        \ g(e,t,n,a){var r=\"undefined\"!=typeof WorkerGlobalScope&&self instanceof\
+        \ WorkerGlobalScope?new OffscreenCanvas(300,150):s.createElement(\"canvas\"\
+        ),o=r.getContext(\"2d\",{willReadFrequently:!0}),i=(o.textBaseline=\"top\"\
+        ,o.font=\"600 32px Arial\",{});return e.forEach(function(e){i[e]=t(o,e,n,a)}),i}function\
+        \ t(e){var t=s.createElement(\"script\");t.src=e,t.defer=!0,s.head.appendChild(t)}\"\
+        undefined\"!=typeof Promise&&(o=\"wpEmojiSettingsSupports\",i=[\"flag\",\"\
+        emoji\"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){s.addEventListener(\"\
+        DOMContentLoaded\",e,{once:!0})}),new Promise(function(t){var n=function(){try{var\
+        \ e=JSON.parse(sessionStorage.getItem(o));if(\"object\"==typeof e&&\"number\"\
+        ==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&\"object\"\
+        ==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if(\"\
+        undefined\"!=typeof Worker&&\"undefined\"!=typeof OffscreenCanvas&&\"undefined\"\
+        !=typeof URL&&URL.createObjectURL&&\"undefined\"!=typeof Blob)try{var e=\"\
+        postMessage(\"+g.toString()+\"(\"+[JSON.stringify(i),f.toString(),p.toString(),u.toString()].join(\"\
+        ,\")+\"));\",a=new Blob([e],{type:\"text/javascript\"}),r=new Worker(URL.createObjectURL(a),{name:\"\
+        wpTestEmojiSupports\"});return void(r.onmessage=function(e){c(n=e.data),r.terminate(),t(n)})}catch(e){}c(n=g(i,f,p,u))}t(n)}).then(function(e){for(var\
+        \ t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],\"\
+        flag\"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return\
+        \ e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);\n\
+        /* ]]> */\n</script>\n<link rel='stylesheet' id='wpa-css-css' href='https://legendei.net/wp-content/plugins/wp-attachments/styles/0/wpa.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='wp-emoji-styles-inline-css' type='text/css'>\n\
+        \n\timg.wp-smiley, img.emoji {\n\t\tdisplay: inline !important;\n\t\tborder:\
+        \ none !important;\n\t\tbox-shadow: none !important;\n\t\theight: 1em !important;\n\
+        \t\twidth: 1em !important;\n\t\tmargin: 0 0.07em !important;\n\t\tvertical-align:\
+        \ -0.1em !important;\n\t\tbackground: none !important;\n\t\tpadding: 0 !important;\n\
+        \t}\n</style>\n<link rel='stylesheet' id='wp-block-library-css' href='https://legendei.net/wp-includes/css/dist/block-library/style.min.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='classic-theme-styles-inline-css'\
+        \ type='text/css'>\n/*! This file is auto-generated */\n.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em\
+        \ + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}\n\
+        </style>\n<style id='wppb-content-restriction-start-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-content-restriction-end-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-edit-profile-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-login-style-inline-css' type='text/css'>\n\n\
+        \n</style>\n<style id='wppb-recover-password-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-register-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='global-styles-inline-css' type='text/css'>\n:root{--wp--preset--aspect-ratio--square:\
+        \ 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4:\
+        \ 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3:\
+        \ 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16:\
+        \ 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray:\
+        \ #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink:\
+        \ #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange:\
+        \ #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan:\
+        \ #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue:\
+        \ #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple:\
+        \ #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1)\
+        \ 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan:\
+        \ linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange:\
+        \ linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red:\
+        \ linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray:\
+        \ linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum:\
+        \ linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186)\
+        \ 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple:\
+        \ linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux:\
+        \ linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62)\
+        \ 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112)\
+        \ 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean:\
+        \ linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181)\
+        \ 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128)\
+        \ 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129)\
+        \ 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium:\
+        \ 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large:\
+        \ 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40:\
+        \ 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70:\
+        \ 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural:\
+        \ 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px\
+        \ rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0,\
+        \ 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255,\
+        \ 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0,\
+        \ 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap:\
+        \ 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items:\
+        \ center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display:\
+        \ grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-color{color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background:\
+        \ var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange)\
+        \ !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background:\
+        \ var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background:\
+        \ var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background:\
+        \ var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background:\
+        \ var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background:\
+        \ var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size:\
+        \ var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size:\
+        \ var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--x-large) !important;}\n:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}\n:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}\n:root :where(.wp-block-pullquote){font-size:\
+        \ 1.5em;line-height: 1.6;}\n</style>\n<link rel='stylesheet' id='lrl-css-css'\
+        \ href='https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-maincss-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css' type='text/css'\
+        \ media='all' />\n<link rel='stylesheet' id='fontawesome-css' href='https://legendei.net/wp-content/themes/simple-grid/assets/css/all.min.css'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-webfont-css'\
+        \ href='//fonts.googleapis.com/css?family=Playfair+Display:400,400i,700,700i|Domine:400,700|Oswald:400,700|Patua+One|Merriweather:400,400i,700,700i&#038;display=swap'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='legendei-style-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css?ver=1782544305'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='wppb_stylesheet-css'\
+        \ href='https://legendei.net/wp-content/plugins/profile-builder/assets/css/style-front-end.css?ver=3.15.2'\
+        \ type='text/css' media='all' />\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-includes/js/jquery/jquery.min.js?ver=3.7.1\" id=\"\
+        jquery-core-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1\"\
+        \ id=\"jquery-migrate-js\"></script>\n<!--[if lt IE 9]>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/respond.min.js\"\
+        \ id=\"respond-js\"></script>\n<![endif]-->\n<link rel=\"https://api.w.org/\"\
+        \ href=\"https://legendei.net/wp-json/\" /><link rel=\"EditURI\" type=\"application/rsd+xml\"\
+        \ title=\"RSD\" href=\"https://legendei.net/xmlrpc.php?rsd\" />\n<meta name=\"\
+        generator\" content=\"WordPress 6.8.3\" />\n<style>\n\n/* FORMUL\xC1RIO TRIAL\
+        \ */\n\n.premium-form {\n    max-width: 760px;\n    margin: 0 auto 20px;\n\
+        \    padding: 30px;\n    border-radius: 10px;\n    background: #212121;\n\
+        \    border: 10px solid transparent;\n    background-image:\n        linear-gradient(#212121,#212121),\n\
+        \        linear-gradient(90deg,#3f8cff,#8a2be2);\n    background-origin: border-box;\n\
+        \    background-clip: padding-box, border-box;\n    box-sizing: border-box;\n\
+        }\n\n/* Campos */\n\n.premium-form .field {\n    position: relative;\n   \
+        \ margin-bottom: 20px;\n}\n\n.premium-form input {\n    width: 100%;\n   \
+        \ padding: 14px;\n    border-radius: 8px;\n    border: 1px solid #ccc;\n \
+        \   font-size: 16px;\n    box-sizing: border-box;\n}\n\n/* Focus bonito */\n\
+        \n.premium-form input:focus {\n    border-color: transparent;\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin: border-box;\n    background-clip: padding-box, border-box;\n\
+        \    box-shadow: 0 0 0 4px rgba(63,140,255,0.20);\n    outline: none;\n}\n\
+        \n/* TOOLTIP */\n\n.premium-form .tooltip {\n    position: absolute;\n   \
+        \ bottom: 100%;\n    left: 0;\n    margin-bottom: 10px;\n    background: linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \tbox-shadow:0 6px 14px rgba(0,0,0,0.25);\n    color: #ffffff;\n    padding:\
+        \ 10px 12px;\n    font-size: 14px;\n    border-radius: 6px;\n    max-width:\
+        \ 260px;\n    opacity: 0;\n    pointer-events: none;\n    transition: .2s;\n\
+        \    z-index: 999;\n}\n\n.premium-form .tooltip::after {\n    content: \"\"\
+        ;\n    position: absolute;\n    top: 100%;\n    left: 15px;\n    border-width:\
+        \ 6px 6px 0 6px;\n    border-style: solid;\n    border-color: #8a2be2 transparent\
+        \ transparent transparent;\n}\n\n.premium-form .field:hover .tooltip,\n.premium-form\
+        \ .field:focus-within .tooltip {\n    opacity: 1;\n    transform: translateY(-4px);\n\
+        }\n\n/* BOT\xC3O */\n\n.premium-form button {\n    padding: 14px 30px;\n \
+        \   font-size: 22px;\n    border-radius: 8px;\n    border: none;\n    background:\
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    color: #fff;\n    cursor: pointer;\n\
+        \    transition: .25s;\n}\n\n.premium-form button:hover {\n    background:\
+        \ linear-gradient(90deg,#4c9aff,#9a3bff);\n}\n\n/* SENHA */\n\n.pass-wrap{\n\
+        \    position:relative;\n}\n\n.toggle-pass{\n    position:absolute;\n    right:12px;\n\
+        \    top:50%;\n    transform:translateY(-50%);\n    cursor:pointer;\n    font-size:18px;\n\
+        }\n\n/* BARRA FOR\xC7A SENHA */\n\n.strength{\n    height:6px;\n    background:#444;\n\
+        \    border-radius:4px;\n    margin-top:8px;\n    overflow:hidden;\n}\n\n\
+        .strength div{\n    height:100%;\n    width:0%;\n    transition:.3s;\n}\n\n\
+        /* MOBILE */\n\n@media (max-width:480px){\n\n.premium-form{\n    padding:20px;\n\
+        }\n\n}\n\n</style>\n<style>\n\n/* remove fundo normal, ativo e hover do logo\
+        \ */\n.simple-grid-primary-nav-menu > li.menu-logo-item > a,\n.simple-grid-primary-nav-menu\
+        \ > li.menu-logo-item > a:hover,\n.simple-grid-primary-nav-menu > li.menu-logo-item.current-menu-item\
+        \ > a{\n    background:none !important;\n}\n\n/* ===================================================\n\
+        \   MOBILE\n   =================================================== */\n\n\
+        @media only screen and (max-width:812px){\n\n    /* ESCONDER LOGO NO MENU\
+        \ MOBILE */\n    .simple-grid-primary-nav-menu > li.menu-logo-item{\n    \
+        \    display:none !important;\n    }\n\n}\n\n</style>\n    <style type=\"\
+        text/css\">\r\n            .simple-grid-site-title, .simple-grid-site-title\
+        \ a, .simple-grid-site-description {color: #ffffff;}\r\n        </style>\r\
+        \n    <style type=\"text/css\" id=\"custom-background-css\">\nbody.custom-background\
+        \ { background-color: #333333; }\n</style>\n\t<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"32x32\" />\n<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"192x192\" />\n<link rel=\"apple-touch-icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n<meta name=\"msapplication-TileImage\" content=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n</head>\t\n\t\n\t\n<body class=\"search search-results custom-background\
+        \ wp-custom-logo wp-theme-simple-grid simple-grid-animated simple-grid-fadein\
+        \ simple-grid-theme-is-active simple-grid-custom-logo-active simple-grid-layout-type-full\
+        \ simple-grid-masonry-inactive simple-grid-float-grid simple-grid-responsive-grid-details\
+        \ simple-grid-layout-full-width simple-grid-header-banner-active simple-grid-tagline-inactive\
+        \ simple-grid-logo-above-title simple-grid-primary-menu-active simple-grid-primary-mobile-menu-active\
+        \ simple-grid-secondary-mobile-menu-active simple-grid-primary-social-icons\"\
+        \ id=\"simple-grid-site-body\" itemscope=\"itemscope\" itemtype=\"http://schema.org/WebPage\"\
+        >\n<a class=\"skip-link screen-reader-text\" href=\"#simple-grid-content-wrapper\"\
+        >Skip to content</a>\n\n\n\n<div class=\"simple-grid-site-header simple-grid-container\"\
+        \ id=\"simple-grid-header\" itemscope=\"itemscope\" itemtype=\"http://schema.org/WPHeader\"\
+        \ role=\"banner\">\n<div class=\"simple-grid-head-content simple-grid-clearfix\"\
+        \ id=\"simple-grid-head-content\">\n\n<div class=\"simple-grid-no-header-content\"\
+        >\n              <p class=\"simple-grid-site-title\"><a href=\"https://legendei.net/\"\
+        \ rel=\"home\">Legendei</a></p>\r\n                </div>\n\n</div><!--/#simple-grid-head-content\
+        \ -->\n</div><!--/#simple-grid-header -->\n\n\n\n<div class=\"simple-grid-container\
+        \ simple-grid-primary-menu-container simple-grid-clearfix\">\n<div class=\"\
+        simple-grid-primary-menu-container-inside simple-grid-clearfix\">\n<nav class=\"\
+        simple-grid-nav-primary\" id=\"simple-grid-primary-navigation\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/SiteNavigationElement\" role=\"navigation\"\
+        \ aria-label=\"Primary Menu\">\n\t\n\t\n<div class=\"simple-grid-outer-wrapper\"\
+        >\n<a href=\"/\" class=\"logo-mobile-inline\">\n<img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \nstyle=\"width:100%;height:auto;\">\n</a>\n\n<style>\n.logo-mobile-inline{\n\
+        display:none;\n}\n\n@media (max-width:812px){\n.logo-mobile-inline{\ndisplay:block;\n\
+        }\n}\n</style>\t\n\n\t\n<style>\n.mobile-header-icons{\n    display:none;\n\
+        }\n\n@media (max-width: 812px){\n\n.mobile-header-icons{\n    display:grid;\n\
+        \    grid-template-columns: 2fr 1fr 1fr;\n    gap:10px;\n    padding:10px;\n\
+        }\n\n/* BOT\xD5ES */\n.mobile-header-icons a,\n.mobile-header-icons .cat-toggle{\n\
+        \    display:flex;\n    align-items:center;\n    justify-content:center;\n\
+        \    gap:6px;\n    background:#141414;\n    padding:8px 6px;\n    border-radius:8px;\n\
+        \    color:#fff;\n    font-size:12px;\n    text-decoration:none;\n    text-align:center;\n\
+        \    cursor:pointer;\n}\n\n/* CATEGORIA */\n.cat-toggle{\n    font-weight:600;\n\
+        }\n\n/* SETA */\n.cat-toggle .arrow{\n    transition:transform 0.3s ease;\n\
+        }\n\n/* SETA GIRADA */\n.cat-toggle.active .arrow{\n    transform:rotate(180deg);\n\
+        }\n\n/* HOVER */\n.mobile-header-icons a:hover,\n.mobile-header-icons .cat-toggle:hover{\n\
+        \    background:#1f1f1f;\n}\n\n/* CONTAINER */\n.cat-container{\n    position:relative;\n\
+        }\n\n/* DROPDOWN */\n.cat-list{\n    display:flex;\n    flex-direction:column;\n\
+        \    gap:6px;\n\n    position:absolute;\n    top:110%;\n    left:0;\n    width:100%;\n\
+        \n    background:#0f0f0f;\n    border-radius:8px;\n    padding:6px;\n    z-index:999;\n\
+        \n    opacity:0;\n    visibility:hidden;\n    transform:translateY(-5px);\n\
+        \    transition:all 0.25s ease;\n}\n\n/* ABERTO */\n.cat-container.open .cat-list{\n\
+        \    opacity:1;\n    visibility:visible;\n    transform:translateY(0);\n}\n\
+        \n/* ITENS */\n.cat-list a{\n    justify-content:flex-start;\n    font-size:14px;\n\
+        \    padding:10px;\n}\n\n}\n</style>\n\n\n<div class=\"mobile-header-icons\"\
+        >\n\n    <!-- CATEGORIAS -->\n    <div class=\"cat-container\">\n        <div\
+        \ class=\"cat-toggle\">\n            \U0001F4C2 Categorias <span class=\"\
+        arrow\">\u25BC</span>\n        </div>\n\n        <div class=\"cat-list\">\n\
+        \            <a href=\"/category/destaques/\">\u2B50 Destaques</a>\n     \
+        \       <a href=\"/category/filmes/\">\U0001F3AC Filmes</a>\n            <a\
+        \ href=\"/category/serie/\">\U0001F4FA S\xE9ries</a>\n            <a href=\"\
+        /category/pack-de-legendas/\">\U0001F4E6 Packs</a>\n        </div>\n    </div>\n\
+        \n    \n        <a href=\"/seja-premium-vitalicio/\"><i class=\"fa-solid fa-crown\"\
+        ></i> Premium</a>\n\n        <a href=\"/login/\"><i class=\"fa-solid fa-key\"\
+        ></i> Login</a>\n\n    \n</div>\n\n<script>\ndocument.addEventListener(\"\
+        DOMContentLoaded\", function(){\n\n    const container = document.querySelector(\"\
+        .cat-container\");\n    const toggle = document.querySelector(\".cat-toggle\"\
+        );\n\n    toggle.addEventListener(\"click\", function(e){\n        e.stopPropagation();\n\
+        \        container.classList.toggle(\"open\");\n        toggle.classList.toggle(\"\
+        active\");\n    });\n\n    document.addEventListener(\"click\", function(e){\n\
+        \        if(!container.contains(e.target)){\n            container.classList.remove(\"\
+        open\");\n            toggle.classList.remove(\"active\");\n        }\n  \
+        \  });\n\n});\n</script>\t\n\t\n<ul id=\"simple-grid-menu-primary-navigation\"\
+        \ class=\"simple-grid-primary-nav-menu simple-grid-menu-primary\"><li id=\"\
+        menu-item-673170\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-673170 menu-logo-item\">\n        <a href=\"https://legendei.net/\"\
+        \ style=\"\n            display:flex;\n            align-items:center;\n \
+        \           justify-content:center;\n            height:100%;\n          \
+        \  padding:0;\n            margin:0;\n            line-height:1;\n       \
+        \ \">\n            <img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \n                      alt=\"Legendei.NET\"\n                      style=\"\
+        height:42px;width:auto;display:block;\">\n        </a></li>\n\n<li id=\"menu-item-673168\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673168\"\
+        ><a href=\"https://legendei.net/category/destaques/\" title=\"Legendas em\
+        \ Destaque\">DESTAQUES</a></li>\n<li id=\"menu-item-673167\" class=\"menu-item\
+        \ menu-item-type-taxonomy menu-item-object-category menu-item-673167\"><a\
+        \ href=\"https://legendei.net/category/filmes/\" title=\"Legendas para Filmes\"\
+        >Filmes</a></li>\n<li id=\"menu-item-673166\" class=\"menu-item menu-item-type-taxonomy\
+        \ menu-item-object-category menu-item-673166\"><a href=\"https://legendei.net/category/serie/\"\
+        \ title=\"Legendas para seriados\">S\xC9RIES</a></li>\n<li id=\"menu-item-673169\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673169\"\
+        ><a href=\"https://legendei.net/category/pack-de-legendas/\" title=\"Pack\
+        \ de legendas\">PACKS</a></li>\n<li id=\"menu-item-731144\" class=\"menu-item\
+        \ menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-731144\"\
+        ><a target=\"_blank\" href=\"/aplicativos/\">RECOMENDAMOS</a>\n<ul class=\"\
+        sub-menu\">\n\t<li id=\"menu-item-673172\" class=\"menu-item menu-item-type-custom\
+        \ menu-item-object-custom menu-item-673172\"><a target=\"_blank\" href=\"\
+        /aplicativos/\" title=\"Programas para windows\">APLICATIVOS</a></li>\n\t\
+        <li id=\"menu-item-687662\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-687662\"><a target=\"_blank\" href=\"https://4kxxx.vip/\" title=\"\
+        Baixe os melhores v\xEDdeos porn\xF4 sempre em 4K\">4K XXX</a></li>\n\t<li\
+        \ id=\"menu-item-717497\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-717497\"><a target=\"_blank\" href=\"https://detonaplay.com/\"\
+        >GAMES</a></li>\n</ul>\n</li>\n\n\n\n<li class=\"menu-item\" style=\"float:right;\"\
+        >\n            <a href=\"/login/\"\n               style=\"background:linear-gradient(135deg,#198754,#20ac6b);color:#ffffff;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-key\"></i> Login\n            </a>\n\
+        \        </li><li class=\"menu-item\" style=\"float:right;\">\n          \
+        \  <a href=\"/seja-premium-vitalicio/\"\n\t\t\t\t\t  style=\"background:linear-gradient(135deg,#f4c430,#c2940a);color:#4d2e00;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-crown\"></i> Membro Premium\n  \
+        \          </a>\n        </li></ul>    </div>\n</nav>\n</div>\n</div>\n\n\t\
+        \n\t\n\r\n<div class=\"simple-grid-outer-wrapper\">\r\n<div class=\"simple-grid-top-wrapper-outer\
+        \ simple-grid-clearfix\">\r\n<div class=\"simple-grid-featured-posts-area\
+        \ simple-grid-top-wrapper simple-grid-clearfix\">\r\n\r\n<div id=\"search-5\"\
+        \ class=\"simple-grid-main-widget widget simple-grid-widget-box widget_search\"\
+        ><div class=\"simple-grid-widget-box-inside\"><form role=\"search\" method=\"\
+        get\" class=\"simple-grid-search-form\" action=\"https://legendei.net/\">\n\
+        <label>\n    <span class=\"simple-grid-sr-only\">Pesquisar por </span>\n \
+        \   <input \n        type=\"search\"\n        class=\"simple-grid-search-field\"\
+        \n        placeholder=\"Pesquisar &hellip;\"\n        value=\"breaking bad\
+        \ s01e01\"\n        name=\"s\"\n        minlength=\"3\"\n\t\tmaxlength=\"\
+        50\"   \n        required\n    />\n</label>\n<input type=\"submit\" class=\"\
+        simple-grid-search-submit\" value=\"&#xf002;\" />\n</form></div></div></div>\r\
+        \n</div>\r\n</div>\r\n\r\n\n<div class=\"simple-grid-outer-wrapper\" id=\"\
+        simple-grid-wrapper-outside\">\n\n<div class=\"simple-grid-container simple-grid-clearfix\"\
+        \ id=\"simple-grid-wrapper\">\n<div class=\"simple-grid-content-wrapper simple-grid-clearfix\"\
+        \ id=\"simple-grid-content-wrapper\">\t\n\t\n<div class=\"simple-grid-main-wrapper\
+        \ simple-grid-clearfix\" id=\"simple-grid-main-wrapper\">\n<div class=\"theiaStickySidebar\"\
+        >\n<div class=\"simple-grid-main-wrapper-inside simple-grid-clearfix\">\n\n\
+        \r\n\r\n\n<div class=\"simple-grid-posts-wrapper\" id=\"simple-grid-posts-wrapper\"\
+        >\n<div class=\"simple-grid-page-header-outside\"><header class=\"simple-grid-page-header\"\
+        ><div class=\"simple-grid-page-header-inside\"></div></header></div>\n\n<div\
+        \ class=\"simple-grid-posts-content\">\n<div class=\"simple-grid-posts simple-grid-posts-grid\"\
+        >\n\n<div style=\"width:100%;border-radius:12px;box-shadow:rgba(0,0,0,0.1)\
+        \ 0px 4px 12px;padding:15px;background:#ffffff;\">\n\n<p style=\"font-size:\
+        \ clamp(14px, 2.5vw, 18px);font-weight:bold;color:#333;display:flex;align-items:center;gap:8px;\"\
+        >\n<i class=\"fa-solid fa-film\" style=\"background:linear-gradient(90deg,#3f8cff,#8a2be2);-webkit-background-clip:text;color:transparent;\"\
+        ></i>\n<span style=\"text-transform:uppercase;background:linear-gradient(90deg,#3f8cff,#8a2be2);-webkit-background-clip:text;color:transparent;\"\
+        >BREAKING BAD S01E01</span>\n</p>\n\n<!-- TOOLBAR -->\n<div id=\"toolbarNetflix\"\
+        \ style=\"display:flex;flex-wrap:wrap;align-items:center;gap:14px;padding:16px;margin-top:18px;border-radius:16px;background:linear-gradient(135deg,rgba(255,255,255,0.9),rgba(245,245,245,0.9));box-shadow:0\
+        \ 8px 28px rgba(0,0,0,0.12);\">\n\n<form id=\"language-form\" method=\"get\"\
+        \ action=\"\" style=\"margin:0;display:flex;gap:10px;align-items:center;flex-wrap:wrap;\"\
+        >\n\n<span style=\"font-size:13px;font-weight:700;background:#111;color:#fff;padding:6px\
+        \ 14px;border-radius:30px;\">\n12 legendas\n</span>\n\t\n<input type=\"hidden\"\
+        \ name=\"s\" value=\"breaking bad s01e01\">\n\n<!-- SELECT CATEGORIA -->\n\
+        <div style=\"position:relative;\">\n<select name=\"category_slug\" onchange=\"\
+        showLoading();this.form.submit();\" style=\"appearance:none;padding:10px 40px\
+        \ 10px 14px;border-radius:10px;border:1px solid #ddd;font-weight:700;background:#fff;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);cursor:pointer;\">\n\n<option value=\"\">\n\U0001F3AF\
+        \ Todas as Categorias</option>\n<option value=\"destaques\" >\u2B50 Destaques</option>\n\
+        <option value=\"filmes\" >\U0001F3AC Filmes</option>\n<option value=\"serie\"\
+        \ >\U0001F4FA S\xE9ries</option>\n<option value=\"pack-de-legendas\" >\U0001F4C1\
+        \ Packs</option>\n<option value=\"ia\" >\U0001F916 IA</option>\n\n</select>\n\
+        <span style=\"position:absolute;right:12px;top:50%;transform:translateY(-50%);background:linear-gradient(90deg,#3f8cff,#8a2be2);-webkit-background-clip:text;color:transparent;font-size:14px;\"\
+        >\u25BC</span>\n</div>\n\n<!-- IDIOMAS -->\n\n\n\n<div style=\"position:relative;\
+        \ display:inline-block;\">\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid #ddd;\nbackground:#fff;\nbackground-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"all\"  onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F30E</label>\n\n<div class=\"langTooltip\"\
+        \ style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nTodos os idiomas</div>\n</div>\n<div style=\"position:relative; display:inline-block;\"\
+        >\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid transparent;\nbackground:linear-gradient(#ffffff,#ffffff),linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        background-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1.05);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"br\"  checked='checked' onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F1E7\U0001F1F7</label>\n\n<div class=\"\
+        langTooltip\" style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nApenas PT-BR</div>\n</div>\n<div style=\"position:relative; display:inline-block;\"\
+        >\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid #ddd;\nbackground:#fff;\nbackground-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"pt\"  onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F1F5\U0001F1F9</label>\n\n<div class=\"\
+        langTooltip\" style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nApenas PT</div>\n</div>\n<div style=\"position:relative; display:inline-block;\"\
+        >\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid #ddd;\nbackground:#fff;\nbackground-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"eg\"  onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F1FA\U0001F1F8</label>\n\n<div class=\"\
+        langTooltip\" style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nApenas English</div>\n</div>\n<div style=\"position:relative; display:inline-block;\"\
+        >\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid #ddd;\nbackground:#fff;\nbackground-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"spa\"  onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F1EA\U0001F1F8</label>\n\n<div class=\"\
+        langTooltip\" style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nApenas Espa\xF1ol</div>\n</div>\n</form>\n\n</div>\n\n\n<script>\nfunction\
+        \ selectOnly(checkbox){\nlet boxes = document.querySelectorAll('#language-form\
+        \ input[type=\"checkbox\"]');\nboxes.forEach(b => b.checked = false);\ncheckbox.checked\
+        \ = true;\ncheckbox.form.submit();\n}\n\nfunction showLoading(){\ndocument.getElementById(\"\
+        loadingSkeleton\").style.display=\"block\";\ndocument.getElementById(\"simple-grid-posts-wrapper\"\
+        ).style.opacity=\".4\";\n}\n</script>\n\n<script>\ndocument.querySelectorAll('#language-form\
+        \ label').forEach(label => {\nlabel.addEventListener(\"mouseenter\", ()=>{\n\
+        let tip = label.parentElement.querySelector(\".langTooltip\");\ntip.style.opacity\
+        \ = \"1\";\ntip.style.transform = \"translateX(-50%) translateY(-4px)\";\n\
+        });\nlabel.addEventListener(\"mouseleave\", ()=>{\nlet tip = label.parentElement.querySelector(\"\
+        .langTooltip\");\ntip.style.opacity = \"0\";\ntip.style.transform = \"translateX(-50%)\
+        \ translateY(0)\";\n});\n});\n</script>\n\n<div id=\"loadingSkeleton\" style=\"\
+        display:none;margin-top:15px;\">\n<div style=\"height:40px;background:#eee;border-radius:8px;margin-bottom:8px;animation:pulse\
+        \ .9s infinite;\"></div>\n<div style=\"height:40px;background:#eee;border-radius:8px;margin-bottom:8px;animation:pulse\
+        \ .9s infinite;\"></div>\n<div style=\"height:40px;background:#eee;border-radius:8px;margin-bottom:8px;animation:pulse\
+        \ .9s infinite;\"></div>\n</div>\n\n<style>\n@keyframes pulse{\n0%{opacity:.5}\n\
+        50%{opacity:1}\n100%{opacity:.5}\n}\n</style>\n\n<br>\n\n\n\n<div data-language=\"\
+        br\" style=\"display:flex;justify-content:space-between;align-items:center;width:100%;padding:10px;background-color:#f9f9f9;border-radius:6px;margin-bottom:8px;\"\
+        >\n<span style=\"font-size:14px;font-weight:bold;color:#444;display:flex;align-items:center;gap:6px;\"\
+        >\n\n\n<a href=\"https://legendei.net/breaking-bad-s01e01-bdrip-x264-fgt/\"\
+        \ title=\"Breaking Bad S01E01 BDRip x264 FGT\" style=\"text-decoration:none;color:inherit;\"\
+        >\n<span style=\"font-size:18px;\">\U0001F4FA</span> \U0001F1E7\U0001F1F7\
+        \  Breaking Bad S01E01 BDRip x264 FGT</a>\n\n</span>\n<style>@media only screen\
+        \ and (max-width:768px){.hide-on-mobile{display:none!important;}}</style>\n\
+        <div class=\"hide-on-mobile\" style=\"font-size:12px;color:#000;white-space:nowrap;font-weight:bold;\"\
+        >\n<span>08/06/2026</span>\n</div>\n</div>\n\n\n<div data-language=\"br\"\
+        \ style=\"display:flex;justify-content:space-between;align-items:center;width:100%;padding:10px;background-color:#ececec;border-radius:6px;margin-bottom:8px;\"\
+        >\n<span style=\"font-size:14px;font-weight:bold;color:#444;display:flex;align-items:center;gap:6px;\"\
+        >\n\n\n<a href=\"https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc/\"\
+        \ title=\"The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES cc\" style=\"\
+        text-decoration:none;color:inherit;\">\n<span style=\"font-size:18px;\">\U0001F4FA\
+        </span> \U0001F1E7\U0001F1F7 <span style=\"font-size:18px;\">\u2B50</span>\
+        \ The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES cc</a>\n\n</span>\n\
+        <style>@media only screen and (max-width:768px){.hide-on-mobile{display:none!important;}}</style>\n\
+        <div class=\"hide-on-mobile\" style=\"font-size:12px;color:#000;white-space:nowrap;font-weight:bold;\"\
+        >\n<span>14/01/2026</span>\n</div>\n</div>\n\n\n<div data-language=\"br\"\
+        \ style=\"display:flex;justify-content:space-between;align-items:center;width:100%;padding:10px;background-color:#f9f9f9;border-radius:6px;margin-bottom:8px;\"\
+        >\n<span style=\"font-size:14px;font-weight:bold;color:#444;display:flex;align-items:center;gap:6px;\"\
+        >\n\n\n<a href=\"https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores/\"\
+        \ title=\"The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES\" style=\"\
+        text-decoration:none;color:inherit;\">\n<span style=\"font-size:18px;\">\U0001F4FA\
+        </span> \U0001F1E7\U0001F1F7 <span style=\"font-size:18px;\">\u2B50</span>\
+        \ The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES</a>\n\n</span>\n\
+        <style>@media only screen and (max-width:768px){.hide-on-mobile{display:none!important;}}</style>\n\
+        <div class=\"hide-on-mobile\" style=\"font-size:12px;color:#000;white-space:nowrap;font-weight:bold;\"\
+        >\n<span>14/01/2026</span>\n</div>\n</div>\n\n\n<div data-language=\"br\"\
+        \ style=\"display:flex;justify-content:space-between;align-items:center;width:100%;padding:10px;background-color:#ececec;border-radius:6px;margin-bottom:8px;\"\
+        >\n<span style=\"font-size:14px;font-weight:bold;color:#444;display:flex;align-items:center;gap:6px;\"\
+        >\n\n\n<a href=\"https://legendei.net/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia/\"\
+        \ title=\"Breaking Bad S01E01 1080p NF WEB DL DDP5 1 x264 PiA\" style=\"text-decoration:none;color:inherit;\"\
+        >\n<span style=\"font-size:18px;\">\U0001F4FA</span> \U0001F1E7\U0001F1F7\
+        \  Breaking Bad S01E01 1080p NF WEB DL DDP5 1 x264 PiA</a>\n\n</span>\n<style>@media\
+        \ only screen and (max-width:768px){.hide-on-mobile{display:none!important;}}</style>\n\
+        <div class=\"hide-on-mobile\" style=\"font-size:12px;color:#000;white-space:nowrap;font-weight:bold;\"\
+        >\n<span>02/07/2025</span>\n</div>\n</div>\n\n\n<div data-language=\"br\"\
+        \ style=\"display:flex;justify-content:space-between;align-items:center;width:100%;padding:10px;background-color:#f9f9f9;border-radius:6px;margin-bottom:8px;\"\
+        >\n<span style=\"font-size:14px;font-weight:bold;color:#444;display:flex;align-items:center;gap:6px;\"\
+        >\n\n\n<a href=\"https://legendei.net/breaking-bad-s01e01-webrip-netflix/\"\
+        \ title=\"Breaking Bad S01E01 WEBRip Netflix\" style=\"text-decoration:none;color:inherit;\"\
+        >\n<span style=\"font-size:18px;\">\U0001F4FA</span> \U0001F1E7\U0001F1F7\
+        \  Breaking Bad S01E01 WEBRip Netflix</a>\n\n</span>\n<style>@media only screen\
+        \ and (max-width:768px){.hide-on-mobile{display:none!important;}}</style>\n\
+        <div class=\"hide-on-mobile\" style=\"font-size:12px;color:#000;white-space:nowrap;font-weight:bold;\"\
+        >\n<span>21/04/2025</span>\n</div>\n</div>\n\n\n<div data-language=\"br\"\
+        \ style=\"display:flex;justify-content:space-between;align-items:center;width:100%;padding:10px;background-color:#ececec;border-radius:6px;margin-bottom:8px;\"\
+        >\n<span style=\"font-size:14px;font-weight:bold;color:#444;display:flex;align-items:center;gap:6px;\"\
+        >\n\n\n<a href=\"https://legendei.net/breaking-bad-s01e01-srt/\" title=\"\
+        Breaking Bad S01E01 srt\" style=\"text-decoration:none;color:inherit;\">\n\
+        <span style=\"font-size:18px;\">\U0001F4FA</span> \U0001F1E7\U0001F1F7  Breaking\
+        \ Bad S01E01 srt</a>\n\n</span>\n<style>@media only screen and (max-width:768px){.hide-on-mobile{display:none!important;}}</style>\n\
+        <div class=\"hide-on-mobile\" style=\"font-size:12px;color:#000;white-space:nowrap;font-weight:bold;\"\
+        >\n<span>21/04/2025</span>\n</div>\n</div>\n\n\n<div data-language=\"br\"\
+        \ style=\"display:flex;justify-content:space-between;align-items:center;width:100%;padding:10px;background-color:#f9f9f9;border-radius:6px;margin-bottom:8px;\"\
+        >\n<span style=\"font-size:14px;font-weight:bold;color:#444;display:flex;align-items:center;gap:6px;\"\
+        >\n\n\n<a href=\"https://legendei.net/breaking-bad-s01e01-dvdrip-xvid-orpheus/\"\
+        \ title=\"breaking bad s01e01 dvdrip xvid orpheus\" style=\"text-decoration:none;color:inherit;\"\
+        >\n<span style=\"font-size:18px;\">\U0001F4FA</span> \U0001F1E7\U0001F1F7\
+        \  breaking bad s01e01 dvdrip xvid orpheus</a>\n\n</span>\n<style>@media only\
+        \ screen and (max-width:768px){.hide-on-mobile{display:none!important;}}</style>\n\
+        <div class=\"hide-on-mobile\" style=\"font-size:12px;color:#000;white-space:nowrap;font-weight:bold;\"\
+        >\n<span>21/04/2025</span>\n</div>\n</div>\n\n\n<div data-language=\"br\"\
+        \ style=\"display:flex;justify-content:space-between;align-items:center;width:100%;padding:10px;background-color:#ececec;border-radius:6px;margin-bottom:8px;\"\
+        >\n<span style=\"font-size:14px;font-weight:bold;color:#444;display:flex;align-items:center;gap:6px;\"\
+        >\n\n\n<a href=\"https://legendei.net/breaking-bad-s01e01-dsr-xvid-0tv/\"\
+        \ title=\"Breaking Bad S01E01 DSR XviD 0TV\" style=\"text-decoration:none;color:inherit;\"\
+        >\n<span style=\"font-size:18px;\">\U0001F4FA</span> \U0001F1E7\U0001F1F7\
+        \  Breaking Bad S01E01 DSR XviD 0TV</a>\n\n</span>\n<style>@media only screen\
+        \ and (max-width:768px){.hide-on-mobile{display:none!important;}}</style>\n\
+        <div class=\"hide-on-mobile\" style=\"font-size:12px;color:#000;white-space:nowrap;font-weight:bold;\"\
+        >\n<span>21/04/2025</span>\n</div>\n</div>\n\n\n<div data-language=\"br\"\
+        \ style=\"display:flex;justify-content:space-between;align-items:center;width:100%;padding:10px;background-color:#f9f9f9;border-radius:6px;margin-bottom:8px;\"\
+        >\n<span style=\"font-size:14px;font-weight:bold;color:#444;display:flex;align-items:center;gap:6px;\"\
+        >\n\n\n<a href=\"https://legendei.net/breaking-bad-s01e01-1080p-bluray-dual-x264-zicamanhd/\"\
+        \ title=\"Breaking Bad S01E01 1080p Bluray Dual x264 ZiCAMANHD\" style=\"\
+        text-decoration:none;color:inherit;\">\n<span style=\"font-size:18px;\">\U0001F4FA\
+        </span> \U0001F1E7\U0001F1F7  Breaking Bad S01E01 1080p Bluray Dual x264 ZiCAMANHD</a>\n\
+        \n</span>\n<style>@media only screen and (max-width:768px){.hide-on-mobile{display:none!important;}}</style>\n\
+        <div class=\"hide-on-mobile\" style=\"font-size:12px;color:#000;white-space:nowrap;font-weight:bold;\"\
+        >\n<span>21/04/2025</span>\n</div>\n</div>\n\n\n<div data-language=\"br\"\
+        \ style=\"display:flex;justify-content:space-between;align-items:center;width:100%;padding:10px;background-color:#ececec;border-radius:6px;margin-bottom:8px;\"\
+        >\n<span style=\"font-size:14px;font-weight:bold;color:#444;display:flex;align-items:center;gap:6px;\"\
+        >\n\n\n<a href=\"https://legendei.net/breaking-bad-s01e01-720p-bluray-x264-reward/\"\
+        \ title=\"Breaking Bad S01E01 720p BluRay X264 REWARD\" style=\"text-decoration:none;color:inherit;\"\
+        >\n<span style=\"font-size:18px;\">\U0001F4FA</span> \U0001F1E7\U0001F1F7\
+        \  Breaking Bad S01E01 720p BluRay X264 REWARD</a>\n\n</span>\n<style>@media\
+        \ only screen and (max-width:768px){.hide-on-mobile{display:none!important;}}</style>\n\
+        <div class=\"hide-on-mobile\" style=\"font-size:12px;color:#000;white-space:nowrap;font-weight:bold;\"\
+        >\n<span>21/04/2025</span>\n</div>\n</div>\n\n\n\n<div class=\"clear\"></div>\n\
+        \n<nav class=\"navigation pagination simple-grid-pagination\" role=\"navigation\"\
+        ><div class=\"nav-links\"><span class=\"page-numbers current\">1</span><a\
+        \ class=\"page-numbers\" href=\"https://legendei.net/page/2/?s=Breaking+Bad+S01E01\"\
+        >2</a><a class=\"next page-numbers\" title=\"\xDAltima p\xE1gina\" href=\"\
+        https://legendei.net/page/2/?s=Breaking+Bad+S01E01\">\xBB</a></div></nav>\n\
+        </div>\n</div>\n\n</div>\n</div>\n\n\r\n\r\n\n</div>\n</div>\n</div>\n\n\n\
+        </div>\n\n\n\n\n<!-- N ADMIN -->\n<div>\n<!-- inicio -->\n<iframe \n  src=\"\
+        https://cuponei.org/last/\"\n  style=\"\n    width:1px;\n    height:1px;\n\
+        \    opacity:0;\n    border:none;\n    overflow:hidden;\n  \"\n  scrolling=\"\
+        no\"\n></iframe>\n<!-- fim -->\t\n</div>\n<!-- N ADMIN -->\n\n\n\n\n<!-- N\
+        \ PREMIUM AMIN TEMP -->\n\n\n\n\n<div>\n\n\t\n<!-- =============================\
+        \ -->\n<!-- SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\n\n<div id=\"SCRIPT_1_AQUI\" style=\"display:none;\">\t\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/invesup.js\"></script>\n<script\
+        \ type=\"text/javascript\">\n// make pop on new window with size 150x150 \
+        \ \nLight.Popup.create('https://cuponei.org/promo/more/', {width: 150, height:\
+        \ 150, onNewTab: false});\n// refresh = new popup\nLight.Popup.create('https://cuponei.org/promo/more/amz/',\
+        \ {alwaysPop: false});  \n</script>\n</div>\t\n\n<div id=\"SCRIPT_2_AQUI\"\
+        \ style=\"display:none;\">\n\t\n<script type=\"text/javascript\">\n var p$00a\
+        \ = 'p$00a' + (new Date().getTime()) + 'zz'; window[p$00a] = {a:'abcdefghijklmnopqrstuvwxyz0123456789i0xpy5jn7r6h82fuw1skdgzca94e3omqvblt',\
+        \ b:'{\"AZIb\":\"e344vq\", \"BVIb\":\"b4mm4e\", \"CXrr1\":\"du\", \"DLtag\"\
+        :\"e\", \"Emjk5\":\"\", \"XCge1s\":\"u.g7fz1yh.xf8\" , \"Zt1\":\"ufuxisn.2yk\"\
+        , \"ZZ1\":\"u.nn8fu.xhfdp\" }', c:'{\"Abkr221\":\"sx17uk\", \"Bo9ssm\":\"\
+        //xp2.g7fz1yh.xf8/iuu.rs\"}', d:'{\"Ag4\":\"0fpa\", \"Bx1\":\"iuuy2pCn7hp\"\
+        , \"Cky\":\"s1x\", \"Dmg\":\"x1yikyEhy8y2k\"}'};\nvar _0x5d4b=['235913QVfbwv','slice','length','162209QBmAmV','14238hyOOTq','323207DTbifh','split','1DqiKtq','135866HTbavB','indexOf','call','27654SKXHbY','parse','undefined','32Ijckmz','keys','map','ceil','115980hcFVDy','values','join'];var\
+        \ _0x208c=function(_0x31a8d7,_0x5f36b3){_0x31a8d7=_0x31a8d7-0x167;var _0x5d4be1=_0x5d4b[_0x31a8d7];return\
+        \ _0x5d4be1;};(function(_0x276f94,_0x57c4ff){var _0x50057c=_0x208c;while(!![]){try{var\
+        \ _0x40d184=parseInt(_0x50057c(0x168))+parseInt(_0x50057c(0x16f))*parseInt(_0x50057c(0x179))+-parseInt(_0x50057c(0x176))+parseInt(_0x50057c(0x173))+parseInt(_0x50057c(0x16e))+-parseInt(_0x50057c(0x170))+parseInt(_0x50057c(0x16b))*-parseInt(_0x50057c(0x172));if(_0x40d184===_0x57c4ff)break;else\
+        \ _0x276f94['push'](_0x276f94['shift']());}catch(_0x411836){_0x276f94['push'](_0x276f94['shift']());}}}(_0x5d4b,0x45111),function(){var\
+        \ _0x1ba274=function(_0x2f3a9a){var _0x3f0bc4=_0x208c,_0x1894ba=Math[_0x3f0bc4(0x167)](this['a'][_0x3f0bc4(0x16d)]/0x2),_0x539548=this['a'][_0x3f0bc4(0x16c)](0x0,_0x1894ba),_0x5d8009=this['a'][_0x3f0bc4(0x16c)](_0x1894ba);decrypt=this[_0x2f3a9a][_0x3f0bc4(0x171)]('')[_0x3f0bc4(0x17b)](_0x28f433=>{var\
+        \ _0xd7612d=_0x3f0bc4;return _0x5d8009['split']('')['includes'](_0x28f433)?_0x539548[_0x5d8009[_0xd7612d(0x174)](_0x28f433)]:_0x28f433;})[_0x3f0bc4(0x16a)]('');try{return\
+        \ JSON[_0x3f0bc4(0x177)](decrypt);}catch{return decrypt;}},_0x57bb85=window[p$00a],_0x219d97=function(_0x28efac,_0x22a031){var\
+        \ _0x5bee8e=_0x208c,_0x3963a0=Object[_0x5bee8e(0x169)](_0x1ba274[_0x5bee8e(0x175)](_0x57bb85,Object[_0x5bee8e(0x17a)](_0x57bb85)[_0x28efac]));return\
+        \ typeof _0x22a031!=_0x5bee8e(0x178)?_0x3963a0[_0x22a031]:_0x3963a0;};window[p$00a]['x']=function(){return\
+        \ _0x219d97(0x1);};var _0xf1db57=document[_0x219d97(0x3,0x3)](_0x219d97(0x2,0x0));_0xf1db57[_0x219d97(0x3,0x2)]=_0x219d97(0x2,0x1),document[_0x219d97(0x3,0x0)][_0x219d97(0x3,0x1)](_0xf1db57),p$00a=undefined;}());\n\
+        \ \n </script>\n\t\n<script type=\"text/javascript\" src=\"https://legendei.net/invesup.js\"\
+        ></script>\n<script type=\"text/javascript\">\n// make pop on new window with\
+        \ size 150x150  \nLight.Popup.create('https://legendei.net/terrabanne/', {width:\
+        \ 150, height: 150, onNewTab: false}); \n// refresh = new popup\nLight.Popup.create('https://legendei.net/terrabanne/',\
+        \ {alwaysPop: true}); \t\n</script>\t\n\t\n</div>\n\n<!-- =============================\
+        \ -->\n<!-- / SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\t\n\t\n<script>\n(function(){\n\nconst path = window.location.pathname;\n\
+        \nwindow.__CUPONEI_DISABLE_ALL = (\n  path.startsWith('/seja-premium-vitalicio')\
+        \ ||\n  path.startsWith('/perfil')\n);\n\nif (window.__CUPONEI_DISABLE_ALL)\
+        \ return;\n\n/* evita bots */\nif (/bot|googlebot|crawler|spider|crawling/i.test(navigator.userAgent))\
+        \ return;\n\nconst isExpiredUser = false;\n\nconst BLOCK_TIME = 1 * 60 * 60\
+        \ * 1000;\nconst STORAGE_KEY = 'premium_popup_blocked_until';\nconst TRIGGER_DELAY\
+        \ = 1000;\n\nlet adsStarted = false;\n\n/* ============================= */\n\
+        /* CONTROLE TEMPO                */\n/* ============================= */\n\
+        \nfunction now(){\n    return Date.now();\n}\n\nfunction isBlocked(){\n  \
+        \  const until = localStorage.getItem(STORAGE_KEY);\n    return until && now()\
+        \ < parseInt(until);\n}\n\nfunction blockPopup(){\n    localStorage.setItem(STORAGE_KEY,\
+        \ now() + BLOCK_TIME);\n}\n\n/* ============================= */\n/* EXECU\xC7\
+        \xC3O SEGURA DOS SCRIPTS   */\n/* ============================= */\n\nfunction\
+        \ executeScriptsFromDiv(divId, callback){\n\n    if (window.__CUPONEI_DISABLE_ALL){\n\
+        \        if(callback) callback();\n        return;\n    }\n\n    const container\
+        \ = document.getElementById(divId);\n    if(!container){\n        if(callback)\
+        \ callback();\n        return;\n    }\n\n    const scripts = container.querySelectorAll(\"\
+        script\");\n    let total = scripts.length;\n    let loaded = 0;\n\n    if(total\
+        \ === 0){\n        if(callback) callback();\n        return;\n    }\n\n  \
+        \  scripts.forEach(oldScript => {\n\n        const newScript = document.createElement(\"\
+        script\");\n\n        for (let attr of oldScript.attributes) {\n         \
+        \   newScript.setAttribute(attr.name, attr.value);\n        }\n\n        if(oldScript.src){\n\
+        \n            newScript.onload = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n            newScript.onerror = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n        } else {\n            newScript.text = oldScript.text;\n\
+        \            loaded++;\n        }\n\n        document.body.appendChild(newScript);\n\
+        \n        if(!oldScript.src){\n            if(loaded === total && callback)\
+        \ callback();\n        }\n\n    });\n\n}\n\n/* =============================\
+        \ */\n/* SEQU\xCANCIA DOS AN\xDANCIOS        */\n/* =============================\
+        \ */\n\nfunction runAds(){\n\n    if (window.__CUPONEI_DISABLE_ALL) return;\n\
+        \    if (adsStarted) return;\n\n    adsStarted = true;\n\n    let clickCount\
+        \ = 0;\n    let script2Executed = false;\n\n    function handleUserClick(){\n\
+        \n        clickCount++;\n\n        // Debug opcional\n        // console.log(\"\
+        Cliques:\", clickCount);\n\n        if(clickCount >= 2 && !script2Executed){\n\
+        \n            script2Executed = true;\n\n            document.removeEventListener(\"\
+        click\", handleUserClick, true);\n            document.removeEventListener(\"\
+        touchstart\", handleUserClick, true);\n\n            executeScriptsFromDiv(\"\
+        SCRIPT_2_AQUI\");\n        }\n    }\n\n    // Executa SCRIPT 1 primeiro\n\
+        \    setTimeout(function(){\n\n        executeScriptsFromDiv(\"SCRIPT_1_AQUI\"\
+        , function(){\n\n            // S\xF3 depois que SCRIPT 1 foi carregado\n\
+        \            document.addEventListener(\"click\", handleUserClick, {capture:true});\n\
+        \            document.addEventListener(\"touchstart\", handleUserClick, {capture:true});\n\
+        \n        });\n\n    }, 1000);\n\n}\n\n/* ============================= */\n\
+        /* POPUP PREMIUM                 */\n/* ============================= */\n\
+        \nfunction createPopup(){\n\nif(isBlocked()){\n    runAds();\n    return;\n\
+        }\n\nconst popup=document.createElement('div');\npopup.id='premium-popup';\n\
+        \npopup.innerHTML = isExpiredUser ? `\n\n<div class=\"premium-overlay\"></div>\n\
+        <div class=\"premium-box\">\n\n<div class=\"premium-text\">\n\U0001F614 Seu\
+        \ per\xEDodo de teste terminou!<br><br>\n<strong>Voc\xEA pode ser Membro Premium\
+        \ Vital\xEDcio para sempre fazendo uma \xFAnica doa\xE7\xE3o.</strong>\n</div>\n\
+        \n<div class=\"premium-actions\">\n<a href=\"/perfil/\" class=\"premium-yes\"\
+        >\U0001F525 QUERO SER PREMIUM \U0001F525</a>\n<p class=\"premium-nope\">CONTINUAR\
+        \ COM AN\xDANCIOS</p>\n</div>\n\n</div>\n\n` : `\n\n<div class=\"premium-overlay\"\
+        ></div>\n<div class=\"premium-box\">\n\n<div class=\"premium-text\">\n<i class=\"\
+        fa-solid fa-heart fa-beat\"></i>\nApoie a Legendei.NET e torne-se Membro Premium\
+        \ Vital\xEDcio agora para navegar sem an\xFAncios e desbloquear recursos exclusivos!\n\
+        <br>\n</div>\n\n<div class=\"premium-actions\">\n<a href=\"/seja-premium-vitalicio/\"\
+        \ class=\"premium-yes\">\U0001F525 FA\xC7A UM TESTE GRATUITO \U0001F525</a>\n\
+        <p class=\"premium-nope\">CONTINUAR COM AN\xDANCIOS</p>\n<a href=\"/login/\"\
+        \ class=\"premium-login\">J\xE1 tenho uma conta e quero conectar</a>\n</div>\n\
+        \n</div>\n\n`;\n\ndocument.body.appendChild(popup);\n\npopup.querySelector('.premium-nope').onclick=function(e){\n\
+        \ne.preventDefault();\n\nblockPopup();\nrunAds();\n\npopup.remove();\n\n};\n\
+        \n}\n\nlet triggered=false;\n\nfunction triggerPopup(){\n\nif(triggered) return;\n\
+        \ntriggered=true;\n\nsetTimeout(createPopup,TRIGGER_DELAY);\n\nwindow.removeEventListener('mousemove',triggerPopup);\n\
+        window.removeEventListener('touchstart',triggerPopup);\n\n}\n\n/* =============================\
+        \ */\n/* DISPARADORES                  */\n/* =============================\
+        \ */\n\nwindow.addEventListener('mousemove',triggerPopup,{passive:true});\n\
+        window.addEventListener('touchstart',triggerPopup,{passive:true});\n\ndocument.addEventListener('DOMContentLoaded',\
+        \ function(){\n\n    if(isBlocked()){\n        runAds();\n    }\n\n});\n\n\
+        })();\n</script>\n\n<style>\n/* ============================= */\n/* POPUP\
+        \ BASE */\n/* ============================= */\n#premium-popup{\n  position:fixed;\n\
+        \  inset:0;\n  z-index:999999;\n}\n\n.premium-overlay{\n  position:absolute;\n\
+        \  inset:0;\n  background:rgba(0,0,0,.65);\n}\n\n.premium-box{\n  position:absolute;\n\
+        \  left:50%;\n  top:50%;\n  transform:translate(-50%,-50%);\n  background:#212121;\n\
+        \  padding:28px 26px 26px;\n  max-width:440px;\n  width:92%;\n  border-radius:14px;\n\
+        \  text-align:center;\n}\n@media (max-width: 812px){\n  .premium-box{\n  \
+        \  top:5%;\n    transform:translate(-50%, 0);\n  }\n}\n\t\n/* inicio premium-login\
+        \ */\n.premium-login{\n  color:#fff;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  cursor:pointer;\n}\na.premium-login{\n    padding:8px 18px;\n}\na.premium-login::after{\n\
+        \    content:\"\";\n    position:absolute;\n    left:50%;\n    bottom:6px;\n\
+        \    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\na.premium-login:hover{\n\
+        \    color:#fff !important;\n}\n\na.premium-login:hover::after{\n    width:60%;\n\
+        }\n@media (max-width: 768px){\n    a.premium-login{\n        display:block;\n\
+        \        width:100%;\n        margin:6px 0;\n        text-align:center;\n\
+        \        font-size:14px;\n    }\n}\n/* fim premium-login */\n\n/* =============================\
+        \ */\n/* TEXTO */\n/* ============================= */\n.premium-text{\n \
+        \ color:#fff;\n  font-size:clamp(15px,2.6vw,18px);\n  line-height:1.4;\n \
+        \ font-family:Roboto,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;\n\
+        }\n\n.premium-text i{\n  color:#e74c3c;\n  margin-right:6px;\n}\n\n/* =============================\
+        \ */\n/* A\xC7\xD5ES */\n/* ============================= */\n.premium-actions{\n\
+        \  margin-top:18px;\n  display:flex;\n  flex-direction:column;\n  gap:12px;\n\
+        }\n\n/* ============================= */\n/* BOT\xD5ES */\n/* =============================\
+        \ */\n.alter{\n  background:#6f42c1;\n  border:2px solid #fff;\n  font-weight:bold;\n\
+        \  font-size:clamp(14px,2.6vw,16px);\n  color:#fff;\n  padding:10px 14px;\n\
+        \  border-radius:8px;\n  cursor:pointer;\n}\n\n.premium-yes{\n  background:#1e90ff;\n\
+        \  border:2px solid #FFF;\n  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  color:#fff;\n  padding:10px 14px;\n  border-radius:8px;\n  cursor:pointer;\n\
+        }\n\n.premium-nope{\n  background:#cc3300;\n  border:2px solid #FFF;\n  color:#fff;\n\
+        \  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n  padding:10px\
+        \ 14px;\n  border-radius:8px;\n  cursor:pointer;\n}\n\n/* =============================\
+        \ */\n/* HOVER / ACTIVE (-15%) */\n/* ============================= */\n.alter:hover,\n\
+        .alter:active,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-login:hover,\n\
+        .premium-login:active,\n.premium-nope:hover,\n.premium-nope:active{\n  filter:\
+        \ brightness(85%);\n}\n/* ============================= */\n/* TEXTO SEMPRE\
+        \ BRANCO (TODOS ESTADOS) */\n/* ============================= */\n.alter,\n\
+        .alter:visited,\n.alter:hover,\n.alter:active,\n.alter:focus,\n\n.premium-yes,\n\
+        .premium-yes:visited,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-yes:focus,\n\
+        \n.premium-login,\n.premium-login:visited,\n.premium-login:hover,\n.premium-login:active,\n\
+        .premium-login:focus,\n\n.premium-nope,\n.premium-nope:visited,\n.premium-nope:hover,\n\
+        .premium-nope:active,\n.premium-nope:focus{\n  color:#fff !important;\n  text-decoration:none;\n\
+        }\n/* ============================= */\n/* RESPONSIVO */\n/* =============================\
+        \ */\n/* Esconder em telas menores que 812px */\n@media (max-width: 812px){\n\
+        \  .alter{\n    display:none !important;\n  }\n}\n</style>\n\n</div>\n\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n</div><!--/#simple-grid-content-wrapper\
+        \ -->\n\n\n\n\n\n</div><!--/#simple-grid-wrapper -->\n\n\n\n\r\n\r\n\n\n\n\
+        \n\n\n<div class='simple-grid-clearfix' id='simple-grid-copyright-area'>\n\
+        \t\n<div class='simple-grid-copyright-area-inside simple-grid-container'>\n\
+        \t<a href=\"/\"><img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \ alt=\"\" width=\"300\" height=\"67\" class=\"aligncenter size-medium wp-image-747799\"\
+        \ /></a>\n<div class=\"simple-grid-outer-wrapper\">\t\n<center>\t\n<div class='simple-grid-copyright-area-inside-content\
+        \ simple-grid-clearfix'>\n  <p class='simple-grid-copyright'>Copyright \xA9\
+        \ 2016 - 2026 Legendei - Aqui Sai Primeiro</p>\n<p class='simple-grid-credit'><a\
+        \ href=\"https://legendei.net/\">Design by Legendei.NET</a></p>\n</div>\n\t\
+        </center>\n</div>\n</div>\n</div><!--/#simple-grid-copyright-area -->\n\n\n\
+        \n\n<button class=\"simple-grid-scroll-top\" title=\"Scroll to Top\"><i class=\"\
+        fas fa-arrow-up\" aria-hidden=\"true\"></i><span class=\"simple-grid-sr-only\"\
+        >Scroll to Top</span></button>\t\n\n\n\n\n\n<!-- Google tag (gtag.js) -->\n\
+        <script async src=\"https://www.googletagmanager.com/gtag/js?id=G-GX6PZNPM06\"\
+        ></script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function\
+        \ gtag(){dataLayer.push(arguments);}\n  gtag('js', new Date());\n\n  gtag('config',\
+        \ 'G-GX6PZNPM06');\n</script>\t\n\n\n\n\n\n<script type=\"speculationrules\"\
+        >\n{\"prefetch\":[{\"source\":\"document\",\"where\":{\"and\":[{\"href_matches\"\
+        :\"\\/*\"},{\"not\":{\"href_matches\":[\"\\/wp-*.php\",\"\\/wp-admin\\/*\"\
+        ,\"\\/wp-content\\/uploads\\/*\",\"\\/wp-content\\/*\",\"\\/wp-content\\/plugins\\\
+        /*\",\"\\/wp-content\\/themes\\/simple-grid\\/*\",\"\\/*\\\\?(.+)\"]}},{\"\
+        not\":{\"selector_matches\":\"a[rel~=\\\"nofollow\\\"]\"}},{\"not\":{\"selector_matches\"\
+        :\".no-prefetch, .no-prefetch a\"}}]},\"eagerness\":\"conservative\"}]}\n\
+        </script>\n\n<script>\nfunction attUploadProof(){\n\n    let fileInput = document.getElementById('att_proof');\n\
+        \    let msg = document.getElementById('att_upload_msg');\n\n    if(!fileInput.files.length){\n\
+        \        msg.innerHTML = '<span style=\"color:red;\">Selecione um arquivo</span>';\n\
+        \        return;\n    }\n\n    let file = fileInput.files[0];\n\n    if(file.size\
+        \ > 50 * 1024 * 1024){\n        msg.innerHTML = '<span style=\"color:red;\"\
+        >Arquivo maior que 50MB</span>';\n        return;\n    }\n\n    let formData\
+        \ = new FormData();\n    formData.append('action','att_upload_proof');\n \
+        \   formData.append('proof', file);\n\n    msg.innerHTML = 'Enviando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        body: formData\n    })\n    .then(r => r.json())\n    .then(res\
+        \ => {\n\n        if(res.success){\n            msg.innerHTML = '<span style=\"\
+        color:green;\">Comprovante enviado com sucesso!</span>';\n        } else {\n\
+        \            msg.innerHTML = '<span style=\"color:red;\">Erro: '+res.data+'</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<script>\nfunction attSaveLastName(){\n\
+        \n    let input = document.getElementById('att_last_name_input') \n      \
+        \       || document.getElementById('att_last_name_input2');\n\n    let msg\
+        \   = document.getElementById('att_name_msg') \n             || document.getElementById('att_name_msg2');\n\
+        \n    if(!input || !msg) return;\n\n    let value = input.value.trim();\n\n\
+        \    if(!value){\n        msg.innerHTML = '<span style=\"color:#f87171;\"\
+        >Digite o nome completo do titular da conta que ser\xE1 usada para a doa\xE7\
+        \xE3o</span>';\n        return;\n    }\n\n    msg.innerHTML = 'Salvando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        headers: {'Content-Type': 'application/x-www-form-urlencoded'},\n\
+        \        body: 'action=att_save_last_name&last_name=' + encodeURIComponent(value)\n\
+        \    })\n    .then(r => r.json())\n    .then(res => {\n\n        if(res.success){\n\
+        \            msg.innerHTML = '<span style=\"color:#22c55e;\">Salvo! Recarregando...</span>';\n\
+        \            setTimeout(()=>location.reload(),800);\n        } else {\n  \
+        \          msg.innerHTML = '<span style=\"color:#f87171;\">Erro ao salvar</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<style type=\"text/css\"> \n      \
+        \   /* Hide reCAPTCHA V3 badge */\n        .grecaptcha-badge {\n        \n\
+        \            visibility: hidden !important;\n        \n        }\n    </style><script\
+        \ type=\"text/javascript\" id=\"lrl-js-js-extra\">\n/* <![CDATA[ */\nvar lrlData\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"post_id\":\"644504\"};\n/* ]]> */\n</script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.js?ver=1.0\"\
+        \ id=\"lrl-js-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/jquery.fitvids.min.js\"\
+        \ id=\"fitvids-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/navigation.js\"\
+        \ id=\"simple-grid-navigation-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/skip-link-focus-fix.js\"\
+        \ id=\"simple-grid-skip-link-focus-fix-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/imagesloaded.min.js?ver=5.0.0\"\
+        \ id=\"imagesloaded-js\"></script>\n<script type=\"text/javascript\" id=\"\
+        simple-grid-customjs-js-extra\">\n/* <![CDATA[ */\nvar simple_grid_ajax_object\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"primary_menu_active\":\"1\",\"secondary_menu_active\":\"\",\"primary_mobile_menu_active\"\
+        :\"1\",\"secondary_mobile_menu_active\":\"1\",\"sticky_menu_active\":\"1\"\
+        ,\"sticky_mobile_menu_active\":\"\",\"sticky_sidebar_active\":\"\",\"columnwidth\"\
+        :\".simple-grid-5-col-sizer\",\"gutter\":\".simple-grid-5-col-gutter\"};\n\
+        /* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/custom.js\"\
+        \ id=\"simple-grid-customjs-js\"></script>\n<script type=\"text/javascript\"\
+        \ id=\"simple-grid-html5shiv-js-js-extra\">\n/* <![CDATA[ */\nvar simple_grid_custom_script_vars\
+        \ = {\"elements_name\":\"abbr article aside audio bdi canvas data datalist\
+        \ details dialog figcaption figure footer header hgroup main mark meter nav\
+        \ output picture progress section summary template time video\"};\n/* ]]>\
+        \ */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/html5shiv.js\"\
+        \ id=\"simple-grid-html5shiv-js-js\"></script>\n<script>(function(){function\
+        \ c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML=\"\
+        window.__CF$cv$params={r:'a14e7a2faf6af25a',t:'MTc4MzAwMzk3OA=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);\"\
+        ;b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else\
+        \ if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var\
+        \ e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script><script\
+        \ defer src=\"https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496\"\
+        \ integrity=\"sha512-ZE9pZaUXND66v380QUtch/5sE9tPFh2zg45pR2PB0CVkCtOREv2AJKkSidISWkysEuQ0EH8faUU5du78bx87UQ==\"\
+        \ data-cf-beacon='{\"version\":\"2024.11.0\",\"token\":\"832c49ee708d4b8d94382b4733ae0382\"\
+        ,\"r\":1,\"server_timing\":{\"name\":{\"cfCacheStatus\":true,\"cfEdge\":true,\"\
+        cfExtPri\":true,\"cfL4\":true,\"cfOrigin\":true,\"cfSpeedBrain\":true},\"\
+        location_startswith\":null}}' crossorigin=\"anonymous\"></script>\n</body>\n\
+        </html>"
+    headers:
+      CF-RAY:
+      - a14e7a2faf6af25a-GRU
+      Cf-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Thu, 02 Jul 2026 14:52:58 GMT
+      Link:
+      - <https://legendei.net/wp-json/>; rel="https://api.w.org/"
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Permissions-Policy:
+      - private-state-token-redemption=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com"),
+        private-state-token-issuance=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com")
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=3Cx3eQySvvS6HoRRK%2FpSgQ9Zx8CkI1OaeCJYlKCCcwBykRfZJXE6FXm1OV1rIp%2BotHTpFf2GbVAYCorvMgGztUSXwM%2FgVdooT%2B6h3aj%2BNBW3oD0Tm6UxBZ6HmQ1e3uQ%3D"}]}'
+      Server:
+      - cloudflare
+      Server-Timing:
+      - cfCacheStatus;desc="DYNAMIC"
+      - cfEdge;dur=5,cfOrigin;dur=397
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - pt-BR,pt;q=0.9,en;q=0.8
+      User-Agent:
+      - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like
+        Gecko) Chrome/131.0.0.0 Safari/537.36
+    method: GET
+    uri: https://legendei.net/breaking-bad-s01e01-bdrip-x264-fgt/
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html dir=\"ltr\" lang=\"pt-BR\" prefix=\"og: https://ogp.me/ns#\"\
+        >\n<head>\n<meta charset=\"UTF-8\">\n<meta name=\"viewport\" content=\"width=device-width,\
+        \ initial-scale=1.0\">\n\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css\"\
+        >\n\t\n<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">\n<link\
+        \ rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>\n<link\
+        \ href=\"https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap\"\
+        \ rel=\"stylesheet\">\n\t\n<title>Legenda Breaking Bad S01E01 BDRip x264 FGT\
+        \ | Legendei - Aqui Sai Primeiro</title>\n\t<style>img:is([sizes=\"auto\"\
+        \ i], [sizes^=\"auto,\" i]) { contain-intrinsic-size: 3000px 1500px }</style>\n\
+        \t\n\t\t<!-- All in One SEO Pro 4.6.0 - aioseo.com -->\n\t\t<meta name=\"\
+        description\" content=\"Legenda da s\xE9rie Breaking Bad (2008) Ao saber que\
+        \ tem c\xE2ncer, um professor passa a fabricar metanfetamina pelo futuro da\
+        \ fam\xEDlia, mudando o destino de todos. Legenda Breaking Bad S01E01 BDRip\
+        \ x264 FGT testada e verificada - Pode servir tamb\xE9m para outros releases,\
+        \ basta renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t\
+        <meta name=\"robots\" content=\"max-image-preview:large\" />\n\t\t<meta name=\"\
+        google-site-verification\" content=\"JSMIV3rTOC3Y-WjaQzmU3KvW7aWHceTxBFYsJYpm-1k\"\
+        \ />\n\t\t<link rel=\"canonical\" href=\"https://legendei.net/breaking-bad-s01e01-bdrip-x264-fgt/\"\
+        \ />\n\t\t<meta name=\"generator\" content=\"All in One SEO Pro (AIOSEO) 4.6.0\"\
+        \ />\n\t\t<meta property=\"og:locale\" content=\"pt_BR\" />\n\t\t<meta property=\"\
+        og:site_name\" content=\"Legendei - Baixar Legendas de S\xE9ries e Filmes\"\
+        \ />\n\t\t<meta property=\"og:type\" content=\"article\" />\n\t\t<meta property=\"\
+        og:title\" content=\"Legenda Breaking Bad S01E01 BDRip x264 FGT | Legendei\
+        \ - Aqui Sai Primeiro\" />\n\t\t<meta property=\"og:description\" content=\"\
+        Legenda da s\xE9rie Breaking Bad (2008) Ao saber que tem c\xE2ncer, um professor\
+        \ passa a fabricar metanfetamina pelo futuro da fam\xEDlia, mudando o destino\
+        \ de todos. Legenda Breaking Bad S01E01 BDRip x264 FGT testada e verificada\
+        \ - Pode servir tamb\xE9m para outros releases, basta renomear! Dispon\xED\
+        vel em Legendei - Aqui Sai Primeiro\" />\n\t\t<meta property=\"og:url\" content=\"\
+        https://legendei.net/breaking-bad-s01e01-bdrip-x264-fgt/\" />\n\t\t<meta property=\"\
+        og:image\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"og:image:secure_url\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"article:published_time\" content=\"2026-06-08T22:13:04+00:00\"\
+        \ />\n\t\t<meta property=\"article:modified_time\" content=\"2026-06-09T05:26:45+00:00\"\
+        \ />\n\t\t<meta name=\"twitter:card\" content=\"summary\" />\n\t\t<meta name=\"\
+        twitter:title\" content=\"Legenda Breaking Bad S01E01 BDRip x264 FGT | Legendei\
+        \ - Aqui Sai Primeiro\" />\n\t\t<meta name=\"twitter:description\" content=\"\
+        Legenda da s\xE9rie Breaking Bad (2008) Ao saber que tem c\xE2ncer, um professor\
+        \ passa a fabricar metanfetamina pelo futuro da fam\xEDlia, mudando o destino\
+        \ de todos. Legenda Breaking Bad S01E01 BDRip x264 FGT testada e verificada\
+        \ - Pode servir tamb\xE9m para outros releases, basta renomear! Dispon\xED\
+        vel em Legendei - Aqui Sai Primeiro\" />\n\t\t<meta name=\"twitter:image\"\
+        \ content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<script type=\"application/ld+json\" class=\"aioseo-schema\">\n\t\
+        \t\t{\"@context\":\"https:\\/\\/schema.org\",\"@graph\":[{\"@type\":\"BlogPosting\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-bdrip-x264-fgt\\\
+        /#blogposting\",\"name\":\"Legenda Breaking Bad S01E01 BDRip x264 FGT | Legendei\
+        \ - Aqui Sai Primeiro\",\"headline\":\"Breaking Bad S01E01 BDRip x264 FGT\"\
+        ,\"author\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /#author\"},\"publisher\":{\"@id\":\"https:\\/\\/legendei.net\\/#organization\"\
+        },\"image\":{\"@type\":\"ImageObject\",\"url\":\"https:\\/\\/legendei.net\\\
+        /wp-content\\/uploads\\/2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /#articleImage\",\"width\":150,\"height\":150},\"datePublished\":\"2026-06-08T23:13:04+01:00\"\
+        ,\"dateModified\":\"2026-06-09T06:26:45+01:00\",\"inLanguage\":\"pt-BR\",\"\
+        mainEntityOfPage\":{\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-bdrip-x264-fgt\\\
+        /#webpage\"},\"isPartOf\":{\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-bdrip-x264-fgt\\\
+        /#webpage\"},\"articleSection\":\"S\\u00e9ries TV, Acervo Legenda Oficial,\
+        \ Acervo Legendas.TV, Legendas Breaking Bad, Legendas Breaking Bad S01\"},{\"\
+        @type\":\"BreadcrumbList\",\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-bdrip-x264-fgt\\\
+        /#breadcrumblist\",\"itemListElement\":[{\"@type\":\"ListItem\",\"@id\":\"\
+        https:\\/\\/legendei.net\\/#listItem\",\"position\":1,\"name\":\"Home\",\"\
+        item\":\"https:\\/\\/legendei.net\\/\",\"nextItem\":\"https:\\/\\/legendei.net\\\
+        /breaking-bad-s01e01-bdrip-x264-fgt\\/#listItem\"},{\"@type\":\"ListItem\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-bdrip-x264-fgt\\\
+        /#listItem\",\"position\":2,\"name\":\"Breaking.Bad.S01E01.BDRip.x264-FGT\"\
+        ,\"previousItem\":\"https:\\/\\/legendei.net\\/#listItem\"}]},{\"@type\":\"\
+        Organization\",\"@id\":\"https:\\/\\/legendei.net\\/#organization\",\"name\"\
+        :\"Legendei\",\"url\":\"https:\\/\\/legendei.net\\/\",\"logo\":{\"@type\"\
+        :\"ImageObject\",\"url\":\"https:\\/\\/legendei.net\\/wp-content\\/uploads\\\
+        /2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-bdrip-x264-fgt\\\
+        /#organizationLogo\",\"width\":150,\"height\":150},\"image\":{\"@id\":\"https:\\\
+        /\\/legendei.net\\/breaking-bad-s01e01-bdrip-x264-fgt\\/#organizationLogo\"\
+        }},{\"@type\":\"Person\",\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /#author\",\"url\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /\",\"name\":\"Admin\"},{\"@type\":\"WebPage\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /breaking-bad-s01e01-bdrip-x264-fgt\\/#webpage\",\"url\":\"https:\\/\\/legendei.net\\\
+        /breaking-bad-s01e01-bdrip-x264-fgt\\/\",\"name\":\"Legenda Breaking Bad S01E01\
+        \ BDRip x264 FGT | Legendei - Aqui Sai Primeiro\",\"description\":\"Legenda\
+        \ da s\\u00e9rie Breaking Bad (2008) Ao saber que tem c\\u00e2ncer, um professor\
+        \ passa a fabricar metanfetamina pelo futuro da fam\\u00edlia, mudando o destino\
+        \ de todos. Legenda Breaking Bad S01E01 BDRip x264 FGT testada e verificada\
+        \ - Pode servir tamb\\u00e9m para outros releases, basta renomear! Dispon\\\
+        u00edvel em Legendei - Aqui Sai Primeiro\",\"inLanguage\":\"pt-BR\",\"isPartOf\"\
+        :{\"@id\":\"https:\\/\\/legendei.net\\/#website\"},\"breadcrumb\":{\"@id\"\
+        :\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-bdrip-x264-fgt\\/#breadcrumblist\"\
+        },\"author\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /#author\"},\"creator\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /#author\"},\"datePublished\":\"2026-06-08T23:13:04+01:00\",\"dateModified\"\
+        :\"2026-06-09T06:26:45+01:00\"},{\"@type\":\"WebSite\",\"@id\":\"https:\\\
+        /\\/legendei.net\\/#website\",\"url\":\"https:\\/\\/legendei.net\\/\",\"name\"\
+        :\"Legendei\",\"description\":\"Baixar Legendas de S\\u00e9ries e Filmes\"\
+        ,\"inLanguage\":\"pt-BR\",\"publisher\":{\"@id\":\"https:\\/\\/legendei.net\\\
+        /#organization\"}}]}\n\t\t</script>\n\t\t<!-- All in One SEO Pro -->\n\n<link\
+        \ rel='dns-prefetch' href='//fonts.googleapis.com' />\n<link rel=\"alternate\"\
+        \ type=\"application/rss+xml\" title=\"Feed para Legendei &raquo;\" href=\"\
+        https://legendei.net/feed/\" />\n<link rel=\"alternate\" type=\"application/rss+xml\"\
+        \ title=\"Feed de coment\xE1rios para Legendei &raquo;\" href=\"https://legendei.net/comments/feed/\"\
+        \ />\n<link rel=\"alternate\" type=\"application/rss+xml\" title=\"Feed de\
+        \ coment\xE1rios para Legendei &raquo; Breaking Bad S01E01 BDRip x264 FGT\"\
+        \ href=\"https://legendei.net/breaking-bad-s01e01-bdrip-x264-fgt/feed/\" />\n\
+        <script type=\"text/javascript\">\n/* <![CDATA[ */\nwindow._wpemojiSettings\
+        \ = {\"baseUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\/emoji\\/16.0.1\\\
+        /72x72\\/\",\"ext\":\".png\",\"svgUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\\
+        /emoji\\/16.0.1\\/svg\\/\",\"svgExt\":\".svg\",\"source\":{\"concatemoji\"\
+        :\"https:\\/\\/legendei.net\\/wp-includes\\/js\\/wp-emoji-release.min.js?ver=6.8.3\"\
+        }};\n/*! This file is auto-generated */\n!function(s,n){var o,i,e;function\
+        \ c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function\
+        \ p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var\
+        \ t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),a=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new\
+        \ Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return\
+        \ t.every(function(e,t){return e===a[t]})}function u(e,t){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);for(var\
+        \ n=e.getImageData(16,16,1,1),a=0;a<n.data.length;a++)if(0!==n.data[a])return!1;return!0}function\
+        \ f(e,t,n,a){switch(t){case\"flag\":return n(e,\"\\ud83c\\udff3\\ufe0f\\u200d\\\
+        u26a7\\ufe0f\",\"\\ud83c\\udff3\\ufe0f\\u200b\\u26a7\\ufe0f\")?!1:!n(e,\"\\\
+        ud83c\\udde8\\ud83c\\uddf6\",\"\\ud83c\\udde8\\u200b\\ud83c\\uddf6\")&&!n(e,\"\
+        \\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc65\\udb40\\udc6e\\udb40\\\
+        udc67\\udb40\\udc7f\",\"\\ud83c\\udff4\\u200b\\udb40\\udc67\\u200b\\udb40\\\
+        udc62\\u200b\\udb40\\udc65\\u200b\\udb40\\udc6e\\u200b\\udb40\\udc67\\u200b\\\
+        udb40\\udc7f\");case\"emoji\":return!a(e,\"\\ud83e\\udedf\")}return!1}function\
+        \ g(e,t,n,a){var r=\"undefined\"!=typeof WorkerGlobalScope&&self instanceof\
+        \ WorkerGlobalScope?new OffscreenCanvas(300,150):s.createElement(\"canvas\"\
+        ),o=r.getContext(\"2d\",{willReadFrequently:!0}),i=(o.textBaseline=\"top\"\
+        ,o.font=\"600 32px Arial\",{});return e.forEach(function(e){i[e]=t(o,e,n,a)}),i}function\
+        \ t(e){var t=s.createElement(\"script\");t.src=e,t.defer=!0,s.head.appendChild(t)}\"\
+        undefined\"!=typeof Promise&&(o=\"wpEmojiSettingsSupports\",i=[\"flag\",\"\
+        emoji\"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){s.addEventListener(\"\
+        DOMContentLoaded\",e,{once:!0})}),new Promise(function(t){var n=function(){try{var\
+        \ e=JSON.parse(sessionStorage.getItem(o));if(\"object\"==typeof e&&\"number\"\
+        ==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&\"object\"\
+        ==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if(\"\
+        undefined\"!=typeof Worker&&\"undefined\"!=typeof OffscreenCanvas&&\"undefined\"\
+        !=typeof URL&&URL.createObjectURL&&\"undefined\"!=typeof Blob)try{var e=\"\
+        postMessage(\"+g.toString()+\"(\"+[JSON.stringify(i),f.toString(),p.toString(),u.toString()].join(\"\
+        ,\")+\"));\",a=new Blob([e],{type:\"text/javascript\"}),r=new Worker(URL.createObjectURL(a),{name:\"\
+        wpTestEmojiSupports\"});return void(r.onmessage=function(e){c(n=e.data),r.terminate(),t(n)})}catch(e){}c(n=g(i,f,p,u))}t(n)}).then(function(e){for(var\
+        \ t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],\"\
+        flag\"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return\
+        \ e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);\n\
+        /* ]]> */\n</script>\n<link rel='stylesheet' id='wpa-css-css' href='https://legendei.net/wp-content/plugins/wp-attachments/styles/0/wpa.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='wp-emoji-styles-inline-css' type='text/css'>\n\
+        \n\timg.wp-smiley, img.emoji {\n\t\tdisplay: inline !important;\n\t\tborder:\
+        \ none !important;\n\t\tbox-shadow: none !important;\n\t\theight: 1em !important;\n\
+        \t\twidth: 1em !important;\n\t\tmargin: 0 0.07em !important;\n\t\tvertical-align:\
+        \ -0.1em !important;\n\t\tbackground: none !important;\n\t\tpadding: 0 !important;\n\
+        \t}\n</style>\n<link rel='stylesheet' id='wp-block-library-css' href='https://legendei.net/wp-includes/css/dist/block-library/style.min.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='classic-theme-styles-inline-css'\
+        \ type='text/css'>\n/*! This file is auto-generated */\n.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em\
+        \ + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}\n\
+        </style>\n<style id='wppb-content-restriction-start-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-content-restriction-end-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-edit-profile-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-login-style-inline-css' type='text/css'>\n\n\
+        \n</style>\n<style id='wppb-recover-password-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-register-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='global-styles-inline-css' type='text/css'>\n:root{--wp--preset--aspect-ratio--square:\
+        \ 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4:\
+        \ 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3:\
+        \ 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16:\
+        \ 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray:\
+        \ #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink:\
+        \ #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange:\
+        \ #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan:\
+        \ #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue:\
+        \ #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple:\
+        \ #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1)\
+        \ 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan:\
+        \ linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange:\
+        \ linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red:\
+        \ linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray:\
+        \ linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum:\
+        \ linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186)\
+        \ 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple:\
+        \ linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux:\
+        \ linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62)\
+        \ 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112)\
+        \ 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean:\
+        \ linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181)\
+        \ 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128)\
+        \ 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129)\
+        \ 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium:\
+        \ 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large:\
+        \ 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40:\
+        \ 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70:\
+        \ 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural:\
+        \ 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px\
+        \ rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0,\
+        \ 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255,\
+        \ 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0,\
+        \ 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap:\
+        \ 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items:\
+        \ center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display:\
+        \ grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-color{color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background:\
+        \ var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange)\
+        \ !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background:\
+        \ var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background:\
+        \ var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background:\
+        \ var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background:\
+        \ var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background:\
+        \ var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size:\
+        \ var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size:\
+        \ var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--x-large) !important;}\n:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}\n:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}\n:root :where(.wp-block-pullquote){font-size:\
+        \ 1.5em;line-height: 1.6;}\n</style>\n<link rel='stylesheet' id='lrl-css-css'\
+        \ href='https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-maincss-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css' type='text/css'\
+        \ media='all' />\n<link rel='stylesheet' id='fontawesome-css' href='https://legendei.net/wp-content/themes/simple-grid/assets/css/all.min.css'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-webfont-css'\
+        \ href='//fonts.googleapis.com/css?family=Playfair+Display:400,400i,700,700i|Domine:400,700|Oswald:400,700|Patua+One|Merriweather:400,400i,700,700i&#038;display=swap'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='legendei-style-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css?ver=1782544305'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='wppb_stylesheet-css'\
+        \ href='https://legendei.net/wp-content/plugins/profile-builder/assets/css/style-front-end.css?ver=3.15.2'\
+        \ type='text/css' media='all' />\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-includes/js/jquery/jquery.min.js?ver=3.7.1\" id=\"\
+        jquery-core-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1\"\
+        \ id=\"jquery-migrate-js\"></script>\n<!--[if lt IE 9]>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/respond.min.js\"\
+        \ id=\"respond-js\"></script>\n<![endif]-->\n<link rel=\"https://api.w.org/\"\
+        \ href=\"https://legendei.net/wp-json/\" /><link rel=\"alternate\" title=\"\
+        JSON\" type=\"application/json\" href=\"https://legendei.net/wp-json/wp/v2/posts/836386\"\
+        \ /><link rel=\"EditURI\" type=\"application/rsd+xml\" title=\"RSD\" href=\"\
+        https://legendei.net/xmlrpc.php?rsd\" />\n<meta name=\"generator\" content=\"\
+        WordPress 6.8.3\" />\n<link rel='shortlink' href='https://legendei.net/?p=836386'\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (JSON)\" type=\"application/json+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fbreaking-bad-s01e01-bdrip-x264-fgt%2F\"\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (XML)\" type=\"text/xml+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fbreaking-bad-s01e01-bdrip-x264-fgt%2F&#038;format=xml\"\
+        \ />\n<style>\n\n/* FORMUL\xC1RIO TRIAL */\n\n.premium-form {\n    max-width:\
+        \ 760px;\n    margin: 0 auto 20px;\n    padding: 30px;\n    border-radius:\
+        \ 10px;\n    background: #212121;\n    border: 10px solid transparent;\n \
+        \   background-image:\n        linear-gradient(#212121,#212121),\n       \
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    background-origin: border-box;\n\
+        \    background-clip: padding-box, border-box;\n    box-sizing: border-box;\n\
+        }\n\n/* Campos */\n\n.premium-form .field {\n    position: relative;\n   \
+        \ margin-bottom: 20px;\n}\n\n.premium-form input {\n    width: 100%;\n   \
+        \ padding: 14px;\n    border-radius: 8px;\n    border: 1px solid #ccc;\n \
+        \   font-size: 16px;\n    box-sizing: border-box;\n}\n\n/* Focus bonito */\n\
+        \n.premium-form input:focus {\n    border-color: transparent;\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin: border-box;\n    background-clip: padding-box, border-box;\n\
+        \    box-shadow: 0 0 0 4px rgba(63,140,255,0.20);\n    outline: none;\n}\n\
+        \n/* TOOLTIP */\n\n.premium-form .tooltip {\n    position: absolute;\n   \
+        \ bottom: 100%;\n    left: 0;\n    margin-bottom: 10px;\n    background: linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \tbox-shadow:0 6px 14px rgba(0,0,0,0.25);\n    color: #ffffff;\n    padding:\
+        \ 10px 12px;\n    font-size: 14px;\n    border-radius: 6px;\n    max-width:\
+        \ 260px;\n    opacity: 0;\n    pointer-events: none;\n    transition: .2s;\n\
+        \    z-index: 999;\n}\n\n.premium-form .tooltip::after {\n    content: \"\"\
+        ;\n    position: absolute;\n    top: 100%;\n    left: 15px;\n    border-width:\
+        \ 6px 6px 0 6px;\n    border-style: solid;\n    border-color: #8a2be2 transparent\
+        \ transparent transparent;\n}\n\n.premium-form .field:hover .tooltip,\n.premium-form\
+        \ .field:focus-within .tooltip {\n    opacity: 1;\n    transform: translateY(-4px);\n\
+        }\n\n/* BOT\xC3O */\n\n.premium-form button {\n    padding: 14px 30px;\n \
+        \   font-size: 22px;\n    border-radius: 8px;\n    border: none;\n    background:\
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    color: #fff;\n    cursor: pointer;\n\
+        \    transition: .25s;\n}\n\n.premium-form button:hover {\n    background:\
+        \ linear-gradient(90deg,#4c9aff,#9a3bff);\n}\n\n/* SENHA */\n\n.pass-wrap{\n\
+        \    position:relative;\n}\n\n.toggle-pass{\n    position:absolute;\n    right:12px;\n\
+        \    top:50%;\n    transform:translateY(-50%);\n    cursor:pointer;\n    font-size:18px;\n\
+        }\n\n/* BARRA FOR\xC7A SENHA */\n\n.strength{\n    height:6px;\n    background:#444;\n\
+        \    border-radius:4px;\n    margin-top:8px;\n    overflow:hidden;\n}\n\n\
+        .strength div{\n    height:100%;\n    width:0%;\n    transition:.3s;\n}\n\n\
+        /* MOBILE */\n\n@media (max-width:480px){\n\n.premium-form{\n    padding:20px;\n\
+        }\n\n}\n\n</style>\n<!-- FIFU: meta tags for featured image (begin) -->\n\
+        <meta property=\"og:image\" content=\"https://image.tmdb.org/t/p/w500/1BP4xYv9ZG4ZVHkL7ocOziBbSYH.jpg\"\
+        \ />\n<!-- FIFU: meta tags for featured image (end) --><meta name=\"twitter:image\"\
+        \ content=\"https://image.tmdb.org/t/p/w500/1BP4xYv9ZG4ZVHkL7ocOziBbSYH.jpg\"\
+        \ /><style>\n\n/* remove fundo normal, ativo e hover do logo */\n.simple-grid-primary-nav-menu\
+        \ > li.menu-logo-item > a,\n.simple-grid-primary-nav-menu > li.menu-logo-item\
+        \ > a:hover,\n.simple-grid-primary-nav-menu > li.menu-logo-item.current-menu-item\
+        \ > a{\n    background:none !important;\n}\n\n/* ===================================================\n\
+        \   MOBILE\n   =================================================== */\n\n\
+        @media only screen and (max-width:812px){\n\n    /* ESCONDER LOGO NO MENU\
+        \ MOBILE */\n    .simple-grid-primary-nav-menu > li.menu-logo-item{\n    \
+        \    display:none !important;\n    }\n\n}\n\n</style>\n    <style type=\"\
+        text/css\">\r\n            .simple-grid-site-title, .simple-grid-site-title\
+        \ a, .simple-grid-site-description {color: #ffffff;}\r\n        </style>\r\
+        \n    <style type=\"text/css\" id=\"custom-background-css\">\nbody.custom-background\
+        \ { background-color: #333333; }\n</style>\n\t<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"32x32\" />\n<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"192x192\" />\n<link rel=\"apple-touch-icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n<meta name=\"msapplication-TileImage\" content=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n</head>\t\n\t\n\t\n<body class=\"wp-singular post-template-default single\
+        \ single-post postid-836386 single-format-standard custom-background wp-custom-logo\
+        \ wp-theme-simple-grid simple-grid-animated simple-grid-fadein simple-grid-theme-is-active\
+        \ simple-grid-custom-logo-active simple-grid-layout-type-full simple-grid-masonry-inactive\
+        \ simple-grid-float-grid simple-grid-responsive-grid-details simple-grid-layout-c-s1\
+        \ simple-grid-header-banner-active simple-grid-tagline-inactive simple-grid-logo-above-title\
+        \ simple-grid-primary-menu-active simple-grid-primary-mobile-menu-active simple-grid-secondary-mobile-menu-active\
+        \ simple-grid-primary-social-icons\" id=\"simple-grid-site-body\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/WebPage\">\n<a class=\"skip-link\
+        \ screen-reader-text\" href=\"#simple-grid-content-wrapper\">Skip to content</a>\n\
+        \n\n\n<div class=\"simple-grid-site-header simple-grid-container\" id=\"simple-grid-header\"\
+        \ itemscope=\"itemscope\" itemtype=\"http://schema.org/WPHeader\" role=\"\
+        banner\">\n<div class=\"simple-grid-head-content simple-grid-clearfix\" id=\"\
+        simple-grid-head-content\">\n\n<div class=\"simple-grid-no-header-content\"\
+        >\n              <p class=\"simple-grid-site-title\"><a href=\"https://legendei.net/\"\
+        \ rel=\"home\">Legendei</a></p>\r\n                </div>\n\n</div><!--/#simple-grid-head-content\
+        \ -->\n</div><!--/#simple-grid-header -->\n\n\n\n<div class=\"simple-grid-container\
+        \ simple-grid-primary-menu-container simple-grid-clearfix\">\n<div class=\"\
+        simple-grid-primary-menu-container-inside simple-grid-clearfix\">\n<nav class=\"\
+        simple-grid-nav-primary\" id=\"simple-grid-primary-navigation\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/SiteNavigationElement\" role=\"navigation\"\
+        \ aria-label=\"Primary Menu\">\n\t\n\t\n<div class=\"simple-grid-outer-wrapper\"\
+        >\n<a href=\"/\" class=\"logo-mobile-inline\">\n<img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \nstyle=\"width:100%;height:auto;\">\n</a>\n\n<style>\n.logo-mobile-inline{\n\
+        display:none;\n}\n\n@media (max-width:812px){\n.logo-mobile-inline{\ndisplay:block;\n\
+        }\n}\n</style>\t\n\n\t\n<style>\n.mobile-header-icons{\n    display:none;\n\
+        }\n\n@media (max-width: 812px){\n\n.mobile-header-icons{\n    display:grid;\n\
+        \    grid-template-columns: 2fr 1fr 1fr;\n    gap:10px;\n    padding:10px;\n\
+        }\n\n/* BOT\xD5ES */\n.mobile-header-icons a,\n.mobile-header-icons .cat-toggle{\n\
+        \    display:flex;\n    align-items:center;\n    justify-content:center;\n\
+        \    gap:6px;\n    background:#141414;\n    padding:8px 6px;\n    border-radius:8px;\n\
+        \    color:#fff;\n    font-size:12px;\n    text-decoration:none;\n    text-align:center;\n\
+        \    cursor:pointer;\n}\n\n/* CATEGORIA */\n.cat-toggle{\n    font-weight:600;\n\
+        }\n\n/* SETA */\n.cat-toggle .arrow{\n    transition:transform 0.3s ease;\n\
+        }\n\n/* SETA GIRADA */\n.cat-toggle.active .arrow{\n    transform:rotate(180deg);\n\
+        }\n\n/* HOVER */\n.mobile-header-icons a:hover,\n.mobile-header-icons .cat-toggle:hover{\n\
+        \    background:#1f1f1f;\n}\n\n/* CONTAINER */\n.cat-container{\n    position:relative;\n\
+        }\n\n/* DROPDOWN */\n.cat-list{\n    display:flex;\n    flex-direction:column;\n\
+        \    gap:6px;\n\n    position:absolute;\n    top:110%;\n    left:0;\n    width:100%;\n\
+        \n    background:#0f0f0f;\n    border-radius:8px;\n    padding:6px;\n    z-index:999;\n\
+        \n    opacity:0;\n    visibility:hidden;\n    transform:translateY(-5px);\n\
+        \    transition:all 0.25s ease;\n}\n\n/* ABERTO */\n.cat-container.open .cat-list{\n\
+        \    opacity:1;\n    visibility:visible;\n    transform:translateY(0);\n}\n\
+        \n/* ITENS */\n.cat-list a{\n    justify-content:flex-start;\n    font-size:14px;\n\
+        \    padding:10px;\n}\n\n}\n</style>\n\n\n<div class=\"mobile-header-icons\"\
+        >\n\n    <!-- CATEGORIAS -->\n    <div class=\"cat-container\">\n        <div\
+        \ class=\"cat-toggle\">\n            \U0001F4C2 Categorias <span class=\"\
+        arrow\">\u25BC</span>\n        </div>\n\n        <div class=\"cat-list\">\n\
+        \            <a href=\"/category/destaques/\">\u2B50 Destaques</a>\n     \
+        \       <a href=\"/category/filmes/\">\U0001F3AC Filmes</a>\n            <a\
+        \ href=\"/category/serie/\">\U0001F4FA S\xE9ries</a>\n            <a href=\"\
+        /category/pack-de-legendas/\">\U0001F4E6 Packs</a>\n        </div>\n    </div>\n\
+        \n    \n        <a href=\"/seja-premium-vitalicio/\"><i class=\"fa-solid fa-crown\"\
+        ></i> Premium</a>\n\n        <a href=\"/login/\"><i class=\"fa-solid fa-key\"\
+        ></i> Login</a>\n\n    \n</div>\n\n<script>\ndocument.addEventListener(\"\
+        DOMContentLoaded\", function(){\n\n    const container = document.querySelector(\"\
+        .cat-container\");\n    const toggle = document.querySelector(\".cat-toggle\"\
+        );\n\n    toggle.addEventListener(\"click\", function(e){\n        e.stopPropagation();\n\
+        \        container.classList.toggle(\"open\");\n        toggle.classList.toggle(\"\
+        active\");\n    });\n\n    document.addEventListener(\"click\", function(e){\n\
+        \        if(!container.contains(e.target)){\n            container.classList.remove(\"\
+        open\");\n            toggle.classList.remove(\"active\");\n        }\n  \
+        \  });\n\n});\n</script>\t\n\t\n<ul id=\"simple-grid-menu-primary-navigation\"\
+        \ class=\"simple-grid-primary-nav-menu simple-grid-menu-primary\"><li id=\"\
+        menu-item-673170\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-673170 menu-logo-item\">\n        <a href=\"https://legendei.net/\"\
+        \ style=\"\n            display:flex;\n            align-items:center;\n \
+        \           justify-content:center;\n            height:100%;\n          \
+        \  padding:0;\n            margin:0;\n            line-height:1;\n       \
+        \ \">\n            <img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \n                      alt=\"Legendei.NET\"\n                      style=\"\
+        height:42px;width:auto;display:block;\">\n        </a></li>\n\n<li id=\"menu-item-673168\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673168\"\
+        ><a href=\"https://legendei.net/category/destaques/\" title=\"Legendas em\
+        \ Destaque\">DESTAQUES</a></li>\n<li id=\"menu-item-673167\" class=\"menu-item\
+        \ menu-item-type-taxonomy menu-item-object-category menu-item-673167\"><a\
+        \ href=\"https://legendei.net/category/filmes/\" title=\"Legendas para Filmes\"\
+        >Filmes</a></li>\n<li id=\"menu-item-673166\" class=\"menu-item menu-item-type-taxonomy\
+        \ menu-item-object-category current-post-ancestor current-menu-parent current-post-parent\
+        \ menu-item-673166\"><a href=\"https://legendei.net/category/serie/\" title=\"\
+        Legendas para seriados\">S\xC9RIES</a></li>\n<li id=\"menu-item-673169\" class=\"\
+        menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673169\"\
+        ><a href=\"https://legendei.net/category/pack-de-legendas/\" title=\"Pack\
+        \ de legendas\">PACKS</a></li>\n<li id=\"menu-item-731144\" class=\"menu-item\
+        \ menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-731144\"\
+        ><a target=\"_blank\" href=\"/aplicativos/\">RECOMENDAMOS</a>\n<ul class=\"\
+        sub-menu\">\n\t<li id=\"menu-item-673172\" class=\"menu-item menu-item-type-custom\
+        \ menu-item-object-custom menu-item-673172\"><a target=\"_blank\" href=\"\
+        /aplicativos/\" title=\"Programas para windows\">APLICATIVOS</a></li>\n\t\
+        <li id=\"menu-item-687662\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-687662\"><a target=\"_blank\" href=\"https://4kxxx.vip/\" title=\"\
+        Baixe os melhores v\xEDdeos porn\xF4 sempre em 4K\">4K XXX</a></li>\n\t<li\
+        \ id=\"menu-item-717497\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-717497\"><a target=\"_blank\" href=\"https://detonaplay.com/\"\
+        >GAMES</a></li>\n</ul>\n</li>\n\n\n\n<li class=\"menu-item\" style=\"float:right;\"\
+        >\n            <a href=\"/login/\"\n               style=\"background:linear-gradient(135deg,#198754,#20ac6b);color:#ffffff;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-key\"></i> Login\n            </a>\n\
+        \        </li><li class=\"menu-item\" style=\"float:right;\">\n          \
+        \  <a href=\"/seja-premium-vitalicio/\"\n\t\t\t\t\t  style=\"background:linear-gradient(135deg,#f4c430,#c2940a);color:#4d2e00;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-crown\"></i> Membro Premium\n  \
+        \          </a>\n        </li></ul>    </div>\n</nav>\n</div>\n</div>\n\n\t\
+        \n\t\n\r\n<div class=\"simple-grid-outer-wrapper\">\r\n<div class=\"simple-grid-top-wrapper-outer\
+        \ simple-grid-clearfix\">\r\n<div class=\"simple-grid-featured-posts-area\
+        \ simple-grid-top-wrapper simple-grid-clearfix\">\r\n\r\n<div id=\"search-5\"\
+        \ class=\"simple-grid-main-widget widget simple-grid-widget-box widget_search\"\
+        ><div class=\"simple-grid-widget-box-inside\"><form role=\"search\" method=\"\
+        get\" class=\"simple-grid-search-form\" action=\"https://legendei.net/\">\n\
+        <label>\n    <span class=\"simple-grid-sr-only\">Pesquisar por </span>\n \
+        \   <input \n        type=\"search\"\n        class=\"simple-grid-search-field\"\
+        \n        placeholder=\"Pesquisar &hellip;\"\n        value=\"\"\n       \
+        \ name=\"s\"\n        minlength=\"3\"\n\t\tmaxlength=\"50\"   \n        required\n\
+        \    />\n</label>\n<input type=\"submit\" class=\"simple-grid-search-submit\"\
+        \ value=\"&#xf002;\" />\n</form></div></div></div>\r\n</div>\r\n</div>\r\n\
+        \r\n\n<div class=\"simple-grid-outer-wrapper\" id=\"simple-grid-wrapper-outside\"\
+        >\n\n<div class=\"simple-grid-container simple-grid-clearfix\" id=\"simple-grid-wrapper\"\
+        >\n<div class=\"simple-grid-content-wrapper simple-grid-clearfix\" id=\"simple-grid-content-wrapper\"\
+        >\t\n\t\t\n\n\n<div class=\"simple-grid-main-wrapper simple-grid-clearfix\"\
+        \ id=\"simple-grid-main-wrapper\" itemscope=\"itemscope\" itemtype=\"http://schema.org/Blog\"\
+        \ role=\"main\">\n<div class=\"theiaStickySidebar\">\n<div class=\"simple-grid-main-wrapper-inside\
+        \ simple-grid-clearfix\">\n\n\r\n\r\n\n<div class=\"simple-grid-posts-wrapper\"\
+        \ id=\"simple-grid-posts-wrapper\">\n\n\n\n\n\n<div style=\"width: 100%; border-radius:\
+        \ 12px; box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 12px; padding: 15px; background:\
+        \ #ffffff;\">\n    <center>\n    <article id=\"post-836386\" class=\"simple-grid-post-singular\
+        \ simple-grid-box post-836386 post type-post status-publish format-standard\
+        \ hentry category-serie tag-acervo-legenda-oficial tag-acervo-legendas-tv\
+        \ tag-legendas-breaking-bad tag-legendas-breaking-bad-s01 wpcat-4-id\">\n\
+        \        <div class=\"simple-grid-box-inside\">\n            \n          \
+        \  \n                            <header class=\"entry-header\">\n       \
+        \             <div class=\"entry-header-inside simple-grid-clearfix\">\n\n\
+        <h1 class=\"post-title entry-title\">Legenda Breaking Bad S01E01 BDRip x264\
+        \ FGT <span aria-label=\"PT-BR\">\U0001F1E7\U0001F1F7</span></h1>\n\n\n  \
+        \                                  <div class=\"simple-grid-entry-meta-single\"\
+        >\n                            <span class=\"simple-grid-entry-meta-single-date\"\
+        >\n                <i class=\"far fa-clock\" aria-hidden=\"true\"></i>&nbsp;8\
+        \ de junho de 2026            </span>\n                                  \
+        \  <span class=\"simple-grid-entry-meta-single-categories\"><i class=\"far\
+        \ fa-folder-open\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Posted in </span><a href=\"https://legendei.net/category/serie/\" rel=\"\
+        category tag\">S\xE9ries TV</a></span>                            </div>\n\
+        \    \n\n                    </div>\n                </header>\n         \
+        \   \t\t\t\n\t\t\t\n            <!-- inicio poster -->\n            <img src=\"\
+        https://image.tmdb.org/t/p/w500/1BP4xYv9ZG4ZVHkL7ocOziBbSYH.jpg\" style=\"\
+        max-width:220px;width:330px;height:auto;margin-bottom:5px;\" alt=\"Breaking\
+        \ Bad S01E01 BDRip x264 FGT\">            <!-- fim poster -->\n\t\t\t\n<!--\
+        \ S admin -->\n            \t\t\t\n<!-- S admin -->\t\n\t\t\t\n          \
+        \  \n            <div class=\"entry-content simple-grid-clearfix\">\n\n<!--\
+        \ N PREMIUM AMIN TEMP -->\t\t\t\t\n\t\n\n   <a href=\"https://cuponei.org/promo/more/\"\
+        \ target=\"_blank\" rel=\"noopener\">\n    <img class=\"aligncenter wp-image-729595\
+        \ size-full\"\n         src=\"https://legendei.net/wp-content/uploads/2026/01/amazon.webp\"\
+        \n         width=\"350\" height=\"334\" />\n  </a>\t\n\t\t\t\t\t\t\t\t\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\t\t\t\t\n<!-- anexos otimizados -->\n<!--\
+        \ /anexos -->\n\n\n                <!-- WP Attachments -->\n        <div style=\"\
+        width:100%;margin:10px 0 10px 0;\">\n            <h3></h3>\n        <ul class=\"\
+        post-attachments\"><p class=\"post-attachment mime-application-zip\">    \
+        \                                                                        \
+        \    <a href=\"https://legendei.net/breaking-bad-s01e01-bdrip-x264-fgt/?download=836385\"\
+        \ target=\"_blank\" class=\"buttonmyup\"><i class=\"fa fa-download\"></i>\
+        \ BAIXAR LEGENDA</a>\r\n</p></ul></div><div class=\"highlight-text-sinopse\"\
+        >\n<p>Legenda da s\xE9rie Breaking Bad (2008) Ao saber que tem c\xE2ncer,\
+        \ um professor passa a fabricar metanfetamina pelo futuro da fam\xEDlia, mudando\
+        \ o destino de todos.</p>\n</div>\n\n        <div class=\"highlight-text\"\
+        >\n\n<style>\n/* ===================================== */\n/* LINKS COM BORDA\
+        \ GRADIENTE + UNDERLINE */\n/* ===================================== */\n\n\
+        .busca-legenda-links a{\n    display:inline-block;\n    padding:8px 18px;\n\
+        \    margin:2px 8px;\n    font-weight:400;\n    font-size:14px;\n    text-decoration:none\
+        \ !important;\n\tmin-width: 180px;\n    color:#1e293b !important; /* texto\
+        \ escuro vis\xEDvel */\n    background:transparent;\n\n    border:2px solid\
+        \ transparent;\n    border-radius:6px;\n\n    /* borda gradiente */\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin:border-box;\n    background-clip:padding-box, border-box;\n\
+        \n    position:relative;\n    transition:all .25s ease;\n}\n\n/* underline\
+        \ gradiente (embaixo do texto) */\n.busca-legenda-links a::after{\n    content:\"\
+        \";\n    position:absolute;\n    left:50%;\n    bottom:6px; /* dentro do bot\xE3\
+        o */\n    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\n\n/*\
+        \ hover */\n.busca-legenda-links a:hover{\n    color:#002080 !important;\n\
+        }\n\n.busca-legenda-links a:hover::after{\n    width:60%;\n}\n\n/* ativo (se\
+        \ quiser usar classe active depois) */\n.busca-legenda-links a.active::after{\n\
+        \    width:60%;\n}\n\n@media (max-width: 768px){\n\n    .busca-legenda-links{\n\
+        \        display:block;\n    }\n\n    /* remove os pontinhos separadores no\
+        \ mobile */\n    .busca-legenda-links span{\n        display:none;\n    }\n\
+        \n    .busca-legenda-links a{\n        display:block;\n        width:100%;\n\
+        \        margin:6px 0; /* controla espa\xE7amento vertical */\n        text-align:center;\n\
+        \t\tfont-size:14px;\n    }\n\n\n}\n</style>\n\n\n\n            <p><strong>Legenda\
+        \ da s\xE9rie Breaking Bad S01E01 BDRip x264 FGT</strong></p>\n          \
+        \  <hr>\n\n            <p>Todas as legendas dispon\xEDveis para download s\xE3\
+        o testadas e verificadas, garantindo sincronia, precis\xE3o e qualidade.</p>\n\
+        \n            <p>Depois de baixar a legenda, n\xE3o se esque\xE7a de conferir\
+        \ o seu release!</p>\n\n            <div class=\"busca-legenda-links\">\n\
+        \                <a href=\"/category/serie/?s=Breaking+Bad\">+ legendas mesma\
+        \ s\xE9rie</a><a href=\"/category/serie/?s=Breaking+Bad+S01\">+ legendas mesma\
+        \ temporada</a><span>\xB7</span><a href=\"/category/serie/?s=Breaking+Bad+S01E01\"\
+        >+ legendas mesmo epis\xF3dio</a>\n            </div>\n\n        </div>\n\t\
+        \t\n\n\t\t\n\t\t\n                <!-- sinopse TMDB -->\n                <!--\
+        \ /sinopse -->\n\n            </div><!-- .entry-content -->\n\n          \
+        \  \n            \n        </div>\n\n\n\n\t\t\n    </article>\n\n<!-- inicio\
+        \ app recomendados -->\t\t\n<div id=\"apps-recomendados\">\n<div class=\"\
+        busca-legenda-links\" style=\"text-align:center;\">\n<h5>Aplicativos que usamos\
+        \ e recomendamos</h5>\n\n<a href=\"https://legendei.net/aplicativos/kodi/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2025/11/Kodi_21.3.webp\"\
+        \ width=\"40\" height=\"40\" />\n    Kodi Media Center\n</a>\n\n<a href=\"\
+        https://legendei.net/aplicativos/utorrent-pro-download-e-guia-completo/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/08/uTorrent-Pro.jpg\"\
+        \ width=\"40\" height=\"40\" />\n    uTorrent Pro\n</a>\n\n<a href=\"https://legendei.net/aplicativos/winzip-pro-windows/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/09/WinZip-Pro.png\"\
+        \ width=\"40\" height=\"40\" />\n    WinZip Pro\n</a>\n</div>\n</div>\n<style>\n\
+        @media (max-width: 812px){\n    #apps-recomendados{\n        display: none;\n\
+        \    }\n}\n</style>\n<!-- fim app recomendados -->\n\t\t\n<span class=\"simple-grid-entry-meta-single-tags\"\
+        ><i class=\"fas fa-tags\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Tagged </span><a href=\"https://legendei.net/tag/acervo-legenda-oficial/\"\
+        \ rel=\"tag\">Acervo Legenda Oficial</a>, <a href=\"https://legendei.net/tag/acervo-legendas-tv/\"\
+        \ rel=\"tag\">Acervo Legendas.TV</a>, <a href=\"https://legendei.net/tag/legendas-breaking-bad/\"\
+        \ rel=\"tag\">Legendas Breaking Bad</a>, <a href=\"https://legendei.net/tag/legendas-breaking-bad-s01/\"\
+        \ rel=\"tag\">Legendas Breaking Bad S01</a></span>\n\t\t\n\t\t\n\n\t\t\n<hr>\n\
+        <div class=\"lrl-report-link\">\n    <a href=\"#\" class=\"lrl-open busca-legenda-links\"\
+        >\U0001F6A8 Reportar problemas \U0001F6A8</a>\n\t</div>\n\n    <div id=\"\
+        lrl-modal\" style=\"display:none;\">\n        <div class=\"lrl-box\">\n  \
+        \          <span class=\"lrl-close\">&times;</span>\n            <h3>Qual\
+        \ \xE9 o problema?</h3><hr>\n\n<label><input type=\"radio\" name=\"lrl_motivo\"\
+        \ value=\"Problemas com o download\"> O download n\xE3o funciona</label><br><br>\n\
+        \n<label><input type=\"radio\" name=\"lrl_motivo\" value=\"Legenda para o\
+        \ filme ou s\xE9rie incorreta\"> Conte\xFAdo \xE9 para outro filme, s\xE9\
+        rie ou epis\xF3dio</label><br><br>\n\n<label><input type=\"radio\" name=\"\
+        lrl_motivo\" value=\"Idioma da legenda incorreto\"> O idioma da legenda est\xE1\
+        \ errado.</label><br><br>\n<hr>\n            <button id=\"lrl-send\" disabled>Enviar</button>\n\
+        \        </div>\n    </div>\n    \t\t\n    </center>\n\t\n</div>\n\n\t\n\t\
+        \n\t\n\t\n\n<!-- S admin -->\t\n<!-- S admin -->\t\n\n\n\t\n<!-- N PREMIUM\
+        \ AMIN TEMP -->\n<div>\t\n<!-- protetor de links -->\n<script>\n(function(){\n\
+        \nconst redirectpage = \"https://legendei.net/noticia.php\";\n\nconst bases\
+        \ = [\n    '/?download=',\n    '/?dl_',\n    '.rar',\n    '.zip',\n    '.srt',\n\
+        \    'magnet:',\n\t'/zip-attachments.php'\n];\n\ndocument.querySelectorAll('a').forEach(a\
+        \ => {\n    const href = a.getAttribute('href') || '';\n\n    if (bases.some(b\
+        \ => href.includes(b))) {\n\n        const token = btoa(href);\n\n       \
+        \ a.href = redirectpage + \"?token=\" + token;\n        a.target = \"_blank\"\
+        ;\n    }\n});\n\n})();\n</script>\n<!-- /protetor de links -->\t\n\t\t\n\n\
+        <!-- BLOQUEADOR LEGENDEI -->\n\n<!-- BLOQUEADOR LEGENDEI -->\n\t\n<!-- inicio\
+        \ reload -->\n<script>\nsetInterval(function(){\n  location.reload();\n},\
+        \ 120000); // 2 minutos\n</script>\n<!-- fim reload -->\t\n\t\n</div>\t\n\
+        <!-- N PREMIUM AMIN TEMP -->\n\t\n\t\n<div class=\"clear\"></div>\n</div><!--/#simple-grid-posts-wrapper\
+        \ -->\n\n\r\n\r\n\t\n\n</div>\n</div>\n</div><!-- /#simple-grid-main-wrapper\
+        \ -->\n\n\n\n</div>\n\n\n\n\n<!-- N ADMIN -->\n<div>\n<!-- inicio -->\n<iframe\
+        \ \n  src=\"https://cuponei.org/last/\"\n  style=\"\n    width:1px;\n    height:1px;\n\
+        \    opacity:0;\n    border:none;\n    overflow:hidden;\n  \"\n  scrolling=\"\
+        no\"\n></iframe>\n<!-- fim -->\t\n</div>\n<!-- N ADMIN -->\n\n\n\n\n<!-- N\
+        \ PREMIUM AMIN TEMP -->\n\n\n\n\n<div>\n\n\t\n<!-- =============================\
+        \ -->\n<!-- SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\n\n<div id=\"SCRIPT_1_AQUI\" style=\"display:none;\">\t\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/invesup.js\"></script>\n<script\
+        \ type=\"text/javascript\">\n// make pop on new window with size 150x150 \
+        \ \nLight.Popup.create('https://cuponei.org/promo/more/', {width: 150, height:\
+        \ 150, onNewTab: false});\n// refresh = new popup\nLight.Popup.create('https://cuponei.org/promo/more/amz/',\
+        \ {alwaysPop: false});  \n</script>\n</div>\t\n\n<div id=\"SCRIPT_2_AQUI\"\
+        \ style=\"display:none;\">\n\t\n<script type=\"text/javascript\">\n var p$00a\
+        \ = 'p$00a' + (new Date().getTime()) + 'zz'; window[p$00a] = {a:'abcdefghijklmnopqrstuvwxyz0123456789i0xpy5jn7r6h82fuw1skdgzca94e3omqvblt',\
+        \ b:'{\"AZIb\":\"e344vq\", \"BVIb\":\"b4mm4e\", \"CXrr1\":\"du\", \"DLtag\"\
+        :\"e\", \"Emjk5\":\"\", \"XCge1s\":\"u.g7fz1yh.xf8\" , \"Zt1\":\"ufuxisn.2yk\"\
+        , \"ZZ1\":\"u.nn8fu.xhfdp\" }', c:'{\"Abkr221\":\"sx17uk\", \"Bo9ssm\":\"\
+        //xp2.g7fz1yh.xf8/iuu.rs\"}', d:'{\"Ag4\":\"0fpa\", \"Bx1\":\"iuuy2pCn7hp\"\
+        , \"Cky\":\"s1x\", \"Dmg\":\"x1yikyEhy8y2k\"}'};\nvar _0x5d4b=['235913QVfbwv','slice','length','162209QBmAmV','14238hyOOTq','323207DTbifh','split','1DqiKtq','135866HTbavB','indexOf','call','27654SKXHbY','parse','undefined','32Ijckmz','keys','map','ceil','115980hcFVDy','values','join'];var\
+        \ _0x208c=function(_0x31a8d7,_0x5f36b3){_0x31a8d7=_0x31a8d7-0x167;var _0x5d4be1=_0x5d4b[_0x31a8d7];return\
+        \ _0x5d4be1;};(function(_0x276f94,_0x57c4ff){var _0x50057c=_0x208c;while(!![]){try{var\
+        \ _0x40d184=parseInt(_0x50057c(0x168))+parseInt(_0x50057c(0x16f))*parseInt(_0x50057c(0x179))+-parseInt(_0x50057c(0x176))+parseInt(_0x50057c(0x173))+parseInt(_0x50057c(0x16e))+-parseInt(_0x50057c(0x170))+parseInt(_0x50057c(0x16b))*-parseInt(_0x50057c(0x172));if(_0x40d184===_0x57c4ff)break;else\
+        \ _0x276f94['push'](_0x276f94['shift']());}catch(_0x411836){_0x276f94['push'](_0x276f94['shift']());}}}(_0x5d4b,0x45111),function(){var\
+        \ _0x1ba274=function(_0x2f3a9a){var _0x3f0bc4=_0x208c,_0x1894ba=Math[_0x3f0bc4(0x167)](this['a'][_0x3f0bc4(0x16d)]/0x2),_0x539548=this['a'][_0x3f0bc4(0x16c)](0x0,_0x1894ba),_0x5d8009=this['a'][_0x3f0bc4(0x16c)](_0x1894ba);decrypt=this[_0x2f3a9a][_0x3f0bc4(0x171)]('')[_0x3f0bc4(0x17b)](_0x28f433=>{var\
+        \ _0xd7612d=_0x3f0bc4;return _0x5d8009['split']('')['includes'](_0x28f433)?_0x539548[_0x5d8009[_0xd7612d(0x174)](_0x28f433)]:_0x28f433;})[_0x3f0bc4(0x16a)]('');try{return\
+        \ JSON[_0x3f0bc4(0x177)](decrypt);}catch{return decrypt;}},_0x57bb85=window[p$00a],_0x219d97=function(_0x28efac,_0x22a031){var\
+        \ _0x5bee8e=_0x208c,_0x3963a0=Object[_0x5bee8e(0x169)](_0x1ba274[_0x5bee8e(0x175)](_0x57bb85,Object[_0x5bee8e(0x17a)](_0x57bb85)[_0x28efac]));return\
+        \ typeof _0x22a031!=_0x5bee8e(0x178)?_0x3963a0[_0x22a031]:_0x3963a0;};window[p$00a]['x']=function(){return\
+        \ _0x219d97(0x1);};var _0xf1db57=document[_0x219d97(0x3,0x3)](_0x219d97(0x2,0x0));_0xf1db57[_0x219d97(0x3,0x2)]=_0x219d97(0x2,0x1),document[_0x219d97(0x3,0x0)][_0x219d97(0x3,0x1)](_0xf1db57),p$00a=undefined;}());\n\
+        \ \n </script>\n\t\n<script type=\"text/javascript\" src=\"https://legendei.net/invesup.js\"\
+        ></script>\n<script type=\"text/javascript\">\n// make pop on new window with\
+        \ size 150x150  \nLight.Popup.create('https://legendei.net/terrabanne/', {width:\
+        \ 150, height: 150, onNewTab: false}); \n// refresh = new popup\nLight.Popup.create('https://legendei.net/terrabanne/',\
+        \ {alwaysPop: true}); \t\n</script>\t\n\t\n</div>\n\n<!-- =============================\
+        \ -->\n<!-- / SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\t\n\t\n<script>\n(function(){\n\nconst path = window.location.pathname;\n\
+        \nwindow.__CUPONEI_DISABLE_ALL = (\n  path.startsWith('/seja-premium-vitalicio')\
+        \ ||\n  path.startsWith('/perfil')\n);\n\nif (window.__CUPONEI_DISABLE_ALL)\
+        \ return;\n\n/* evita bots */\nif (/bot|googlebot|crawler|spider|crawling/i.test(navigator.userAgent))\
+        \ return;\n\nconst isExpiredUser = false;\n\nconst BLOCK_TIME = 1 * 60 * 60\
+        \ * 1000;\nconst STORAGE_KEY = 'premium_popup_blocked_until';\nconst TRIGGER_DELAY\
+        \ = 1000;\n\nlet adsStarted = false;\n\n/* ============================= */\n\
+        /* CONTROLE TEMPO                */\n/* ============================= */\n\
+        \nfunction now(){\n    return Date.now();\n}\n\nfunction isBlocked(){\n  \
+        \  const until = localStorage.getItem(STORAGE_KEY);\n    return until && now()\
+        \ < parseInt(until);\n}\n\nfunction blockPopup(){\n    localStorage.setItem(STORAGE_KEY,\
+        \ now() + BLOCK_TIME);\n}\n\n/* ============================= */\n/* EXECU\xC7\
+        \xC3O SEGURA DOS SCRIPTS   */\n/* ============================= */\n\nfunction\
+        \ executeScriptsFromDiv(divId, callback){\n\n    if (window.__CUPONEI_DISABLE_ALL){\n\
+        \        if(callback) callback();\n        return;\n    }\n\n    const container\
+        \ = document.getElementById(divId);\n    if(!container){\n        if(callback)\
+        \ callback();\n        return;\n    }\n\n    const scripts = container.querySelectorAll(\"\
+        script\");\n    let total = scripts.length;\n    let loaded = 0;\n\n    if(total\
+        \ === 0){\n        if(callback) callback();\n        return;\n    }\n\n  \
+        \  scripts.forEach(oldScript => {\n\n        const newScript = document.createElement(\"\
+        script\");\n\n        for (let attr of oldScript.attributes) {\n         \
+        \   newScript.setAttribute(attr.name, attr.value);\n        }\n\n        if(oldScript.src){\n\
+        \n            newScript.onload = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n            newScript.onerror = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n        } else {\n            newScript.text = oldScript.text;\n\
+        \            loaded++;\n        }\n\n        document.body.appendChild(newScript);\n\
+        \n        if(!oldScript.src){\n            if(loaded === total && callback)\
+        \ callback();\n        }\n\n    });\n\n}\n\n/* =============================\
+        \ */\n/* SEQU\xCANCIA DOS AN\xDANCIOS        */\n/* =============================\
+        \ */\n\nfunction runAds(){\n\n    if (window.__CUPONEI_DISABLE_ALL) return;\n\
+        \    if (adsStarted) return;\n\n    adsStarted = true;\n\n    let clickCount\
+        \ = 0;\n    let script2Executed = false;\n\n    function handleUserClick(){\n\
+        \n        clickCount++;\n\n        // Debug opcional\n        // console.log(\"\
+        Cliques:\", clickCount);\n\n        if(clickCount >= 2 && !script2Executed){\n\
+        \n            script2Executed = true;\n\n            document.removeEventListener(\"\
+        click\", handleUserClick, true);\n            document.removeEventListener(\"\
+        touchstart\", handleUserClick, true);\n\n            executeScriptsFromDiv(\"\
+        SCRIPT_2_AQUI\");\n        }\n    }\n\n    // Executa SCRIPT 1 primeiro\n\
+        \    setTimeout(function(){\n\n        executeScriptsFromDiv(\"SCRIPT_1_AQUI\"\
+        , function(){\n\n            // S\xF3 depois que SCRIPT 1 foi carregado\n\
+        \            document.addEventListener(\"click\", handleUserClick, {capture:true});\n\
+        \            document.addEventListener(\"touchstart\", handleUserClick, {capture:true});\n\
+        \n        });\n\n    }, 1000);\n\n}\n\n/* ============================= */\n\
+        /* POPUP PREMIUM                 */\n/* ============================= */\n\
+        \nfunction createPopup(){\n\nif(isBlocked()){\n    runAds();\n    return;\n\
+        }\n\nconst popup=document.createElement('div');\npopup.id='premium-popup';\n\
+        \npopup.innerHTML = isExpiredUser ? `\n\n<div class=\"premium-overlay\"></div>\n\
+        <div class=\"premium-box\">\n\n<div class=\"premium-text\">\n\U0001F614 Seu\
+        \ per\xEDodo de teste terminou!<br><br>\n<strong>Voc\xEA pode ser Membro Premium\
+        \ Vital\xEDcio para sempre fazendo uma \xFAnica doa\xE7\xE3o.</strong>\n</div>\n\
+        \n<div class=\"premium-actions\">\n<a href=\"/perfil/\" class=\"premium-yes\"\
+        >\U0001F525 QUERO SER PREMIUM \U0001F525</a>\n<p class=\"premium-nope\">CONTINUAR\
+        \ COM AN\xDANCIOS</p>\n</div>\n\n</div>\n\n` : `\n\n<div class=\"premium-overlay\"\
+        ></div>\n<div class=\"premium-box\">\n\n<div class=\"premium-text\">\n<i class=\"\
+        fa-solid fa-heart fa-beat\"></i>\nApoie a Legendei.NET e torne-se Membro Premium\
+        \ Vital\xEDcio agora para navegar sem an\xFAncios e desbloquear recursos exclusivos!\n\
+        <br>\n</div>\n\n<div class=\"premium-actions\">\n<a href=\"/seja-premium-vitalicio/\"\
+        \ class=\"premium-yes\">\U0001F525 FA\xC7A UM TESTE GRATUITO \U0001F525</a>\n\
+        <p class=\"premium-nope\">CONTINUAR COM AN\xDANCIOS</p>\n<a href=\"/login/\"\
+        \ class=\"premium-login\">J\xE1 tenho uma conta e quero conectar</a>\n</div>\n\
+        \n</div>\n\n`;\n\ndocument.body.appendChild(popup);\n\npopup.querySelector('.premium-nope').onclick=function(e){\n\
+        \ne.preventDefault();\n\nblockPopup();\nrunAds();\n\npopup.remove();\n\n};\n\
+        \n}\n\nlet triggered=false;\n\nfunction triggerPopup(){\n\nif(triggered) return;\n\
+        \ntriggered=true;\n\nsetTimeout(createPopup,TRIGGER_DELAY);\n\nwindow.removeEventListener('mousemove',triggerPopup);\n\
+        window.removeEventListener('touchstart',triggerPopup);\n\n}\n\n/* =============================\
+        \ */\n/* DISPARADORES                  */\n/* =============================\
+        \ */\n\nwindow.addEventListener('mousemove',triggerPopup,{passive:true});\n\
+        window.addEventListener('touchstart',triggerPopup,{passive:true});\n\ndocument.addEventListener('DOMContentLoaded',\
+        \ function(){\n\n    if(isBlocked()){\n        runAds();\n    }\n\n});\n\n\
+        })();\n</script>\n\n<style>\n/* ============================= */\n/* POPUP\
+        \ BASE */\n/* ============================= */\n#premium-popup{\n  position:fixed;\n\
+        \  inset:0;\n  z-index:999999;\n}\n\n.premium-overlay{\n  position:absolute;\n\
+        \  inset:0;\n  background:rgba(0,0,0,.65);\n}\n\n.premium-box{\n  position:absolute;\n\
+        \  left:50%;\n  top:50%;\n  transform:translate(-50%,-50%);\n  background:#212121;\n\
+        \  padding:28px 26px 26px;\n  max-width:440px;\n  width:92%;\n  border-radius:14px;\n\
+        \  text-align:center;\n}\n@media (max-width: 812px){\n  .premium-box{\n  \
+        \  top:5%;\n    transform:translate(-50%, 0);\n  }\n}\n\t\n/* inicio premium-login\
+        \ */\n.premium-login{\n  color:#fff;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  cursor:pointer;\n}\na.premium-login{\n    padding:8px 18px;\n}\na.premium-login::after{\n\
+        \    content:\"\";\n    position:absolute;\n    left:50%;\n    bottom:6px;\n\
+        \    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\na.premium-login:hover{\n\
+        \    color:#fff !important;\n}\n\na.premium-login:hover::after{\n    width:60%;\n\
+        }\n@media (max-width: 768px){\n    a.premium-login{\n        display:block;\n\
+        \        width:100%;\n        margin:6px 0;\n        text-align:center;\n\
+        \        font-size:14px;\n    }\n}\n/* fim premium-login */\n\n/* =============================\
+        \ */\n/* TEXTO */\n/* ============================= */\n.premium-text{\n \
+        \ color:#fff;\n  font-size:clamp(15px,2.6vw,18px);\n  line-height:1.4;\n \
+        \ font-family:Roboto,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;\n\
+        }\n\n.premium-text i{\n  color:#e74c3c;\n  margin-right:6px;\n}\n\n/* =============================\
+        \ */\n/* A\xC7\xD5ES */\n/* ============================= */\n.premium-actions{\n\
+        \  margin-top:18px;\n  display:flex;\n  flex-direction:column;\n  gap:12px;\n\
+        }\n\n/* ============================= */\n/* BOT\xD5ES */\n/* =============================\
+        \ */\n.alter{\n  background:#6f42c1;\n  border:2px solid #fff;\n  font-weight:bold;\n\
+        \  font-size:clamp(14px,2.6vw,16px);\n  color:#fff;\n  padding:10px 14px;\n\
+        \  border-radius:8px;\n  cursor:pointer;\n}\n\n.premium-yes{\n  background:#1e90ff;\n\
+        \  border:2px solid #FFF;\n  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  color:#fff;\n  padding:10px 14px;\n  border-radius:8px;\n  cursor:pointer;\n\
+        }\n\n.premium-nope{\n  background:#cc3300;\n  border:2px solid #FFF;\n  color:#fff;\n\
+        \  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n  padding:10px\
+        \ 14px;\n  border-radius:8px;\n  cursor:pointer;\n}\n\n/* =============================\
+        \ */\n/* HOVER / ACTIVE (-15%) */\n/* ============================= */\n.alter:hover,\n\
+        .alter:active,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-login:hover,\n\
+        .premium-login:active,\n.premium-nope:hover,\n.premium-nope:active{\n  filter:\
+        \ brightness(85%);\n}\n/* ============================= */\n/* TEXTO SEMPRE\
+        \ BRANCO (TODOS ESTADOS) */\n/* ============================= */\n.alter,\n\
+        .alter:visited,\n.alter:hover,\n.alter:active,\n.alter:focus,\n\n.premium-yes,\n\
+        .premium-yes:visited,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-yes:focus,\n\
+        \n.premium-login,\n.premium-login:visited,\n.premium-login:hover,\n.premium-login:active,\n\
+        .premium-login:focus,\n\n.premium-nope,\n.premium-nope:visited,\n.premium-nope:hover,\n\
+        .premium-nope:active,\n.premium-nope:focus{\n  color:#fff !important;\n  text-decoration:none;\n\
+        }\n/* ============================= */\n/* RESPONSIVO */\n/* =============================\
+        \ */\n/* Esconder em telas menores que 812px */\n@media (max-width: 812px){\n\
+        \  .alter{\n    display:none !important;\n  }\n}\n</style>\n\n</div>\n\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n</div><!--/#simple-grid-content-wrapper\
+        \ -->\n\n\n\n\n\n</div><!--/#simple-grid-wrapper -->\n\n\n\n\r\n\r\n\n\n\n\
+        \n\n\n<div class='simple-grid-clearfix' id='simple-grid-copyright-area'>\n\
+        \t\n<div class='simple-grid-copyright-area-inside simple-grid-container'>\n\
+        \t<a href=\"/\"><img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \ alt=\"\" width=\"300\" height=\"67\" class=\"aligncenter size-medium wp-image-747799\"\
+        \ /></a>\n<div class=\"simple-grid-outer-wrapper\">\t\n<center>\t\n<div class='simple-grid-copyright-area-inside-content\
+        \ simple-grid-clearfix'>\n  <p class='simple-grid-copyright'>Copyright \xA9\
+        \ 2016 - 2026 Legendei - Aqui Sai Primeiro</p>\n<p class='simple-grid-credit'><a\
+        \ href=\"https://legendei.net/\">Design by Legendei.NET</a></p>\n</div>\n\t\
+        </center>\n</div>\n</div>\n</div><!--/#simple-grid-copyright-area -->\n\n\n\
+        \n\n<button class=\"simple-grid-scroll-top\" title=\"Scroll to Top\"><i class=\"\
+        fas fa-arrow-up\" aria-hidden=\"true\"></i><span class=\"simple-grid-sr-only\"\
+        >Scroll to Top</span></button>\t\n\n\n\n\n\n<!-- Google tag (gtag.js) -->\n\
+        <script async src=\"https://www.googletagmanager.com/gtag/js?id=G-GX6PZNPM06\"\
+        ></script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function\
+        \ gtag(){dataLayer.push(arguments);}\n  gtag('js', new Date());\n\n  gtag('config',\
+        \ 'G-GX6PZNPM06');\n</script>\t\n\n\n\n\n\n<script type=\"speculationrules\"\
+        >\n{\"prefetch\":[{\"source\":\"document\",\"where\":{\"and\":[{\"href_matches\"\
+        :\"\\/*\"},{\"not\":{\"href_matches\":[\"\\/wp-*.php\",\"\\/wp-admin\\/*\"\
+        ,\"\\/wp-content\\/uploads\\/*\",\"\\/wp-content\\/*\",\"\\/wp-content\\/plugins\\\
+        /*\",\"\\/wp-content\\/themes\\/simple-grid\\/*\",\"\\/*\\\\?(.+)\"]}},{\"\
+        not\":{\"selector_matches\":\"a[rel~=\\\"nofollow\\\"]\"}},{\"not\":{\"selector_matches\"\
+        :\".no-prefetch, .no-prefetch a\"}}]},\"eagerness\":\"conservative\"}]}\n\
+        </script>\n\n<script>\nfunction attUploadProof(){\n\n    let fileInput = document.getElementById('att_proof');\n\
+        \    let msg = document.getElementById('att_upload_msg');\n\n    if(!fileInput.files.length){\n\
+        \        msg.innerHTML = '<span style=\"color:red;\">Selecione um arquivo</span>';\n\
+        \        return;\n    }\n\n    let file = fileInput.files[0];\n\n    if(file.size\
+        \ > 50 * 1024 * 1024){\n        msg.innerHTML = '<span style=\"color:red;\"\
+        >Arquivo maior que 50MB</span>';\n        return;\n    }\n\n    let formData\
+        \ = new FormData();\n    formData.append('action','att_upload_proof');\n \
+        \   formData.append('proof', file);\n\n    msg.innerHTML = 'Enviando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        body: formData\n    })\n    .then(r => r.json())\n    .then(res\
+        \ => {\n\n        if(res.success){\n            msg.innerHTML = '<span style=\"\
+        color:green;\">Comprovante enviado com sucesso!</span>';\n        } else {\n\
+        \            msg.innerHTML = '<span style=\"color:red;\">Erro: '+res.data+'</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<script>\nfunction attSaveLastName(){\n\
+        \n    let input = document.getElementById('att_last_name_input') \n      \
+        \       || document.getElementById('att_last_name_input2');\n\n    let msg\
+        \   = document.getElementById('att_name_msg') \n             || document.getElementById('att_name_msg2');\n\
+        \n    if(!input || !msg) return;\n\n    let value = input.value.trim();\n\n\
+        \    if(!value){\n        msg.innerHTML = '<span style=\"color:#f87171;\"\
+        >Digite o nome completo do titular da conta que ser\xE1 usada para a doa\xE7\
+        \xE3o</span>';\n        return;\n    }\n\n    msg.innerHTML = 'Salvando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        headers: {'Content-Type': 'application/x-www-form-urlencoded'},\n\
+        \        body: 'action=att_save_last_name&last_name=' + encodeURIComponent(value)\n\
+        \    })\n    .then(r => r.json())\n    .then(res => {\n\n        if(res.success){\n\
+        \            msg.innerHTML = '<span style=\"color:#22c55e;\">Salvo! Recarregando...</span>';\n\
+        \            setTimeout(()=>location.reload(),800);\n        } else {\n  \
+        \          msg.innerHTML = '<span style=\"color:#f87171;\">Erro ao salvar</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<style type=\"text/css\"> \n      \
+        \   /* Hide reCAPTCHA V3 badge */\n        .grecaptcha-badge {\n        \n\
+        \            visibility: hidden !important;\n        \n        }\n    </style><script\
+        \ type=\"text/javascript\" id=\"lrl-js-js-extra\">\n/* <![CDATA[ */\nvar lrlData\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"post_id\":\"836386\"};\n/* ]]> */\n</script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.js?ver=1.0\"\
+        \ id=\"lrl-js-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/jquery.fitvids.min.js\"\
+        \ id=\"fitvids-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/ResizeSensor.min.js\"\
+        \ id=\"ResizeSensor-js\"></script>\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-content/themes/simple-grid/assets/js/theia-sticky-sidebar.min.js\"\
+        \ id=\"theia-sticky-sidebar-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/navigation.js\"\
+        \ id=\"simple-grid-navigation-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/skip-link-focus-fix.js\"\
+        \ id=\"simple-grid-skip-link-focus-fix-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/imagesloaded.min.js?ver=5.0.0\"\
+        \ id=\"imagesloaded-js\"></script>\n<script type=\"text/javascript\" id=\"\
+        simple-grid-customjs-js-extra\">\n/* <![CDATA[ */\nvar simple_grid_ajax_object\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"primary_menu_active\":\"1\",\"secondary_menu_active\":\"\",\"primary_mobile_menu_active\"\
+        :\"1\",\"secondary_mobile_menu_active\":\"1\",\"sticky_menu_active\":\"1\"\
+        ,\"sticky_mobile_menu_active\":\"\",\"sticky_sidebar_active\":\"1\",\"columnwidth\"\
+        :\".simple-grid-5-col-sizer\",\"gutter\":\".simple-grid-5-col-gutter\"};\n\
+        /* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/custom.js\"\
+        \ id=\"simple-grid-customjs-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/comment-reply.min.js?ver=6.8.3\"\
+        \ id=\"comment-reply-js\" async=\"async\" data-wp-strategy=\"async\"></script>\n\
+        <script type=\"text/javascript\" id=\"simple-grid-html5shiv-js-js-extra\"\
+        >\n/* <![CDATA[ */\nvar simple_grid_custom_script_vars = {\"elements_name\"\
+        :\"abbr article aside audio bdi canvas data datalist details dialog figcaption\
+        \ figure footer header hgroup main mark meter nav output picture progress\
+        \ section summary template time video\"};\n/* ]]> */\n</script>\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/html5shiv.js\"\
+        \ id=\"simple-grid-html5shiv-js-js\"></script>\n<script type=\"text/javascript\"\
+        \ id=\"fifu-json-ld-js-extra\">\n/* <![CDATA[ */\nvar fifuJsonLd = {\"url\"\
+        :\"https:\\/\\/image.tmdb.org\\/t\\/p\\/w500\\/1BP4xYv9ZG4ZVHkL7ocOziBbSYH.jpg\"\
+        };\n/* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/plugins/featured-image-from-url/includes/html/js/json-ld.js?ver=4.9.2\"\
+        \ id=\"fifu-json-ld-js\"></script>\n<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var\
+        \ d=b.createElement('script');d.innerHTML=\"window.__CF$cv$params={r:'a14e7a392f08f3f1',t:'MTc4MzAwMzk3OQ=='};var\
+        \ a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);\"\
+        ;b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else\
+        \ if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var\
+        \ e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script><script\
+        \ defer src=\"https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496\"\
+        \ integrity=\"sha512-ZE9pZaUXND66v380QUtch/5sE9tPFh2zg45pR2PB0CVkCtOREv2AJKkSidISWkysEuQ0EH8faUU5du78bx87UQ==\"\
+        \ data-cf-beacon='{\"version\":\"2024.11.0\",\"token\":\"832c49ee708d4b8d94382b4733ae0382\"\
+        ,\"r\":1,\"server_timing\":{\"name\":{\"cfCacheStatus\":true,\"cfEdge\":true,\"\
+        cfExtPri\":true,\"cfL4\":true,\"cfOrigin\":true,\"cfSpeedBrain\":true},\"\
+        location_startswith\":null}}' crossorigin=\"anonymous\"></script>\n</body>\n\
+        </html>"
+    headers:
+      CF-RAY:
+      - a14e7a392f08f3f1-GRU
+      Cf-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Thu, 02 Jul 2026 14:53:00 GMT
+      Link:
+      - <https://legendei.net/wp-json/>; rel="https://api.w.org/", <https://legendei.net/wp-json/wp/v2/posts/836386>;
+        rel="alternate"; title="JSON"; type="application/json", <https://legendei.net/?p=836386>;
+        rel=shortlink
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Permissions-Policy:
+      - private-state-token-redemption=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com"),
+        private-state-token-issuance=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com")
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=HrJ1pBFHYKbURNP7KIfMIJUjTeVgRNblcl4RBIyasm9dyQ7mQA6dCi%2B7QE8I5tjn3Oh6u1ZiXetWBYG1YsRpD%2Foy4pVGcGGPOxVps4McHz2cz1%2BSNTQMu9400f9Ymbw%3D"}]}'
+      Server:
+      - cloudflare
+      Server-Timing:
+      - cfCacheStatus;desc="DYNAMIC"
+      - cfEdge;dur=6,cfOrigin;dur=374
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - pt-BR,pt;q=0.9,en;q=0.8
+      User-Agent:
+      - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like
+        Gecko) Chrome/131.0.0.0 Safari/537.36
+    method: GET
+    uri: https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc/
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html dir=\"ltr\" lang=\"pt-BR\" prefix=\"og: https://ogp.me/ns#\"\
+        >\n<head>\n<meta charset=\"UTF-8\">\n<meta name=\"viewport\" content=\"width=device-width,\
+        \ initial-scale=1.0\">\n\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css\"\
+        >\n\t\n<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">\n<link\
+        \ rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>\n<link\
+        \ href=\"https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap\"\
+        \ rel=\"stylesheet\">\n\t\n<title>Legenda The Bad Guys Breaking In S01E01\
+        \ 1080p WEB h264 DOLORES cc | Legendei - Aqui Sai Primeiro</title>\n\t<style>img:is([sizes=\"\
+        auto\" i], [sizes^=\"auto,\" i]) { contain-intrinsic-size: 3000px 1500px }</style>\n\
+        \t\n\t\t<!-- All in One SEO Pro 4.6.0 - aioseo.com -->\n\t\t<meta name=\"\
+        description\" content=\"Legenda da s\xE9rie The Bad Guys: Breaking In (2025)\
+        \ Os Caras Malvados No Peda\xE7o \u2014 Como \xE9 que os Caras Malvados acabaram\
+        \ ficando malvados? Esta s\xE9rie hil\xE1ria ambientada antes dos filmes conta\
+        \ a hist\xF3ria inteira. Legenda The Bad Guys Breaking In S01E01 1080p WEB\
+        \ h264 DOLORES cc testada e verificada - Pode servir tamb\xE9m para outros\
+        \ releases, basta renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\"\
+        \ />\n\t\t<meta name=\"robots\" content=\"max-image-preview:large\" />\n\t\
+        \t<meta name=\"google-site-verification\" content=\"JSMIV3rTOC3Y-WjaQzmU3KvW7aWHceTxBFYsJYpm-1k\"\
+        \ />\n\t\t<link rel=\"canonical\" href=\"https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc/\"\
+        \ />\n\t\t<meta name=\"generator\" content=\"All in One SEO Pro (AIOSEO) 4.6.0\"\
+        \ />\n\t\t<meta property=\"og:locale\" content=\"pt_BR\" />\n\t\t<meta property=\"\
+        og:site_name\" content=\"Legendei - Baixar Legendas de S\xE9ries e Filmes\"\
+        \ />\n\t\t<meta property=\"og:type\" content=\"article\" />\n\t\t<meta property=\"\
+        og:title\" content=\"Legenda The Bad Guys Breaking In S01E01 1080p WEB h264\
+        \ DOLORES cc | Legendei - Aqui Sai Primeiro\" />\n\t\t<meta property=\"og:description\"\
+        \ content=\"Legenda da s\xE9rie The Bad Guys: Breaking In (2025) Os Caras\
+        \ Malvados No Peda\xE7o \u2014 Como \xE9 que os Caras Malvados acabaram ficando\
+        \ malvados? Esta s\xE9rie hil\xE1ria ambientada antes dos filmes conta a hist\xF3\
+        ria inteira. Legenda The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES\
+        \ cc testada e verificada - Pode servir tamb\xE9m para outros releases, basta\
+        \ renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t<meta\
+        \ property=\"og:url\" content=\"https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc/\"\
+        \ />\n\t\t<meta property=\"og:image\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"og:image:secure_url\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"article:published_time\" content=\"2026-01-14T14:26:08+00:00\"\
+        \ />\n\t\t<meta property=\"article:modified_time\" content=\"2026-01-14T14:37:08+00:00\"\
+        \ />\n\t\t<meta name=\"twitter:card\" content=\"summary\" />\n\t\t<meta name=\"\
+        twitter:title\" content=\"Legenda The Bad Guys Breaking In S01E01 1080p WEB\
+        \ h264 DOLORES cc | Legendei - Aqui Sai Primeiro\" />\n\t\t<meta name=\"twitter:description\"\
+        \ content=\"Legenda da s\xE9rie The Bad Guys: Breaking In (2025) Os Caras\
+        \ Malvados No Peda\xE7o \u2014 Como \xE9 que os Caras Malvados acabaram ficando\
+        \ malvados? Esta s\xE9rie hil\xE1ria ambientada antes dos filmes conta a hist\xF3\
+        ria inteira. Legenda The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES\
+        \ cc testada e verificada - Pode servir tamb\xE9m para outros releases, basta\
+        \ renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t<meta\
+        \ name=\"twitter:image\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<script type=\"application/ld+json\" class=\"aioseo-schema\">\n\t\
+        \t\t{\"@context\":\"https:\\/\\/schema.org\",\"@graph\":[{\"@type\":\"BlogPosting\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc\\\
+        /#blogposting\",\"name\":\"Legenda The Bad Guys Breaking In S01E01 1080p WEB\
+        \ h264 DOLORES cc | Legendei - Aqui Sai Primeiro\",\"headline\":\"The Bad\
+        \ Guys Breaking In S01E01 1080p WEB h264 DOLORES cc\",\"author\":{\"@id\"\
+        :\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\/#author\"},\"publisher\"\
+        :{\"@id\":\"https:\\/\\/legendei.net\\/#organization\"},\"image\":{\"@type\"\
+        :\"ImageObject\",\"url\":\"https:\\/\\/legendei.net\\/wp-content\\/uploads\\\
+        /2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\/#articleImage\"\
+        ,\"width\":150,\"height\":150},\"datePublished\":\"2026-01-14T15:26:08+01:00\"\
+        ,\"dateModified\":\"2026-01-14T15:37:08+01:00\",\"inLanguage\":\"pt-BR\",\"\
+        mainEntityOfPage\":{\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc\\\
+        /#webpage\"},\"isPartOf\":{\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc\\\
+        /#webpage\"},\"articleSection\":\"Destaques, S\\u00e9ries TV, Lan\\u00e7amentos,\
+        \ Legendado Portugu\\u00eas, Legendas The Bad Guys Breaking In, Legendas The\
+        \ Bad Guys Breaking In S01, S\\u00e9ries Legendadas, S\\u00e9ries Populares\"\
+        },{\"@type\":\"BreadcrumbList\",\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc\\\
+        /#breadcrumblist\",\"itemListElement\":[{\"@type\":\"ListItem\",\"@id\":\"\
+        https:\\/\\/legendei.net\\/#listItem\",\"position\":1,\"name\":\"Home\",\"\
+        item\":\"https:\\/\\/legendei.net\\/\",\"nextItem\":\"https:\\/\\/legendei.net\\\
+        /the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc\\/#listItem\"\
+        },{\"@type\":\"ListItem\",\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc\\\
+        /#listItem\",\"position\":2,\"name\":\"The.Bad.Guys.Breaking.In.S01E01.1080p.WEB.h264-DOLORES.pt.cc\"\
+        ,\"previousItem\":\"https:\\/\\/legendei.net\\/#listItem\"}]},{\"@type\":\"\
+        Organization\",\"@id\":\"https:\\/\\/legendei.net\\/#organization\",\"name\"\
+        :\"Legendei\",\"url\":\"https:\\/\\/legendei.net\\/\",\"logo\":{\"@type\"\
+        :\"ImageObject\",\"url\":\"https:\\/\\/legendei.net\\/wp-content\\/uploads\\\
+        /2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc\\\
+        /#organizationLogo\",\"width\":150,\"height\":150},\"image\":{\"@id\":\"https:\\\
+        /\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc\\\
+        /#organizationLogo\"}},{\"@type\":\"Person\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /author\\/eneinsubtitles\\/#author\",\"url\":\"https:\\/\\/legendei.net\\\
+        /author\\/eneinsubtitles\\/\",\"name\":\"Admin\"},{\"@type\":\"WebPage\",\"\
+        @id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc\\\
+        /#webpage\",\"url\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc\\\
+        /\",\"name\":\"Legenda The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES\
+        \ cc | Legendei - Aqui Sai Primeiro\",\"description\":\"Legenda da s\\u00e9rie\
+        \ The Bad Guys: Breaking In (2025) Os Caras Malvados No Peda\\u00e7o \\u2014\
+        \ Como \\u00e9 que os Caras Malvados acabaram ficando malvados? Esta s\\u00e9rie\
+        \ hil\\u00e1ria ambientada antes dos filmes conta a hist\\u00f3ria inteira.\
+        \ Legenda The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES cc testada\
+        \ e verificada - Pode servir tamb\\u00e9m para outros releases, basta renomear!\
+        \ Dispon\\u00edvel em Legendei - Aqui Sai Primeiro\",\"inLanguage\":\"pt-BR\"\
+        ,\"isPartOf\":{\"@id\":\"https:\\/\\/legendei.net\\/#website\"},\"breadcrumb\"\
+        :{\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc\\\
+        /#breadcrumblist\"},\"author\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\\
+        /eneinsubtitles\\/#author\"},\"creator\":{\"@id\":\"https:\\/\\/legendei.net\\\
+        /author\\/eneinsubtitles\\/#author\"},\"datePublished\":\"2026-01-14T15:26:08+01:00\"\
+        ,\"dateModified\":\"2026-01-14T15:37:08+01:00\"},{\"@type\":\"WebSite\",\"\
+        @id\":\"https:\\/\\/legendei.net\\/#website\",\"url\":\"https:\\/\\/legendei.net\\\
+        /\",\"name\":\"Legendei\",\"description\":\"Baixar Legendas de S\\u00e9ries\
+        \ e Filmes\",\"inLanguage\":\"pt-BR\",\"publisher\":{\"@id\":\"https:\\/\\\
+        /legendei.net\\/#organization\"}}]}\n\t\t</script>\n\t\t<!-- All in One SEO\
+        \ Pro -->\n\n<link rel='dns-prefetch' href='//fonts.googleapis.com' />\n<link\
+        \ rel=\"alternate\" type=\"application/rss+xml\" title=\"Feed para Legendei\
+        \ &raquo;\" href=\"https://legendei.net/feed/\" />\n<link rel=\"alternate\"\
+        \ type=\"application/rss+xml\" title=\"Feed de coment\xE1rios para Legendei\
+        \ &raquo;\" href=\"https://legendei.net/comments/feed/\" />\n<link rel=\"\
+        alternate\" type=\"application/rss+xml\" title=\"Feed de coment\xE1rios para\
+        \ Legendei &raquo; The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES\
+        \ cc\" href=\"https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc/feed/\"\
+        \ />\n<script type=\"text/javascript\">\n/* <![CDATA[ */\nwindow._wpemojiSettings\
+        \ = {\"baseUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\/emoji\\/16.0.1\\\
+        /72x72\\/\",\"ext\":\".png\",\"svgUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\\
+        /emoji\\/16.0.1\\/svg\\/\",\"svgExt\":\".svg\",\"source\":{\"concatemoji\"\
+        :\"https:\\/\\/legendei.net\\/wp-includes\\/js\\/wp-emoji-release.min.js?ver=6.8.3\"\
+        }};\n/*! This file is auto-generated */\n!function(s,n){var o,i,e;function\
+        \ c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function\
+        \ p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var\
+        \ t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),a=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new\
+        \ Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return\
+        \ t.every(function(e,t){return e===a[t]})}function u(e,t){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);for(var\
+        \ n=e.getImageData(16,16,1,1),a=0;a<n.data.length;a++)if(0!==n.data[a])return!1;return!0}function\
+        \ f(e,t,n,a){switch(t){case\"flag\":return n(e,\"\\ud83c\\udff3\\ufe0f\\u200d\\\
+        u26a7\\ufe0f\",\"\\ud83c\\udff3\\ufe0f\\u200b\\u26a7\\ufe0f\")?!1:!n(e,\"\\\
+        ud83c\\udde8\\ud83c\\uddf6\",\"\\ud83c\\udde8\\u200b\\ud83c\\uddf6\")&&!n(e,\"\
+        \\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc65\\udb40\\udc6e\\udb40\\\
+        udc67\\udb40\\udc7f\",\"\\ud83c\\udff4\\u200b\\udb40\\udc67\\u200b\\udb40\\\
+        udc62\\u200b\\udb40\\udc65\\u200b\\udb40\\udc6e\\u200b\\udb40\\udc67\\u200b\\\
+        udb40\\udc7f\");case\"emoji\":return!a(e,\"\\ud83e\\udedf\")}return!1}function\
+        \ g(e,t,n,a){var r=\"undefined\"!=typeof WorkerGlobalScope&&self instanceof\
+        \ WorkerGlobalScope?new OffscreenCanvas(300,150):s.createElement(\"canvas\"\
+        ),o=r.getContext(\"2d\",{willReadFrequently:!0}),i=(o.textBaseline=\"top\"\
+        ,o.font=\"600 32px Arial\",{});return e.forEach(function(e){i[e]=t(o,e,n,a)}),i}function\
+        \ t(e){var t=s.createElement(\"script\");t.src=e,t.defer=!0,s.head.appendChild(t)}\"\
+        undefined\"!=typeof Promise&&(o=\"wpEmojiSettingsSupports\",i=[\"flag\",\"\
+        emoji\"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){s.addEventListener(\"\
+        DOMContentLoaded\",e,{once:!0})}),new Promise(function(t){var n=function(){try{var\
+        \ e=JSON.parse(sessionStorage.getItem(o));if(\"object\"==typeof e&&\"number\"\
+        ==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&\"object\"\
+        ==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if(\"\
+        undefined\"!=typeof Worker&&\"undefined\"!=typeof OffscreenCanvas&&\"undefined\"\
+        !=typeof URL&&URL.createObjectURL&&\"undefined\"!=typeof Blob)try{var e=\"\
+        postMessage(\"+g.toString()+\"(\"+[JSON.stringify(i),f.toString(),p.toString(),u.toString()].join(\"\
+        ,\")+\"));\",a=new Blob([e],{type:\"text/javascript\"}),r=new Worker(URL.createObjectURL(a),{name:\"\
+        wpTestEmojiSupports\"});return void(r.onmessage=function(e){c(n=e.data),r.terminate(),t(n)})}catch(e){}c(n=g(i,f,p,u))}t(n)}).then(function(e){for(var\
+        \ t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],\"\
+        flag\"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return\
+        \ e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);\n\
+        /* ]]> */\n</script>\n<link rel='stylesheet' id='wpa-css-css' href='https://legendei.net/wp-content/plugins/wp-attachments/styles/0/wpa.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='wp-emoji-styles-inline-css' type='text/css'>\n\
+        \n\timg.wp-smiley, img.emoji {\n\t\tdisplay: inline !important;\n\t\tborder:\
+        \ none !important;\n\t\tbox-shadow: none !important;\n\t\theight: 1em !important;\n\
+        \t\twidth: 1em !important;\n\t\tmargin: 0 0.07em !important;\n\t\tvertical-align:\
+        \ -0.1em !important;\n\t\tbackground: none !important;\n\t\tpadding: 0 !important;\n\
+        \t}\n</style>\n<link rel='stylesheet' id='wp-block-library-css' href='https://legendei.net/wp-includes/css/dist/block-library/style.min.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='classic-theme-styles-inline-css'\
+        \ type='text/css'>\n/*! This file is auto-generated */\n.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em\
+        \ + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}\n\
+        </style>\n<style id='wppb-content-restriction-start-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-content-restriction-end-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-edit-profile-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-login-style-inline-css' type='text/css'>\n\n\
+        \n</style>\n<style id='wppb-recover-password-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-register-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='global-styles-inline-css' type='text/css'>\n:root{--wp--preset--aspect-ratio--square:\
+        \ 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4:\
+        \ 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3:\
+        \ 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16:\
+        \ 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray:\
+        \ #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink:\
+        \ #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange:\
+        \ #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan:\
+        \ #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue:\
+        \ #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple:\
+        \ #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1)\
+        \ 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan:\
+        \ linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange:\
+        \ linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red:\
+        \ linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray:\
+        \ linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum:\
+        \ linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186)\
+        \ 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple:\
+        \ linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux:\
+        \ linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62)\
+        \ 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112)\
+        \ 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean:\
+        \ linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181)\
+        \ 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128)\
+        \ 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129)\
+        \ 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium:\
+        \ 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large:\
+        \ 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40:\
+        \ 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70:\
+        \ 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural:\
+        \ 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px\
+        \ rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0,\
+        \ 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255,\
+        \ 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0,\
+        \ 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap:\
+        \ 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items:\
+        \ center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display:\
+        \ grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-color{color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background:\
+        \ var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange)\
+        \ !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background:\
+        \ var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background:\
+        \ var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background:\
+        \ var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background:\
+        \ var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background:\
+        \ var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size:\
+        \ var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size:\
+        \ var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--x-large) !important;}\n:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}\n:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}\n:root :where(.wp-block-pullquote){font-size:\
+        \ 1.5em;line-height: 1.6;}\n</style>\n<link rel='stylesheet' id='lrl-css-css'\
+        \ href='https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-maincss-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css' type='text/css'\
+        \ media='all' />\n<link rel='stylesheet' id='fontawesome-css' href='https://legendei.net/wp-content/themes/simple-grid/assets/css/all.min.css'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-webfont-css'\
+        \ href='//fonts.googleapis.com/css?family=Playfair+Display:400,400i,700,700i|Domine:400,700|Oswald:400,700|Patua+One|Merriweather:400,400i,700,700i&#038;display=swap'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='legendei-style-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css?ver=1782544305'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='wppb_stylesheet-css'\
+        \ href='https://legendei.net/wp-content/plugins/profile-builder/assets/css/style-front-end.css?ver=3.15.2'\
+        \ type='text/css' media='all' />\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-includes/js/jquery/jquery.min.js?ver=3.7.1\" id=\"\
+        jquery-core-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1\"\
+        \ id=\"jquery-migrate-js\"></script>\n<!--[if lt IE 9]>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/respond.min.js\"\
+        \ id=\"respond-js\"></script>\n<![endif]-->\n<link rel=\"https://api.w.org/\"\
+        \ href=\"https://legendei.net/wp-json/\" /><link rel=\"alternate\" title=\"\
+        JSON\" type=\"application/json\" href=\"https://legendei.net/wp-json/wp/v2/posts/729772\"\
+        \ /><link rel=\"EditURI\" type=\"application/rsd+xml\" title=\"RSD\" href=\"\
+        https://legendei.net/xmlrpc.php?rsd\" />\n<meta name=\"generator\" content=\"\
+        WordPress 6.8.3\" />\n<link rel='shortlink' href='https://legendei.net/?p=729772'\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (JSON)\" type=\"application/json+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fthe-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc%2F\"\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (XML)\" type=\"text/xml+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fthe-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc%2F&#038;format=xml\"\
+        \ />\n<style>\n\n/* FORMUL\xC1RIO TRIAL */\n\n.premium-form {\n    max-width:\
+        \ 760px;\n    margin: 0 auto 20px;\n    padding: 30px;\n    border-radius:\
+        \ 10px;\n    background: #212121;\n    border: 10px solid transparent;\n \
+        \   background-image:\n        linear-gradient(#212121,#212121),\n       \
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    background-origin: border-box;\n\
+        \    background-clip: padding-box, border-box;\n    box-sizing: border-box;\n\
+        }\n\n/* Campos */\n\n.premium-form .field {\n    position: relative;\n   \
+        \ margin-bottom: 20px;\n}\n\n.premium-form input {\n    width: 100%;\n   \
+        \ padding: 14px;\n    border-radius: 8px;\n    border: 1px solid #ccc;\n \
+        \   font-size: 16px;\n    box-sizing: border-box;\n}\n\n/* Focus bonito */\n\
+        \n.premium-form input:focus {\n    border-color: transparent;\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin: border-box;\n    background-clip: padding-box, border-box;\n\
+        \    box-shadow: 0 0 0 4px rgba(63,140,255,0.20);\n    outline: none;\n}\n\
+        \n/* TOOLTIP */\n\n.premium-form .tooltip {\n    position: absolute;\n   \
+        \ bottom: 100%;\n    left: 0;\n    margin-bottom: 10px;\n    background: linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \tbox-shadow:0 6px 14px rgba(0,0,0,0.25);\n    color: #ffffff;\n    padding:\
+        \ 10px 12px;\n    font-size: 14px;\n    border-radius: 6px;\n    max-width:\
+        \ 260px;\n    opacity: 0;\n    pointer-events: none;\n    transition: .2s;\n\
+        \    z-index: 999;\n}\n\n.premium-form .tooltip::after {\n    content: \"\"\
+        ;\n    position: absolute;\n    top: 100%;\n    left: 15px;\n    border-width:\
+        \ 6px 6px 0 6px;\n    border-style: solid;\n    border-color: #8a2be2 transparent\
+        \ transparent transparent;\n}\n\n.premium-form .field:hover .tooltip,\n.premium-form\
+        \ .field:focus-within .tooltip {\n    opacity: 1;\n    transform: translateY(-4px);\n\
+        }\n\n/* BOT\xC3O */\n\n.premium-form button {\n    padding: 14px 30px;\n \
+        \   font-size: 22px;\n    border-radius: 8px;\n    border: none;\n    background:\
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    color: #fff;\n    cursor: pointer;\n\
+        \    transition: .25s;\n}\n\n.premium-form button:hover {\n    background:\
+        \ linear-gradient(90deg,#4c9aff,#9a3bff);\n}\n\n/* SENHA */\n\n.pass-wrap{\n\
+        \    position:relative;\n}\n\n.toggle-pass{\n    position:absolute;\n    right:12px;\n\
+        \    top:50%;\n    transform:translateY(-50%);\n    cursor:pointer;\n    font-size:18px;\n\
+        }\n\n/* BARRA FOR\xC7A SENHA */\n\n.strength{\n    height:6px;\n    background:#444;\n\
+        \    border-radius:4px;\n    margin-top:8px;\n    overflow:hidden;\n}\n\n\
+        .strength div{\n    height:100%;\n    width:0%;\n    transition:.3s;\n}\n\n\
+        /* MOBILE */\n\n@media (max-width:480px){\n\n.premium-form{\n    padding:20px;\n\
+        }\n\n}\n\n</style>\n<!-- FIFU: meta tags for featured image (begin) -->\n\
+        <meta property=\"og:image\" content=\"https://image.tmdb.org/t/p/w500/owTRRXuxpJT5n68IddsvDtAeK6K.jpg\"\
+        \ />\n<!-- FIFU: meta tags for featured image (end) --><meta name=\"twitter:image\"\
+        \ content=\"https://image.tmdb.org/t/p/w500/owTRRXuxpJT5n68IddsvDtAeK6K.jpg\"\
+        \ /><style>\n\n/* remove fundo normal, ativo e hover do logo */\n.simple-grid-primary-nav-menu\
+        \ > li.menu-logo-item > a,\n.simple-grid-primary-nav-menu > li.menu-logo-item\
+        \ > a:hover,\n.simple-grid-primary-nav-menu > li.menu-logo-item.current-menu-item\
+        \ > a{\n    background:none !important;\n}\n\n/* ===================================================\n\
+        \   MOBILE\n   =================================================== */\n\n\
+        @media only screen and (max-width:812px){\n\n    /* ESCONDER LOGO NO MENU\
+        \ MOBILE */\n    .simple-grid-primary-nav-menu > li.menu-logo-item{\n    \
+        \    display:none !important;\n    }\n\n}\n\n</style>\n    <style type=\"\
+        text/css\">\r\n            .simple-grid-site-title, .simple-grid-site-title\
+        \ a, .simple-grid-site-description {color: #ffffff;}\r\n        </style>\r\
+        \n    <style type=\"text/css\" id=\"custom-background-css\">\nbody.custom-background\
+        \ { background-color: #333333; }\n</style>\n\t<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"32x32\" />\n<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"192x192\" />\n<link rel=\"apple-touch-icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n<meta name=\"msapplication-TileImage\" content=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n</head>\t\n\t\n\t\n<body class=\"wp-singular post-template-default single\
+        \ single-post postid-729772 single-format-standard custom-background wp-custom-logo\
+        \ wp-theme-simple-grid simple-grid-animated simple-grid-fadein simple-grid-theme-is-active\
+        \ simple-grid-custom-logo-active simple-grid-layout-type-full simple-grid-masonry-inactive\
+        \ simple-grid-float-grid simple-grid-responsive-grid-details simple-grid-layout-c-s1\
+        \ simple-grid-header-banner-active simple-grid-tagline-inactive simple-grid-logo-above-title\
+        \ simple-grid-primary-menu-active simple-grid-primary-mobile-menu-active simple-grid-secondary-mobile-menu-active\
+        \ simple-grid-primary-social-icons\" id=\"simple-grid-site-body\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/WebPage\">\n<a class=\"skip-link\
+        \ screen-reader-text\" href=\"#simple-grid-content-wrapper\">Skip to content</a>\n\
+        \n\n\n<div class=\"simple-grid-site-header simple-grid-container\" id=\"simple-grid-header\"\
+        \ itemscope=\"itemscope\" itemtype=\"http://schema.org/WPHeader\" role=\"\
+        banner\">\n<div class=\"simple-grid-head-content simple-grid-clearfix\" id=\"\
+        simple-grid-head-content\">\n\n<div class=\"simple-grid-no-header-content\"\
+        >\n              <p class=\"simple-grid-site-title\"><a href=\"https://legendei.net/\"\
+        \ rel=\"home\">Legendei</a></p>\r\n                </div>\n\n</div><!--/#simple-grid-head-content\
+        \ -->\n</div><!--/#simple-grid-header -->\n\n\n\n<div class=\"simple-grid-container\
+        \ simple-grid-primary-menu-container simple-grid-clearfix\">\n<div class=\"\
+        simple-grid-primary-menu-container-inside simple-grid-clearfix\">\n<nav class=\"\
+        simple-grid-nav-primary\" id=\"simple-grid-primary-navigation\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/SiteNavigationElement\" role=\"navigation\"\
+        \ aria-label=\"Primary Menu\">\n\t\n\t\n<div class=\"simple-grid-outer-wrapper\"\
+        >\n<a href=\"/\" class=\"logo-mobile-inline\">\n<img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \nstyle=\"width:100%;height:auto;\">\n</a>\n\n<style>\n.logo-mobile-inline{\n\
+        display:none;\n}\n\n@media (max-width:812px){\n.logo-mobile-inline{\ndisplay:block;\n\
+        }\n}\n</style>\t\n\n\t\n<style>\n.mobile-header-icons{\n    display:none;\n\
+        }\n\n@media (max-width: 812px){\n\n.mobile-header-icons{\n    display:grid;\n\
+        \    grid-template-columns: 2fr 1fr 1fr;\n    gap:10px;\n    padding:10px;\n\
+        }\n\n/* BOT\xD5ES */\n.mobile-header-icons a,\n.mobile-header-icons .cat-toggle{\n\
+        \    display:flex;\n    align-items:center;\n    justify-content:center;\n\
+        \    gap:6px;\n    background:#141414;\n    padding:8px 6px;\n    border-radius:8px;\n\
+        \    color:#fff;\n    font-size:12px;\n    text-decoration:none;\n    text-align:center;\n\
+        \    cursor:pointer;\n}\n\n/* CATEGORIA */\n.cat-toggle{\n    font-weight:600;\n\
+        }\n\n/* SETA */\n.cat-toggle .arrow{\n    transition:transform 0.3s ease;\n\
+        }\n\n/* SETA GIRADA */\n.cat-toggle.active .arrow{\n    transform:rotate(180deg);\n\
+        }\n\n/* HOVER */\n.mobile-header-icons a:hover,\n.mobile-header-icons .cat-toggle:hover{\n\
+        \    background:#1f1f1f;\n}\n\n/* CONTAINER */\n.cat-container{\n    position:relative;\n\
+        }\n\n/* DROPDOWN */\n.cat-list{\n    display:flex;\n    flex-direction:column;\n\
+        \    gap:6px;\n\n    position:absolute;\n    top:110%;\n    left:0;\n    width:100%;\n\
+        \n    background:#0f0f0f;\n    border-radius:8px;\n    padding:6px;\n    z-index:999;\n\
+        \n    opacity:0;\n    visibility:hidden;\n    transform:translateY(-5px);\n\
+        \    transition:all 0.25s ease;\n}\n\n/* ABERTO */\n.cat-container.open .cat-list{\n\
+        \    opacity:1;\n    visibility:visible;\n    transform:translateY(0);\n}\n\
+        \n/* ITENS */\n.cat-list a{\n    justify-content:flex-start;\n    font-size:14px;\n\
+        \    padding:10px;\n}\n\n}\n</style>\n\n\n<div class=\"mobile-header-icons\"\
+        >\n\n    <!-- CATEGORIAS -->\n    <div class=\"cat-container\">\n        <div\
+        \ class=\"cat-toggle\">\n            \U0001F4C2 Categorias <span class=\"\
+        arrow\">\u25BC</span>\n        </div>\n\n        <div class=\"cat-list\">\n\
+        \            <a href=\"/category/destaques/\">\u2B50 Destaques</a>\n     \
+        \       <a href=\"/category/filmes/\">\U0001F3AC Filmes</a>\n            <a\
+        \ href=\"/category/serie/\">\U0001F4FA S\xE9ries</a>\n            <a href=\"\
+        /category/pack-de-legendas/\">\U0001F4E6 Packs</a>\n        </div>\n    </div>\n\
+        \n    \n        <a href=\"/seja-premium-vitalicio/\"><i class=\"fa-solid fa-crown\"\
+        ></i> Premium</a>\n\n        <a href=\"/login/\"><i class=\"fa-solid fa-key\"\
+        ></i> Login</a>\n\n    \n</div>\n\n<script>\ndocument.addEventListener(\"\
+        DOMContentLoaded\", function(){\n\n    const container = document.querySelector(\"\
+        .cat-container\");\n    const toggle = document.querySelector(\".cat-toggle\"\
+        );\n\n    toggle.addEventListener(\"click\", function(e){\n        e.stopPropagation();\n\
+        \        container.classList.toggle(\"open\");\n        toggle.classList.toggle(\"\
+        active\");\n    });\n\n    document.addEventListener(\"click\", function(e){\n\
+        \        if(!container.contains(e.target)){\n            container.classList.remove(\"\
+        open\");\n            toggle.classList.remove(\"active\");\n        }\n  \
+        \  });\n\n});\n</script>\t\n\t\n<ul id=\"simple-grid-menu-primary-navigation\"\
+        \ class=\"simple-grid-primary-nav-menu simple-grid-menu-primary\"><li id=\"\
+        menu-item-673170\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-673170 menu-logo-item\">\n        <a href=\"https://legendei.net/\"\
+        \ style=\"\n            display:flex;\n            align-items:center;\n \
+        \           justify-content:center;\n            height:100%;\n          \
+        \  padding:0;\n            margin:0;\n            line-height:1;\n       \
+        \ \">\n            <img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \n                      alt=\"Legendei.NET\"\n                      style=\"\
+        height:42px;width:auto;display:block;\">\n        </a></li>\n\n<li id=\"menu-item-673168\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category current-post-ancestor\
+        \ current-menu-parent current-post-parent menu-item-673168\"><a href=\"https://legendei.net/category/destaques/\"\
+        \ title=\"Legendas em Destaque\">DESTAQUES</a></li>\n<li id=\"menu-item-673167\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673167\"\
+        ><a href=\"https://legendei.net/category/filmes/\" title=\"Legendas para Filmes\"\
+        >Filmes</a></li>\n<li id=\"menu-item-673166\" class=\"menu-item menu-item-type-taxonomy\
+        \ menu-item-object-category current-post-ancestor current-menu-parent current-post-parent\
+        \ menu-item-673166\"><a href=\"https://legendei.net/category/serie/\" title=\"\
+        Legendas para seriados\">S\xC9RIES</a></li>\n<li id=\"menu-item-673169\" class=\"\
+        menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673169\"\
+        ><a href=\"https://legendei.net/category/pack-de-legendas/\" title=\"Pack\
+        \ de legendas\">PACKS</a></li>\n<li id=\"menu-item-731144\" class=\"menu-item\
+        \ menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-731144\"\
+        ><a target=\"_blank\" href=\"/aplicativos/\">RECOMENDAMOS</a>\n<ul class=\"\
+        sub-menu\">\n\t<li id=\"menu-item-673172\" class=\"menu-item menu-item-type-custom\
+        \ menu-item-object-custom menu-item-673172\"><a target=\"_blank\" href=\"\
+        /aplicativos/\" title=\"Programas para windows\">APLICATIVOS</a></li>\n\t\
+        <li id=\"menu-item-687662\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-687662\"><a target=\"_blank\" href=\"https://4kxxx.vip/\" title=\"\
+        Baixe os melhores v\xEDdeos porn\xF4 sempre em 4K\">4K XXX</a></li>\n\t<li\
+        \ id=\"menu-item-717497\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-717497\"><a target=\"_blank\" href=\"https://detonaplay.com/\"\
+        >GAMES</a></li>\n</ul>\n</li>\n\n\n\n<li class=\"menu-item\" style=\"float:right;\"\
+        >\n            <a href=\"/login/\"\n               style=\"background:linear-gradient(135deg,#198754,#20ac6b);color:#ffffff;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-key\"></i> Login\n            </a>\n\
+        \        </li><li class=\"menu-item\" style=\"float:right;\">\n          \
+        \  <a href=\"/seja-premium-vitalicio/\"\n\t\t\t\t\t  style=\"background:linear-gradient(135deg,#f4c430,#c2940a);color:#4d2e00;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-crown\"></i> Membro Premium\n  \
+        \          </a>\n        </li></ul>    </div>\n</nav>\n</div>\n</div>\n\n\t\
+        \n\t\n\r\n<div class=\"simple-grid-outer-wrapper\">\r\n<div class=\"simple-grid-top-wrapper-outer\
+        \ simple-grid-clearfix\">\r\n<div class=\"simple-grid-featured-posts-area\
+        \ simple-grid-top-wrapper simple-grid-clearfix\">\r\n\r\n<div id=\"search-5\"\
+        \ class=\"simple-grid-main-widget widget simple-grid-widget-box widget_search\"\
+        ><div class=\"simple-grid-widget-box-inside\"><form role=\"search\" method=\"\
+        get\" class=\"simple-grid-search-form\" action=\"https://legendei.net/\">\n\
+        <label>\n    <span class=\"simple-grid-sr-only\">Pesquisar por </span>\n \
+        \   <input \n        type=\"search\"\n        class=\"simple-grid-search-field\"\
+        \n        placeholder=\"Pesquisar &hellip;\"\n        value=\"\"\n       \
+        \ name=\"s\"\n        minlength=\"3\"\n\t\tmaxlength=\"50\"   \n        required\n\
+        \    />\n</label>\n<input type=\"submit\" class=\"simple-grid-search-submit\"\
+        \ value=\"&#xf002;\" />\n</form></div></div></div>\r\n</div>\r\n</div>\r\n\
+        \r\n\n<div class=\"simple-grid-outer-wrapper\" id=\"simple-grid-wrapper-outside\"\
+        >\n\n<div class=\"simple-grid-container simple-grid-clearfix\" id=\"simple-grid-wrapper\"\
+        >\n<div class=\"simple-grid-content-wrapper simple-grid-clearfix\" id=\"simple-grid-content-wrapper\"\
+        >\t\n\t\t\n\n\n<div class=\"simple-grid-main-wrapper simple-grid-clearfix\"\
+        \ id=\"simple-grid-main-wrapper\" itemscope=\"itemscope\" itemtype=\"http://schema.org/Blog\"\
+        \ role=\"main\">\n<div class=\"theiaStickySidebar\">\n<div class=\"simple-grid-main-wrapper-inside\
+        \ simple-grid-clearfix\">\n\n\r\n\r\n\n<div class=\"simple-grid-posts-wrapper\"\
+        \ id=\"simple-grid-posts-wrapper\">\n\n\n\n\n\n<div style=\"width: 100%; border-radius:\
+        \ 12px; box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 12px; padding: 15px; background:\
+        \ #ffffff;\">\n    <center>\n    <article id=\"post-729772\" class=\"simple-grid-post-singular\
+        \ simple-grid-box post-729772 post type-post status-publish format-standard\
+        \ hentry category-destaques category-serie tag-lancamentos tag-legendado-portugues\
+        \ tag-legendas-the-bad-guys-breaking-in tag-legendas-the-bad-guys-breaking-in-s01\
+        \ tag-series-legendadas tag-series-populares wpcat-8225-id wpcat-4-id\">\n\
+        \        <div class=\"simple-grid-box-inside\">\n            \n          \
+        \  \n                            <header class=\"entry-header\">\n       \
+        \             <div class=\"entry-header-inside simple-grid-clearfix\">\n\n\
+        <h1 class=\"post-title entry-title\"><i class=\"fa-solid fa-star fa-beat\"\
+        \ style=\"color:#f39c12;\"></i> Legenda The Bad Guys Breaking In S01E01 1080p\
+        \ WEB h264 DOLORES cc <span aria-label=\"PT-BR\">\U0001F1E7\U0001F1F7</span></h1>\n\
+        \n\n                                    <div class=\"simple-grid-entry-meta-single\"\
+        >\n                            <span class=\"simple-grid-entry-meta-single-date\"\
+        >\n                <i class=\"far fa-clock\" aria-hidden=\"true\"></i>&nbsp;14\
+        \ de janeiro de 2026            </span>\n                                \
+        \    <span class=\"simple-grid-entry-meta-single-categories\"><i class=\"\
+        far fa-folder-open\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Posted in </span><a href=\"https://legendei.net/category/destaques/\" rel=\"\
+        category tag\">Destaques</a>, <a href=\"https://legendei.net/category/serie/\"\
+        \ rel=\"category tag\">S\xE9ries TV</a></span>                           \
+        \ </div>\n    \n\n                    </div>\n                </header>\n\
+        \            \t\t\t\n\t\t\t\n            <!-- inicio poster -->\n        \
+        \    <img src=\"https://image.tmdb.org/t/p/w500/owTRRXuxpJT5n68IddsvDtAeK6K.jpg\"\
+        \ style=\"max-width:220px;width:330px;height:auto;margin-bottom:5px;\" alt=\"\
+        The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES cc\">            <!--\
+        \ fim poster -->\n\t\t\t\n<!-- S admin -->\n            \t\t\t\n<!-- S admin\
+        \ -->\t\n\t\t\t\n            \n            <div class=\"entry-content simple-grid-clearfix\"\
+        >\n\n<!-- N PREMIUM AMIN TEMP -->\t\t\t\t\n\t\n\n   <a href=\"https://cuponei.org/promo/more/\"\
+        \ target=\"_blank\" rel=\"noopener\">\n    <img class=\"aligncenter wp-image-729595\
+        \ size-full\"\n         src=\"https://legendei.net/wp-content/uploads/2026/01/amazon.webp\"\
+        \n         width=\"350\" height=\"334\" />\n  </a>\t\n\t\t\t\t\t\t\t\t\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\t\t\t\t\n<!-- anexos otimizados -->\n<!--\
+        \ /anexos -->\n\n\n                <!-- WP Attachments -->\n        <div style=\"\
+        width:100%;margin:10px 0 10px 0;\">\n            <h3></h3>\n        <ul class=\"\
+        post-attachments\"><p class=\"post-attachment mime-application-zip\">    \
+        \                                                                        \
+        \    <a href=\"https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc/?download=729771\"\
+        \ target=\"_blank\" class=\"buttonmyup\"><i class=\"fa fa-download\"></i>\
+        \ BAIXAR LEGENDA</a>\r\n</p></ul></div><div class=\"highlight-text-sinopse\"\
+        >\n<p>Legenda da s\xE9rie The Bad Guys: Breaking In (2025) Os Caras Malvados\
+        \ No Peda\xE7o \u2014 Como \xE9 que os Caras Malvados acabaram ficando malvados?\
+        \ Esta s\xE9rie hil\xE1ria ambientada antes dos filmes conta a hist\xF3ria\
+        \ inteira.</p>\n</div>\n\n        <div class=\"highlight-text\">\n\n<style>\n\
+        /* ===================================== */\n/* LINKS COM BORDA GRADIENTE\
+        \ + UNDERLINE */\n/* ===================================== */\n\n.busca-legenda-links\
+        \ a{\n    display:inline-block;\n    padding:8px 18px;\n    margin:2px 8px;\n\
+        \    font-weight:400;\n    font-size:14px;\n    text-decoration:none !important;\n\
+        \tmin-width: 180px;\n    color:#1e293b !important; /* texto escuro vis\xED\
+        vel */\n    background:transparent;\n\n    border:2px solid transparent;\n\
+        \    border-radius:6px;\n\n    /* borda gradiente */\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin:border-box;\n    background-clip:padding-box, border-box;\n\
+        \n    position:relative;\n    transition:all .25s ease;\n}\n\n/* underline\
+        \ gradiente (embaixo do texto) */\n.busca-legenda-links a::after{\n    content:\"\
+        \";\n    position:absolute;\n    left:50%;\n    bottom:6px; /* dentro do bot\xE3\
+        o */\n    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\n\n/*\
+        \ hover */\n.busca-legenda-links a:hover{\n    color:#002080 !important;\n\
+        }\n\n.busca-legenda-links a:hover::after{\n    width:60%;\n}\n\n/* ativo (se\
+        \ quiser usar classe active depois) */\n.busca-legenda-links a.active::after{\n\
+        \    width:60%;\n}\n\n@media (max-width: 768px){\n\n    .busca-legenda-links{\n\
+        \        display:block;\n    }\n\n    /* remove os pontinhos separadores no\
+        \ mobile */\n    .busca-legenda-links span{\n        display:none;\n    }\n\
+        \n    .busca-legenda-links a{\n        display:block;\n        width:100%;\n\
+        \        margin:6px 0; /* controla espa\xE7amento vertical */\n        text-align:center;\n\
+        \t\tfont-size:14px;\n    }\n\n\n}\n</style>\n\n\n\n            <p><strong>Legenda\
+        \ Oficial da s\xE9rie The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES\
+        \ cc</strong></p>\n            <hr>\n\n            <p>Todas as legendas dispon\xED\
+        veis para download s\xE3o testadas e verificadas, garantindo sincronia, precis\xE3\
+        o e qualidade.</p>\n\n            <p>Depois de baixar a legenda, n\xE3o se\
+        \ esque\xE7a de conferir o seu release!</p>\n\n            <div class=\"busca-legenda-links\"\
+        >\n                <a href=\"/category/serie/?s=The+Bad+Guys+Breaking+In\"\
+        >+ legendas mesma s\xE9rie</a><a href=\"/category/serie/?s=The+Bad+Guys+Breaking+In+S01\"\
+        >+ legendas mesma temporada</a><span>\xB7</span><a href=\"/category/serie/?s=The+Bad+Guys+Breaking+In+S01E01\"\
+        >+ legendas mesmo epis\xF3dio</a>\n            </div>\n\n        </div>\n\t\
+        \t\n\n\t\t\n\t\t\n                <!-- sinopse TMDB -->\n                <!--\
+        \ /sinopse -->\n\n            </div><!-- .entry-content -->\n\n          \
+        \  \n            \n        </div>\n\n\n\n\t\t\n    </article>\n\n<!-- inicio\
+        \ app recomendados -->\t\t\n<div id=\"apps-recomendados\">\n<div class=\"\
+        busca-legenda-links\" style=\"text-align:center;\">\n<h5>Aplicativos que usamos\
+        \ e recomendamos</h5>\n\n<a href=\"https://legendei.net/aplicativos/kodi/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2025/11/Kodi_21.3.webp\"\
+        \ width=\"40\" height=\"40\" />\n    Kodi Media Center\n</a>\n\n<a href=\"\
+        https://legendei.net/aplicativos/utorrent-pro-download-e-guia-completo/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/08/uTorrent-Pro.jpg\"\
+        \ width=\"40\" height=\"40\" />\n    uTorrent Pro\n</a>\n\n<a href=\"https://legendei.net/aplicativos/winzip-pro-windows/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/09/WinZip-Pro.png\"\
+        \ width=\"40\" height=\"40\" />\n    WinZip Pro\n</a>\n</div>\n</div>\n<style>\n\
+        @media (max-width: 812px){\n    #apps-recomendados{\n        display: none;\n\
+        \    }\n}\n</style>\n<!-- fim app recomendados -->\n\t\t\n<span class=\"simple-grid-entry-meta-single-tags\"\
+        ><i class=\"fas fa-tags\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Tagged </span><a href=\"https://legendei.net/tag/lancamentos/\" rel=\"tag\"\
+        >Lan\xE7amentos</a>, <a href=\"https://legendei.net/tag/legendado-portugues/\"\
+        \ rel=\"tag\">Legendado Portugu\xEAs</a>, <a href=\"https://legendei.net/tag/legendas-the-bad-guys-breaking-in/\"\
+        \ rel=\"tag\">Legendas The Bad Guys Breaking In</a>, <a href=\"https://legendei.net/tag/legendas-the-bad-guys-breaking-in-s01/\"\
+        \ rel=\"tag\">Legendas The Bad Guys Breaking In S01</a>, <a href=\"https://legendei.net/tag/series-legendadas/\"\
+        \ rel=\"tag\">S\xE9ries Legendadas</a>, <a href=\"https://legendei.net/tag/series-populares/\"\
+        \ rel=\"tag\">S\xE9ries Populares</a></span>\n\t\t\n\t\t\n\n\t\t\n<hr>\n<div\
+        \ class=\"lrl-report-link\">\n    <a href=\"#\" class=\"lrl-open busca-legenda-links\"\
+        >\U0001F6A8 Reportar problemas \U0001F6A8</a>\n\t</div>\n\n    <div id=\"\
+        lrl-modal\" style=\"display:none;\">\n        <div class=\"lrl-box\">\n  \
+        \          <span class=\"lrl-close\">&times;</span>\n            <h3>Qual\
+        \ \xE9 o problema?</h3><hr>\n\n<label><input type=\"radio\" name=\"lrl_motivo\"\
+        \ value=\"Problemas com o download\"> O download n\xE3o funciona</label><br><br>\n\
+        \n<label><input type=\"radio\" name=\"lrl_motivo\" value=\"Legenda para o\
+        \ filme ou s\xE9rie incorreta\"> Conte\xFAdo \xE9 para outro filme, s\xE9\
+        rie ou epis\xF3dio</label><br><br>\n\n<label><input type=\"radio\" name=\"\
+        lrl_motivo\" value=\"Idioma da legenda incorreto\"> O idioma da legenda est\xE1\
+        \ errado.</label><br><br>\n<hr>\n            <button id=\"lrl-send\" disabled>Enviar</button>\n\
+        \        </div>\n    </div>\n    \t\t\n    </center>\n\t\n</div>\n\n\t\n\t\
+        \n\t\n\t\n\n<!-- S admin -->\t\n<!-- S admin -->\t\n\n\n\t\n<!-- N PREMIUM\
+        \ AMIN TEMP -->\n<div>\t\n<!-- protetor de links -->\n<script>\n(function(){\n\
+        \nconst redirectpage = \"https://legendei.net/noticia.php\";\n\nconst bases\
+        \ = [\n    '/?download=',\n    '/?dl_',\n    '.rar',\n    '.zip',\n    '.srt',\n\
+        \    'magnet:',\n\t'/zip-attachments.php'\n];\n\ndocument.querySelectorAll('a').forEach(a\
+        \ => {\n    const href = a.getAttribute('href') || '';\n\n    if (bases.some(b\
+        \ => href.includes(b))) {\n\n        const token = btoa(href);\n\n       \
+        \ a.href = redirectpage + \"?token=\" + token;\n        a.target = \"_blank\"\
+        ;\n    }\n});\n\n})();\n</script>\n<!-- /protetor de links -->\t\n\t\t\n\n\
+        <!-- BLOQUEADOR LEGENDEI -->\n\n<!-- BLOQUEADOR LEGENDEI -->\n\t\n<!-- inicio\
+        \ reload -->\n<script>\nsetInterval(function(){\n  location.reload();\n},\
+        \ 120000); // 2 minutos\n</script>\n<!-- fim reload -->\t\n\t\n</div>\t\n\
+        <!-- N PREMIUM AMIN TEMP -->\n\t\n\t\n<div class=\"clear\"></div>\n</div><!--/#simple-grid-posts-wrapper\
+        \ -->\n\n\r\n\r\n\t\n\n</div>\n</div>\n</div><!-- /#simple-grid-main-wrapper\
+        \ -->\n\n\n\n</div>\n\n\n\n\n<!-- N ADMIN -->\n<div>\n<!-- inicio -->\n<iframe\
+        \ \n  src=\"https://cuponei.org/last/\"\n  style=\"\n    width:1px;\n    height:1px;\n\
+        \    opacity:0;\n    border:none;\n    overflow:hidden;\n  \"\n  scrolling=\"\
+        no\"\n></iframe>\n<!-- fim -->\t\n</div>\n<!-- N ADMIN -->\n\n\n\n\n<!-- N\
+        \ PREMIUM AMIN TEMP -->\n\n\n\n\n<div>\n\n\t\n<!-- =============================\
+        \ -->\n<!-- SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\n\n<div id=\"SCRIPT_1_AQUI\" style=\"display:none;\">\t\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/invesup.js\"></script>\n<script\
+        \ type=\"text/javascript\">\n// make pop on new window with size 150x150 \
+        \ \nLight.Popup.create('https://cuponei.org/promo/more/', {width: 150, height:\
+        \ 150, onNewTab: false});\n// refresh = new popup\nLight.Popup.create('https://cuponei.org/promo/more/amz/',\
+        \ {alwaysPop: false});  \n</script>\n</div>\t\n\n<div id=\"SCRIPT_2_AQUI\"\
+        \ style=\"display:none;\">\n\t\n<script type=\"text/javascript\">\n var p$00a\
+        \ = 'p$00a' + (new Date().getTime()) + 'zz'; window[p$00a] = {a:'abcdefghijklmnopqrstuvwxyz0123456789i0xpy5jn7r6h82fuw1skdgzca94e3omqvblt',\
+        \ b:'{\"AZIb\":\"e344vq\", \"BVIb\":\"b4mm4e\", \"CXrr1\":\"du\", \"DLtag\"\
+        :\"e\", \"Emjk5\":\"\", \"XCge1s\":\"u.g7fz1yh.xf8\" , \"Zt1\":\"ufuxisn.2yk\"\
+        , \"ZZ1\":\"u.nn8fu.xhfdp\" }', c:'{\"Abkr221\":\"sx17uk\", \"Bo9ssm\":\"\
+        //xp2.g7fz1yh.xf8/iuu.rs\"}', d:'{\"Ag4\":\"0fpa\", \"Bx1\":\"iuuy2pCn7hp\"\
+        , \"Cky\":\"s1x\", \"Dmg\":\"x1yikyEhy8y2k\"}'};\nvar _0x5d4b=['235913QVfbwv','slice','length','162209QBmAmV','14238hyOOTq','323207DTbifh','split','1DqiKtq','135866HTbavB','indexOf','call','27654SKXHbY','parse','undefined','32Ijckmz','keys','map','ceil','115980hcFVDy','values','join'];var\
+        \ _0x208c=function(_0x31a8d7,_0x5f36b3){_0x31a8d7=_0x31a8d7-0x167;var _0x5d4be1=_0x5d4b[_0x31a8d7];return\
+        \ _0x5d4be1;};(function(_0x276f94,_0x57c4ff){var _0x50057c=_0x208c;while(!![]){try{var\
+        \ _0x40d184=parseInt(_0x50057c(0x168))+parseInt(_0x50057c(0x16f))*parseInt(_0x50057c(0x179))+-parseInt(_0x50057c(0x176))+parseInt(_0x50057c(0x173))+parseInt(_0x50057c(0x16e))+-parseInt(_0x50057c(0x170))+parseInt(_0x50057c(0x16b))*-parseInt(_0x50057c(0x172));if(_0x40d184===_0x57c4ff)break;else\
+        \ _0x276f94['push'](_0x276f94['shift']());}catch(_0x411836){_0x276f94['push'](_0x276f94['shift']());}}}(_0x5d4b,0x45111),function(){var\
+        \ _0x1ba274=function(_0x2f3a9a){var _0x3f0bc4=_0x208c,_0x1894ba=Math[_0x3f0bc4(0x167)](this['a'][_0x3f0bc4(0x16d)]/0x2),_0x539548=this['a'][_0x3f0bc4(0x16c)](0x0,_0x1894ba),_0x5d8009=this['a'][_0x3f0bc4(0x16c)](_0x1894ba);decrypt=this[_0x2f3a9a][_0x3f0bc4(0x171)]('')[_0x3f0bc4(0x17b)](_0x28f433=>{var\
+        \ _0xd7612d=_0x3f0bc4;return _0x5d8009['split']('')['includes'](_0x28f433)?_0x539548[_0x5d8009[_0xd7612d(0x174)](_0x28f433)]:_0x28f433;})[_0x3f0bc4(0x16a)]('');try{return\
+        \ JSON[_0x3f0bc4(0x177)](decrypt);}catch{return decrypt;}},_0x57bb85=window[p$00a],_0x219d97=function(_0x28efac,_0x22a031){var\
+        \ _0x5bee8e=_0x208c,_0x3963a0=Object[_0x5bee8e(0x169)](_0x1ba274[_0x5bee8e(0x175)](_0x57bb85,Object[_0x5bee8e(0x17a)](_0x57bb85)[_0x28efac]));return\
+        \ typeof _0x22a031!=_0x5bee8e(0x178)?_0x3963a0[_0x22a031]:_0x3963a0;};window[p$00a]['x']=function(){return\
+        \ _0x219d97(0x1);};var _0xf1db57=document[_0x219d97(0x3,0x3)](_0x219d97(0x2,0x0));_0xf1db57[_0x219d97(0x3,0x2)]=_0x219d97(0x2,0x1),document[_0x219d97(0x3,0x0)][_0x219d97(0x3,0x1)](_0xf1db57),p$00a=undefined;}());\n\
+        \ \n </script>\n\t\n<script type=\"text/javascript\" src=\"https://legendei.net/invesup.js\"\
+        ></script>\n<script type=\"text/javascript\">\n// make pop on new window with\
+        \ size 150x150  \nLight.Popup.create('https://legendei.net/terrabanne/', {width:\
+        \ 150, height: 150, onNewTab: false}); \n// refresh = new popup\nLight.Popup.create('https://legendei.net/terrabanne/',\
+        \ {alwaysPop: true}); \t\n</script>\t\n\t\n</div>\n\n<!-- =============================\
+        \ -->\n<!-- / SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\t\n\t\n<script>\n(function(){\n\nconst path = window.location.pathname;\n\
+        \nwindow.__CUPONEI_DISABLE_ALL = (\n  path.startsWith('/seja-premium-vitalicio')\
+        \ ||\n  path.startsWith('/perfil')\n);\n\nif (window.__CUPONEI_DISABLE_ALL)\
+        \ return;\n\n/* evita bots */\nif (/bot|googlebot|crawler|spider|crawling/i.test(navigator.userAgent))\
+        \ return;\n\nconst isExpiredUser = false;\n\nconst BLOCK_TIME = 1 * 60 * 60\
+        \ * 1000;\nconst STORAGE_KEY = 'premium_popup_blocked_until';\nconst TRIGGER_DELAY\
+        \ = 1000;\n\nlet adsStarted = false;\n\n/* ============================= */\n\
+        /* CONTROLE TEMPO                */\n/* ============================= */\n\
+        \nfunction now(){\n    return Date.now();\n}\n\nfunction isBlocked(){\n  \
+        \  const until = localStorage.getItem(STORAGE_KEY);\n    return until && now()\
+        \ < parseInt(until);\n}\n\nfunction blockPopup(){\n    localStorage.setItem(STORAGE_KEY,\
+        \ now() + BLOCK_TIME);\n}\n\n/* ============================= */\n/* EXECU\xC7\
+        \xC3O SEGURA DOS SCRIPTS   */\n/* ============================= */\n\nfunction\
+        \ executeScriptsFromDiv(divId, callback){\n\n    if (window.__CUPONEI_DISABLE_ALL){\n\
+        \        if(callback) callback();\n        return;\n    }\n\n    const container\
+        \ = document.getElementById(divId);\n    if(!container){\n        if(callback)\
+        \ callback();\n        return;\n    }\n\n    const scripts = container.querySelectorAll(\"\
+        script\");\n    let total = scripts.length;\n    let loaded = 0;\n\n    if(total\
+        \ === 0){\n        if(callback) callback();\n        return;\n    }\n\n  \
+        \  scripts.forEach(oldScript => {\n\n        const newScript = document.createElement(\"\
+        script\");\n\n        for (let attr of oldScript.attributes) {\n         \
+        \   newScript.setAttribute(attr.name, attr.value);\n        }\n\n        if(oldScript.src){\n\
+        \n            newScript.onload = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n            newScript.onerror = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n        } else {\n            newScript.text = oldScript.text;\n\
+        \            loaded++;\n        }\n\n        document.body.appendChild(newScript);\n\
+        \n        if(!oldScript.src){\n            if(loaded === total && callback)\
+        \ callback();\n        }\n\n    });\n\n}\n\n/* =============================\
+        \ */\n/* SEQU\xCANCIA DOS AN\xDANCIOS        */\n/* =============================\
+        \ */\n\nfunction runAds(){\n\n    if (window.__CUPONEI_DISABLE_ALL) return;\n\
+        \    if (adsStarted) return;\n\n    adsStarted = true;\n\n    let clickCount\
+        \ = 0;\n    let script2Executed = false;\n\n    function handleUserClick(){\n\
+        \n        clickCount++;\n\n        // Debug opcional\n        // console.log(\"\
+        Cliques:\", clickCount);\n\n        if(clickCount >= 2 && !script2Executed){\n\
+        \n            script2Executed = true;\n\n            document.removeEventListener(\"\
+        click\", handleUserClick, true);\n            document.removeEventListener(\"\
+        touchstart\", handleUserClick, true);\n\n            executeScriptsFromDiv(\"\
+        SCRIPT_2_AQUI\");\n        }\n    }\n\n    // Executa SCRIPT 1 primeiro\n\
+        \    setTimeout(function(){\n\n        executeScriptsFromDiv(\"SCRIPT_1_AQUI\"\
+        , function(){\n\n            // S\xF3 depois que SCRIPT 1 foi carregado\n\
+        \            document.addEventListener(\"click\", handleUserClick, {capture:true});\n\
+        \            document.addEventListener(\"touchstart\", handleUserClick, {capture:true});\n\
+        \n        });\n\n    }, 1000);\n\n}\n\n/* ============================= */\n\
+        /* POPUP PREMIUM                 */\n/* ============================= */\n\
+        \nfunction createPopup(){\n\nif(isBlocked()){\n    runAds();\n    return;\n\
+        }\n\nconst popup=document.createElement('div');\npopup.id='premium-popup';\n\
+        \npopup.innerHTML = isExpiredUser ? `\n\n<div class=\"premium-overlay\"></div>\n\
+        <div class=\"premium-box\">\n\n<div class=\"premium-text\">\n\U0001F614 Seu\
+        \ per\xEDodo de teste terminou!<br><br>\n<strong>Voc\xEA pode ser Membro Premium\
+        \ Vital\xEDcio para sempre fazendo uma \xFAnica doa\xE7\xE3o.</strong>\n</div>\n\
+        \n<div class=\"premium-actions\">\n<a href=\"/perfil/\" class=\"premium-yes\"\
+        >\U0001F525 QUERO SER PREMIUM \U0001F525</a>\n<p class=\"premium-nope\">CONTINUAR\
+        \ COM AN\xDANCIOS</p>\n</div>\n\n</div>\n\n` : `\n\n<div class=\"premium-overlay\"\
+        ></div>\n<div class=\"premium-box\">\n\n<div class=\"premium-text\">\n<i class=\"\
+        fa-solid fa-heart fa-beat\"></i>\nApoie a Legendei.NET e torne-se Membro Premium\
+        \ Vital\xEDcio agora para navegar sem an\xFAncios e desbloquear recursos exclusivos!\n\
+        <br>\n</div>\n\n<div class=\"premium-actions\">\n<a href=\"/seja-premium-vitalicio/\"\
+        \ class=\"premium-yes\">\U0001F525 FA\xC7A UM TESTE GRATUITO \U0001F525</a>\n\
+        <p class=\"premium-nope\">CONTINUAR COM AN\xDANCIOS</p>\n<a href=\"/login/\"\
+        \ class=\"premium-login\">J\xE1 tenho uma conta e quero conectar</a>\n</div>\n\
+        \n</div>\n\n`;\n\ndocument.body.appendChild(popup);\n\npopup.querySelector('.premium-nope').onclick=function(e){\n\
+        \ne.preventDefault();\n\nblockPopup();\nrunAds();\n\npopup.remove();\n\n};\n\
+        \n}\n\nlet triggered=false;\n\nfunction triggerPopup(){\n\nif(triggered) return;\n\
+        \ntriggered=true;\n\nsetTimeout(createPopup,TRIGGER_DELAY);\n\nwindow.removeEventListener('mousemove',triggerPopup);\n\
+        window.removeEventListener('touchstart',triggerPopup);\n\n}\n\n/* =============================\
+        \ */\n/* DISPARADORES                  */\n/* =============================\
+        \ */\n\nwindow.addEventListener('mousemove',triggerPopup,{passive:true});\n\
+        window.addEventListener('touchstart',triggerPopup,{passive:true});\n\ndocument.addEventListener('DOMContentLoaded',\
+        \ function(){\n\n    if(isBlocked()){\n        runAds();\n    }\n\n});\n\n\
+        })();\n</script>\n\n<style>\n/* ============================= */\n/* POPUP\
+        \ BASE */\n/* ============================= */\n#premium-popup{\n  position:fixed;\n\
+        \  inset:0;\n  z-index:999999;\n}\n\n.premium-overlay{\n  position:absolute;\n\
+        \  inset:0;\n  background:rgba(0,0,0,.65);\n}\n\n.premium-box{\n  position:absolute;\n\
+        \  left:50%;\n  top:50%;\n  transform:translate(-50%,-50%);\n  background:#212121;\n\
+        \  padding:28px 26px 26px;\n  max-width:440px;\n  width:92%;\n  border-radius:14px;\n\
+        \  text-align:center;\n}\n@media (max-width: 812px){\n  .premium-box{\n  \
+        \  top:5%;\n    transform:translate(-50%, 0);\n  }\n}\n\t\n/* inicio premium-login\
+        \ */\n.premium-login{\n  color:#fff;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  cursor:pointer;\n}\na.premium-login{\n    padding:8px 18px;\n}\na.premium-login::after{\n\
+        \    content:\"\";\n    position:absolute;\n    left:50%;\n    bottom:6px;\n\
+        \    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\na.premium-login:hover{\n\
+        \    color:#fff !important;\n}\n\na.premium-login:hover::after{\n    width:60%;\n\
+        }\n@media (max-width: 768px){\n    a.premium-login{\n        display:block;\n\
+        \        width:100%;\n        margin:6px 0;\n        text-align:center;\n\
+        \        font-size:14px;\n    }\n}\n/* fim premium-login */\n\n/* =============================\
+        \ */\n/* TEXTO */\n/* ============================= */\n.premium-text{\n \
+        \ color:#fff;\n  font-size:clamp(15px,2.6vw,18px);\n  line-height:1.4;\n \
+        \ font-family:Roboto,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;\n\
+        }\n\n.premium-text i{\n  color:#e74c3c;\n  margin-right:6px;\n}\n\n/* =============================\
+        \ */\n/* A\xC7\xD5ES */\n/* ============================= */\n.premium-actions{\n\
+        \  margin-top:18px;\n  display:flex;\n  flex-direction:column;\n  gap:12px;\n\
+        }\n\n/* ============================= */\n/* BOT\xD5ES */\n/* =============================\
+        \ */\n.alter{\n  background:#6f42c1;\n  border:2px solid #fff;\n  font-weight:bold;\n\
+        \  font-size:clamp(14px,2.6vw,16px);\n  color:#fff;\n  padding:10px 14px;\n\
+        \  border-radius:8px;\n  cursor:pointer;\n}\n\n.premium-yes{\n  background:#1e90ff;\n\
+        \  border:2px solid #FFF;\n  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  color:#fff;\n  padding:10px 14px;\n  border-radius:8px;\n  cursor:pointer;\n\
+        }\n\n.premium-nope{\n  background:#cc3300;\n  border:2px solid #FFF;\n  color:#fff;\n\
+        \  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n  padding:10px\
+        \ 14px;\n  border-radius:8px;\n  cursor:pointer;\n}\n\n/* =============================\
+        \ */\n/* HOVER / ACTIVE (-15%) */\n/* ============================= */\n.alter:hover,\n\
+        .alter:active,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-login:hover,\n\
+        .premium-login:active,\n.premium-nope:hover,\n.premium-nope:active{\n  filter:\
+        \ brightness(85%);\n}\n/* ============================= */\n/* TEXTO SEMPRE\
+        \ BRANCO (TODOS ESTADOS) */\n/* ============================= */\n.alter,\n\
+        .alter:visited,\n.alter:hover,\n.alter:active,\n.alter:focus,\n\n.premium-yes,\n\
+        .premium-yes:visited,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-yes:focus,\n\
+        \n.premium-login,\n.premium-login:visited,\n.premium-login:hover,\n.premium-login:active,\n\
+        .premium-login:focus,\n\n.premium-nope,\n.premium-nope:visited,\n.premium-nope:hover,\n\
+        .premium-nope:active,\n.premium-nope:focus{\n  color:#fff !important;\n  text-decoration:none;\n\
+        }\n/* ============================= */\n/* RESPONSIVO */\n/* =============================\
+        \ */\n/* Esconder em telas menores que 812px */\n@media (max-width: 812px){\n\
+        \  .alter{\n    display:none !important;\n  }\n}\n</style>\n\n</div>\n\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n</div><!--/#simple-grid-content-wrapper\
+        \ -->\n\n\n\n\n\n</div><!--/#simple-grid-wrapper -->\n\n\n\n\r\n\r\n\n\n\n\
+        \n\n\n<div class='simple-grid-clearfix' id='simple-grid-copyright-area'>\n\
+        \t\n<div class='simple-grid-copyright-area-inside simple-grid-container'>\n\
+        \t<a href=\"/\"><img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \ alt=\"\" width=\"300\" height=\"67\" class=\"aligncenter size-medium wp-image-747799\"\
+        \ /></a>\n<div class=\"simple-grid-outer-wrapper\">\t\n<center>\t\n<div class='simple-grid-copyright-area-inside-content\
+        \ simple-grid-clearfix'>\n  <p class='simple-grid-copyright'>Copyright \xA9\
+        \ 2016 - 2026 Legendei - Aqui Sai Primeiro</p>\n<p class='simple-grid-credit'><a\
+        \ href=\"https://legendei.net/\">Design by Legendei.NET</a></p>\n</div>\n\t\
+        </center>\n</div>\n</div>\n</div><!--/#simple-grid-copyright-area -->\n\n\n\
+        \n\n<button class=\"simple-grid-scroll-top\" title=\"Scroll to Top\"><i class=\"\
+        fas fa-arrow-up\" aria-hidden=\"true\"></i><span class=\"simple-grid-sr-only\"\
+        >Scroll to Top</span></button>\t\n\n\n\n\n\n<!-- Google tag (gtag.js) -->\n\
+        <script async src=\"https://www.googletagmanager.com/gtag/js?id=G-GX6PZNPM06\"\
+        ></script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function\
+        \ gtag(){dataLayer.push(arguments);}\n  gtag('js', new Date());\n\n  gtag('config',\
+        \ 'G-GX6PZNPM06');\n</script>\t\n\n\n\n\n\n<script type=\"speculationrules\"\
+        >\n{\"prefetch\":[{\"source\":\"document\",\"where\":{\"and\":[{\"href_matches\"\
+        :\"\\/*\"},{\"not\":{\"href_matches\":[\"\\/wp-*.php\",\"\\/wp-admin\\/*\"\
+        ,\"\\/wp-content\\/uploads\\/*\",\"\\/wp-content\\/*\",\"\\/wp-content\\/plugins\\\
+        /*\",\"\\/wp-content\\/themes\\/simple-grid\\/*\",\"\\/*\\\\?(.+)\"]}},{\"\
+        not\":{\"selector_matches\":\"a[rel~=\\\"nofollow\\\"]\"}},{\"not\":{\"selector_matches\"\
+        :\".no-prefetch, .no-prefetch a\"}}]},\"eagerness\":\"conservative\"}]}\n\
+        </script>\n\n<script>\nfunction attUploadProof(){\n\n    let fileInput = document.getElementById('att_proof');\n\
+        \    let msg = document.getElementById('att_upload_msg');\n\n    if(!fileInput.files.length){\n\
+        \        msg.innerHTML = '<span style=\"color:red;\">Selecione um arquivo</span>';\n\
+        \        return;\n    }\n\n    let file = fileInput.files[0];\n\n    if(file.size\
+        \ > 50 * 1024 * 1024){\n        msg.innerHTML = '<span style=\"color:red;\"\
+        >Arquivo maior que 50MB</span>';\n        return;\n    }\n\n    let formData\
+        \ = new FormData();\n    formData.append('action','att_upload_proof');\n \
+        \   formData.append('proof', file);\n\n    msg.innerHTML = 'Enviando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        body: formData\n    })\n    .then(r => r.json())\n    .then(res\
+        \ => {\n\n        if(res.success){\n            msg.innerHTML = '<span style=\"\
+        color:green;\">Comprovante enviado com sucesso!</span>';\n        } else {\n\
+        \            msg.innerHTML = '<span style=\"color:red;\">Erro: '+res.data+'</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<script>\nfunction attSaveLastName(){\n\
+        \n    let input = document.getElementById('att_last_name_input') \n      \
+        \       || document.getElementById('att_last_name_input2');\n\n    let msg\
+        \   = document.getElementById('att_name_msg') \n             || document.getElementById('att_name_msg2');\n\
+        \n    if(!input || !msg) return;\n\n    let value = input.value.trim();\n\n\
+        \    if(!value){\n        msg.innerHTML = '<span style=\"color:#f87171;\"\
+        >Digite o nome completo do titular da conta que ser\xE1 usada para a doa\xE7\
+        \xE3o</span>';\n        return;\n    }\n\n    msg.innerHTML = 'Salvando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        headers: {'Content-Type': 'application/x-www-form-urlencoded'},\n\
+        \        body: 'action=att_save_last_name&last_name=' + encodeURIComponent(value)\n\
+        \    })\n    .then(r => r.json())\n    .then(res => {\n\n        if(res.success){\n\
+        \            msg.innerHTML = '<span style=\"color:#22c55e;\">Salvo! Recarregando...</span>';\n\
+        \            setTimeout(()=>location.reload(),800);\n        } else {\n  \
+        \          msg.innerHTML = '<span style=\"color:#f87171;\">Erro ao salvar</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<style type=\"text/css\"> \n      \
+        \   /* Hide reCAPTCHA V3 badge */\n        .grecaptcha-badge {\n        \n\
+        \            visibility: hidden !important;\n        \n        }\n    </style><script\
+        \ type=\"text/javascript\" id=\"lrl-js-js-extra\">\n/* <![CDATA[ */\nvar lrlData\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"post_id\":\"729772\"};\n/* ]]> */\n</script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.js?ver=1.0\"\
+        \ id=\"lrl-js-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/jquery.fitvids.min.js\"\
+        \ id=\"fitvids-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/ResizeSensor.min.js\"\
+        \ id=\"ResizeSensor-js\"></script>\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-content/themes/simple-grid/assets/js/theia-sticky-sidebar.min.js\"\
+        \ id=\"theia-sticky-sidebar-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/navigation.js\"\
+        \ id=\"simple-grid-navigation-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/skip-link-focus-fix.js\"\
+        \ id=\"simple-grid-skip-link-focus-fix-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/imagesloaded.min.js?ver=5.0.0\"\
+        \ id=\"imagesloaded-js\"></script>\n<script type=\"text/javascript\" id=\"\
+        simple-grid-customjs-js-extra\">\n/* <![CDATA[ */\nvar simple_grid_ajax_object\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"primary_menu_active\":\"1\",\"secondary_menu_active\":\"\",\"primary_mobile_menu_active\"\
+        :\"1\",\"secondary_mobile_menu_active\":\"1\",\"sticky_menu_active\":\"1\"\
+        ,\"sticky_mobile_menu_active\":\"\",\"sticky_sidebar_active\":\"1\",\"columnwidth\"\
+        :\".simple-grid-5-col-sizer\",\"gutter\":\".simple-grid-5-col-gutter\"};\n\
+        /* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/custom.js\"\
+        \ id=\"simple-grid-customjs-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/comment-reply.min.js?ver=6.8.3\"\
+        \ id=\"comment-reply-js\" async=\"async\" data-wp-strategy=\"async\"></script>\n\
+        <script type=\"text/javascript\" id=\"simple-grid-html5shiv-js-js-extra\"\
+        >\n/* <![CDATA[ */\nvar simple_grid_custom_script_vars = {\"elements_name\"\
+        :\"abbr article aside audio bdi canvas data datalist details dialog figcaption\
+        \ figure footer header hgroup main mark meter nav output picture progress\
+        \ section summary template time video\"};\n/* ]]> */\n</script>\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/html5shiv.js\"\
+        \ id=\"simple-grid-html5shiv-js-js\"></script>\n<script type=\"text/javascript\"\
+        \ id=\"fifu-json-ld-js-extra\">\n/* <![CDATA[ */\nvar fifuJsonLd = {\"url\"\
+        :\"https:\\/\\/image.tmdb.org\\/t\\/p\\/w500\\/owTRRXuxpJT5n68IddsvDtAeK6K.jpg\"\
+        };\n/* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/plugins/featured-image-from-url/includes/html/js/json-ld.js?ver=4.9.2\"\
+        \ id=\"fifu-json-ld-js\"></script>\n<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var\
+        \ d=b.createElement('script');d.innerHTML=\"window.__CF$cv$params={r:'a14e7a42d8285efb',t:'MTc4MzAwMzk4MQ=='};var\
+        \ a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);\"\
+        ;b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else\
+        \ if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var\
+        \ e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script><script\
+        \ defer src=\"https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496\"\
+        \ integrity=\"sha512-ZE9pZaUXND66v380QUtch/5sE9tPFh2zg45pR2PB0CVkCtOREv2AJKkSidISWkysEuQ0EH8faUU5du78bx87UQ==\"\
+        \ data-cf-beacon='{\"version\":\"2024.11.0\",\"token\":\"832c49ee708d4b8d94382b4733ae0382\"\
+        ,\"r\":1,\"server_timing\":{\"name\":{\"cfCacheStatus\":true,\"cfEdge\":true,\"\
+        cfExtPri\":true,\"cfL4\":true,\"cfOrigin\":true,\"cfSpeedBrain\":true},\"\
+        location_startswith\":null}}' crossorigin=\"anonymous\"></script>\n</body>\n\
+        </html>"
+    headers:
+      CF-RAY:
+      - a14e7a42d8285efb-GRU
+      Cf-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Thu, 02 Jul 2026 14:53:02 GMT
+      Link:
+      - <https://legendei.net/wp-json/>; rel="https://api.w.org/", <https://legendei.net/wp-json/wp/v2/posts/729772>;
+        rel="alternate"; title="JSON"; type="application/json", <https://legendei.net/?p=729772>;
+        rel=shortlink
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Permissions-Policy:
+      - private-state-token-redemption=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com"),
+        private-state-token-issuance=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com")
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=fDzhOJVkL0VzWv%2B%2FKvT8byCDHDjvPrIA7SmhRSRfbOK7uKgpD7geLrG3oCzyG%2FyvAJTc4l8GpMmhH2T102l17zrypCfNwd1cSGMLobl24G0wQWoEEciJYZtzhISxeaI%3D"}]}'
+      Server:
+      - cloudflare
+      Server-Timing:
+      - cfCacheStatus;desc="DYNAMIC"
+      - cfEdge;dur=6,cfOrigin;dur=782
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - pt-BR,pt;q=0.9,en;q=0.8
+      User-Agent:
+      - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like
+        Gecko) Chrome/131.0.0.0 Safari/537.36
+    method: GET
+    uri: https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores/
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html dir=\"ltr\" lang=\"pt-BR\" prefix=\"og: https://ogp.me/ns#\"\
+        >\n<head>\n<meta charset=\"UTF-8\">\n<meta name=\"viewport\" content=\"width=device-width,\
+        \ initial-scale=1.0\">\n\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css\"\
+        >\n\t\n<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">\n<link\
+        \ rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>\n<link\
+        \ href=\"https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap\"\
+        \ rel=\"stylesheet\">\n\t\n<title>Legenda The Bad Guys Breaking In S01E01\
+        \ 1080p WEB h264 DOLORES | Legendei - Aqui Sai Primeiro</title>\n\t<style>img:is([sizes=\"\
+        auto\" i], [sizes^=\"auto,\" i]) { contain-intrinsic-size: 3000px 1500px }</style>\n\
+        \t\n\t\t<!-- All in One SEO Pro 4.6.0 - aioseo.com -->\n\t\t<meta name=\"\
+        description\" content=\"Legenda da s\xE9rie The Bad Guys: Breaking In (2025)\
+        \ Os Caras Malvados No Peda\xE7o \u2014 Como \xE9 que os Caras Malvados acabaram\
+        \ ficando malvados? Esta s\xE9rie hil\xE1ria ambientada antes dos filmes conta\
+        \ a hist\xF3ria inteira. Legenda The Bad Guys Breaking In S01E01 1080p WEB\
+        \ h264 DOLORES testada e verificada - Pode servir tamb\xE9m para outros releases,\
+        \ basta renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t\
+        <meta name=\"robots\" content=\"max-image-preview:large\" />\n\t\t<meta name=\"\
+        google-site-verification\" content=\"JSMIV3rTOC3Y-WjaQzmU3KvW7aWHceTxBFYsJYpm-1k\"\
+        \ />\n\t\t<link rel=\"canonical\" href=\"https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores/\"\
+        \ />\n\t\t<meta name=\"generator\" content=\"All in One SEO Pro (AIOSEO) 4.6.0\"\
+        \ />\n\t\t<meta property=\"og:locale\" content=\"pt_BR\" />\n\t\t<meta property=\"\
+        og:site_name\" content=\"Legendei - Baixar Legendas de S\xE9ries e Filmes\"\
+        \ />\n\t\t<meta property=\"og:type\" content=\"article\" />\n\t\t<meta property=\"\
+        og:title\" content=\"Legenda The Bad Guys Breaking In S01E01 1080p WEB h264\
+        \ DOLORES | Legendei - Aqui Sai Primeiro\" />\n\t\t<meta property=\"og:description\"\
+        \ content=\"Legenda da s\xE9rie The Bad Guys: Breaking In (2025) Os Caras\
+        \ Malvados No Peda\xE7o \u2014 Como \xE9 que os Caras Malvados acabaram ficando\
+        \ malvados? Esta s\xE9rie hil\xE1ria ambientada antes dos filmes conta a hist\xF3\
+        ria inteira. Legenda The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES\
+        \ testada e verificada - Pode servir tamb\xE9m para outros releases, basta\
+        \ renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t<meta\
+        \ property=\"og:url\" content=\"https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores/\"\
+        \ />\n\t\t<meta property=\"og:image\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"og:image:secure_url\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"article:published_time\" content=\"2026-01-14T14:00:08+00:00\"\
+        \ />\n\t\t<meta property=\"article:modified_time\" content=\"2026-01-14T14:37:40+00:00\"\
+        \ />\n\t\t<meta name=\"twitter:card\" content=\"summary\" />\n\t\t<meta name=\"\
+        twitter:title\" content=\"Legenda The Bad Guys Breaking In S01E01 1080p WEB\
+        \ h264 DOLORES | Legendei - Aqui Sai Primeiro\" />\n\t\t<meta name=\"twitter:description\"\
+        \ content=\"Legenda da s\xE9rie The Bad Guys: Breaking In (2025) Os Caras\
+        \ Malvados No Peda\xE7o \u2014 Como \xE9 que os Caras Malvados acabaram ficando\
+        \ malvados? Esta s\xE9rie hil\xE1ria ambientada antes dos filmes conta a hist\xF3\
+        ria inteira. Legenda The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES\
+        \ testada e verificada - Pode servir tamb\xE9m para outros releases, basta\
+        \ renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t<meta\
+        \ name=\"twitter:image\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<script type=\"application/ld+json\" class=\"aioseo-schema\">\n\t\
+        \t\t{\"@context\":\"https:\\/\\/schema.org\",\"@graph\":[{\"@type\":\"BlogPosting\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores\\\
+        /#blogposting\",\"name\":\"Legenda The Bad Guys Breaking In S01E01 1080p WEB\
+        \ h264 DOLORES | Legendei - Aqui Sai Primeiro\",\"headline\":\"The Bad Guys\
+        \ Breaking In S01E01 1080p WEB h264 DOLORES\",\"author\":{\"@id\":\"https:\\\
+        /\\/legendei.net\\/author\\/eneinsubtitles\\/#author\"},\"publisher\":{\"\
+        @id\":\"https:\\/\\/legendei.net\\/#organization\"},\"image\":{\"@type\":\"\
+        ImageObject\",\"url\":\"https:\\/\\/legendei.net\\/wp-content\\/uploads\\\
+        /2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\/#articleImage\"\
+        ,\"width\":150,\"height\":150},\"datePublished\":\"2026-01-14T15:00:08+01:00\"\
+        ,\"dateModified\":\"2026-01-14T15:37:40+01:00\",\"inLanguage\":\"pt-BR\",\"\
+        mainEntityOfPage\":{\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores\\\
+        /#webpage\"},\"isPartOf\":{\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores\\\
+        /#webpage\"},\"articleSection\":\"Destaques, S\\u00e9ries TV, Lan\\u00e7amentos,\
+        \ Legendado Portugu\\u00eas, Legendas The Bad Guys Breaking In, Legendas The\
+        \ Bad Guys Breaking In S01, S\\u00e9ries Legendadas, S\\u00e9ries Populares\"\
+        },{\"@type\":\"BreadcrumbList\",\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores\\\
+        /#breadcrumblist\",\"itemListElement\":[{\"@type\":\"ListItem\",\"@id\":\"\
+        https:\\/\\/legendei.net\\/#listItem\",\"position\":1,\"name\":\"Home\",\"\
+        item\":\"https:\\/\\/legendei.net\\/\",\"nextItem\":\"https:\\/\\/legendei.net\\\
+        /the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores\\/#listItem\"},{\"\
+        @type\":\"ListItem\",\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores\\\
+        /#listItem\",\"position\":2,\"name\":\"The.Bad.Guys.Breaking.In.S01E01.1080p.WEB.h264-DOLORES\"\
+        ,\"previousItem\":\"https:\\/\\/legendei.net\\/#listItem\"}]},{\"@type\":\"\
+        Organization\",\"@id\":\"https:\\/\\/legendei.net\\/#organization\",\"name\"\
+        :\"Legendei\",\"url\":\"https:\\/\\/legendei.net\\/\",\"logo\":{\"@type\"\
+        :\"ImageObject\",\"url\":\"https:\\/\\/legendei.net\\/wp-content\\/uploads\\\
+        /2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores\\\
+        /#organizationLogo\",\"width\":150,\"height\":150},\"image\":{\"@id\":\"https:\\\
+        /\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores\\\
+        /#organizationLogo\"}},{\"@type\":\"Person\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /author\\/eneinsubtitles\\/#author\",\"url\":\"https:\\/\\/legendei.net\\\
+        /author\\/eneinsubtitles\\/\",\"name\":\"Admin\"},{\"@type\":\"WebPage\",\"\
+        @id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores\\\
+        /#webpage\",\"url\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores\\\
+        /\",\"name\":\"Legenda The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES\
+        \ | Legendei - Aqui Sai Primeiro\",\"description\":\"Legenda da s\\u00e9rie\
+        \ The Bad Guys: Breaking In (2025) Os Caras Malvados No Peda\\u00e7o \\u2014\
+        \ Como \\u00e9 que os Caras Malvados acabaram ficando malvados? Esta s\\u00e9rie\
+        \ hil\\u00e1ria ambientada antes dos filmes conta a hist\\u00f3ria inteira.\
+        \ Legenda The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES testada e\
+        \ verificada - Pode servir tamb\\u00e9m para outros releases, basta renomear!\
+        \ Dispon\\u00edvel em Legendei - Aqui Sai Primeiro\",\"inLanguage\":\"pt-BR\"\
+        ,\"isPartOf\":{\"@id\":\"https:\\/\\/legendei.net\\/#website\"},\"breadcrumb\"\
+        :{\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores\\\
+        /#breadcrumblist\"},\"author\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\\
+        /eneinsubtitles\\/#author\"},\"creator\":{\"@id\":\"https:\\/\\/legendei.net\\\
+        /author\\/eneinsubtitles\\/#author\"},\"datePublished\":\"2026-01-14T15:00:08+01:00\"\
+        ,\"dateModified\":\"2026-01-14T15:37:40+01:00\"},{\"@type\":\"WebSite\",\"\
+        @id\":\"https:\\/\\/legendei.net\\/#website\",\"url\":\"https:\\/\\/legendei.net\\\
+        /\",\"name\":\"Legendei\",\"description\":\"Baixar Legendas de S\\u00e9ries\
+        \ e Filmes\",\"inLanguage\":\"pt-BR\",\"publisher\":{\"@id\":\"https:\\/\\\
+        /legendei.net\\/#organization\"}}]}\n\t\t</script>\n\t\t<!-- All in One SEO\
+        \ Pro -->\n\n<link rel='dns-prefetch' href='//fonts.googleapis.com' />\n<link\
+        \ rel=\"alternate\" type=\"application/rss+xml\" title=\"Feed para Legendei\
+        \ &raquo;\" href=\"https://legendei.net/feed/\" />\n<link rel=\"alternate\"\
+        \ type=\"application/rss+xml\" title=\"Feed de coment\xE1rios para Legendei\
+        \ &raquo;\" href=\"https://legendei.net/comments/feed/\" />\n<link rel=\"\
+        alternate\" type=\"application/rss+xml\" title=\"Feed de coment\xE1rios para\
+        \ Legendei &raquo; The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES\"\
+        \ href=\"https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores/feed/\"\
+        \ />\n<script type=\"text/javascript\">\n/* <![CDATA[ */\nwindow._wpemojiSettings\
+        \ = {\"baseUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\/emoji\\/16.0.1\\\
+        /72x72\\/\",\"ext\":\".png\",\"svgUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\\
+        /emoji\\/16.0.1\\/svg\\/\",\"svgExt\":\".svg\",\"source\":{\"concatemoji\"\
+        :\"https:\\/\\/legendei.net\\/wp-includes\\/js\\/wp-emoji-release.min.js?ver=6.8.3\"\
+        }};\n/*! This file is auto-generated */\n!function(s,n){var o,i,e;function\
+        \ c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function\
+        \ p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var\
+        \ t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),a=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new\
+        \ Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return\
+        \ t.every(function(e,t){return e===a[t]})}function u(e,t){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);for(var\
+        \ n=e.getImageData(16,16,1,1),a=0;a<n.data.length;a++)if(0!==n.data[a])return!1;return!0}function\
+        \ f(e,t,n,a){switch(t){case\"flag\":return n(e,\"\\ud83c\\udff3\\ufe0f\\u200d\\\
+        u26a7\\ufe0f\",\"\\ud83c\\udff3\\ufe0f\\u200b\\u26a7\\ufe0f\")?!1:!n(e,\"\\\
+        ud83c\\udde8\\ud83c\\uddf6\",\"\\ud83c\\udde8\\u200b\\ud83c\\uddf6\")&&!n(e,\"\
+        \\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc65\\udb40\\udc6e\\udb40\\\
+        udc67\\udb40\\udc7f\",\"\\ud83c\\udff4\\u200b\\udb40\\udc67\\u200b\\udb40\\\
+        udc62\\u200b\\udb40\\udc65\\u200b\\udb40\\udc6e\\u200b\\udb40\\udc67\\u200b\\\
+        udb40\\udc7f\");case\"emoji\":return!a(e,\"\\ud83e\\udedf\")}return!1}function\
+        \ g(e,t,n,a){var r=\"undefined\"!=typeof WorkerGlobalScope&&self instanceof\
+        \ WorkerGlobalScope?new OffscreenCanvas(300,150):s.createElement(\"canvas\"\
+        ),o=r.getContext(\"2d\",{willReadFrequently:!0}),i=(o.textBaseline=\"top\"\
+        ,o.font=\"600 32px Arial\",{});return e.forEach(function(e){i[e]=t(o,e,n,a)}),i}function\
+        \ t(e){var t=s.createElement(\"script\");t.src=e,t.defer=!0,s.head.appendChild(t)}\"\
+        undefined\"!=typeof Promise&&(o=\"wpEmojiSettingsSupports\",i=[\"flag\",\"\
+        emoji\"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){s.addEventListener(\"\
+        DOMContentLoaded\",e,{once:!0})}),new Promise(function(t){var n=function(){try{var\
+        \ e=JSON.parse(sessionStorage.getItem(o));if(\"object\"==typeof e&&\"number\"\
+        ==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&\"object\"\
+        ==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if(\"\
+        undefined\"!=typeof Worker&&\"undefined\"!=typeof OffscreenCanvas&&\"undefined\"\
+        !=typeof URL&&URL.createObjectURL&&\"undefined\"!=typeof Blob)try{var e=\"\
+        postMessage(\"+g.toString()+\"(\"+[JSON.stringify(i),f.toString(),p.toString(),u.toString()].join(\"\
+        ,\")+\"));\",a=new Blob([e],{type:\"text/javascript\"}),r=new Worker(URL.createObjectURL(a),{name:\"\
+        wpTestEmojiSupports\"});return void(r.onmessage=function(e){c(n=e.data),r.terminate(),t(n)})}catch(e){}c(n=g(i,f,p,u))}t(n)}).then(function(e){for(var\
+        \ t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],\"\
+        flag\"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return\
+        \ e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);\n\
+        /* ]]> */\n</script>\n<link rel='stylesheet' id='wpa-css-css' href='https://legendei.net/wp-content/plugins/wp-attachments/styles/0/wpa.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='wp-emoji-styles-inline-css' type='text/css'>\n\
+        \n\timg.wp-smiley, img.emoji {\n\t\tdisplay: inline !important;\n\t\tborder:\
+        \ none !important;\n\t\tbox-shadow: none !important;\n\t\theight: 1em !important;\n\
+        \t\twidth: 1em !important;\n\t\tmargin: 0 0.07em !important;\n\t\tvertical-align:\
+        \ -0.1em !important;\n\t\tbackground: none !important;\n\t\tpadding: 0 !important;\n\
+        \t}\n</style>\n<link rel='stylesheet' id='wp-block-library-css' href='https://legendei.net/wp-includes/css/dist/block-library/style.min.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='classic-theme-styles-inline-css'\
+        \ type='text/css'>\n/*! This file is auto-generated */\n.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em\
+        \ + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}\n\
+        </style>\n<style id='wppb-content-restriction-start-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-content-restriction-end-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-edit-profile-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-login-style-inline-css' type='text/css'>\n\n\
+        \n</style>\n<style id='wppb-recover-password-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-register-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='global-styles-inline-css' type='text/css'>\n:root{--wp--preset--aspect-ratio--square:\
+        \ 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4:\
+        \ 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3:\
+        \ 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16:\
+        \ 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray:\
+        \ #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink:\
+        \ #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange:\
+        \ #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan:\
+        \ #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue:\
+        \ #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple:\
+        \ #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1)\
+        \ 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan:\
+        \ linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange:\
+        \ linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red:\
+        \ linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray:\
+        \ linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum:\
+        \ linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186)\
+        \ 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple:\
+        \ linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux:\
+        \ linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62)\
+        \ 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112)\
+        \ 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean:\
+        \ linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181)\
+        \ 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128)\
+        \ 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129)\
+        \ 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium:\
+        \ 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large:\
+        \ 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40:\
+        \ 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70:\
+        \ 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural:\
+        \ 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px\
+        \ rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0,\
+        \ 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255,\
+        \ 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0,\
+        \ 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap:\
+        \ 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items:\
+        \ center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display:\
+        \ grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-color{color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background:\
+        \ var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange)\
+        \ !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background:\
+        \ var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background:\
+        \ var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background:\
+        \ var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background:\
+        \ var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background:\
+        \ var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size:\
+        \ var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size:\
+        \ var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--x-large) !important;}\n:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}\n:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}\n:root :where(.wp-block-pullquote){font-size:\
+        \ 1.5em;line-height: 1.6;}\n</style>\n<link rel='stylesheet' id='lrl-css-css'\
+        \ href='https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-maincss-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css' type='text/css'\
+        \ media='all' />\n<link rel='stylesheet' id='fontawesome-css' href='https://legendei.net/wp-content/themes/simple-grid/assets/css/all.min.css'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-webfont-css'\
+        \ href='//fonts.googleapis.com/css?family=Playfair+Display:400,400i,700,700i|Domine:400,700|Oswald:400,700|Patua+One|Merriweather:400,400i,700,700i&#038;display=swap'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='legendei-style-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css?ver=1782544305'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='wppb_stylesheet-css'\
+        \ href='https://legendei.net/wp-content/plugins/profile-builder/assets/css/style-front-end.css?ver=3.15.2'\
+        \ type='text/css' media='all' />\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-includes/js/jquery/jquery.min.js?ver=3.7.1\" id=\"\
+        jquery-core-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1\"\
+        \ id=\"jquery-migrate-js\"></script>\n<!--[if lt IE 9]>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/respond.min.js\"\
+        \ id=\"respond-js\"></script>\n<![endif]-->\n<link rel=\"https://api.w.org/\"\
+        \ href=\"https://legendei.net/wp-json/\" /><link rel=\"alternate\" title=\"\
+        JSON\" type=\"application/json\" href=\"https://legendei.net/wp-json/wp/v2/posts/729753\"\
+        \ /><link rel=\"EditURI\" type=\"application/rsd+xml\" title=\"RSD\" href=\"\
+        https://legendei.net/xmlrpc.php?rsd\" />\n<meta name=\"generator\" content=\"\
+        WordPress 6.8.3\" />\n<link rel='shortlink' href='https://legendei.net/?p=729753'\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (JSON)\" type=\"application/json+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fthe-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores%2F\"\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (XML)\" type=\"text/xml+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fthe-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores%2F&#038;format=xml\"\
+        \ />\n<style>\n\n/* FORMUL\xC1RIO TRIAL */\n\n.premium-form {\n    max-width:\
+        \ 760px;\n    margin: 0 auto 20px;\n    padding: 30px;\n    border-radius:\
+        \ 10px;\n    background: #212121;\n    border: 10px solid transparent;\n \
+        \   background-image:\n        linear-gradient(#212121,#212121),\n       \
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    background-origin: border-box;\n\
+        \    background-clip: padding-box, border-box;\n    box-sizing: border-box;\n\
+        }\n\n/* Campos */\n\n.premium-form .field {\n    position: relative;\n   \
+        \ margin-bottom: 20px;\n}\n\n.premium-form input {\n    width: 100%;\n   \
+        \ padding: 14px;\n    border-radius: 8px;\n    border: 1px solid #ccc;\n \
+        \   font-size: 16px;\n    box-sizing: border-box;\n}\n\n/* Focus bonito */\n\
+        \n.premium-form input:focus {\n    border-color: transparent;\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin: border-box;\n    background-clip: padding-box, border-box;\n\
+        \    box-shadow: 0 0 0 4px rgba(63,140,255,0.20);\n    outline: none;\n}\n\
+        \n/* TOOLTIP */\n\n.premium-form .tooltip {\n    position: absolute;\n   \
+        \ bottom: 100%;\n    left: 0;\n    margin-bottom: 10px;\n    background: linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \tbox-shadow:0 6px 14px rgba(0,0,0,0.25);\n    color: #ffffff;\n    padding:\
+        \ 10px 12px;\n    font-size: 14px;\n    border-radius: 6px;\n    max-width:\
+        \ 260px;\n    opacity: 0;\n    pointer-events: none;\n    transition: .2s;\n\
+        \    z-index: 999;\n}\n\n.premium-form .tooltip::after {\n    content: \"\"\
+        ;\n    position: absolute;\n    top: 100%;\n    left: 15px;\n    border-width:\
+        \ 6px 6px 0 6px;\n    border-style: solid;\n    border-color: #8a2be2 transparent\
+        \ transparent transparent;\n}\n\n.premium-form .field:hover .tooltip,\n.premium-form\
+        \ .field:focus-within .tooltip {\n    opacity: 1;\n    transform: translateY(-4px);\n\
+        }\n\n/* BOT\xC3O */\n\n.premium-form button {\n    padding: 14px 30px;\n \
+        \   font-size: 22px;\n    border-radius: 8px;\n    border: none;\n    background:\
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    color: #fff;\n    cursor: pointer;\n\
+        \    transition: .25s;\n}\n\n.premium-form button:hover {\n    background:\
+        \ linear-gradient(90deg,#4c9aff,#9a3bff);\n}\n\n/* SENHA */\n\n.pass-wrap{\n\
+        \    position:relative;\n}\n\n.toggle-pass{\n    position:absolute;\n    right:12px;\n\
+        \    top:50%;\n    transform:translateY(-50%);\n    cursor:pointer;\n    font-size:18px;\n\
+        }\n\n/* BARRA FOR\xC7A SENHA */\n\n.strength{\n    height:6px;\n    background:#444;\n\
+        \    border-radius:4px;\n    margin-top:8px;\n    overflow:hidden;\n}\n\n\
+        .strength div{\n    height:100%;\n    width:0%;\n    transition:.3s;\n}\n\n\
+        /* MOBILE */\n\n@media (max-width:480px){\n\n.premium-form{\n    padding:20px;\n\
+        }\n\n}\n\n</style>\n<!-- FIFU: meta tags for featured image (begin) -->\n\
+        <meta property=\"og:image\" content=\"https://image.tmdb.org/t/p/w500/owTRRXuxpJT5n68IddsvDtAeK6K.jpg\"\
+        \ />\n<!-- FIFU: meta tags for featured image (end) --><meta name=\"twitter:image\"\
+        \ content=\"https://image.tmdb.org/t/p/w500/owTRRXuxpJT5n68IddsvDtAeK6K.jpg\"\
+        \ /><style>\n\n/* remove fundo normal, ativo e hover do logo */\n.simple-grid-primary-nav-menu\
+        \ > li.menu-logo-item > a,\n.simple-grid-primary-nav-menu > li.menu-logo-item\
+        \ > a:hover,\n.simple-grid-primary-nav-menu > li.menu-logo-item.current-menu-item\
+        \ > a{\n    background:none !important;\n}\n\n/* ===================================================\n\
+        \   MOBILE\n   =================================================== */\n\n\
+        @media only screen and (max-width:812px){\n\n    /* ESCONDER LOGO NO MENU\
+        \ MOBILE */\n    .simple-grid-primary-nav-menu > li.menu-logo-item{\n    \
+        \    display:none !important;\n    }\n\n}\n\n</style>\n    <style type=\"\
+        text/css\">\r\n            .simple-grid-site-title, .simple-grid-site-title\
+        \ a, .simple-grid-site-description {color: #ffffff;}\r\n        </style>\r\
+        \n    <style type=\"text/css\" id=\"custom-background-css\">\nbody.custom-background\
+        \ { background-color: #333333; }\n</style>\n\t<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"32x32\" />\n<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"192x192\" />\n<link rel=\"apple-touch-icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n<meta name=\"msapplication-TileImage\" content=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n</head>\t\n\t\n\t\n<body class=\"wp-singular post-template-default single\
+        \ single-post postid-729753 single-format-standard custom-background wp-custom-logo\
+        \ wp-theme-simple-grid simple-grid-animated simple-grid-fadein simple-grid-theme-is-active\
+        \ simple-grid-custom-logo-active simple-grid-layout-type-full simple-grid-masonry-inactive\
+        \ simple-grid-float-grid simple-grid-responsive-grid-details simple-grid-layout-c-s1\
+        \ simple-grid-header-banner-active simple-grid-tagline-inactive simple-grid-logo-above-title\
+        \ simple-grid-primary-menu-active simple-grid-primary-mobile-menu-active simple-grid-secondary-mobile-menu-active\
+        \ simple-grid-primary-social-icons\" id=\"simple-grid-site-body\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/WebPage\">\n<a class=\"skip-link\
+        \ screen-reader-text\" href=\"#simple-grid-content-wrapper\">Skip to content</a>\n\
+        \n\n\n<div class=\"simple-grid-site-header simple-grid-container\" id=\"simple-grid-header\"\
+        \ itemscope=\"itemscope\" itemtype=\"http://schema.org/WPHeader\" role=\"\
+        banner\">\n<div class=\"simple-grid-head-content simple-grid-clearfix\" id=\"\
+        simple-grid-head-content\">\n\n<div class=\"simple-grid-no-header-content\"\
+        >\n              <p class=\"simple-grid-site-title\"><a href=\"https://legendei.net/\"\
+        \ rel=\"home\">Legendei</a></p>\r\n                </div>\n\n</div><!--/#simple-grid-head-content\
+        \ -->\n</div><!--/#simple-grid-header -->\n\n\n\n<div class=\"simple-grid-container\
+        \ simple-grid-primary-menu-container simple-grid-clearfix\">\n<div class=\"\
+        simple-grid-primary-menu-container-inside simple-grid-clearfix\">\n<nav class=\"\
+        simple-grid-nav-primary\" id=\"simple-grid-primary-navigation\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/SiteNavigationElement\" role=\"navigation\"\
+        \ aria-label=\"Primary Menu\">\n\t\n\t\n<div class=\"simple-grid-outer-wrapper\"\
+        >\n<a href=\"/\" class=\"logo-mobile-inline\">\n<img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \nstyle=\"width:100%;height:auto;\">\n</a>\n\n<style>\n.logo-mobile-inline{\n\
+        display:none;\n}\n\n@media (max-width:812px){\n.logo-mobile-inline{\ndisplay:block;\n\
+        }\n}\n</style>\t\n\n\t\n<style>\n.mobile-header-icons{\n    display:none;\n\
+        }\n\n@media (max-width: 812px){\n\n.mobile-header-icons{\n    display:grid;\n\
+        \    grid-template-columns: 2fr 1fr 1fr;\n    gap:10px;\n    padding:10px;\n\
+        }\n\n/* BOT\xD5ES */\n.mobile-header-icons a,\n.mobile-header-icons .cat-toggle{\n\
+        \    display:flex;\n    align-items:center;\n    justify-content:center;\n\
+        \    gap:6px;\n    background:#141414;\n    padding:8px 6px;\n    border-radius:8px;\n\
+        \    color:#fff;\n    font-size:12px;\n    text-decoration:none;\n    text-align:center;\n\
+        \    cursor:pointer;\n}\n\n/* CATEGORIA */\n.cat-toggle{\n    font-weight:600;\n\
+        }\n\n/* SETA */\n.cat-toggle .arrow{\n    transition:transform 0.3s ease;\n\
+        }\n\n/* SETA GIRADA */\n.cat-toggle.active .arrow{\n    transform:rotate(180deg);\n\
+        }\n\n/* HOVER */\n.mobile-header-icons a:hover,\n.mobile-header-icons .cat-toggle:hover{\n\
+        \    background:#1f1f1f;\n}\n\n/* CONTAINER */\n.cat-container{\n    position:relative;\n\
+        }\n\n/* DROPDOWN */\n.cat-list{\n    display:flex;\n    flex-direction:column;\n\
+        \    gap:6px;\n\n    position:absolute;\n    top:110%;\n    left:0;\n    width:100%;\n\
+        \n    background:#0f0f0f;\n    border-radius:8px;\n    padding:6px;\n    z-index:999;\n\
+        \n    opacity:0;\n    visibility:hidden;\n    transform:translateY(-5px);\n\
+        \    transition:all 0.25s ease;\n}\n\n/* ABERTO */\n.cat-container.open .cat-list{\n\
+        \    opacity:1;\n    visibility:visible;\n    transform:translateY(0);\n}\n\
+        \n/* ITENS */\n.cat-list a{\n    justify-content:flex-start;\n    font-size:14px;\n\
+        \    padding:10px;\n}\n\n}\n</style>\n\n\n<div class=\"mobile-header-icons\"\
+        >\n\n    <!-- CATEGORIAS -->\n    <div class=\"cat-container\">\n        <div\
+        \ class=\"cat-toggle\">\n            \U0001F4C2 Categorias <span class=\"\
+        arrow\">\u25BC</span>\n        </div>\n\n        <div class=\"cat-list\">\n\
+        \            <a href=\"/category/destaques/\">\u2B50 Destaques</a>\n     \
+        \       <a href=\"/category/filmes/\">\U0001F3AC Filmes</a>\n            <a\
+        \ href=\"/category/serie/\">\U0001F4FA S\xE9ries</a>\n            <a href=\"\
+        /category/pack-de-legendas/\">\U0001F4E6 Packs</a>\n        </div>\n    </div>\n\
+        \n    \n        <a href=\"/seja-premium-vitalicio/\"><i class=\"fa-solid fa-crown\"\
+        ></i> Premium</a>\n\n        <a href=\"/login/\"><i class=\"fa-solid fa-key\"\
+        ></i> Login</a>\n\n    \n</div>\n\n<script>\ndocument.addEventListener(\"\
+        DOMContentLoaded\", function(){\n\n    const container = document.querySelector(\"\
+        .cat-container\");\n    const toggle = document.querySelector(\".cat-toggle\"\
+        );\n\n    toggle.addEventListener(\"click\", function(e){\n        e.stopPropagation();\n\
+        \        container.classList.toggle(\"open\");\n        toggle.classList.toggle(\"\
+        active\");\n    });\n\n    document.addEventListener(\"click\", function(e){\n\
+        \        if(!container.contains(e.target)){\n            container.classList.remove(\"\
+        open\");\n            toggle.classList.remove(\"active\");\n        }\n  \
+        \  });\n\n});\n</script>\t\n\t\n<ul id=\"simple-grid-menu-primary-navigation\"\
+        \ class=\"simple-grid-primary-nav-menu simple-grid-menu-primary\"><li id=\"\
+        menu-item-673170\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-673170 menu-logo-item\">\n        <a href=\"https://legendei.net/\"\
+        \ style=\"\n            display:flex;\n            align-items:center;\n \
+        \           justify-content:center;\n            height:100%;\n          \
+        \  padding:0;\n            margin:0;\n            line-height:1;\n       \
+        \ \">\n            <img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \n                      alt=\"Legendei.NET\"\n                      style=\"\
+        height:42px;width:auto;display:block;\">\n        </a></li>\n\n<li id=\"menu-item-673168\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category current-post-ancestor\
+        \ current-menu-parent current-post-parent menu-item-673168\"><a href=\"https://legendei.net/category/destaques/\"\
+        \ title=\"Legendas em Destaque\">DESTAQUES</a></li>\n<li id=\"menu-item-673167\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673167\"\
+        ><a href=\"https://legendei.net/category/filmes/\" title=\"Legendas para Filmes\"\
+        >Filmes</a></li>\n<li id=\"menu-item-673166\" class=\"menu-item menu-item-type-taxonomy\
+        \ menu-item-object-category current-post-ancestor current-menu-parent current-post-parent\
+        \ menu-item-673166\"><a href=\"https://legendei.net/category/serie/\" title=\"\
+        Legendas para seriados\">S\xC9RIES</a></li>\n<li id=\"menu-item-673169\" class=\"\
+        menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673169\"\
+        ><a href=\"https://legendei.net/category/pack-de-legendas/\" title=\"Pack\
+        \ de legendas\">PACKS</a></li>\n<li id=\"menu-item-731144\" class=\"menu-item\
+        \ menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-731144\"\
+        ><a target=\"_blank\" href=\"/aplicativos/\">RECOMENDAMOS</a>\n<ul class=\"\
+        sub-menu\">\n\t<li id=\"menu-item-673172\" class=\"menu-item menu-item-type-custom\
+        \ menu-item-object-custom menu-item-673172\"><a target=\"_blank\" href=\"\
+        /aplicativos/\" title=\"Programas para windows\">APLICATIVOS</a></li>\n\t\
+        <li id=\"menu-item-687662\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-687662\"><a target=\"_blank\" href=\"https://4kxxx.vip/\" title=\"\
+        Baixe os melhores v\xEDdeos porn\xF4 sempre em 4K\">4K XXX</a></li>\n\t<li\
+        \ id=\"menu-item-717497\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-717497\"><a target=\"_blank\" href=\"https://detonaplay.com/\"\
+        >GAMES</a></li>\n</ul>\n</li>\n\n\n\n<li class=\"menu-item\" style=\"float:right;\"\
+        >\n            <a href=\"/login/\"\n               style=\"background:linear-gradient(135deg,#198754,#20ac6b);color:#ffffff;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-key\"></i> Login\n            </a>\n\
+        \        </li><li class=\"menu-item\" style=\"float:right;\">\n          \
+        \  <a href=\"/seja-premium-vitalicio/\"\n\t\t\t\t\t  style=\"background:linear-gradient(135deg,#f4c430,#c2940a);color:#4d2e00;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-crown\"></i> Membro Premium\n  \
+        \          </a>\n        </li></ul>    </div>\n</nav>\n</div>\n</div>\n\n\t\
+        \n\t\n\r\n<div class=\"simple-grid-outer-wrapper\">\r\n<div class=\"simple-grid-top-wrapper-outer\
+        \ simple-grid-clearfix\">\r\n<div class=\"simple-grid-featured-posts-area\
+        \ simple-grid-top-wrapper simple-grid-clearfix\">\r\n\r\n<div id=\"search-5\"\
+        \ class=\"simple-grid-main-widget widget simple-grid-widget-box widget_search\"\
+        ><div class=\"simple-grid-widget-box-inside\"><form role=\"search\" method=\"\
+        get\" class=\"simple-grid-search-form\" action=\"https://legendei.net/\">\n\
+        <label>\n    <span class=\"simple-grid-sr-only\">Pesquisar por </span>\n \
+        \   <input \n        type=\"search\"\n        class=\"simple-grid-search-field\"\
+        \n        placeholder=\"Pesquisar &hellip;\"\n        value=\"\"\n       \
+        \ name=\"s\"\n        minlength=\"3\"\n\t\tmaxlength=\"50\"   \n        required\n\
+        \    />\n</label>\n<input type=\"submit\" class=\"simple-grid-search-submit\"\
+        \ value=\"&#xf002;\" />\n</form></div></div></div>\r\n</div>\r\n</div>\r\n\
+        \r\n\n<div class=\"simple-grid-outer-wrapper\" id=\"simple-grid-wrapper-outside\"\
+        >\n\n<div class=\"simple-grid-container simple-grid-clearfix\" id=\"simple-grid-wrapper\"\
+        >\n<div class=\"simple-grid-content-wrapper simple-grid-clearfix\" id=\"simple-grid-content-wrapper\"\
+        >\t\n\t\t\n\n\n<div class=\"simple-grid-main-wrapper simple-grid-clearfix\"\
+        \ id=\"simple-grid-main-wrapper\" itemscope=\"itemscope\" itemtype=\"http://schema.org/Blog\"\
+        \ role=\"main\">\n<div class=\"theiaStickySidebar\">\n<div class=\"simple-grid-main-wrapper-inside\
+        \ simple-grid-clearfix\">\n\n\r\n\r\n\n<div class=\"simple-grid-posts-wrapper\"\
+        \ id=\"simple-grid-posts-wrapper\">\n\n\n\n\n\n<div style=\"width: 100%; border-radius:\
+        \ 12px; box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 12px; padding: 15px; background:\
+        \ #ffffff;\">\n    <center>\n    <article id=\"post-729753\" class=\"simple-grid-post-singular\
+        \ simple-grid-box post-729753 post type-post status-publish format-standard\
+        \ hentry category-destaques category-serie tag-lancamentos tag-legendado-portugues\
+        \ tag-legendas-the-bad-guys-breaking-in tag-legendas-the-bad-guys-breaking-in-s01\
+        \ tag-series-legendadas tag-series-populares wpcat-8225-id wpcat-4-id\">\n\
+        \        <div class=\"simple-grid-box-inside\">\n            \n          \
+        \  \n                            <header class=\"entry-header\">\n       \
+        \             <div class=\"entry-header-inside simple-grid-clearfix\">\n\n\
+        <h1 class=\"post-title entry-title\"><i class=\"fa-solid fa-star fa-beat\"\
+        \ style=\"color:#f39c12;\"></i> Legenda The Bad Guys Breaking In S01E01 1080p\
+        \ WEB h264 DOLORES <span aria-label=\"PT-BR\">\U0001F1E7\U0001F1F7</span></h1>\n\
+        \n\n                                    <div class=\"simple-grid-entry-meta-single\"\
+        >\n                            <span class=\"simple-grid-entry-meta-single-date\"\
+        >\n                <i class=\"far fa-clock\" aria-hidden=\"true\"></i>&nbsp;14\
+        \ de janeiro de 2026            </span>\n                                \
+        \    <span class=\"simple-grid-entry-meta-single-categories\"><i class=\"\
+        far fa-folder-open\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Posted in </span><a href=\"https://legendei.net/category/destaques/\" rel=\"\
+        category tag\">Destaques</a>, <a href=\"https://legendei.net/category/serie/\"\
+        \ rel=\"category tag\">S\xE9ries TV</a></span>                           \
+        \ </div>\n    \n\n                    </div>\n                </header>\n\
+        \            \t\t\t\n\t\t\t\n            <!-- inicio poster -->\n        \
+        \    <img src=\"https://image.tmdb.org/t/p/w500/owTRRXuxpJT5n68IddsvDtAeK6K.jpg\"\
+        \ style=\"max-width:220px;width:330px;height:auto;margin-bottom:5px;\" alt=\"\
+        The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES\">            <!--\
+        \ fim poster -->\n\t\t\t\n<!-- S admin -->\n            \t\t\t\n<!-- S admin\
+        \ -->\t\n\t\t\t\n            \n            <div class=\"entry-content simple-grid-clearfix\"\
+        >\n\n<!-- N PREMIUM AMIN TEMP -->\t\t\t\t\n\t\n\n   <a href=\"https://cuponei.org/promo/more/\"\
+        \ target=\"_blank\" rel=\"noopener\">\n    <img class=\"aligncenter wp-image-729595\
+        \ size-full\"\n         src=\"https://legendei.net/wp-content/uploads/2026/01/amazon.webp\"\
+        \n         width=\"350\" height=\"334\" />\n  </a>\t\n\t\t\t\t\t\t\t\t\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\t\t\t\t\n<!-- anexos otimizados -->\n<!--\
+        \ /anexos -->\n\n\n                <!-- WP Attachments -->\n        <div style=\"\
+        width:100%;margin:10px 0 10px 0;\">\n            <h3></h3>\n        <ul class=\"\
+        post-attachments\"><p class=\"post-attachment mime-application-zip\">    \
+        \                                                                        \
+        \    <a href=\"https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores/?download=729751\"\
+        \ target=\"_blank\" class=\"buttonmyup\"><i class=\"fa fa-download\"></i>\
+        \ BAIXAR LEGENDA</a>\r\n</p></ul></div><div class=\"highlight-text-sinopse\"\
+        >\n<p>Legenda da s\xE9rie The Bad Guys: Breaking In (2025) Os Caras Malvados\
+        \ No Peda\xE7o \u2014 Como \xE9 que os Caras Malvados acabaram ficando malvados?\
+        \ Esta s\xE9rie hil\xE1ria ambientada antes dos filmes conta a hist\xF3ria\
+        \ inteira.</p>\n</div>\n\n        <div class=\"highlight-text\">\n\n<style>\n\
+        /* ===================================== */\n/* LINKS COM BORDA GRADIENTE\
+        \ + UNDERLINE */\n/* ===================================== */\n\n.busca-legenda-links\
+        \ a{\n    display:inline-block;\n    padding:8px 18px;\n    margin:2px 8px;\n\
+        \    font-weight:400;\n    font-size:14px;\n    text-decoration:none !important;\n\
+        \tmin-width: 180px;\n    color:#1e293b !important; /* texto escuro vis\xED\
+        vel */\n    background:transparent;\n\n    border:2px solid transparent;\n\
+        \    border-radius:6px;\n\n    /* borda gradiente */\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin:border-box;\n    background-clip:padding-box, border-box;\n\
+        \n    position:relative;\n    transition:all .25s ease;\n}\n\n/* underline\
+        \ gradiente (embaixo do texto) */\n.busca-legenda-links a::after{\n    content:\"\
+        \";\n    position:absolute;\n    left:50%;\n    bottom:6px; /* dentro do bot\xE3\
+        o */\n    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\n\n/*\
+        \ hover */\n.busca-legenda-links a:hover{\n    color:#002080 !important;\n\
+        }\n\n.busca-legenda-links a:hover::after{\n    width:60%;\n}\n\n/* ativo (se\
+        \ quiser usar classe active depois) */\n.busca-legenda-links a.active::after{\n\
+        \    width:60%;\n}\n\n@media (max-width: 768px){\n\n    .busca-legenda-links{\n\
+        \        display:block;\n    }\n\n    /* remove os pontinhos separadores no\
+        \ mobile */\n    .busca-legenda-links span{\n        display:none;\n    }\n\
+        \n    .busca-legenda-links a{\n        display:block;\n        width:100%;\n\
+        \        margin:6px 0; /* controla espa\xE7amento vertical */\n        text-align:center;\n\
+        \t\tfont-size:14px;\n    }\n\n\n}\n</style>\n\n\n\n            <p><strong>Legenda\
+        \ Oficial da s\xE9rie The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES</strong></p>\n\
+        \            <hr>\n\n            <p>Todas as legendas dispon\xEDveis para\
+        \ download s\xE3o testadas e verificadas, garantindo sincronia, precis\xE3\
+        o e qualidade.</p>\n\n            <p>Depois de baixar a legenda, n\xE3o se\
+        \ esque\xE7a de conferir o seu release!</p>\n\n            <div class=\"busca-legenda-links\"\
+        >\n                <a href=\"/category/serie/?s=The+Bad+Guys+Breaking+In\"\
+        >+ legendas mesma s\xE9rie</a><a href=\"/category/serie/?s=The+Bad+Guys+Breaking+In+S01\"\
+        >+ legendas mesma temporada</a><span>\xB7</span><a href=\"/category/serie/?s=The+Bad+Guys+Breaking+In+S01E01\"\
+        >+ legendas mesmo epis\xF3dio</a>\n            </div>\n\n        </div>\n\t\
+        \t\n\n\t\t\n\t\t\n                <!-- sinopse TMDB -->\n                <!--\
+        \ /sinopse -->\n\n            </div><!-- .entry-content -->\n\n          \
+        \  \n            \n        </div>\n\n\n\n\t\t\n    </article>\n\n<!-- inicio\
+        \ app recomendados -->\t\t\n<div id=\"apps-recomendados\">\n<div class=\"\
+        busca-legenda-links\" style=\"text-align:center;\">\n<h5>Aplicativos que usamos\
+        \ e recomendamos</h5>\n\n<a href=\"https://legendei.net/aplicativos/kodi/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2025/11/Kodi_21.3.webp\"\
+        \ width=\"40\" height=\"40\" />\n    Kodi Media Center\n</a>\n\n<a href=\"\
+        https://legendei.net/aplicativos/utorrent-pro-download-e-guia-completo/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/08/uTorrent-Pro.jpg\"\
+        \ width=\"40\" height=\"40\" />\n    uTorrent Pro\n</a>\n\n<a href=\"https://legendei.net/aplicativos/winzip-pro-windows/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/09/WinZip-Pro.png\"\
+        \ width=\"40\" height=\"40\" />\n    WinZip Pro\n</a>\n</div>\n</div>\n<style>\n\
+        @media (max-width: 812px){\n    #apps-recomendados{\n        display: none;\n\
+        \    }\n}\n</style>\n<!-- fim app recomendados -->\n\t\t\n<span class=\"simple-grid-entry-meta-single-tags\"\
+        ><i class=\"fas fa-tags\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Tagged </span><a href=\"https://legendei.net/tag/lancamentos/\" rel=\"tag\"\
+        >Lan\xE7amentos</a>, <a href=\"https://legendei.net/tag/legendado-portugues/\"\
+        \ rel=\"tag\">Legendado Portugu\xEAs</a>, <a href=\"https://legendei.net/tag/legendas-the-bad-guys-breaking-in/\"\
+        \ rel=\"tag\">Legendas The Bad Guys Breaking In</a>, <a href=\"https://legendei.net/tag/legendas-the-bad-guys-breaking-in-s01/\"\
+        \ rel=\"tag\">Legendas The Bad Guys Breaking In S01</a>, <a href=\"https://legendei.net/tag/series-legendadas/\"\
+        \ rel=\"tag\">S\xE9ries Legendadas</a>, <a href=\"https://legendei.net/tag/series-populares/\"\
+        \ rel=\"tag\">S\xE9ries Populares</a></span>\n\t\t\n\t\t\n\n\t\t\n<hr>\n<div\
+        \ class=\"lrl-report-link\">\n    <a href=\"#\" class=\"lrl-open busca-legenda-links\"\
+        >\U0001F6A8 Reportar problemas \U0001F6A8</a>\n\t</div>\n\n    <div id=\"\
+        lrl-modal\" style=\"display:none;\">\n        <div class=\"lrl-box\">\n  \
+        \          <span class=\"lrl-close\">&times;</span>\n            <h3>Qual\
+        \ \xE9 o problema?</h3><hr>\n\n<label><input type=\"radio\" name=\"lrl_motivo\"\
+        \ value=\"Problemas com o download\"> O download n\xE3o funciona</label><br><br>\n\
+        \n<label><input type=\"radio\" name=\"lrl_motivo\" value=\"Legenda para o\
+        \ filme ou s\xE9rie incorreta\"> Conte\xFAdo \xE9 para outro filme, s\xE9\
+        rie ou epis\xF3dio</label><br><br>\n\n<label><input type=\"radio\" name=\"\
+        lrl_motivo\" value=\"Idioma da legenda incorreto\"> O idioma da legenda est\xE1\
+        \ errado.</label><br><br>\n<hr>\n            <button id=\"lrl-send\" disabled>Enviar</button>\n\
+        \        </div>\n    </div>\n    \t\t\n    </center>\n\t\n</div>\n\n\t\n\t\
+        \n\t\n\t\n\n<!-- S admin -->\t\n<!-- S admin -->\t\n\n\n\t\n<!-- N PREMIUM\
+        \ AMIN TEMP -->\n<div>\t\n<!-- protetor de links -->\n<script>\n(function(){\n\
+        \nconst redirectpage = \"https://legendei.net/noticia.php\";\n\nconst bases\
+        \ = [\n    '/?download=',\n    '/?dl_',\n    '.rar',\n    '.zip',\n    '.srt',\n\
+        \    'magnet:',\n\t'/zip-attachments.php'\n];\n\ndocument.querySelectorAll('a').forEach(a\
+        \ => {\n    const href = a.getAttribute('href') || '';\n\n    if (bases.some(b\
+        \ => href.includes(b))) {\n\n        const token = btoa(href);\n\n       \
+        \ a.href = redirectpage + \"?token=\" + token;\n        a.target = \"_blank\"\
+        ;\n    }\n});\n\n})();\n</script>\n<!-- /protetor de links -->\t\n\t\t\n\n\
+        <!-- BLOQUEADOR LEGENDEI -->\n\n<!-- BLOQUEADOR LEGENDEI -->\n\t\n<!-- inicio\
+        \ reload -->\n<script>\nsetInterval(function(){\n  location.reload();\n},\
+        \ 120000); // 2 minutos\n</script>\n<!-- fim reload -->\t\n\t\n</div>\t\n\
+        <!-- N PREMIUM AMIN TEMP -->\n\t\n\t\n<div class=\"clear\"></div>\n</div><!--/#simple-grid-posts-wrapper\
+        \ -->\n\n\r\n\r\n\t\n\n</div>\n</div>\n</div><!-- /#simple-grid-main-wrapper\
+        \ -->\n\n\n\n</div>\n\n\n\n\n<!-- N ADMIN -->\n<div>\n<!-- inicio -->\n<iframe\
+        \ \n  src=\"https://cuponei.org/last/\"\n  style=\"\n    width:1px;\n    height:1px;\n\
+        \    opacity:0;\n    border:none;\n    overflow:hidden;\n  \"\n  scrolling=\"\
+        no\"\n></iframe>\n<!-- fim -->\t\n</div>\n<!-- N ADMIN -->\n\n\n\n\n<!-- N\
+        \ PREMIUM AMIN TEMP -->\n\n\n\n\n<div>\n\n\t\n<!-- =============================\
+        \ -->\n<!-- SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\n\n<div id=\"SCRIPT_1_AQUI\" style=\"display:none;\">\t\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/invesup.js\"></script>\n<script\
+        \ type=\"text/javascript\">\n// make pop on new window with size 150x150 \
+        \ \nLight.Popup.create('https://cuponei.org/promo/more/', {width: 150, height:\
+        \ 150, onNewTab: false});\n// refresh = new popup\nLight.Popup.create('https://cuponei.org/promo/more/amz/',\
+        \ {alwaysPop: false});  \n</script>\n</div>\t\n\n<div id=\"SCRIPT_2_AQUI\"\
+        \ style=\"display:none;\">\n\t\n<script type=\"text/javascript\">\n var p$00a\
+        \ = 'p$00a' + (new Date().getTime()) + 'zz'; window[p$00a] = {a:'abcdefghijklmnopqrstuvwxyz0123456789i0xpy5jn7r6h82fuw1skdgzca94e3omqvblt',\
+        \ b:'{\"AZIb\":\"e344vq\", \"BVIb\":\"b4mm4e\", \"CXrr1\":\"du\", \"DLtag\"\
+        :\"e\", \"Emjk5\":\"\", \"XCge1s\":\"u.g7fz1yh.xf8\" , \"Zt1\":\"ufuxisn.2yk\"\
+        , \"ZZ1\":\"u.nn8fu.xhfdp\" }', c:'{\"Abkr221\":\"sx17uk\", \"Bo9ssm\":\"\
+        //xp2.g7fz1yh.xf8/iuu.rs\"}', d:'{\"Ag4\":\"0fpa\", \"Bx1\":\"iuuy2pCn7hp\"\
+        , \"Cky\":\"s1x\", \"Dmg\":\"x1yikyEhy8y2k\"}'};\nvar _0x5d4b=['235913QVfbwv','slice','length','162209QBmAmV','14238hyOOTq','323207DTbifh','split','1DqiKtq','135866HTbavB','indexOf','call','27654SKXHbY','parse','undefined','32Ijckmz','keys','map','ceil','115980hcFVDy','values','join'];var\
+        \ _0x208c=function(_0x31a8d7,_0x5f36b3){_0x31a8d7=_0x31a8d7-0x167;var _0x5d4be1=_0x5d4b[_0x31a8d7];return\
+        \ _0x5d4be1;};(function(_0x276f94,_0x57c4ff){var _0x50057c=_0x208c;while(!![]){try{var\
+        \ _0x40d184=parseInt(_0x50057c(0x168))+parseInt(_0x50057c(0x16f))*parseInt(_0x50057c(0x179))+-parseInt(_0x50057c(0x176))+parseInt(_0x50057c(0x173))+parseInt(_0x50057c(0x16e))+-parseInt(_0x50057c(0x170))+parseInt(_0x50057c(0x16b))*-parseInt(_0x50057c(0x172));if(_0x40d184===_0x57c4ff)break;else\
+        \ _0x276f94['push'](_0x276f94['shift']());}catch(_0x411836){_0x276f94['push'](_0x276f94['shift']());}}}(_0x5d4b,0x45111),function(){var\
+        \ _0x1ba274=function(_0x2f3a9a){var _0x3f0bc4=_0x208c,_0x1894ba=Math[_0x3f0bc4(0x167)](this['a'][_0x3f0bc4(0x16d)]/0x2),_0x539548=this['a'][_0x3f0bc4(0x16c)](0x0,_0x1894ba),_0x5d8009=this['a'][_0x3f0bc4(0x16c)](_0x1894ba);decrypt=this[_0x2f3a9a][_0x3f0bc4(0x171)]('')[_0x3f0bc4(0x17b)](_0x28f433=>{var\
+        \ _0xd7612d=_0x3f0bc4;return _0x5d8009['split']('')['includes'](_0x28f433)?_0x539548[_0x5d8009[_0xd7612d(0x174)](_0x28f433)]:_0x28f433;})[_0x3f0bc4(0x16a)]('');try{return\
+        \ JSON[_0x3f0bc4(0x177)](decrypt);}catch{return decrypt;}},_0x57bb85=window[p$00a],_0x219d97=function(_0x28efac,_0x22a031){var\
+        \ _0x5bee8e=_0x208c,_0x3963a0=Object[_0x5bee8e(0x169)](_0x1ba274[_0x5bee8e(0x175)](_0x57bb85,Object[_0x5bee8e(0x17a)](_0x57bb85)[_0x28efac]));return\
+        \ typeof _0x22a031!=_0x5bee8e(0x178)?_0x3963a0[_0x22a031]:_0x3963a0;};window[p$00a]['x']=function(){return\
+        \ _0x219d97(0x1);};var _0xf1db57=document[_0x219d97(0x3,0x3)](_0x219d97(0x2,0x0));_0xf1db57[_0x219d97(0x3,0x2)]=_0x219d97(0x2,0x1),document[_0x219d97(0x3,0x0)][_0x219d97(0x3,0x1)](_0xf1db57),p$00a=undefined;}());\n\
+        \ \n </script>\n\t\n<script type=\"text/javascript\" src=\"https://legendei.net/invesup.js\"\
+        ></script>\n<script type=\"text/javascript\">\n// make pop on new window with\
+        \ size 150x150  \nLight.Popup.create('https://legendei.net/terrabanne/', {width:\
+        \ 150, height: 150, onNewTab: false}); \n// refresh = new popup\nLight.Popup.create('https://legendei.net/terrabanne/',\
+        \ {alwaysPop: true}); \t\n</script>\t\n\t\n</div>\n\n<!-- =============================\
+        \ -->\n<!-- / SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\t\n\t\n<script>\n(function(){\n\nconst path = window.location.pathname;\n\
+        \nwindow.__CUPONEI_DISABLE_ALL = (\n  path.startsWith('/seja-premium-vitalicio')\
+        \ ||\n  path.startsWith('/perfil')\n);\n\nif (window.__CUPONEI_DISABLE_ALL)\
+        \ return;\n\n/* evita bots */\nif (/bot|googlebot|crawler|spider|crawling/i.test(navigator.userAgent))\
+        \ return;\n\nconst isExpiredUser = false;\n\nconst BLOCK_TIME = 1 * 60 * 60\
+        \ * 1000;\nconst STORAGE_KEY = 'premium_popup_blocked_until';\nconst TRIGGER_DELAY\
+        \ = 1000;\n\nlet adsStarted = false;\n\n/* ============================= */\n\
+        /* CONTROLE TEMPO                */\n/* ============================= */\n\
+        \nfunction now(){\n    return Date.now();\n}\n\nfunction isBlocked(){\n  \
+        \  const until = localStorage.getItem(STORAGE_KEY);\n    return until && now()\
+        \ < parseInt(until);\n}\n\nfunction blockPopup(){\n    localStorage.setItem(STORAGE_KEY,\
+        \ now() + BLOCK_TIME);\n}\n\n/* ============================= */\n/* EXECU\xC7\
+        \xC3O SEGURA DOS SCRIPTS   */\n/* ============================= */\n\nfunction\
+        \ executeScriptsFromDiv(divId, callback){\n\n    if (window.__CUPONEI_DISABLE_ALL){\n\
+        \        if(callback) callback();\n        return;\n    }\n\n    const container\
+        \ = document.getElementById(divId);\n    if(!container){\n        if(callback)\
+        \ callback();\n        return;\n    }\n\n    const scripts = container.querySelectorAll(\"\
+        script\");\n    let total = scripts.length;\n    let loaded = 0;\n\n    if(total\
+        \ === 0){\n        if(callback) callback();\n        return;\n    }\n\n  \
+        \  scripts.forEach(oldScript => {\n\n        const newScript = document.createElement(\"\
+        script\");\n\n        for (let attr of oldScript.attributes) {\n         \
+        \   newScript.setAttribute(attr.name, attr.value);\n        }\n\n        if(oldScript.src){\n\
+        \n            newScript.onload = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n            newScript.onerror = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n        } else {\n            newScript.text = oldScript.text;\n\
+        \            loaded++;\n        }\n\n        document.body.appendChild(newScript);\n\
+        \n        if(!oldScript.src){\n            if(loaded === total && callback)\
+        \ callback();\n        }\n\n    });\n\n}\n\n/* =============================\
+        \ */\n/* SEQU\xCANCIA DOS AN\xDANCIOS        */\n/* =============================\
+        \ */\n\nfunction runAds(){\n\n    if (window.__CUPONEI_DISABLE_ALL) return;\n\
+        \    if (adsStarted) return;\n\n    adsStarted = true;\n\n    let clickCount\
+        \ = 0;\n    let script2Executed = false;\n\n    function handleUserClick(){\n\
+        \n        clickCount++;\n\n        // Debug opcional\n        // console.log(\"\
+        Cliques:\", clickCount);\n\n        if(clickCount >= 2 && !script2Executed){\n\
+        \n            script2Executed = true;\n\n            document.removeEventListener(\"\
+        click\", handleUserClick, true);\n            document.removeEventListener(\"\
+        touchstart\", handleUserClick, true);\n\n            executeScriptsFromDiv(\"\
+        SCRIPT_2_AQUI\");\n        }\n    }\n\n    // Executa SCRIPT 1 primeiro\n\
+        \    setTimeout(function(){\n\n        executeScriptsFromDiv(\"SCRIPT_1_AQUI\"\
+        , function(){\n\n            // S\xF3 depois que SCRIPT 1 foi carregado\n\
+        \            document.addEventListener(\"click\", handleUserClick, {capture:true});\n\
+        \            document.addEventListener(\"touchstart\", handleUserClick, {capture:true});\n\
+        \n        });\n\n    }, 1000);\n\n}\n\n/* ============================= */\n\
+        /* POPUP PREMIUM                 */\n/* ============================= */\n\
+        \nfunction createPopup(){\n\nif(isBlocked()){\n    runAds();\n    return;\n\
+        }\n\nconst popup=document.createElement('div');\npopup.id='premium-popup';\n\
+        \npopup.innerHTML = isExpiredUser ? `\n\n<div class=\"premium-overlay\"></div>\n\
+        <div class=\"premium-box\">\n\n<div class=\"premium-text\">\n\U0001F614 Seu\
+        \ per\xEDodo de teste terminou!<br><br>\n<strong>Voc\xEA pode ser Membro Premium\
+        \ Vital\xEDcio para sempre fazendo uma \xFAnica doa\xE7\xE3o.</strong>\n</div>\n\
+        \n<div class=\"premium-actions\">\n<a href=\"/perfil/\" class=\"premium-yes\"\
+        >\U0001F525 QUERO SER PREMIUM \U0001F525</a>\n<p class=\"premium-nope\">CONTINUAR\
+        \ COM AN\xDANCIOS</p>\n</div>\n\n</div>\n\n` : `\n\n<div class=\"premium-overlay\"\
+        ></div>\n<div class=\"premium-box\">\n\n<div class=\"premium-text\">\n<i class=\"\
+        fa-solid fa-heart fa-beat\"></i>\nApoie a Legendei.NET e torne-se Membro Premium\
+        \ Vital\xEDcio agora para navegar sem an\xFAncios e desbloquear recursos exclusivos!\n\
+        <br>\n</div>\n\n<div class=\"premium-actions\">\n<a href=\"/seja-premium-vitalicio/\"\
+        \ class=\"premium-yes\">\U0001F525 FA\xC7A UM TESTE GRATUITO \U0001F525</a>\n\
+        <p class=\"premium-nope\">CONTINUAR COM AN\xDANCIOS</p>\n<a href=\"/login/\"\
+        \ class=\"premium-login\">J\xE1 tenho uma conta e quero conectar</a>\n</div>\n\
+        \n</div>\n\n`;\n\ndocument.body.appendChild(popup);\n\npopup.querySelector('.premium-nope').onclick=function(e){\n\
+        \ne.preventDefault();\n\nblockPopup();\nrunAds();\n\npopup.remove();\n\n};\n\
+        \n}\n\nlet triggered=false;\n\nfunction triggerPopup(){\n\nif(triggered) return;\n\
+        \ntriggered=true;\n\nsetTimeout(createPopup,TRIGGER_DELAY);\n\nwindow.removeEventListener('mousemove',triggerPopup);\n\
+        window.removeEventListener('touchstart',triggerPopup);\n\n}\n\n/* =============================\
+        \ */\n/* DISPARADORES                  */\n/* =============================\
+        \ */\n\nwindow.addEventListener('mousemove',triggerPopup,{passive:true});\n\
+        window.addEventListener('touchstart',triggerPopup,{passive:true});\n\ndocument.addEventListener('DOMContentLoaded',\
+        \ function(){\n\n    if(isBlocked()){\n        runAds();\n    }\n\n});\n\n\
+        })();\n</script>\n\n<style>\n/* ============================= */\n/* POPUP\
+        \ BASE */\n/* ============================= */\n#premium-popup{\n  position:fixed;\n\
+        \  inset:0;\n  z-index:999999;\n}\n\n.premium-overlay{\n  position:absolute;\n\
+        \  inset:0;\n  background:rgba(0,0,0,.65);\n}\n\n.premium-box{\n  position:absolute;\n\
+        \  left:50%;\n  top:50%;\n  transform:translate(-50%,-50%);\n  background:#212121;\n\
+        \  padding:28px 26px 26px;\n  max-width:440px;\n  width:92%;\n  border-radius:14px;\n\
+        \  text-align:center;\n}\n@media (max-width: 812px){\n  .premium-box{\n  \
+        \  top:5%;\n    transform:translate(-50%, 0);\n  }\n}\n\t\n/* inicio premium-login\
+        \ */\n.premium-login{\n  color:#fff;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  cursor:pointer;\n}\na.premium-login{\n    padding:8px 18px;\n}\na.premium-login::after{\n\
+        \    content:\"\";\n    position:absolute;\n    left:50%;\n    bottom:6px;\n\
+        \    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\na.premium-login:hover{\n\
+        \    color:#fff !important;\n}\n\na.premium-login:hover::after{\n    width:60%;\n\
+        }\n@media (max-width: 768px){\n    a.premium-login{\n        display:block;\n\
+        \        width:100%;\n        margin:6px 0;\n        text-align:center;\n\
+        \        font-size:14px;\n    }\n}\n/* fim premium-login */\n\n/* =============================\
+        \ */\n/* TEXTO */\n/* ============================= */\n.premium-text{\n \
+        \ color:#fff;\n  font-size:clamp(15px,2.6vw,18px);\n  line-height:1.4;\n \
+        \ font-family:Roboto,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;\n\
+        }\n\n.premium-text i{\n  color:#e74c3c;\n  margin-right:6px;\n}\n\n/* =============================\
+        \ */\n/* A\xC7\xD5ES */\n/* ============================= */\n.premium-actions{\n\
+        \  margin-top:18px;\n  display:flex;\n  flex-direction:column;\n  gap:12px;\n\
+        }\n\n/* ============================= */\n/* BOT\xD5ES */\n/* =============================\
+        \ */\n.alter{\n  background:#6f42c1;\n  border:2px solid #fff;\n  font-weight:bold;\n\
+        \  font-size:clamp(14px,2.6vw,16px);\n  color:#fff;\n  padding:10px 14px;\n\
+        \  border-radius:8px;\n  cursor:pointer;\n}\n\n.premium-yes{\n  background:#1e90ff;\n\
+        \  border:2px solid #FFF;\n  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  color:#fff;\n  padding:10px 14px;\n  border-radius:8px;\n  cursor:pointer;\n\
+        }\n\n.premium-nope{\n  background:#cc3300;\n  border:2px solid #FFF;\n  color:#fff;\n\
+        \  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n  padding:10px\
+        \ 14px;\n  border-radius:8px;\n  cursor:pointer;\n}\n\n/* =============================\
+        \ */\n/* HOVER / ACTIVE (-15%) */\n/* ============================= */\n.alter:hover,\n\
+        .alter:active,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-login:hover,\n\
+        .premium-login:active,\n.premium-nope:hover,\n.premium-nope:active{\n  filter:\
+        \ brightness(85%);\n}\n/* ============================= */\n/* TEXTO SEMPRE\
+        \ BRANCO (TODOS ESTADOS) */\n/* ============================= */\n.alter,\n\
+        .alter:visited,\n.alter:hover,\n.alter:active,\n.alter:focus,\n\n.premium-yes,\n\
+        .premium-yes:visited,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-yes:focus,\n\
+        \n.premium-login,\n.premium-login:visited,\n.premium-login:hover,\n.premium-login:active,\n\
+        .premium-login:focus,\n\n.premium-nope,\n.premium-nope:visited,\n.premium-nope:hover,\n\
+        .premium-nope:active,\n.premium-nope:focus{\n  color:#fff !important;\n  text-decoration:none;\n\
+        }\n/* ============================= */\n/* RESPONSIVO */\n/* =============================\
+        \ */\n/* Esconder em telas menores que 812px */\n@media (max-width: 812px){\n\
+        \  .alter{\n    display:none !important;\n  }\n}\n</style>\n\n</div>\n\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n</div><!--/#simple-grid-content-wrapper\
+        \ -->\n\n\n\n\n\n</div><!--/#simple-grid-wrapper -->\n\n\n\n\r\n\r\n\n\n\n\
+        \n\n\n<div class='simple-grid-clearfix' id='simple-grid-copyright-area'>\n\
+        \t\n<div class='simple-grid-copyright-area-inside simple-grid-container'>\n\
+        \t<a href=\"/\"><img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \ alt=\"\" width=\"300\" height=\"67\" class=\"aligncenter size-medium wp-image-747799\"\
+        \ /></a>\n<div class=\"simple-grid-outer-wrapper\">\t\n<center>\t\n<div class='simple-grid-copyright-area-inside-content\
+        \ simple-grid-clearfix'>\n  <p class='simple-grid-copyright'>Copyright \xA9\
+        \ 2016 - 2026 Legendei - Aqui Sai Primeiro</p>\n<p class='simple-grid-credit'><a\
+        \ href=\"https://legendei.net/\">Design by Legendei.NET</a></p>\n</div>\n\t\
+        </center>\n</div>\n</div>\n</div><!--/#simple-grid-copyright-area -->\n\n\n\
+        \n\n<button class=\"simple-grid-scroll-top\" title=\"Scroll to Top\"><i class=\"\
+        fas fa-arrow-up\" aria-hidden=\"true\"></i><span class=\"simple-grid-sr-only\"\
+        >Scroll to Top</span></button>\t\n\n\n\n\n\n<!-- Google tag (gtag.js) -->\n\
+        <script async src=\"https://www.googletagmanager.com/gtag/js?id=G-GX6PZNPM06\"\
+        ></script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function\
+        \ gtag(){dataLayer.push(arguments);}\n  gtag('js', new Date());\n\n  gtag('config',\
+        \ 'G-GX6PZNPM06');\n</script>\t\n\n\n\n\n\n<script type=\"speculationrules\"\
+        >\n{\"prefetch\":[{\"source\":\"document\",\"where\":{\"and\":[{\"href_matches\"\
+        :\"\\/*\"},{\"not\":{\"href_matches\":[\"\\/wp-*.php\",\"\\/wp-admin\\/*\"\
+        ,\"\\/wp-content\\/uploads\\/*\",\"\\/wp-content\\/*\",\"\\/wp-content\\/plugins\\\
+        /*\",\"\\/wp-content\\/themes\\/simple-grid\\/*\",\"\\/*\\\\?(.+)\"]}},{\"\
+        not\":{\"selector_matches\":\"a[rel~=\\\"nofollow\\\"]\"}},{\"not\":{\"selector_matches\"\
+        :\".no-prefetch, .no-prefetch a\"}}]},\"eagerness\":\"conservative\"}]}\n\
+        </script>\n\n<script>\nfunction attUploadProof(){\n\n    let fileInput = document.getElementById('att_proof');\n\
+        \    let msg = document.getElementById('att_upload_msg');\n\n    if(!fileInput.files.length){\n\
+        \        msg.innerHTML = '<span style=\"color:red;\">Selecione um arquivo</span>';\n\
+        \        return;\n    }\n\n    let file = fileInput.files[0];\n\n    if(file.size\
+        \ > 50 * 1024 * 1024){\n        msg.innerHTML = '<span style=\"color:red;\"\
+        >Arquivo maior que 50MB</span>';\n        return;\n    }\n\n    let formData\
+        \ = new FormData();\n    formData.append('action','att_upload_proof');\n \
+        \   formData.append('proof', file);\n\n    msg.innerHTML = 'Enviando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        body: formData\n    })\n    .then(r => r.json())\n    .then(res\
+        \ => {\n\n        if(res.success){\n            msg.innerHTML = '<span style=\"\
+        color:green;\">Comprovante enviado com sucesso!</span>';\n        } else {\n\
+        \            msg.innerHTML = '<span style=\"color:red;\">Erro: '+res.data+'</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<script>\nfunction attSaveLastName(){\n\
+        \n    let input = document.getElementById('att_last_name_input') \n      \
+        \       || document.getElementById('att_last_name_input2');\n\n    let msg\
+        \   = document.getElementById('att_name_msg') \n             || document.getElementById('att_name_msg2');\n\
+        \n    if(!input || !msg) return;\n\n    let value = input.value.trim();\n\n\
+        \    if(!value){\n        msg.innerHTML = '<span style=\"color:#f87171;\"\
+        >Digite o nome completo do titular da conta que ser\xE1 usada para a doa\xE7\
+        \xE3o</span>';\n        return;\n    }\n\n    msg.innerHTML = 'Salvando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        headers: {'Content-Type': 'application/x-www-form-urlencoded'},\n\
+        \        body: 'action=att_save_last_name&last_name=' + encodeURIComponent(value)\n\
+        \    })\n    .then(r => r.json())\n    .then(res => {\n\n        if(res.success){\n\
+        \            msg.innerHTML = '<span style=\"color:#22c55e;\">Salvo! Recarregando...</span>';\n\
+        \            setTimeout(()=>location.reload(),800);\n        } else {\n  \
+        \          msg.innerHTML = '<span style=\"color:#f87171;\">Erro ao salvar</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<style type=\"text/css\"> \n      \
+        \   /* Hide reCAPTCHA V3 badge */\n        .grecaptcha-badge {\n        \n\
+        \            visibility: hidden !important;\n        \n        }\n    </style><script\
+        \ type=\"text/javascript\" id=\"lrl-js-js-extra\">\n/* <![CDATA[ */\nvar lrlData\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"post_id\":\"729753\"};\n/* ]]> */\n</script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.js?ver=1.0\"\
+        \ id=\"lrl-js-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/jquery.fitvids.min.js\"\
+        \ id=\"fitvids-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/ResizeSensor.min.js\"\
+        \ id=\"ResizeSensor-js\"></script>\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-content/themes/simple-grid/assets/js/theia-sticky-sidebar.min.js\"\
+        \ id=\"theia-sticky-sidebar-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/navigation.js\"\
+        \ id=\"simple-grid-navigation-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/skip-link-focus-fix.js\"\
+        \ id=\"simple-grid-skip-link-focus-fix-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/imagesloaded.min.js?ver=5.0.0\"\
+        \ id=\"imagesloaded-js\"></script>\n<script type=\"text/javascript\" id=\"\
+        simple-grid-customjs-js-extra\">\n/* <![CDATA[ */\nvar simple_grid_ajax_object\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"primary_menu_active\":\"1\",\"secondary_menu_active\":\"\",\"primary_mobile_menu_active\"\
+        :\"1\",\"secondary_mobile_menu_active\":\"1\",\"sticky_menu_active\":\"1\"\
+        ,\"sticky_mobile_menu_active\":\"\",\"sticky_sidebar_active\":\"1\",\"columnwidth\"\
+        :\".simple-grid-5-col-sizer\",\"gutter\":\".simple-grid-5-col-gutter\"};\n\
+        /* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/custom.js\"\
+        \ id=\"simple-grid-customjs-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/comment-reply.min.js?ver=6.8.3\"\
+        \ id=\"comment-reply-js\" async=\"async\" data-wp-strategy=\"async\"></script>\n\
+        <script type=\"text/javascript\" id=\"simple-grid-html5shiv-js-js-extra\"\
+        >\n/* <![CDATA[ */\nvar simple_grid_custom_script_vars = {\"elements_name\"\
+        :\"abbr article aside audio bdi canvas data datalist details dialog figcaption\
+        \ figure footer header hgroup main mark meter nav output picture progress\
+        \ section summary template time video\"};\n/* ]]> */\n</script>\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/html5shiv.js\"\
+        \ id=\"simple-grid-html5shiv-js-js\"></script>\n<script type=\"text/javascript\"\
+        \ id=\"fifu-json-ld-js-extra\">\n/* <![CDATA[ */\nvar fifuJsonLd = {\"url\"\
+        :\"https:\\/\\/image.tmdb.org\\/t\\/p\\/w500\\/owTRRXuxpJT5n68IddsvDtAeK6K.jpg\"\
+        };\n/* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/plugins/featured-image-from-url/includes/html/js/json-ld.js?ver=4.9.2\"\
+        \ id=\"fifu-json-ld-js\"></script>\n<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var\
+        \ d=b.createElement('script');d.innerHTML=\"window.__CF$cv$params={r:'a14e7a4f1a6703da',t:'MTc4MzAwMzk4Mw=='};var\
+        \ a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);\"\
+        ;b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else\
+        \ if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var\
+        \ e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script><script\
+        \ defer src=\"https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496\"\
+        \ integrity=\"sha512-ZE9pZaUXND66v380QUtch/5sE9tPFh2zg45pR2PB0CVkCtOREv2AJKkSidISWkysEuQ0EH8faUU5du78bx87UQ==\"\
+        \ data-cf-beacon='{\"version\":\"2024.11.0\",\"token\":\"832c49ee708d4b8d94382b4733ae0382\"\
+        ,\"r\":1,\"server_timing\":{\"name\":{\"cfCacheStatus\":true,\"cfEdge\":true,\"\
+        cfExtPri\":true,\"cfL4\":true,\"cfOrigin\":true,\"cfSpeedBrain\":true},\"\
+        location_startswith\":null}}' crossorigin=\"anonymous\"></script>\n</body>\n\
+        </html>"
+    headers:
+      CF-RAY:
+      - a14e7a4f1a6703da-GRU
+      Cf-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Thu, 02 Jul 2026 14:53:04 GMT
+      Link:
+      - <https://legendei.net/wp-json/>; rel="https://api.w.org/", <https://legendei.net/wp-json/wp/v2/posts/729753>;
+        rel="alternate"; title="JSON"; type="application/json", <https://legendei.net/?p=729753>;
+        rel=shortlink
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Permissions-Policy:
+      - private-state-token-redemption=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com"),
+        private-state-token-issuance=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com")
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=MIemrLXvmEZ8l5JihzhKK9oH4qJA02v5v8pnYgSBd5%2BhWQZKgMJtQBoz66RN0W%2F3LnNMFycHrI4EdTHM%2FSUdf0wM4wmYcUCylUcTNfgM8L5t2EM7LM4HaQQbmDXYUcE%3D"}]}'
+      Server:
+      - cloudflare
+      Server-Timing:
+      - cfCacheStatus;desc="DYNAMIC"
+      - cfEdge;dur=5,cfOrigin;dur=1602
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - pt-BR,pt;q=0.9,en;q=0.8
+      User-Agent:
+      - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like
+        Gecko) Chrome/131.0.0.0 Safari/537.36
+    method: GET
+    uri: https://legendei.net/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia/
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html dir=\"ltr\" lang=\"pt-BR\" prefix=\"og: https://ogp.me/ns#\"\
+        >\n<head>\n<meta charset=\"UTF-8\">\n<meta name=\"viewport\" content=\"width=device-width,\
+        \ initial-scale=1.0\">\n\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css\"\
+        >\n\t\n<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">\n<link\
+        \ rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>\n<link\
+        \ href=\"https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap\"\
+        \ rel=\"stylesheet\">\n\t\n<title>Legenda Breaking Bad S01E01 1080p NF WEB\
+        \ DL DDP5 1 x264 PiA | Legendei - Aqui Sai Primeiro</title>\n\t<style>img:is([sizes=\"\
+        auto\" i], [sizes^=\"auto,\" i]) { contain-intrinsic-size: 3000px 1500px }</style>\n\
+        \t\n\t\t<!-- All in One SEO Pro 4.6.0 - aioseo.com -->\n\t\t<meta name=\"\
+        description\" content=\"Legenda Breaking Bad S01E01 1080p NF WEB DL DDP5 1\
+        \ x264 PiA testada e verificada - Pode servir tamb\xE9m para outros releases,\
+        \ basta renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t\
+        <meta name=\"robots\" content=\"max-image-preview:large\" />\n\t\t<meta name=\"\
+        google-site-verification\" content=\"JSMIV3rTOC3Y-WjaQzmU3KvW7aWHceTxBFYsJYpm-1k\"\
+        \ />\n\t\t<link rel=\"canonical\" href=\"https://legendei.net/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia/\"\
+        \ />\n\t\t<meta name=\"generator\" content=\"All in One SEO Pro (AIOSEO) 4.6.0\"\
+        \ />\n\t\t<meta property=\"og:locale\" content=\"pt_BR\" />\n\t\t<meta property=\"\
+        og:site_name\" content=\"Legendei - Baixar Legendas de S\xE9ries e Filmes\"\
+        \ />\n\t\t<meta property=\"og:type\" content=\"article\" />\n\t\t<meta property=\"\
+        og:title\" content=\"Legenda Breaking Bad S01E01 1080p NF WEB DL DDP5 1 x264\
+        \ PiA | Legendei - Aqui Sai Primeiro\" />\n\t\t<meta property=\"og:description\"\
+        \ content=\"Legenda Breaking Bad S01E01 1080p NF WEB DL DDP5 1 x264 PiA testada\
+        \ e verificada - Pode servir tamb\xE9m para outros releases, basta renomear!\
+        \ Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t<meta property=\"\
+        og:url\" content=\"https://legendei.net/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia/\"\
+        \ />\n\t\t<meta property=\"og:image\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"og:image:secure_url\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"article:published_time\" content=\"2025-07-01T23:00:17+00:00\"\
+        \ />\n\t\t<meta property=\"article:modified_time\" content=\"2025-07-01T23:00:17+00:00\"\
+        \ />\n\t\t<meta name=\"twitter:card\" content=\"summary\" />\n\t\t<meta name=\"\
+        twitter:title\" content=\"Legenda Breaking Bad S01E01 1080p NF WEB DL DDP5\
+        \ 1 x264 PiA | Legendei - Aqui Sai Primeiro\" />\n\t\t<meta name=\"twitter:description\"\
+        \ content=\"Legenda Breaking Bad S01E01 1080p NF WEB DL DDP5 1 x264 PiA testada\
+        \ e verificada - Pode servir tamb\xE9m para outros releases, basta renomear!\
+        \ Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t<meta name=\"twitter:image\"\
+        \ content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<script type=\"application/ld+json\" class=\"aioseo-schema\">\n\t\
+        \t\t{\"@context\":\"https:\\/\\/schema.org\",\"@graph\":[{\"@type\":\"BlogPosting\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia\\\
+        /#blogposting\",\"name\":\"Legenda Breaking Bad S01E01 1080p NF WEB DL DDP5\
+        \ 1 x264 PiA | Legendei - Aqui Sai Primeiro\",\"headline\":\"Breaking Bad\
+        \ S01E01 1080p NF WEB DL DDP5 1 x264 PiA\",\"author\":{\"@id\":\"https:\\\
+        /\\/legendei.net\\/author\\/eneinsubtitles\\/#author\"},\"publisher\":{\"\
+        @id\":\"https:\\/\\/legendei.net\\/#organization\"},\"image\":{\"@type\":\"\
+        ImageObject\",\"url\":\"https:\\/\\/legendei.net\\/wp-content\\/uploads\\\
+        /2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\/#articleImage\"\
+        ,\"width\":150,\"height\":150},\"datePublished\":\"2025-07-02T01:00:17+01:00\"\
+        ,\"dateModified\":\"2025-07-02T01:00:17+01:00\",\"inLanguage\":\"pt-BR\",\"\
+        mainEntityOfPage\":{\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia\\\
+        /#webpage\"},\"isPartOf\":{\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia\\\
+        /#webpage\"},\"articleSection\":\"S\\u00e9ries TV, Legendas Breaking Bad,\
+        \ Legendas Breaking Bad S01\"},{\"@type\":\"BreadcrumbList\",\"@id\":\"https:\\\
+        /\\/legendei.net\\/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia\\/#breadcrumblist\"\
+        ,\"itemListElement\":[{\"@type\":\"ListItem\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /#listItem\",\"position\":1,\"name\":\"Home\",\"item\":\"https:\\/\\/legendei.net\\\
+        /\",\"nextItem\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia\\\
+        /#listItem\"},{\"@type\":\"ListItem\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia\\/#listItem\",\"position\"\
+        :2,\"name\":\"Breaking.Bad.S01E01.1080p.NF.WEB-DL.DDP5.1.x264-PiA\",\"previousItem\"\
+        :\"https:\\/\\/legendei.net\\/#listItem\"}]},{\"@type\":\"Organization\",\"\
+        @id\":\"https:\\/\\/legendei.net\\/#organization\",\"name\":\"Legendei\",\"\
+        url\":\"https:\\/\\/legendei.net\\/\",\"logo\":{\"@type\":\"ImageObject\"\
+        ,\"url\":\"https:\\/\\/legendei.net\\/wp-content\\/uploads\\/2026\\/03\\/favicon.webp\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia\\\
+        /#organizationLogo\",\"width\":150,\"height\":150},\"image\":{\"@id\":\"https:\\\
+        /\\/legendei.net\\/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia\\/#organizationLogo\"\
+        }},{\"@type\":\"Person\",\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /#author\",\"url\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /\",\"name\":\"Admin\"},{\"@type\":\"WebPage\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia\\/#webpage\",\"url\"\
+        :\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia\\\
+        /\",\"name\":\"Legenda Breaking Bad S01E01 1080p NF WEB DL DDP5 1 x264 PiA\
+        \ | Legendei - Aqui Sai Primeiro\",\"description\":\"Legenda Breaking Bad\
+        \ S01E01 1080p NF WEB DL DDP5 1 x264 PiA testada e verificada - Pode servir\
+        \ tamb\\u00e9m para outros releases, basta renomear! Dispon\\u00edvel em Legendei\
+        \ - Aqui Sai Primeiro\",\"inLanguage\":\"pt-BR\",\"isPartOf\":{\"@id\":\"\
+        https:\\/\\/legendei.net\\/#website\"},\"breadcrumb\":{\"@id\":\"https:\\\
+        /\\/legendei.net\\/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia\\/#breadcrumblist\"\
+        },\"author\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /#author\"},\"creator\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /#author\"},\"datePublished\":\"2025-07-02T01:00:17+01:00\",\"dateModified\"\
+        :\"2025-07-02T01:00:17+01:00\"},{\"@type\":\"WebSite\",\"@id\":\"https:\\\
+        /\\/legendei.net\\/#website\",\"url\":\"https:\\/\\/legendei.net\\/\",\"name\"\
+        :\"Legendei\",\"description\":\"Baixar Legendas de S\\u00e9ries e Filmes\"\
+        ,\"inLanguage\":\"pt-BR\",\"publisher\":{\"@id\":\"https:\\/\\/legendei.net\\\
+        /#organization\"}}]}\n\t\t</script>\n\t\t<!-- All in One SEO Pro -->\n\n<link\
+        \ rel='dns-prefetch' href='//fonts.googleapis.com' />\n<link rel=\"alternate\"\
+        \ type=\"application/rss+xml\" title=\"Feed para Legendei &raquo;\" href=\"\
+        https://legendei.net/feed/\" />\n<link rel=\"alternate\" type=\"application/rss+xml\"\
+        \ title=\"Feed de coment\xE1rios para Legendei &raquo;\" href=\"https://legendei.net/comments/feed/\"\
+        \ />\n<link rel=\"alternate\" type=\"application/rss+xml\" title=\"Feed de\
+        \ coment\xE1rios para Legendei &raquo; Breaking Bad S01E01 1080p NF WEB DL\
+        \ DDP5 1 x264 PiA\" href=\"https://legendei.net/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia/feed/\"\
+        \ />\n<script type=\"text/javascript\">\n/* <![CDATA[ */\nwindow._wpemojiSettings\
+        \ = {\"baseUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\/emoji\\/16.0.1\\\
+        /72x72\\/\",\"ext\":\".png\",\"svgUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\\
+        /emoji\\/16.0.1\\/svg\\/\",\"svgExt\":\".svg\",\"source\":{\"concatemoji\"\
+        :\"https:\\/\\/legendei.net\\/wp-includes\\/js\\/wp-emoji-release.min.js?ver=6.8.3\"\
+        }};\n/*! This file is auto-generated */\n!function(s,n){var o,i,e;function\
+        \ c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function\
+        \ p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var\
+        \ t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),a=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new\
+        \ Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return\
+        \ t.every(function(e,t){return e===a[t]})}function u(e,t){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);for(var\
+        \ n=e.getImageData(16,16,1,1),a=0;a<n.data.length;a++)if(0!==n.data[a])return!1;return!0}function\
+        \ f(e,t,n,a){switch(t){case\"flag\":return n(e,\"\\ud83c\\udff3\\ufe0f\\u200d\\\
+        u26a7\\ufe0f\",\"\\ud83c\\udff3\\ufe0f\\u200b\\u26a7\\ufe0f\")?!1:!n(e,\"\\\
+        ud83c\\udde8\\ud83c\\uddf6\",\"\\ud83c\\udde8\\u200b\\ud83c\\uddf6\")&&!n(e,\"\
+        \\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc65\\udb40\\udc6e\\udb40\\\
+        udc67\\udb40\\udc7f\",\"\\ud83c\\udff4\\u200b\\udb40\\udc67\\u200b\\udb40\\\
+        udc62\\u200b\\udb40\\udc65\\u200b\\udb40\\udc6e\\u200b\\udb40\\udc67\\u200b\\\
+        udb40\\udc7f\");case\"emoji\":return!a(e,\"\\ud83e\\udedf\")}return!1}function\
+        \ g(e,t,n,a){var r=\"undefined\"!=typeof WorkerGlobalScope&&self instanceof\
+        \ WorkerGlobalScope?new OffscreenCanvas(300,150):s.createElement(\"canvas\"\
+        ),o=r.getContext(\"2d\",{willReadFrequently:!0}),i=(o.textBaseline=\"top\"\
+        ,o.font=\"600 32px Arial\",{});return e.forEach(function(e){i[e]=t(o,e,n,a)}),i}function\
+        \ t(e){var t=s.createElement(\"script\");t.src=e,t.defer=!0,s.head.appendChild(t)}\"\
+        undefined\"!=typeof Promise&&(o=\"wpEmojiSettingsSupports\",i=[\"flag\",\"\
+        emoji\"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){s.addEventListener(\"\
+        DOMContentLoaded\",e,{once:!0})}),new Promise(function(t){var n=function(){try{var\
+        \ e=JSON.parse(sessionStorage.getItem(o));if(\"object\"==typeof e&&\"number\"\
+        ==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&\"object\"\
+        ==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if(\"\
+        undefined\"!=typeof Worker&&\"undefined\"!=typeof OffscreenCanvas&&\"undefined\"\
+        !=typeof URL&&URL.createObjectURL&&\"undefined\"!=typeof Blob)try{var e=\"\
+        postMessage(\"+g.toString()+\"(\"+[JSON.stringify(i),f.toString(),p.toString(),u.toString()].join(\"\
+        ,\")+\"));\",a=new Blob([e],{type:\"text/javascript\"}),r=new Worker(URL.createObjectURL(a),{name:\"\
+        wpTestEmojiSupports\"});return void(r.onmessage=function(e){c(n=e.data),r.terminate(),t(n)})}catch(e){}c(n=g(i,f,p,u))}t(n)}).then(function(e){for(var\
+        \ t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],\"\
+        flag\"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return\
+        \ e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);\n\
+        /* ]]> */\n</script>\n<link rel='stylesheet' id='wpa-css-css' href='https://legendei.net/wp-content/plugins/wp-attachments/styles/0/wpa.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='wp-emoji-styles-inline-css' type='text/css'>\n\
+        \n\timg.wp-smiley, img.emoji {\n\t\tdisplay: inline !important;\n\t\tborder:\
+        \ none !important;\n\t\tbox-shadow: none !important;\n\t\theight: 1em !important;\n\
+        \t\twidth: 1em !important;\n\t\tmargin: 0 0.07em !important;\n\t\tvertical-align:\
+        \ -0.1em !important;\n\t\tbackground: none !important;\n\t\tpadding: 0 !important;\n\
+        \t}\n</style>\n<link rel='stylesheet' id='wp-block-library-css' href='https://legendei.net/wp-includes/css/dist/block-library/style.min.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='classic-theme-styles-inline-css'\
+        \ type='text/css'>\n/*! This file is auto-generated */\n.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em\
+        \ + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}\n\
+        </style>\n<style id='wppb-content-restriction-start-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-content-restriction-end-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-edit-profile-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-login-style-inline-css' type='text/css'>\n\n\
+        \n</style>\n<style id='wppb-recover-password-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-register-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='global-styles-inline-css' type='text/css'>\n:root{--wp--preset--aspect-ratio--square:\
+        \ 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4:\
+        \ 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3:\
+        \ 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16:\
+        \ 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray:\
+        \ #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink:\
+        \ #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange:\
+        \ #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan:\
+        \ #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue:\
+        \ #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple:\
+        \ #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1)\
+        \ 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan:\
+        \ linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange:\
+        \ linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red:\
+        \ linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray:\
+        \ linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum:\
+        \ linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186)\
+        \ 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple:\
+        \ linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux:\
+        \ linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62)\
+        \ 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112)\
+        \ 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean:\
+        \ linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181)\
+        \ 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128)\
+        \ 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129)\
+        \ 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium:\
+        \ 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large:\
+        \ 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40:\
+        \ 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70:\
+        \ 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural:\
+        \ 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px\
+        \ rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0,\
+        \ 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255,\
+        \ 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0,\
+        \ 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap:\
+        \ 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items:\
+        \ center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display:\
+        \ grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-color{color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background:\
+        \ var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange)\
+        \ !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background:\
+        \ var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background:\
+        \ var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background:\
+        \ var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background:\
+        \ var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background:\
+        \ var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size:\
+        \ var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size:\
+        \ var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--x-large) !important;}\n:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}\n:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}\n:root :where(.wp-block-pullquote){font-size:\
+        \ 1.5em;line-height: 1.6;}\n</style>\n<link rel='stylesheet' id='lrl-css-css'\
+        \ href='https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-maincss-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css' type='text/css'\
+        \ media='all' />\n<link rel='stylesheet' id='fontawesome-css' href='https://legendei.net/wp-content/themes/simple-grid/assets/css/all.min.css'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-webfont-css'\
+        \ href='//fonts.googleapis.com/css?family=Playfair+Display:400,400i,700,700i|Domine:400,700|Oswald:400,700|Patua+One|Merriweather:400,400i,700,700i&#038;display=swap'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='legendei-style-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css?ver=1782544305'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='wppb_stylesheet-css'\
+        \ href='https://legendei.net/wp-content/plugins/profile-builder/assets/css/style-front-end.css?ver=3.15.2'\
+        \ type='text/css' media='all' />\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-includes/js/jquery/jquery.min.js?ver=3.7.1\" id=\"\
+        jquery-core-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1\"\
+        \ id=\"jquery-migrate-js\"></script>\n<!--[if lt IE 9]>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/respond.min.js\"\
+        \ id=\"respond-js\"></script>\n<![endif]-->\n<link rel=\"https://api.w.org/\"\
+        \ href=\"https://legendei.net/wp-json/\" /><link rel=\"alternate\" title=\"\
+        JSON\" type=\"application/json\" href=\"https://legendei.net/wp-json/wp/v2/posts/664955\"\
+        \ /><link rel=\"EditURI\" type=\"application/rsd+xml\" title=\"RSD\" href=\"\
+        https://legendei.net/xmlrpc.php?rsd\" />\n<meta name=\"generator\" content=\"\
+        WordPress 6.8.3\" />\n<link rel='shortlink' href='https://legendei.net/?p=664955'\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (JSON)\" type=\"application/json+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fbreaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia%2F\"\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (XML)\" type=\"text/xml+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fbreaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia%2F&#038;format=xml\"\
+        \ />\n<style>\n\n/* FORMUL\xC1RIO TRIAL */\n\n.premium-form {\n    max-width:\
+        \ 760px;\n    margin: 0 auto 20px;\n    padding: 30px;\n    border-radius:\
+        \ 10px;\n    background: #212121;\n    border: 10px solid transparent;\n \
+        \   background-image:\n        linear-gradient(#212121,#212121),\n       \
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    background-origin: border-box;\n\
+        \    background-clip: padding-box, border-box;\n    box-sizing: border-box;\n\
+        }\n\n/* Campos */\n\n.premium-form .field {\n    position: relative;\n   \
+        \ margin-bottom: 20px;\n}\n\n.premium-form input {\n    width: 100%;\n   \
+        \ padding: 14px;\n    border-radius: 8px;\n    border: 1px solid #ccc;\n \
+        \   font-size: 16px;\n    box-sizing: border-box;\n}\n\n/* Focus bonito */\n\
+        \n.premium-form input:focus {\n    border-color: transparent;\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin: border-box;\n    background-clip: padding-box, border-box;\n\
+        \    box-shadow: 0 0 0 4px rgba(63,140,255,0.20);\n    outline: none;\n}\n\
+        \n/* TOOLTIP */\n\n.premium-form .tooltip {\n    position: absolute;\n   \
+        \ bottom: 100%;\n    left: 0;\n    margin-bottom: 10px;\n    background: linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \tbox-shadow:0 6px 14px rgba(0,0,0,0.25);\n    color: #ffffff;\n    padding:\
+        \ 10px 12px;\n    font-size: 14px;\n    border-radius: 6px;\n    max-width:\
+        \ 260px;\n    opacity: 0;\n    pointer-events: none;\n    transition: .2s;\n\
+        \    z-index: 999;\n}\n\n.premium-form .tooltip::after {\n    content: \"\"\
+        ;\n    position: absolute;\n    top: 100%;\n    left: 15px;\n    border-width:\
+        \ 6px 6px 0 6px;\n    border-style: solid;\n    border-color: #8a2be2 transparent\
+        \ transparent transparent;\n}\n\n.premium-form .field:hover .tooltip,\n.premium-form\
+        \ .field:focus-within .tooltip {\n    opacity: 1;\n    transform: translateY(-4px);\n\
+        }\n\n/* BOT\xC3O */\n\n.premium-form button {\n    padding: 14px 30px;\n \
+        \   font-size: 22px;\n    border-radius: 8px;\n    border: none;\n    background:\
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    color: #fff;\n    cursor: pointer;\n\
+        \    transition: .25s;\n}\n\n.premium-form button:hover {\n    background:\
+        \ linear-gradient(90deg,#4c9aff,#9a3bff);\n}\n\n/* SENHA */\n\n.pass-wrap{\n\
+        \    position:relative;\n}\n\n.toggle-pass{\n    position:absolute;\n    right:12px;\n\
+        \    top:50%;\n    transform:translateY(-50%);\n    cursor:pointer;\n    font-size:18px;\n\
+        }\n\n/* BARRA FOR\xC7A SENHA */\n\n.strength{\n    height:6px;\n    background:#444;\n\
+        \    border-radius:4px;\n    margin-top:8px;\n    overflow:hidden;\n}\n\n\
+        .strength div{\n    height:100%;\n    width:0%;\n    transition:.3s;\n}\n\n\
+        /* MOBILE */\n\n@media (max-width:480px){\n\n.premium-form{\n    padding:20px;\n\
+        }\n\n}\n\n</style>\n<style>\n\n/* remove fundo normal, ativo e hover do logo\
+        \ */\n.simple-grid-primary-nav-menu > li.menu-logo-item > a,\n.simple-grid-primary-nav-menu\
+        \ > li.menu-logo-item > a:hover,\n.simple-grid-primary-nav-menu > li.menu-logo-item.current-menu-item\
+        \ > a{\n    background:none !important;\n}\n\n/* ===================================================\n\
+        \   MOBILE\n   =================================================== */\n\n\
+        @media only screen and (max-width:812px){\n\n    /* ESCONDER LOGO NO MENU\
+        \ MOBILE */\n    .simple-grid-primary-nav-menu > li.menu-logo-item{\n    \
+        \    display:none !important;\n    }\n\n}\n\n</style>\n    <style type=\"\
+        text/css\">\r\n            .simple-grid-site-title, .simple-grid-site-title\
+        \ a, .simple-grid-site-description {color: #ffffff;}\r\n        </style>\r\
+        \n    <style type=\"text/css\" id=\"custom-background-css\">\nbody.custom-background\
+        \ { background-color: #333333; }\n</style>\n\t<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"32x32\" />\n<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"192x192\" />\n<link rel=\"apple-touch-icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n<meta name=\"msapplication-TileImage\" content=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n</head>\t\n\t\n\t\n<body class=\"wp-singular post-template-default single\
+        \ single-post postid-664955 single-format-standard custom-background wp-custom-logo\
+        \ wp-theme-simple-grid simple-grid-animated simple-grid-fadein simple-grid-theme-is-active\
+        \ simple-grid-custom-logo-active simple-grid-layout-type-full simple-grid-masonry-inactive\
+        \ simple-grid-float-grid simple-grid-responsive-grid-details simple-grid-layout-c-s1\
+        \ simple-grid-header-banner-active simple-grid-tagline-inactive simple-grid-logo-above-title\
+        \ simple-grid-primary-menu-active simple-grid-primary-mobile-menu-active simple-grid-secondary-mobile-menu-active\
+        \ simple-grid-primary-social-icons\" id=\"simple-grid-site-body\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/WebPage\">\n<a class=\"skip-link\
+        \ screen-reader-text\" href=\"#simple-grid-content-wrapper\">Skip to content</a>\n\
+        \n\n\n<div class=\"simple-grid-site-header simple-grid-container\" id=\"simple-grid-header\"\
+        \ itemscope=\"itemscope\" itemtype=\"http://schema.org/WPHeader\" role=\"\
+        banner\">\n<div class=\"simple-grid-head-content simple-grid-clearfix\" id=\"\
+        simple-grid-head-content\">\n\n<div class=\"simple-grid-no-header-content\"\
+        >\n              <p class=\"simple-grid-site-title\"><a href=\"https://legendei.net/\"\
+        \ rel=\"home\">Legendei</a></p>\r\n                </div>\n\n</div><!--/#simple-grid-head-content\
+        \ -->\n</div><!--/#simple-grid-header -->\n\n\n\n<div class=\"simple-grid-container\
+        \ simple-grid-primary-menu-container simple-grid-clearfix\">\n<div class=\"\
+        simple-grid-primary-menu-container-inside simple-grid-clearfix\">\n<nav class=\"\
+        simple-grid-nav-primary\" id=\"simple-grid-primary-navigation\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/SiteNavigationElement\" role=\"navigation\"\
+        \ aria-label=\"Primary Menu\">\n\t\n\t\n<div class=\"simple-grid-outer-wrapper\"\
+        >\n<a href=\"/\" class=\"logo-mobile-inline\">\n<img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \nstyle=\"width:100%;height:auto;\">\n</a>\n\n<style>\n.logo-mobile-inline{\n\
+        display:none;\n}\n\n@media (max-width:812px){\n.logo-mobile-inline{\ndisplay:block;\n\
+        }\n}\n</style>\t\n\n\t\n<style>\n.mobile-header-icons{\n    display:none;\n\
+        }\n\n@media (max-width: 812px){\n\n.mobile-header-icons{\n    display:grid;\n\
+        \    grid-template-columns: 2fr 1fr 1fr;\n    gap:10px;\n    padding:10px;\n\
+        }\n\n/* BOT\xD5ES */\n.mobile-header-icons a,\n.mobile-header-icons .cat-toggle{\n\
+        \    display:flex;\n    align-items:center;\n    justify-content:center;\n\
+        \    gap:6px;\n    background:#141414;\n    padding:8px 6px;\n    border-radius:8px;\n\
+        \    color:#fff;\n    font-size:12px;\n    text-decoration:none;\n    text-align:center;\n\
+        \    cursor:pointer;\n}\n\n/* CATEGORIA */\n.cat-toggle{\n    font-weight:600;\n\
+        }\n\n/* SETA */\n.cat-toggle .arrow{\n    transition:transform 0.3s ease;\n\
+        }\n\n/* SETA GIRADA */\n.cat-toggle.active .arrow{\n    transform:rotate(180deg);\n\
+        }\n\n/* HOVER */\n.mobile-header-icons a:hover,\n.mobile-header-icons .cat-toggle:hover{\n\
+        \    background:#1f1f1f;\n}\n\n/* CONTAINER */\n.cat-container{\n    position:relative;\n\
+        }\n\n/* DROPDOWN */\n.cat-list{\n    display:flex;\n    flex-direction:column;\n\
+        \    gap:6px;\n\n    position:absolute;\n    top:110%;\n    left:0;\n    width:100%;\n\
+        \n    background:#0f0f0f;\n    border-radius:8px;\n    padding:6px;\n    z-index:999;\n\
+        \n    opacity:0;\n    visibility:hidden;\n    transform:translateY(-5px);\n\
+        \    transition:all 0.25s ease;\n}\n\n/* ABERTO */\n.cat-container.open .cat-list{\n\
+        \    opacity:1;\n    visibility:visible;\n    transform:translateY(0);\n}\n\
+        \n/* ITENS */\n.cat-list a{\n    justify-content:flex-start;\n    font-size:14px;\n\
+        \    padding:10px;\n}\n\n}\n</style>\n\n\n<div class=\"mobile-header-icons\"\
+        >\n\n    <!-- CATEGORIAS -->\n    <div class=\"cat-container\">\n        <div\
+        \ class=\"cat-toggle\">\n            \U0001F4C2 Categorias <span class=\"\
+        arrow\">\u25BC</span>\n        </div>\n\n        <div class=\"cat-list\">\n\
+        \            <a href=\"/category/destaques/\">\u2B50 Destaques</a>\n     \
+        \       <a href=\"/category/filmes/\">\U0001F3AC Filmes</a>\n            <a\
+        \ href=\"/category/serie/\">\U0001F4FA S\xE9ries</a>\n            <a href=\"\
+        /category/pack-de-legendas/\">\U0001F4E6 Packs</a>\n        </div>\n    </div>\n\
+        \n    \n        <a href=\"/seja-premium-vitalicio/\"><i class=\"fa-solid fa-crown\"\
+        ></i> Premium</a>\n\n        <a href=\"/login/\"><i class=\"fa-solid fa-key\"\
+        ></i> Login</a>\n\n    \n</div>\n\n<script>\ndocument.addEventListener(\"\
+        DOMContentLoaded\", function(){\n\n    const container = document.querySelector(\"\
+        .cat-container\");\n    const toggle = document.querySelector(\".cat-toggle\"\
+        );\n\n    toggle.addEventListener(\"click\", function(e){\n        e.stopPropagation();\n\
+        \        container.classList.toggle(\"open\");\n        toggle.classList.toggle(\"\
+        active\");\n    });\n\n    document.addEventListener(\"click\", function(e){\n\
+        \        if(!container.contains(e.target)){\n            container.classList.remove(\"\
+        open\");\n            toggle.classList.remove(\"active\");\n        }\n  \
+        \  });\n\n});\n</script>\t\n\t\n<ul id=\"simple-grid-menu-primary-navigation\"\
+        \ class=\"simple-grid-primary-nav-menu simple-grid-menu-primary\"><li id=\"\
+        menu-item-673170\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-673170 menu-logo-item\">\n        <a href=\"https://legendei.net/\"\
+        \ style=\"\n            display:flex;\n            align-items:center;\n \
+        \           justify-content:center;\n            height:100%;\n          \
+        \  padding:0;\n            margin:0;\n            line-height:1;\n       \
+        \ \">\n            <img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \n                      alt=\"Legendei.NET\"\n                      style=\"\
+        height:42px;width:auto;display:block;\">\n        </a></li>\n\n<li id=\"menu-item-673168\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673168\"\
+        ><a href=\"https://legendei.net/category/destaques/\" title=\"Legendas em\
+        \ Destaque\">DESTAQUES</a></li>\n<li id=\"menu-item-673167\" class=\"menu-item\
+        \ menu-item-type-taxonomy menu-item-object-category menu-item-673167\"><a\
+        \ href=\"https://legendei.net/category/filmes/\" title=\"Legendas para Filmes\"\
+        >Filmes</a></li>\n<li id=\"menu-item-673166\" class=\"menu-item menu-item-type-taxonomy\
+        \ menu-item-object-category current-post-ancestor current-menu-parent current-post-parent\
+        \ menu-item-673166\"><a href=\"https://legendei.net/category/serie/\" title=\"\
+        Legendas para seriados\">S\xC9RIES</a></li>\n<li id=\"menu-item-673169\" class=\"\
+        menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673169\"\
+        ><a href=\"https://legendei.net/category/pack-de-legendas/\" title=\"Pack\
+        \ de legendas\">PACKS</a></li>\n<li id=\"menu-item-731144\" class=\"menu-item\
+        \ menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-731144\"\
+        ><a target=\"_blank\" href=\"/aplicativos/\">RECOMENDAMOS</a>\n<ul class=\"\
+        sub-menu\">\n\t<li id=\"menu-item-673172\" class=\"menu-item menu-item-type-custom\
+        \ menu-item-object-custom menu-item-673172\"><a target=\"_blank\" href=\"\
+        /aplicativos/\" title=\"Programas para windows\">APLICATIVOS</a></li>\n\t\
+        <li id=\"menu-item-687662\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-687662\"><a target=\"_blank\" href=\"https://4kxxx.vip/\" title=\"\
+        Baixe os melhores v\xEDdeos porn\xF4 sempre em 4K\">4K XXX</a></li>\n\t<li\
+        \ id=\"menu-item-717497\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-717497\"><a target=\"_blank\" href=\"https://detonaplay.com/\"\
+        >GAMES</a></li>\n</ul>\n</li>\n\n\n\n<li class=\"menu-item\" style=\"float:right;\"\
+        >\n            <a href=\"/login/\"\n               style=\"background:linear-gradient(135deg,#198754,#20ac6b);color:#ffffff;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-key\"></i> Login\n            </a>\n\
+        \        </li><li class=\"menu-item\" style=\"float:right;\">\n          \
+        \  <a href=\"/seja-premium-vitalicio/\"\n\t\t\t\t\t  style=\"background:linear-gradient(135deg,#f4c430,#c2940a);color:#4d2e00;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-crown\"></i> Membro Premium\n  \
+        \          </a>\n        </li></ul>    </div>\n</nav>\n</div>\n</div>\n\n\t\
+        \n\t\n\r\n<div class=\"simple-grid-outer-wrapper\">\r\n<div class=\"simple-grid-top-wrapper-outer\
+        \ simple-grid-clearfix\">\r\n<div class=\"simple-grid-featured-posts-area\
+        \ simple-grid-top-wrapper simple-grid-clearfix\">\r\n\r\n<div id=\"search-5\"\
+        \ class=\"simple-grid-main-widget widget simple-grid-widget-box widget_search\"\
+        ><div class=\"simple-grid-widget-box-inside\"><form role=\"search\" method=\"\
+        get\" class=\"simple-grid-search-form\" action=\"https://legendei.net/\">\n\
+        <label>\n    <span class=\"simple-grid-sr-only\">Pesquisar por </span>\n \
+        \   <input \n        type=\"search\"\n        class=\"simple-grid-search-field\"\
+        \n        placeholder=\"Pesquisar &hellip;\"\n        value=\"\"\n       \
+        \ name=\"s\"\n        minlength=\"3\"\n\t\tmaxlength=\"50\"   \n        required\n\
+        \    />\n</label>\n<input type=\"submit\" class=\"simple-grid-search-submit\"\
+        \ value=\"&#xf002;\" />\n</form></div></div></div>\r\n</div>\r\n</div>\r\n\
+        \r\n\n<div class=\"simple-grid-outer-wrapper\" id=\"simple-grid-wrapper-outside\"\
+        >\n\n<div class=\"simple-grid-container simple-grid-clearfix\" id=\"simple-grid-wrapper\"\
+        >\n<div class=\"simple-grid-content-wrapper simple-grid-clearfix\" id=\"simple-grid-content-wrapper\"\
+        >\t\n\t\t\n\n\n<div class=\"simple-grid-main-wrapper simple-grid-clearfix\"\
+        \ id=\"simple-grid-main-wrapper\" itemscope=\"itemscope\" itemtype=\"http://schema.org/Blog\"\
+        \ role=\"main\">\n<div class=\"theiaStickySidebar\">\n<div class=\"simple-grid-main-wrapper-inside\
+        \ simple-grid-clearfix\">\n\n\r\n\r\n\n<div class=\"simple-grid-posts-wrapper\"\
+        \ id=\"simple-grid-posts-wrapper\">\n\n\n\n\n\n<div style=\"width: 100%; border-radius:\
+        \ 12px; box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 12px; padding: 15px; background:\
+        \ #ffffff;\">\n    <center>\n    <article id=\"post-664955\" class=\"simple-grid-post-singular\
+        \ simple-grid-box post-664955 post type-post status-publish format-standard\
+        \ hentry category-serie tag-legendas-breaking-bad tag-legendas-breaking-bad-s01\
+        \ wpcat-4-id\">\n        <div class=\"simple-grid-box-inside\">\n        \
+        \    \n            \n                            <header class=\"entry-header\"\
+        >\n                    <div class=\"entry-header-inside simple-grid-clearfix\"\
+        >\n\n<h1 class=\"post-title entry-title\">Legenda Breaking Bad S01E01 1080p\
+        \ NF WEB DL DDP5 1 x264 PiA <span aria-label=\"PT-BR\">\U0001F1E7\U0001F1F7\
+        </span></h1>\n\n\n                                    <div class=\"simple-grid-entry-meta-single\"\
+        >\n                            <span class=\"simple-grid-entry-meta-single-date\"\
+        >\n                <i class=\"far fa-clock\" aria-hidden=\"true\"></i>&nbsp;2\
+        \ de julho de 2025            </span>\n                                  \
+        \  <span class=\"simple-grid-entry-meta-single-categories\"><i class=\"far\
+        \ fa-folder-open\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Posted in </span><a href=\"https://legendei.net/category/serie/\" rel=\"\
+        category tag\">S\xE9ries TV</a></span>                            </div>\n\
+        \    \n\n                    </div>\n                </header>\n         \
+        \   \t\t\t\n\t\t\t\n            <!-- inicio poster -->\n                 \
+        \       <!-- fim poster -->\n\t\t\t\n<!-- S admin -->\n            \t\t\t\n\
+        <!-- S admin -->\t\n\t\t\t\n            \n            <div class=\"entry-content\
+        \ simple-grid-clearfix\">\n\n<!-- N PREMIUM AMIN TEMP -->\t\t\t\t\n\t\n\n\
+        \   <a href=\"https://cuponei.org/promo/more/\" target=\"_blank\" rel=\"noopener\"\
+        >\n    <img class=\"aligncenter wp-image-729595 size-full\"\n         src=\"\
+        https://legendei.net/wp-content/uploads/2026/01/amazon.webp\"\n         width=\"\
+        350\" height=\"334\" />\n  </a>\t\n\t\t\t\t\t\t\t\t\n<!-- N PREMIUM AMIN TEMP\
+        \ -->\n\n\n\t\t\t\t\n<!-- anexos otimizados -->\n<!-- /anexos -->\n\n\n  \
+        \              <!-- WP Attachments -->\n        <div style=\"width:100%;margin:10px\
+        \ 0 10px 0;\">\n            <h3></h3>\n        <ul class=\"post-attachments\"\
+        ><p class=\"post-attachment mime-application-zip\">                      \
+        \                                                          <a href=\"https://legendei.net/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia/?download=664954\"\
+        \ target=\"_blank\" class=\"buttonmyup\"><i class=\"fa fa-download\"></i>\
+        \ BAIXAR LEGENDA</a>\r\n</p></ul></div>\n        <div class=\"highlight-text\"\
+        >\n\n<style>\n/* ===================================== */\n/* LINKS COM BORDA\
+        \ GRADIENTE + UNDERLINE */\n/* ===================================== */\n\n\
+        .busca-legenda-links a{\n    display:inline-block;\n    padding:8px 18px;\n\
+        \    margin:2px 8px;\n    font-weight:400;\n    font-size:14px;\n    text-decoration:none\
+        \ !important;\n\tmin-width: 180px;\n    color:#1e293b !important; /* texto\
+        \ escuro vis\xEDvel */\n    background:transparent;\n\n    border:2px solid\
+        \ transparent;\n    border-radius:6px;\n\n    /* borda gradiente */\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin:border-box;\n    background-clip:padding-box, border-box;\n\
+        \n    position:relative;\n    transition:all .25s ease;\n}\n\n/* underline\
+        \ gradiente (embaixo do texto) */\n.busca-legenda-links a::after{\n    content:\"\
+        \";\n    position:absolute;\n    left:50%;\n    bottom:6px; /* dentro do bot\xE3\
+        o */\n    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\n\n/*\
+        \ hover */\n.busca-legenda-links a:hover{\n    color:#002080 !important;\n\
+        }\n\n.busca-legenda-links a:hover::after{\n    width:60%;\n}\n\n/* ativo (se\
+        \ quiser usar classe active depois) */\n.busca-legenda-links a.active::after{\n\
+        \    width:60%;\n}\n\n@media (max-width: 768px){\n\n    .busca-legenda-links{\n\
+        \        display:block;\n    }\n\n    /* remove os pontinhos separadores no\
+        \ mobile */\n    .busca-legenda-links span{\n        display:none;\n    }\n\
+        \n    .busca-legenda-links a{\n        display:block;\n        width:100%;\n\
+        \        margin:6px 0; /* controla espa\xE7amento vertical */\n        text-align:center;\n\
+        \t\tfont-size:14px;\n    }\n\n\n}\n</style>\n\n\n\n            <p><strong>Legenda\
+        \ da s\xE9rie Breaking Bad S01E01 1080p NF WEB DL DDP5 1 x264 PiA</strong></p>\n\
+        \            <hr>\n\n            <p>Todas as legendas dispon\xEDveis para\
+        \ download s\xE3o testadas e verificadas, garantindo sincronia, precis\xE3\
+        o e qualidade.</p>\n\n            <p>Depois de baixar a legenda, n\xE3o se\
+        \ esque\xE7a de conferir o seu release!</p>\n\n            <div class=\"busca-legenda-links\"\
+        >\n                <a href=\"/category/serie/?s=Breaking+Bad\">+ legendas\
+        \ mesma s\xE9rie</a><a href=\"/category/serie/?s=Breaking+Bad+S01\">+ legendas\
+        \ mesma temporada</a><span>\xB7</span><a href=\"/category/serie/?s=Breaking+Bad+S01E01\"\
+        >+ legendas mesmo epis\xF3dio</a>\n            </div>\n\n        </div>\n\t\
+        \t\n\n\t\t\n\t\t\n                <!-- sinopse TMDB -->\n                <!--\
+        \ /sinopse -->\n\n            </div><!-- .entry-content -->\n\n          \
+        \  \n            \n        </div>\n\n\n\n\t\t\n    </article>\n\n<!-- inicio\
+        \ app recomendados -->\t\t\n<div id=\"apps-recomendados\">\n<div class=\"\
+        busca-legenda-links\" style=\"text-align:center;\">\n<h5>Aplicativos que usamos\
+        \ e recomendamos</h5>\n\n<a href=\"https://legendei.net/aplicativos/kodi/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2025/11/Kodi_21.3.webp\"\
+        \ width=\"40\" height=\"40\" />\n    Kodi Media Center\n</a>\n\n<a href=\"\
+        https://legendei.net/aplicativos/utorrent-pro-download-e-guia-completo/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/08/uTorrent-Pro.jpg\"\
+        \ width=\"40\" height=\"40\" />\n    uTorrent Pro\n</a>\n\n<a href=\"https://legendei.net/aplicativos/winzip-pro-windows/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/09/WinZip-Pro.png\"\
+        \ width=\"40\" height=\"40\" />\n    WinZip Pro\n</a>\n</div>\n</div>\n<style>\n\
+        @media (max-width: 812px){\n    #apps-recomendados{\n        display: none;\n\
+        \    }\n}\n</style>\n<!-- fim app recomendados -->\n\t\t\n<span class=\"simple-grid-entry-meta-single-tags\"\
+        ><i class=\"fas fa-tags\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Tagged </span><a href=\"https://legendei.net/tag/legendas-breaking-bad/\"\
+        \ rel=\"tag\">Legendas Breaking Bad</a>, <a href=\"https://legendei.net/tag/legendas-breaking-bad-s01/\"\
+        \ rel=\"tag\">Legendas Breaking Bad S01</a></span>\n\t\t\n\t\t\n\n\t\t\n<hr>\n\
+        <div class=\"lrl-report-link\">\n    <a href=\"#\" class=\"lrl-open busca-legenda-links\"\
+        >\U0001F6A8 Reportar problemas \U0001F6A8</a>\n\t</div>\n\n    <div id=\"\
+        lrl-modal\" style=\"display:none;\">\n        <div class=\"lrl-box\">\n  \
+        \          <span class=\"lrl-close\">&times;</span>\n            <h3>Qual\
+        \ \xE9 o problema?</h3><hr>\n\n<label><input type=\"radio\" name=\"lrl_motivo\"\
+        \ value=\"Problemas com o download\"> O download n\xE3o funciona</label><br><br>\n\
+        \n<label><input type=\"radio\" name=\"lrl_motivo\" value=\"Legenda para o\
+        \ filme ou s\xE9rie incorreta\"> Conte\xFAdo \xE9 para outro filme, s\xE9\
+        rie ou epis\xF3dio</label><br><br>\n\n<label><input type=\"radio\" name=\"\
+        lrl_motivo\" value=\"Idioma da legenda incorreto\"> O idioma da legenda est\xE1\
+        \ errado.</label><br><br>\n<hr>\n            <button id=\"lrl-send\" disabled>Enviar</button>\n\
+        \        </div>\n    </div>\n    \t\t\n    </center>\n\t\n</div>\n\n\t\n\t\
+        \n\t\n\t\n\n<!-- S admin -->\t\n<!-- S admin -->\t\n\n\n\t\n<!-- N PREMIUM\
+        \ AMIN TEMP -->\n<div>\t\n<!-- protetor de links -->\n<script>\n(function(){\n\
+        \nconst redirectpage = \"https://legendei.net/noticia.php\";\n\nconst bases\
+        \ = [\n    '/?download=',\n    '/?dl_',\n    '.rar',\n    '.zip',\n    '.srt',\n\
+        \    'magnet:',\n\t'/zip-attachments.php'\n];\n\ndocument.querySelectorAll('a').forEach(a\
+        \ => {\n    const href = a.getAttribute('href') || '';\n\n    if (bases.some(b\
+        \ => href.includes(b))) {\n\n        const token = btoa(href);\n\n       \
+        \ a.href = redirectpage + \"?token=\" + token;\n        a.target = \"_blank\"\
+        ;\n    }\n});\n\n})();\n</script>\n<!-- /protetor de links -->\t\n\t\t\n\n\
+        <!-- BLOQUEADOR LEGENDEI -->\n\n<!-- BLOQUEADOR LEGENDEI -->\n\t\n<!-- inicio\
+        \ reload -->\n<script>\nsetInterval(function(){\n  location.reload();\n},\
+        \ 120000); // 2 minutos\n</script>\n<!-- fim reload -->\t\n\t\n</div>\t\n\
+        <!-- N PREMIUM AMIN TEMP -->\n\t\n\t\n<div class=\"clear\"></div>\n</div><!--/#simple-grid-posts-wrapper\
+        \ -->\n\n\r\n\r\n\t\n\n</div>\n</div>\n</div><!-- /#simple-grid-main-wrapper\
+        \ -->\n\n\n\n</div>\n\n\n\n\n<!-- N ADMIN -->\n<div>\n<!-- inicio -->\n<iframe\
+        \ \n  src=\"https://cuponei.org/last/\"\n  style=\"\n    width:1px;\n    height:1px;\n\
+        \    opacity:0;\n    border:none;\n    overflow:hidden;\n  \"\n  scrolling=\"\
+        no\"\n></iframe>\n<!-- fim -->\t\n</div>\n<!-- N ADMIN -->\n\n\n\n\n<!-- N\
+        \ PREMIUM AMIN TEMP -->\n\n\n\n\n<div>\n\n\t\n<!-- =============================\
+        \ -->\n<!-- SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\n\n<div id=\"SCRIPT_1_AQUI\" style=\"display:none;\">\t\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/invesup.js\"></script>\n<script\
+        \ type=\"text/javascript\">\n// make pop on new window with size 150x150 \
+        \ \nLight.Popup.create('https://cuponei.org/promo/more/', {width: 150, height:\
+        \ 150, onNewTab: false});\n// refresh = new popup\nLight.Popup.create('https://cuponei.org/promo/more/amz/',\
+        \ {alwaysPop: false});  \n</script>\n</div>\t\n\n<div id=\"SCRIPT_2_AQUI\"\
+        \ style=\"display:none;\">\n\t\n<script type=\"text/javascript\">\n var p$00a\
+        \ = 'p$00a' + (new Date().getTime()) + 'zz'; window[p$00a] = {a:'abcdefghijklmnopqrstuvwxyz0123456789i0xpy5jn7r6h82fuw1skdgzca94e3omqvblt',\
+        \ b:'{\"AZIb\":\"e344vq\", \"BVIb\":\"b4mm4e\", \"CXrr1\":\"du\", \"DLtag\"\
+        :\"e\", \"Emjk5\":\"\", \"XCge1s\":\"u.g7fz1yh.xf8\" , \"Zt1\":\"ufuxisn.2yk\"\
+        , \"ZZ1\":\"u.nn8fu.xhfdp\" }', c:'{\"Abkr221\":\"sx17uk\", \"Bo9ssm\":\"\
+        //xp2.g7fz1yh.xf8/iuu.rs\"}', d:'{\"Ag4\":\"0fpa\", \"Bx1\":\"iuuy2pCn7hp\"\
+        , \"Cky\":\"s1x\", \"Dmg\":\"x1yikyEhy8y2k\"}'};\nvar _0x5d4b=['235913QVfbwv','slice','length','162209QBmAmV','14238hyOOTq','323207DTbifh','split','1DqiKtq','135866HTbavB','indexOf','call','27654SKXHbY','parse','undefined','32Ijckmz','keys','map','ceil','115980hcFVDy','values','join'];var\
+        \ _0x208c=function(_0x31a8d7,_0x5f36b3){_0x31a8d7=_0x31a8d7-0x167;var _0x5d4be1=_0x5d4b[_0x31a8d7];return\
+        \ _0x5d4be1;};(function(_0x276f94,_0x57c4ff){var _0x50057c=_0x208c;while(!![]){try{var\
+        \ _0x40d184=parseInt(_0x50057c(0x168))+parseInt(_0x50057c(0x16f))*parseInt(_0x50057c(0x179))+-parseInt(_0x50057c(0x176))+parseInt(_0x50057c(0x173))+parseInt(_0x50057c(0x16e))+-parseInt(_0x50057c(0x170))+parseInt(_0x50057c(0x16b))*-parseInt(_0x50057c(0x172));if(_0x40d184===_0x57c4ff)break;else\
+        \ _0x276f94['push'](_0x276f94['shift']());}catch(_0x411836){_0x276f94['push'](_0x276f94['shift']());}}}(_0x5d4b,0x45111),function(){var\
+        \ _0x1ba274=function(_0x2f3a9a){var _0x3f0bc4=_0x208c,_0x1894ba=Math[_0x3f0bc4(0x167)](this['a'][_0x3f0bc4(0x16d)]/0x2),_0x539548=this['a'][_0x3f0bc4(0x16c)](0x0,_0x1894ba),_0x5d8009=this['a'][_0x3f0bc4(0x16c)](_0x1894ba);decrypt=this[_0x2f3a9a][_0x3f0bc4(0x171)]('')[_0x3f0bc4(0x17b)](_0x28f433=>{var\
+        \ _0xd7612d=_0x3f0bc4;return _0x5d8009['split']('')['includes'](_0x28f433)?_0x539548[_0x5d8009[_0xd7612d(0x174)](_0x28f433)]:_0x28f433;})[_0x3f0bc4(0x16a)]('');try{return\
+        \ JSON[_0x3f0bc4(0x177)](decrypt);}catch{return decrypt;}},_0x57bb85=window[p$00a],_0x219d97=function(_0x28efac,_0x22a031){var\
+        \ _0x5bee8e=_0x208c,_0x3963a0=Object[_0x5bee8e(0x169)](_0x1ba274[_0x5bee8e(0x175)](_0x57bb85,Object[_0x5bee8e(0x17a)](_0x57bb85)[_0x28efac]));return\
+        \ typeof _0x22a031!=_0x5bee8e(0x178)?_0x3963a0[_0x22a031]:_0x3963a0;};window[p$00a]['x']=function(){return\
+        \ _0x219d97(0x1);};var _0xf1db57=document[_0x219d97(0x3,0x3)](_0x219d97(0x2,0x0));_0xf1db57[_0x219d97(0x3,0x2)]=_0x219d97(0x2,0x1),document[_0x219d97(0x3,0x0)][_0x219d97(0x3,0x1)](_0xf1db57),p$00a=undefined;}());\n\
+        \ \n </script>\n\t\n<script type=\"text/javascript\" src=\"https://legendei.net/invesup.js\"\
+        ></script>\n<script type=\"text/javascript\">\n// make pop on new window with\
+        \ size 150x150  \nLight.Popup.create('https://legendei.net/terrabanne/', {width:\
+        \ 150, height: 150, onNewTab: false}); \n// refresh = new popup\nLight.Popup.create('https://legendei.net/terrabanne/',\
+        \ {alwaysPop: true}); \t\n</script>\t\n\t\n</div>\n\n<!-- =============================\
+        \ -->\n<!-- / SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\t\n\t\n<script>\n(function(){\n\nconst path = window.location.pathname;\n\
+        \nwindow.__CUPONEI_DISABLE_ALL = (\n  path.startsWith('/seja-premium-vitalicio')\
+        \ ||\n  path.startsWith('/perfil')\n);\n\nif (window.__CUPONEI_DISABLE_ALL)\
+        \ return;\n\n/* evita bots */\nif (/bot|googlebot|crawler|spider|crawling/i.test(navigator.userAgent))\
+        \ return;\n\nconst isExpiredUser = false;\n\nconst BLOCK_TIME = 1 * 60 * 60\
+        \ * 1000;\nconst STORAGE_KEY = 'premium_popup_blocked_until';\nconst TRIGGER_DELAY\
+        \ = 1000;\n\nlet adsStarted = false;\n\n/* ============================= */\n\
+        /* CONTROLE TEMPO                */\n/* ============================= */\n\
+        \nfunction now(){\n    return Date.now();\n}\n\nfunction isBlocked(){\n  \
+        \  const until = localStorage.getItem(STORAGE_KEY);\n    return until && now()\
+        \ < parseInt(until);\n}\n\nfunction blockPopup(){\n    localStorage.setItem(STORAGE_KEY,\
+        \ now() + BLOCK_TIME);\n}\n\n/* ============================= */\n/* EXECU\xC7\
+        \xC3O SEGURA DOS SCRIPTS   */\n/* ============================= */\n\nfunction\
+        \ executeScriptsFromDiv(divId, callback){\n\n    if (window.__CUPONEI_DISABLE_ALL){\n\
+        \        if(callback) callback();\n        return;\n    }\n\n    const container\
+        \ = document.getElementById(divId);\n    if(!container){\n        if(callback)\
+        \ callback();\n        return;\n    }\n\n    const scripts = container.querySelectorAll(\"\
+        script\");\n    let total = scripts.length;\n    let loaded = 0;\n\n    if(total\
+        \ === 0){\n        if(callback) callback();\n        return;\n    }\n\n  \
+        \  scripts.forEach(oldScript => {\n\n        const newScript = document.createElement(\"\
+        script\");\n\n        for (let attr of oldScript.attributes) {\n         \
+        \   newScript.setAttribute(attr.name, attr.value);\n        }\n\n        if(oldScript.src){\n\
+        \n            newScript.onload = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n            newScript.onerror = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n        } else {\n            newScript.text = oldScript.text;\n\
+        \            loaded++;\n        }\n\n        document.body.appendChild(newScript);\n\
+        \n        if(!oldScript.src){\n            if(loaded === total && callback)\
+        \ callback();\n        }\n\n    });\n\n}\n\n/* =============================\
+        \ */\n/* SEQU\xCANCIA DOS AN\xDANCIOS        */\n/* =============================\
+        \ */\n\nfunction runAds(){\n\n    if (window.__CUPONEI_DISABLE_ALL) return;\n\
+        \    if (adsStarted) return;\n\n    adsStarted = true;\n\n    let clickCount\
+        \ = 0;\n    let script2Executed = false;\n\n    function handleUserClick(){\n\
+        \n        clickCount++;\n\n        // Debug opcional\n        // console.log(\"\
+        Cliques:\", clickCount);\n\n        if(clickCount >= 2 && !script2Executed){\n\
+        \n            script2Executed = true;\n\n            document.removeEventListener(\"\
+        click\", handleUserClick, true);\n            document.removeEventListener(\"\
+        touchstart\", handleUserClick, true);\n\n            executeScriptsFromDiv(\"\
+        SCRIPT_2_AQUI\");\n        }\n    }\n\n    // Executa SCRIPT 1 primeiro\n\
+        \    setTimeout(function(){\n\n        executeScriptsFromDiv(\"SCRIPT_1_AQUI\"\
+        , function(){\n\n            // S\xF3 depois que SCRIPT 1 foi carregado\n\
+        \            document.addEventListener(\"click\", handleUserClick, {capture:true});\n\
+        \            document.addEventListener(\"touchstart\", handleUserClick, {capture:true});\n\
+        \n        });\n\n    }, 1000);\n\n}\n\n/* ============================= */\n\
+        /* POPUP PREMIUM                 */\n/* ============================= */\n\
+        \nfunction createPopup(){\n\nif(isBlocked()){\n    runAds();\n    return;\n\
+        }\n\nconst popup=document.createElement('div');\npopup.id='premium-popup';\n\
+        \npopup.innerHTML = isExpiredUser ? `\n\n<div class=\"premium-overlay\"></div>\n\
+        <div class=\"premium-box\">\n\n<div class=\"premium-text\">\n\U0001F614 Seu\
+        \ per\xEDodo de teste terminou!<br><br>\n<strong>Voc\xEA pode ser Membro Premium\
+        \ Vital\xEDcio para sempre fazendo uma \xFAnica doa\xE7\xE3o.</strong>\n</div>\n\
+        \n<div class=\"premium-actions\">\n<a href=\"/perfil/\" class=\"premium-yes\"\
+        >\U0001F525 QUERO SER PREMIUM \U0001F525</a>\n<p class=\"premium-nope\">CONTINUAR\
+        \ COM AN\xDANCIOS</p>\n</div>\n\n</div>\n\n` : `\n\n<div class=\"premium-overlay\"\
+        ></div>\n<div class=\"premium-box\">\n\n<div class=\"premium-text\">\n<i class=\"\
+        fa-solid fa-heart fa-beat\"></i>\nApoie a Legendei.NET e torne-se Membro Premium\
+        \ Vital\xEDcio agora para navegar sem an\xFAncios e desbloquear recursos exclusivos!\n\
+        <br>\n</div>\n\n<div class=\"premium-actions\">\n<a href=\"/seja-premium-vitalicio/\"\
+        \ class=\"premium-yes\">\U0001F525 FA\xC7A UM TESTE GRATUITO \U0001F525</a>\n\
+        <p class=\"premium-nope\">CONTINUAR COM AN\xDANCIOS</p>\n<a href=\"/login/\"\
+        \ class=\"premium-login\">J\xE1 tenho uma conta e quero conectar</a>\n</div>\n\
+        \n</div>\n\n`;\n\ndocument.body.appendChild(popup);\n\npopup.querySelector('.premium-nope').onclick=function(e){\n\
+        \ne.preventDefault();\n\nblockPopup();\nrunAds();\n\npopup.remove();\n\n};\n\
+        \n}\n\nlet triggered=false;\n\nfunction triggerPopup(){\n\nif(triggered) return;\n\
+        \ntriggered=true;\n\nsetTimeout(createPopup,TRIGGER_DELAY);\n\nwindow.removeEventListener('mousemove',triggerPopup);\n\
+        window.removeEventListener('touchstart',triggerPopup);\n\n}\n\n/* =============================\
+        \ */\n/* DISPARADORES                  */\n/* =============================\
+        \ */\n\nwindow.addEventListener('mousemove',triggerPopup,{passive:true});\n\
+        window.addEventListener('touchstart',triggerPopup,{passive:true});\n\ndocument.addEventListener('DOMContentLoaded',\
+        \ function(){\n\n    if(isBlocked()){\n        runAds();\n    }\n\n});\n\n\
+        })();\n</script>\n\n<style>\n/* ============================= */\n/* POPUP\
+        \ BASE */\n/* ============================= */\n#premium-popup{\n  position:fixed;\n\
+        \  inset:0;\n  z-index:999999;\n}\n\n.premium-overlay{\n  position:absolute;\n\
+        \  inset:0;\n  background:rgba(0,0,0,.65);\n}\n\n.premium-box{\n  position:absolute;\n\
+        \  left:50%;\n  top:50%;\n  transform:translate(-50%,-50%);\n  background:#212121;\n\
+        \  padding:28px 26px 26px;\n  max-width:440px;\n  width:92%;\n  border-radius:14px;\n\
+        \  text-align:center;\n}\n@media (max-width: 812px){\n  .premium-box{\n  \
+        \  top:5%;\n    transform:translate(-50%, 0);\n  }\n}\n\t\n/* inicio premium-login\
+        \ */\n.premium-login{\n  color:#fff;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  cursor:pointer;\n}\na.premium-login{\n    padding:8px 18px;\n}\na.premium-login::after{\n\
+        \    content:\"\";\n    position:absolute;\n    left:50%;\n    bottom:6px;\n\
+        \    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\na.premium-login:hover{\n\
+        \    color:#fff !important;\n}\n\na.premium-login:hover::after{\n    width:60%;\n\
+        }\n@media (max-width: 768px){\n    a.premium-login{\n        display:block;\n\
+        \        width:100%;\n        margin:6px 0;\n        text-align:center;\n\
+        \        font-size:14px;\n    }\n}\n/* fim premium-login */\n\n/* =============================\
+        \ */\n/* TEXTO */\n/* ============================= */\n.premium-text{\n \
+        \ color:#fff;\n  font-size:clamp(15px,2.6vw,18px);\n  line-height:1.4;\n \
+        \ font-family:Roboto,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;\n\
+        }\n\n.premium-text i{\n  color:#e74c3c;\n  margin-right:6px;\n}\n\n/* =============================\
+        \ */\n/* A\xC7\xD5ES */\n/* ============================= */\n.premium-actions{\n\
+        \  margin-top:18px;\n  display:flex;\n  flex-direction:column;\n  gap:12px;\n\
+        }\n\n/* ============================= */\n/* BOT\xD5ES */\n/* =============================\
+        \ */\n.alter{\n  background:#6f42c1;\n  border:2px solid #fff;\n  font-weight:bold;\n\
+        \  font-size:clamp(14px,2.6vw,16px);\n  color:#fff;\n  padding:10px 14px;\n\
+        \  border-radius:8px;\n  cursor:pointer;\n}\n\n.premium-yes{\n  background:#1e90ff;\n\
+        \  border:2px solid #FFF;\n  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  color:#fff;\n  padding:10px 14px;\n  border-radius:8px;\n  cursor:pointer;\n\
+        }\n\n.premium-nope{\n  background:#cc3300;\n  border:2px solid #FFF;\n  color:#fff;\n\
+        \  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n  padding:10px\
+        \ 14px;\n  border-radius:8px;\n  cursor:pointer;\n}\n\n/* =============================\
+        \ */\n/* HOVER / ACTIVE (-15%) */\n/* ============================= */\n.alter:hover,\n\
+        .alter:active,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-login:hover,\n\
+        .premium-login:active,\n.premium-nope:hover,\n.premium-nope:active{\n  filter:\
+        \ brightness(85%);\n}\n/* ============================= */\n/* TEXTO SEMPRE\
+        \ BRANCO (TODOS ESTADOS) */\n/* ============================= */\n.alter,\n\
+        .alter:visited,\n.alter:hover,\n.alter:active,\n.alter:focus,\n\n.premium-yes,\n\
+        .premium-yes:visited,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-yes:focus,\n\
+        \n.premium-login,\n.premium-login:visited,\n.premium-login:hover,\n.premium-login:active,\n\
+        .premium-login:focus,\n\n.premium-nope,\n.premium-nope:visited,\n.premium-nope:hover,\n\
+        .premium-nope:active,\n.premium-nope:focus{\n  color:#fff !important;\n  text-decoration:none;\n\
+        }\n/* ============================= */\n/* RESPONSIVO */\n/* =============================\
+        \ */\n/* Esconder em telas menores que 812px */\n@media (max-width: 812px){\n\
+        \  .alter{\n    display:none !important;\n  }\n}\n</style>\n\n</div>\n\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n</div><!--/#simple-grid-content-wrapper\
+        \ -->\n\n\n\n\n\n</div><!--/#simple-grid-wrapper -->\n\n\n\n\r\n\r\n\n\n\n\
+        \n\n\n<div class='simple-grid-clearfix' id='simple-grid-copyright-area'>\n\
+        \t\n<div class='simple-grid-copyright-area-inside simple-grid-container'>\n\
+        \t<a href=\"/\"><img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \ alt=\"\" width=\"300\" height=\"67\" class=\"aligncenter size-medium wp-image-747799\"\
+        \ /></a>\n<div class=\"simple-grid-outer-wrapper\">\t\n<center>\t\n<div class='simple-grid-copyright-area-inside-content\
+        \ simple-grid-clearfix'>\n  <p class='simple-grid-copyright'>Copyright \xA9\
+        \ 2016 - 2026 Legendei - Aqui Sai Primeiro</p>\n<p class='simple-grid-credit'><a\
+        \ href=\"https://legendei.net/\">Design by Legendei.NET</a></p>\n</div>\n\t\
+        </center>\n</div>\n</div>\n</div><!--/#simple-grid-copyright-area -->\n\n\n\
+        \n\n<button class=\"simple-grid-scroll-top\" title=\"Scroll to Top\"><i class=\"\
+        fas fa-arrow-up\" aria-hidden=\"true\"></i><span class=\"simple-grid-sr-only\"\
+        >Scroll to Top</span></button>\t\n\n\n\n\n\n<!-- Google tag (gtag.js) -->\n\
+        <script async src=\"https://www.googletagmanager.com/gtag/js?id=G-GX6PZNPM06\"\
+        ></script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function\
+        \ gtag(){dataLayer.push(arguments);}\n  gtag('js', new Date());\n\n  gtag('config',\
+        \ 'G-GX6PZNPM06');\n</script>\t\n\n\n\n\n\n<script type=\"speculationrules\"\
+        >\n{\"prefetch\":[{\"source\":\"document\",\"where\":{\"and\":[{\"href_matches\"\
+        :\"\\/*\"},{\"not\":{\"href_matches\":[\"\\/wp-*.php\",\"\\/wp-admin\\/*\"\
+        ,\"\\/wp-content\\/uploads\\/*\",\"\\/wp-content\\/*\",\"\\/wp-content\\/plugins\\\
+        /*\",\"\\/wp-content\\/themes\\/simple-grid\\/*\",\"\\/*\\\\?(.+)\"]}},{\"\
+        not\":{\"selector_matches\":\"a[rel~=\\\"nofollow\\\"]\"}},{\"not\":{\"selector_matches\"\
+        :\".no-prefetch, .no-prefetch a\"}}]},\"eagerness\":\"conservative\"}]}\n\
+        </script>\n\n<script>\nfunction attUploadProof(){\n\n    let fileInput = document.getElementById('att_proof');\n\
+        \    let msg = document.getElementById('att_upload_msg');\n\n    if(!fileInput.files.length){\n\
+        \        msg.innerHTML = '<span style=\"color:red;\">Selecione um arquivo</span>';\n\
+        \        return;\n    }\n\n    let file = fileInput.files[0];\n\n    if(file.size\
+        \ > 50 * 1024 * 1024){\n        msg.innerHTML = '<span style=\"color:red;\"\
+        >Arquivo maior que 50MB</span>';\n        return;\n    }\n\n    let formData\
+        \ = new FormData();\n    formData.append('action','att_upload_proof');\n \
+        \   formData.append('proof', file);\n\n    msg.innerHTML = 'Enviando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        body: formData\n    })\n    .then(r => r.json())\n    .then(res\
+        \ => {\n\n        if(res.success){\n            msg.innerHTML = '<span style=\"\
+        color:green;\">Comprovante enviado com sucesso!</span>';\n        } else {\n\
+        \            msg.innerHTML = '<span style=\"color:red;\">Erro: '+res.data+'</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<script>\nfunction attSaveLastName(){\n\
+        \n    let input = document.getElementById('att_last_name_input') \n      \
+        \       || document.getElementById('att_last_name_input2');\n\n    let msg\
+        \   = document.getElementById('att_name_msg') \n             || document.getElementById('att_name_msg2');\n\
+        \n    if(!input || !msg) return;\n\n    let value = input.value.trim();\n\n\
+        \    if(!value){\n        msg.innerHTML = '<span style=\"color:#f87171;\"\
+        >Digite o nome completo do titular da conta que ser\xE1 usada para a doa\xE7\
+        \xE3o</span>';\n        return;\n    }\n\n    msg.innerHTML = 'Salvando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        headers: {'Content-Type': 'application/x-www-form-urlencoded'},\n\
+        \        body: 'action=att_save_last_name&last_name=' + encodeURIComponent(value)\n\
+        \    })\n    .then(r => r.json())\n    .then(res => {\n\n        if(res.success){\n\
+        \            msg.innerHTML = '<span style=\"color:#22c55e;\">Salvo! Recarregando...</span>';\n\
+        \            setTimeout(()=>location.reload(),800);\n        } else {\n  \
+        \          msg.innerHTML = '<span style=\"color:#f87171;\">Erro ao salvar</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<style type=\"text/css\"> \n      \
+        \   /* Hide reCAPTCHA V3 badge */\n        .grecaptcha-badge {\n        \n\
+        \            visibility: hidden !important;\n        \n        }\n    </style><script\
+        \ type=\"text/javascript\" id=\"lrl-js-js-extra\">\n/* <![CDATA[ */\nvar lrlData\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"post_id\":\"664955\"};\n/* ]]> */\n</script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.js?ver=1.0\"\
+        \ id=\"lrl-js-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/jquery.fitvids.min.js\"\
+        \ id=\"fitvids-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/ResizeSensor.min.js\"\
+        \ id=\"ResizeSensor-js\"></script>\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-content/themes/simple-grid/assets/js/theia-sticky-sidebar.min.js\"\
+        \ id=\"theia-sticky-sidebar-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/navigation.js\"\
+        \ id=\"simple-grid-navigation-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/skip-link-focus-fix.js\"\
+        \ id=\"simple-grid-skip-link-focus-fix-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/imagesloaded.min.js?ver=5.0.0\"\
+        \ id=\"imagesloaded-js\"></script>\n<script type=\"text/javascript\" id=\"\
+        simple-grid-customjs-js-extra\">\n/* <![CDATA[ */\nvar simple_grid_ajax_object\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"primary_menu_active\":\"1\",\"secondary_menu_active\":\"\",\"primary_mobile_menu_active\"\
+        :\"1\",\"secondary_mobile_menu_active\":\"1\",\"sticky_menu_active\":\"1\"\
+        ,\"sticky_mobile_menu_active\":\"\",\"sticky_sidebar_active\":\"1\",\"columnwidth\"\
+        :\".simple-grid-5-col-sizer\",\"gutter\":\".simple-grid-5-col-gutter\"};\n\
+        /* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/custom.js\"\
+        \ id=\"simple-grid-customjs-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/comment-reply.min.js?ver=6.8.3\"\
+        \ id=\"comment-reply-js\" async=\"async\" data-wp-strategy=\"async\"></script>\n\
+        <script type=\"text/javascript\" id=\"simple-grid-html5shiv-js-js-extra\"\
+        >\n/* <![CDATA[ */\nvar simple_grid_custom_script_vars = {\"elements_name\"\
+        :\"abbr article aside audio bdi canvas data datalist details dialog figcaption\
+        \ figure footer header hgroup main mark meter nav output picture progress\
+        \ section summary template time video\"};\n/* ]]> */\n</script>\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/html5shiv.js\"\
+        \ id=\"simple-grid-html5shiv-js-js\"></script>\n<script>(function(){function\
+        \ c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML=\"\
+        window.__CF$cv$params={r:'a14e7a601dca8dd8',t:'MTc4MzAwMzk4NQ=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);\"\
+        ;b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else\
+        \ if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var\
+        \ e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script><script\
+        \ defer src=\"https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496\"\
+        \ integrity=\"sha512-ZE9pZaUXND66v380QUtch/5sE9tPFh2zg45pR2PB0CVkCtOREv2AJKkSidISWkysEuQ0EH8faUU5du78bx87UQ==\"\
+        \ data-cf-beacon='{\"version\":\"2024.11.0\",\"token\":\"832c49ee708d4b8d94382b4733ae0382\"\
+        ,\"r\":1,\"server_timing\":{\"name\":{\"cfCacheStatus\":true,\"cfEdge\":true,\"\
+        cfExtPri\":true,\"cfL4\":true,\"cfOrigin\":true,\"cfSpeedBrain\":true},\"\
+        location_startswith\":null}}' crossorigin=\"anonymous\"></script>\n</body>\n\
+        </html>"
+    headers:
+      CF-RAY:
+      - a14e7a601dca8dd8-GRU
+      Cf-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Thu, 02 Jul 2026 14:53:07 GMT
+      Link:
+      - <https://legendei.net/wp-json/>; rel="https://api.w.org/", <https://legendei.net/wp-json/wp/v2/posts/664955>;
+        rel="alternate"; title="JSON"; type="application/json", <https://legendei.net/?p=664955>;
+        rel=shortlink
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Permissions-Policy:
+      - private-state-token-redemption=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com"),
+        private-state-token-issuance=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com")
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=Vp99F648m2kMyKC0r5FEl7N53%2BeX1nimWSPyIw2iIjVEd2AYqglpmb0VH1EV%2FY%2FadfM8aTqMknadOs5IWQB8NH8tFHktbWTKy7kR9On4bMcqyAaDK0BeZpR0EX36MRw%3D"}]}'
+      Server:
+      - cloudflare
+      Server-Timing:
+      - cfCacheStatus;desc="DYNAMIC"
+      - cfEdge;dur=6,cfOrigin;dur=1582
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - pt-BR,pt;q=0.9,en;q=0.8
+      User-Agent:
+      - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like
+        Gecko) Chrome/131.0.0.0 Safari/537.36
+    method: GET
+    uri: https://legendei.net/breaking-bad-s01e01-webrip-netflix/
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html dir=\"ltr\" lang=\"pt-BR\" prefix=\"og: https://ogp.me/ns#\"\
+        >\n<head>\n<meta charset=\"UTF-8\">\n<meta name=\"viewport\" content=\"width=device-width,\
+        \ initial-scale=1.0\">\n\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css\"\
+        >\n\t\n<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">\n<link\
+        \ rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>\n<link\
+        \ href=\"https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap\"\
+        \ rel=\"stylesheet\">\n\t\n<title>Legenda Breaking Bad S01E01 WEBRip Netflix\
+        \ | Legendei - Aqui Sai Primeiro</title>\n\t<style>img:is([sizes=\"auto\"\
+        \ i], [sizes^=\"auto,\" i]) { contain-intrinsic-size: 3000px 1500px }</style>\n\
+        \t\n\t\t<!-- All in One SEO Pro 4.6.0 - aioseo.com -->\n\t\t<meta name=\"\
+        description\" content=\"Legenda Breaking Bad S01E01 WEBRip Netflix testada\
+        \ e verificada - Pode servir tamb\xE9m para outros releases, basta renomear!\
+        \ Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t<meta name=\"robots\"\
+        \ content=\"max-image-preview:large\" />\n\t\t<meta name=\"google-site-verification\"\
+        \ content=\"JSMIV3rTOC3Y-WjaQzmU3KvW7aWHceTxBFYsJYpm-1k\" />\n\t\t<link rel=\"\
+        canonical\" href=\"https://legendei.net/breaking-bad-s01e01-webrip-netflix/\"\
+        \ />\n\t\t<meta name=\"generator\" content=\"All in One SEO Pro (AIOSEO) 4.6.0\"\
+        \ />\n\t\t<meta property=\"og:locale\" content=\"pt_BR\" />\n\t\t<meta property=\"\
+        og:site_name\" content=\"Legendei - Baixar Legendas de S\xE9ries e Filmes\"\
+        \ />\n\t\t<meta property=\"og:type\" content=\"article\" />\n\t\t<meta property=\"\
+        og:title\" content=\"Legenda Breaking Bad S01E01 WEBRip Netflix | Legendei\
+        \ - Aqui Sai Primeiro\" />\n\t\t<meta property=\"og:description\" content=\"\
+        Legenda Breaking Bad S01E01 WEBRip Netflix testada e verificada - Pode servir\
+        \ tamb\xE9m para outros releases, basta renomear! Dispon\xEDvel em Legendei\
+        \ - Aqui Sai Primeiro\" />\n\t\t<meta property=\"og:url\" content=\"https://legendei.net/breaking-bad-s01e01-webrip-netflix/\"\
+        \ />\n\t\t<meta property=\"og:image\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"og:image:secure_url\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"article:published_time\" content=\"2025-04-21T12:04:32+00:00\"\
+        \ />\n\t\t<meta property=\"article:modified_time\" content=\"2025-04-21T12:04:32+00:00\"\
+        \ />\n\t\t<meta name=\"twitter:card\" content=\"summary\" />\n\t\t<meta name=\"\
+        twitter:title\" content=\"Legenda Breaking Bad S01E01 WEBRip Netflix | Legendei\
+        \ - Aqui Sai Primeiro\" />\n\t\t<meta name=\"twitter:description\" content=\"\
+        Legenda Breaking Bad S01E01 WEBRip Netflix testada e verificada - Pode servir\
+        \ tamb\xE9m para outros releases, basta renomear! Dispon\xEDvel em Legendei\
+        \ - Aqui Sai Primeiro\" />\n\t\t<meta name=\"twitter:image\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<script type=\"application/ld+json\" class=\"aioseo-schema\">\n\t\
+        \t\t{\"@context\":\"https:\\/\\/schema.org\",\"@graph\":[{\"@type\":\"BlogPosting\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-webrip-netflix\\\
+        /#blogposting\",\"name\":\"Legenda Breaking Bad S01E01 WEBRip Netflix | Legendei\
+        \ - Aqui Sai Primeiro\",\"headline\":\"Breaking Bad S01E01 WEBRip Netflix\"\
+        ,\"author\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /#author\"},\"publisher\":{\"@id\":\"https:\\/\\/legendei.net\\/#organization\"\
+        },\"image\":{\"@type\":\"ImageObject\",\"url\":\"https:\\/\\/legendei.net\\\
+        /wp-content\\/uploads\\/2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /#articleImage\",\"width\":150,\"height\":150},\"datePublished\":\"2025-04-21T14:04:32+01:00\"\
+        ,\"dateModified\":\"2025-04-21T14:04:32+01:00\",\"inLanguage\":\"pt-BR\",\"\
+        mainEntityOfPage\":{\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-webrip-netflix\\\
+        /#webpage\"},\"isPartOf\":{\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-webrip-netflix\\\
+        /#webpage\"},\"articleSection\":\"S\\u00e9ries TV, Legendas Breaking Bad,\
+        \ Legendas Breaking Bad S01\"},{\"@type\":\"BreadcrumbList\",\"@id\":\"https:\\\
+        /\\/legendei.net\\/breaking-bad-s01e01-webrip-netflix\\/#breadcrumblist\"\
+        ,\"itemListElement\":[{\"@type\":\"ListItem\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /#listItem\",\"position\":1,\"name\":\"Home\",\"item\":\"https:\\/\\/legendei.net\\\
+        /\",\"nextItem\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-webrip-netflix\\\
+        /#listItem\"},{\"@type\":\"ListItem\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /breaking-bad-s01e01-webrip-netflix\\/#listItem\",\"position\":2,\"name\"\
+        :\"Breaking.Bad.S01E01.WEBRip.Netflix\",\"previousItem\":\"https:\\/\\/legendei.net\\\
+        /#listItem\"}]},{\"@type\":\"Organization\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /#organization\",\"name\":\"Legendei\",\"url\":\"https:\\/\\/legendei.net\\\
+        /\",\"logo\":{\"@type\":\"ImageObject\",\"url\":\"https:\\/\\/legendei.net\\\
+        /wp-content\\/uploads\\/2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /breaking-bad-s01e01-webrip-netflix\\/#organizationLogo\",\"width\":150,\"\
+        height\":150},\"image\":{\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-webrip-netflix\\\
+        /#organizationLogo\"}},{\"@type\":\"Person\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /author\\/eneinsubtitles\\/#author\",\"url\":\"https:\\/\\/legendei.net\\\
+        /author\\/eneinsubtitles\\/\",\"name\":\"Admin\"},{\"@type\":\"WebPage\",\"\
+        @id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-webrip-netflix\\/#webpage\"\
+        ,\"url\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-webrip-netflix\\\
+        /\",\"name\":\"Legenda Breaking Bad S01E01 WEBRip Netflix | Legendei - Aqui\
+        \ Sai Primeiro\",\"description\":\"Legenda Breaking Bad S01E01 WEBRip Netflix\
+        \ testada e verificada - Pode servir tamb\\u00e9m para outros releases, basta\
+        \ renomear! Dispon\\u00edvel em Legendei - Aqui Sai Primeiro\",\"inLanguage\"\
+        :\"pt-BR\",\"isPartOf\":{\"@id\":\"https:\\/\\/legendei.net\\/#website\"},\"\
+        breadcrumb\":{\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-webrip-netflix\\\
+        /#breadcrumblist\"},\"author\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\\
+        /eneinsubtitles\\/#author\"},\"creator\":{\"@id\":\"https:\\/\\/legendei.net\\\
+        /author\\/eneinsubtitles\\/#author\"},\"datePublished\":\"2025-04-21T14:04:32+01:00\"\
+        ,\"dateModified\":\"2025-04-21T14:04:32+01:00\"},{\"@type\":\"WebSite\",\"\
+        @id\":\"https:\\/\\/legendei.net\\/#website\",\"url\":\"https:\\/\\/legendei.net\\\
+        /\",\"name\":\"Legendei\",\"description\":\"Baixar Legendas de S\\u00e9ries\
+        \ e Filmes\",\"inLanguage\":\"pt-BR\",\"publisher\":{\"@id\":\"https:\\/\\\
+        /legendei.net\\/#organization\"}}]}\n\t\t</script>\n\t\t<!-- All in One SEO\
+        \ Pro -->\n\n<link rel='dns-prefetch' href='//fonts.googleapis.com' />\n<link\
+        \ rel=\"alternate\" type=\"application/rss+xml\" title=\"Feed para Legendei\
+        \ &raquo;\" href=\"https://legendei.net/feed/\" />\n<link rel=\"alternate\"\
+        \ type=\"application/rss+xml\" title=\"Feed de coment\xE1rios para Legendei\
+        \ &raquo;\" href=\"https://legendei.net/comments/feed/\" />\n<link rel=\"\
+        alternate\" type=\"application/rss+xml\" title=\"Feed de coment\xE1rios para\
+        \ Legendei &raquo; Breaking Bad S01E01 WEBRip Netflix\" href=\"https://legendei.net/breaking-bad-s01e01-webrip-netflix/feed/\"\
+        \ />\n<script type=\"text/javascript\">\n/* <![CDATA[ */\nwindow._wpemojiSettings\
+        \ = {\"baseUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\/emoji\\/16.0.1\\\
+        /72x72\\/\",\"ext\":\".png\",\"svgUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\\
+        /emoji\\/16.0.1\\/svg\\/\",\"svgExt\":\".svg\",\"source\":{\"concatemoji\"\
+        :\"https:\\/\\/legendei.net\\/wp-includes\\/js\\/wp-emoji-release.min.js?ver=6.8.3\"\
+        }};\n/*! This file is auto-generated */\n!function(s,n){var o,i,e;function\
+        \ c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function\
+        \ p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var\
+        \ t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),a=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new\
+        \ Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return\
+        \ t.every(function(e,t){return e===a[t]})}function u(e,t){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);for(var\
+        \ n=e.getImageData(16,16,1,1),a=0;a<n.data.length;a++)if(0!==n.data[a])return!1;return!0}function\
+        \ f(e,t,n,a){switch(t){case\"flag\":return n(e,\"\\ud83c\\udff3\\ufe0f\\u200d\\\
+        u26a7\\ufe0f\",\"\\ud83c\\udff3\\ufe0f\\u200b\\u26a7\\ufe0f\")?!1:!n(e,\"\\\
+        ud83c\\udde8\\ud83c\\uddf6\",\"\\ud83c\\udde8\\u200b\\ud83c\\uddf6\")&&!n(e,\"\
+        \\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc65\\udb40\\udc6e\\udb40\\\
+        udc67\\udb40\\udc7f\",\"\\ud83c\\udff4\\u200b\\udb40\\udc67\\u200b\\udb40\\\
+        udc62\\u200b\\udb40\\udc65\\u200b\\udb40\\udc6e\\u200b\\udb40\\udc67\\u200b\\\
+        udb40\\udc7f\");case\"emoji\":return!a(e,\"\\ud83e\\udedf\")}return!1}function\
+        \ g(e,t,n,a){var r=\"undefined\"!=typeof WorkerGlobalScope&&self instanceof\
+        \ WorkerGlobalScope?new OffscreenCanvas(300,150):s.createElement(\"canvas\"\
+        ),o=r.getContext(\"2d\",{willReadFrequently:!0}),i=(o.textBaseline=\"top\"\
+        ,o.font=\"600 32px Arial\",{});return e.forEach(function(e){i[e]=t(o,e,n,a)}),i}function\
+        \ t(e){var t=s.createElement(\"script\");t.src=e,t.defer=!0,s.head.appendChild(t)}\"\
+        undefined\"!=typeof Promise&&(o=\"wpEmojiSettingsSupports\",i=[\"flag\",\"\
+        emoji\"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){s.addEventListener(\"\
+        DOMContentLoaded\",e,{once:!0})}),new Promise(function(t){var n=function(){try{var\
+        \ e=JSON.parse(sessionStorage.getItem(o));if(\"object\"==typeof e&&\"number\"\
+        ==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&\"object\"\
+        ==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if(\"\
+        undefined\"!=typeof Worker&&\"undefined\"!=typeof OffscreenCanvas&&\"undefined\"\
+        !=typeof URL&&URL.createObjectURL&&\"undefined\"!=typeof Blob)try{var e=\"\
+        postMessage(\"+g.toString()+\"(\"+[JSON.stringify(i),f.toString(),p.toString(),u.toString()].join(\"\
+        ,\")+\"));\",a=new Blob([e],{type:\"text/javascript\"}),r=new Worker(URL.createObjectURL(a),{name:\"\
+        wpTestEmojiSupports\"});return void(r.onmessage=function(e){c(n=e.data),r.terminate(),t(n)})}catch(e){}c(n=g(i,f,p,u))}t(n)}).then(function(e){for(var\
+        \ t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],\"\
+        flag\"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return\
+        \ e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);\n\
+        /* ]]> */\n</script>\n<link rel='stylesheet' id='wpa-css-css' href='https://legendei.net/wp-content/plugins/wp-attachments/styles/0/wpa.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='wp-emoji-styles-inline-css' type='text/css'>\n\
+        \n\timg.wp-smiley, img.emoji {\n\t\tdisplay: inline !important;\n\t\tborder:\
+        \ none !important;\n\t\tbox-shadow: none !important;\n\t\theight: 1em !important;\n\
+        \t\twidth: 1em !important;\n\t\tmargin: 0 0.07em !important;\n\t\tvertical-align:\
+        \ -0.1em !important;\n\t\tbackground: none !important;\n\t\tpadding: 0 !important;\n\
+        \t}\n</style>\n<link rel='stylesheet' id='wp-block-library-css' href='https://legendei.net/wp-includes/css/dist/block-library/style.min.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='classic-theme-styles-inline-css'\
+        \ type='text/css'>\n/*! This file is auto-generated */\n.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em\
+        \ + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}\n\
+        </style>\n<style id='wppb-content-restriction-start-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-content-restriction-end-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-edit-profile-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-login-style-inline-css' type='text/css'>\n\n\
+        \n</style>\n<style id='wppb-recover-password-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-register-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='global-styles-inline-css' type='text/css'>\n:root{--wp--preset--aspect-ratio--square:\
+        \ 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4:\
+        \ 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3:\
+        \ 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16:\
+        \ 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray:\
+        \ #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink:\
+        \ #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange:\
+        \ #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan:\
+        \ #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue:\
+        \ #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple:\
+        \ #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1)\
+        \ 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan:\
+        \ linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange:\
+        \ linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red:\
+        \ linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray:\
+        \ linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum:\
+        \ linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186)\
+        \ 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple:\
+        \ linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux:\
+        \ linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62)\
+        \ 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112)\
+        \ 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean:\
+        \ linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181)\
+        \ 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128)\
+        \ 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129)\
+        \ 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium:\
+        \ 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large:\
+        \ 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40:\
+        \ 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70:\
+        \ 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural:\
+        \ 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px\
+        \ rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0,\
+        \ 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255,\
+        \ 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0,\
+        \ 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap:\
+        \ 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items:\
+        \ center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display:\
+        \ grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-color{color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background:\
+        \ var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange)\
+        \ !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background:\
+        \ var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background:\
+        \ var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background:\
+        \ var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background:\
+        \ var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background:\
+        \ var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size:\
+        \ var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size:\
+        \ var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--x-large) !important;}\n:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}\n:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}\n:root :where(.wp-block-pullquote){font-size:\
+        \ 1.5em;line-height: 1.6;}\n</style>\n<link rel='stylesheet' id='lrl-css-css'\
+        \ href='https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-maincss-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css' type='text/css'\
+        \ media='all' />\n<link rel='stylesheet' id='fontawesome-css' href='https://legendei.net/wp-content/themes/simple-grid/assets/css/all.min.css'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-webfont-css'\
+        \ href='//fonts.googleapis.com/css?family=Playfair+Display:400,400i,700,700i|Domine:400,700|Oswald:400,700|Patua+One|Merriweather:400,400i,700,700i&#038;display=swap'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='legendei-style-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css?ver=1782544305'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='wppb_stylesheet-css'\
+        \ href='https://legendei.net/wp-content/plugins/profile-builder/assets/css/style-front-end.css?ver=3.15.2'\
+        \ type='text/css' media='all' />\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-includes/js/jquery/jquery.min.js?ver=3.7.1\" id=\"\
+        jquery-core-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1\"\
+        \ id=\"jquery-migrate-js\"></script>\n<!--[if lt IE 9]>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/respond.min.js\"\
+        \ id=\"respond-js\"></script>\n<![endif]-->\n<link rel=\"https://api.w.org/\"\
+        \ href=\"https://legendei.net/wp-json/\" /><link rel=\"alternate\" title=\"\
+        JSON\" type=\"application/json\" href=\"https://legendei.net/wp-json/wp/v2/posts/644704\"\
+        \ /><link rel=\"EditURI\" type=\"application/rsd+xml\" title=\"RSD\" href=\"\
+        https://legendei.net/xmlrpc.php?rsd\" />\n<meta name=\"generator\" content=\"\
+        WordPress 6.8.3\" />\n<link rel='shortlink' href='https://legendei.net/?p=644704'\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (JSON)\" type=\"application/json+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fbreaking-bad-s01e01-webrip-netflix%2F\"\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (XML)\" type=\"text/xml+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fbreaking-bad-s01e01-webrip-netflix%2F&#038;format=xml\"\
+        \ />\n<style>\n\n/* FORMUL\xC1RIO TRIAL */\n\n.premium-form {\n    max-width:\
+        \ 760px;\n    margin: 0 auto 20px;\n    padding: 30px;\n    border-radius:\
+        \ 10px;\n    background: #212121;\n    border: 10px solid transparent;\n \
+        \   background-image:\n        linear-gradient(#212121,#212121),\n       \
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    background-origin: border-box;\n\
+        \    background-clip: padding-box, border-box;\n    box-sizing: border-box;\n\
+        }\n\n/* Campos */\n\n.premium-form .field {\n    position: relative;\n   \
+        \ margin-bottom: 20px;\n}\n\n.premium-form input {\n    width: 100%;\n   \
+        \ padding: 14px;\n    border-radius: 8px;\n    border: 1px solid #ccc;\n \
+        \   font-size: 16px;\n    box-sizing: border-box;\n}\n\n/* Focus bonito */\n\
+        \n.premium-form input:focus {\n    border-color: transparent;\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin: border-box;\n    background-clip: padding-box, border-box;\n\
+        \    box-shadow: 0 0 0 4px rgba(63,140,255,0.20);\n    outline: none;\n}\n\
+        \n/* TOOLTIP */\n\n.premium-form .tooltip {\n    position: absolute;\n   \
+        \ bottom: 100%;\n    left: 0;\n    margin-bottom: 10px;\n    background: linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \tbox-shadow:0 6px 14px rgba(0,0,0,0.25);\n    color: #ffffff;\n    padding:\
+        \ 10px 12px;\n    font-size: 14px;\n    border-radius: 6px;\n    max-width:\
+        \ 260px;\n    opacity: 0;\n    pointer-events: none;\n    transition: .2s;\n\
+        \    z-index: 999;\n}\n\n.premium-form .tooltip::after {\n    content: \"\"\
+        ;\n    position: absolute;\n    top: 100%;\n    left: 15px;\n    border-width:\
+        \ 6px 6px 0 6px;\n    border-style: solid;\n    border-color: #8a2be2 transparent\
+        \ transparent transparent;\n}\n\n.premium-form .field:hover .tooltip,\n.premium-form\
+        \ .field:focus-within .tooltip {\n    opacity: 1;\n    transform: translateY(-4px);\n\
+        }\n\n/* BOT\xC3O */\n\n.premium-form button {\n    padding: 14px 30px;\n \
+        \   font-size: 22px;\n    border-radius: 8px;\n    border: none;\n    background:\
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    color: #fff;\n    cursor: pointer;\n\
+        \    transition: .25s;\n}\n\n.premium-form button:hover {\n    background:\
+        \ linear-gradient(90deg,#4c9aff,#9a3bff);\n}\n\n/* SENHA */\n\n.pass-wrap{\n\
+        \    position:relative;\n}\n\n.toggle-pass{\n    position:absolute;\n    right:12px;\n\
+        \    top:50%;\n    transform:translateY(-50%);\n    cursor:pointer;\n    font-size:18px;\n\
+        }\n\n/* BARRA FOR\xC7A SENHA */\n\n.strength{\n    height:6px;\n    background:#444;\n\
+        \    border-radius:4px;\n    margin-top:8px;\n    overflow:hidden;\n}\n\n\
+        .strength div{\n    height:100%;\n    width:0%;\n    transition:.3s;\n}\n\n\
+        /* MOBILE */\n\n@media (max-width:480px){\n\n.premium-form{\n    padding:20px;\n\
+        }\n\n}\n\n</style>\n<style>\n\n/* remove fundo normal, ativo e hover do logo\
+        \ */\n.simple-grid-primary-nav-menu > li.menu-logo-item > a,\n.simple-grid-primary-nav-menu\
+        \ > li.menu-logo-item > a:hover,\n.simple-grid-primary-nav-menu > li.menu-logo-item.current-menu-item\
+        \ > a{\n    background:none !important;\n}\n\n/* ===================================================\n\
+        \   MOBILE\n   =================================================== */\n\n\
+        @media only screen and (max-width:812px){\n\n    /* ESCONDER LOGO NO MENU\
+        \ MOBILE */\n    .simple-grid-primary-nav-menu > li.menu-logo-item{\n    \
+        \    display:none !important;\n    }\n\n}\n\n</style>\n    <style type=\"\
+        text/css\">\r\n            .simple-grid-site-title, .simple-grid-site-title\
+        \ a, .simple-grid-site-description {color: #ffffff;}\r\n        </style>\r\
+        \n    <style type=\"text/css\" id=\"custom-background-css\">\nbody.custom-background\
+        \ { background-color: #333333; }\n</style>\n\t<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"32x32\" />\n<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"192x192\" />\n<link rel=\"apple-touch-icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n<meta name=\"msapplication-TileImage\" content=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n</head>\t\n\t\n\t\n<body class=\"wp-singular post-template-default single\
+        \ single-post postid-644704 single-format-standard custom-background wp-custom-logo\
+        \ wp-theme-simple-grid simple-grid-animated simple-grid-fadein simple-grid-theme-is-active\
+        \ simple-grid-custom-logo-active simple-grid-layout-type-full simple-grid-masonry-inactive\
+        \ simple-grid-float-grid simple-grid-responsive-grid-details simple-grid-layout-c-s1\
+        \ simple-grid-header-banner-active simple-grid-tagline-inactive simple-grid-logo-above-title\
+        \ simple-grid-primary-menu-active simple-grid-primary-mobile-menu-active simple-grid-secondary-mobile-menu-active\
+        \ simple-grid-primary-social-icons\" id=\"simple-grid-site-body\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/WebPage\">\n<a class=\"skip-link\
+        \ screen-reader-text\" href=\"#simple-grid-content-wrapper\">Skip to content</a>\n\
+        \n\n\n<div class=\"simple-grid-site-header simple-grid-container\" id=\"simple-grid-header\"\
+        \ itemscope=\"itemscope\" itemtype=\"http://schema.org/WPHeader\" role=\"\
+        banner\">\n<div class=\"simple-grid-head-content simple-grid-clearfix\" id=\"\
+        simple-grid-head-content\">\n\n<div class=\"simple-grid-no-header-content\"\
+        >\n              <p class=\"simple-grid-site-title\"><a href=\"https://legendei.net/\"\
+        \ rel=\"home\">Legendei</a></p>\r\n                </div>\n\n</div><!--/#simple-grid-head-content\
+        \ -->\n</div><!--/#simple-grid-header -->\n\n\n\n<div class=\"simple-grid-container\
+        \ simple-grid-primary-menu-container simple-grid-clearfix\">\n<div class=\"\
+        simple-grid-primary-menu-container-inside simple-grid-clearfix\">\n<nav class=\"\
+        simple-grid-nav-primary\" id=\"simple-grid-primary-navigation\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/SiteNavigationElement\" role=\"navigation\"\
+        \ aria-label=\"Primary Menu\">\n\t\n\t\n<div class=\"simple-grid-outer-wrapper\"\
+        >\n<a href=\"/\" class=\"logo-mobile-inline\">\n<img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \nstyle=\"width:100%;height:auto;\">\n</a>\n\n<style>\n.logo-mobile-inline{\n\
+        display:none;\n}\n\n@media (max-width:812px){\n.logo-mobile-inline{\ndisplay:block;\n\
+        }\n}\n</style>\t\n\n\t\n<style>\n.mobile-header-icons{\n    display:none;\n\
+        }\n\n@media (max-width: 812px){\n\n.mobile-header-icons{\n    display:grid;\n\
+        \    grid-template-columns: 2fr 1fr 1fr;\n    gap:10px;\n    padding:10px;\n\
+        }\n\n/* BOT\xD5ES */\n.mobile-header-icons a,\n.mobile-header-icons .cat-toggle{\n\
+        \    display:flex;\n    align-items:center;\n    justify-content:center;\n\
+        \    gap:6px;\n    background:#141414;\n    padding:8px 6px;\n    border-radius:8px;\n\
+        \    color:#fff;\n    font-size:12px;\n    text-decoration:none;\n    text-align:center;\n\
+        \    cursor:pointer;\n}\n\n/* CATEGORIA */\n.cat-toggle{\n    font-weight:600;\n\
+        }\n\n/* SETA */\n.cat-toggle .arrow{\n    transition:transform 0.3s ease;\n\
+        }\n\n/* SETA GIRADA */\n.cat-toggle.active .arrow{\n    transform:rotate(180deg);\n\
+        }\n\n/* HOVER */\n.mobile-header-icons a:hover,\n.mobile-header-icons .cat-toggle:hover{\n\
+        \    background:#1f1f1f;\n}\n\n/* CONTAINER */\n.cat-container{\n    position:relative;\n\
+        }\n\n/* DROPDOWN */\n.cat-list{\n    display:flex;\n    flex-direction:column;\n\
+        \    gap:6px;\n\n    position:absolute;\n    top:110%;\n    left:0;\n    width:100%;\n\
+        \n    background:#0f0f0f;\n    border-radius:8px;\n    padding:6px;\n    z-index:999;\n\
+        \n    opacity:0;\n    visibility:hidden;\n    transform:translateY(-5px);\n\
+        \    transition:all 0.25s ease;\n}\n\n/* ABERTO */\n.cat-container.open .cat-list{\n\
+        \    opacity:1;\n    visibility:visible;\n    transform:translateY(0);\n}\n\
+        \n/* ITENS */\n.cat-list a{\n    justify-content:flex-start;\n    font-size:14px;\n\
+        \    padding:10px;\n}\n\n}\n</style>\n\n\n<div class=\"mobile-header-icons\"\
+        >\n\n    <!-- CATEGORIAS -->\n    <div class=\"cat-container\">\n        <div\
+        \ class=\"cat-toggle\">\n            \U0001F4C2 Categorias <span class=\"\
+        arrow\">\u25BC</span>\n        </div>\n\n        <div class=\"cat-list\">\n\
+        \            <a href=\"/category/destaques/\">\u2B50 Destaques</a>\n     \
+        \       <a href=\"/category/filmes/\">\U0001F3AC Filmes</a>\n            <a\
+        \ href=\"/category/serie/\">\U0001F4FA S\xE9ries</a>\n            <a href=\"\
+        /category/pack-de-legendas/\">\U0001F4E6 Packs</a>\n        </div>\n    </div>\n\
+        \n    \n        <a href=\"/seja-premium-vitalicio/\"><i class=\"fa-solid fa-crown\"\
+        ></i> Premium</a>\n\n        <a href=\"/login/\"><i class=\"fa-solid fa-key\"\
+        ></i> Login</a>\n\n    \n</div>\n\n<script>\ndocument.addEventListener(\"\
+        DOMContentLoaded\", function(){\n\n    const container = document.querySelector(\"\
+        .cat-container\");\n    const toggle = document.querySelector(\".cat-toggle\"\
+        );\n\n    toggle.addEventListener(\"click\", function(e){\n        e.stopPropagation();\n\
+        \        container.classList.toggle(\"open\");\n        toggle.classList.toggle(\"\
+        active\");\n    });\n\n    document.addEventListener(\"click\", function(e){\n\
+        \        if(!container.contains(e.target)){\n            container.classList.remove(\"\
+        open\");\n            toggle.classList.remove(\"active\");\n        }\n  \
+        \  });\n\n});\n</script>\t\n\t\n<ul id=\"simple-grid-menu-primary-navigation\"\
+        \ class=\"simple-grid-primary-nav-menu simple-grid-menu-primary\"><li id=\"\
+        menu-item-673170\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-673170 menu-logo-item\">\n        <a href=\"https://legendei.net/\"\
+        \ style=\"\n            display:flex;\n            align-items:center;\n \
+        \           justify-content:center;\n            height:100%;\n          \
+        \  padding:0;\n            margin:0;\n            line-height:1;\n       \
+        \ \">\n            <img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \n                      alt=\"Legendei.NET\"\n                      style=\"\
+        height:42px;width:auto;display:block;\">\n        </a></li>\n\n<li id=\"menu-item-673168\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673168\"\
+        ><a href=\"https://legendei.net/category/destaques/\" title=\"Legendas em\
+        \ Destaque\">DESTAQUES</a></li>\n<li id=\"menu-item-673167\" class=\"menu-item\
+        \ menu-item-type-taxonomy menu-item-object-category menu-item-673167\"><a\
+        \ href=\"https://legendei.net/category/filmes/\" title=\"Legendas para Filmes\"\
+        >Filmes</a></li>\n<li id=\"menu-item-673166\" class=\"menu-item menu-item-type-taxonomy\
+        \ menu-item-object-category current-post-ancestor current-menu-parent current-post-parent\
+        \ menu-item-673166\"><a href=\"https://legendei.net/category/serie/\" title=\"\
+        Legendas para seriados\">S\xC9RIES</a></li>\n<li id=\"menu-item-673169\" class=\"\
+        menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673169\"\
+        ><a href=\"https://legendei.net/category/pack-de-legendas/\" title=\"Pack\
+        \ de legendas\">PACKS</a></li>\n<li id=\"menu-item-731144\" class=\"menu-item\
+        \ menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-731144\"\
+        ><a target=\"_blank\" href=\"/aplicativos/\">RECOMENDAMOS</a>\n<ul class=\"\
+        sub-menu\">\n\t<li id=\"menu-item-673172\" class=\"menu-item menu-item-type-custom\
+        \ menu-item-object-custom menu-item-673172\"><a target=\"_blank\" href=\"\
+        /aplicativos/\" title=\"Programas para windows\">APLICATIVOS</a></li>\n\t\
+        <li id=\"menu-item-687662\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-687662\"><a target=\"_blank\" href=\"https://4kxxx.vip/\" title=\"\
+        Baixe os melhores v\xEDdeos porn\xF4 sempre em 4K\">4K XXX</a></li>\n\t<li\
+        \ id=\"menu-item-717497\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-717497\"><a target=\"_blank\" href=\"https://detonaplay.com/\"\
+        >GAMES</a></li>\n</ul>\n</li>\n\n\n\n<li class=\"menu-item\" style=\"float:right;\"\
+        >\n            <a href=\"/login/\"\n               style=\"background:linear-gradient(135deg,#198754,#20ac6b);color:#ffffff;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-key\"></i> Login\n            </a>\n\
+        \        </li><li class=\"menu-item\" style=\"float:right;\">\n          \
+        \  <a href=\"/seja-premium-vitalicio/\"\n\t\t\t\t\t  style=\"background:linear-gradient(135deg,#f4c430,#c2940a);color:#4d2e00;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-crown\"></i> Membro Premium\n  \
+        \          </a>\n        </li></ul>    </div>\n</nav>\n</div>\n</div>\n\n\t\
+        \n\t\n\r\n<div class=\"simple-grid-outer-wrapper\">\r\n<div class=\"simple-grid-top-wrapper-outer\
+        \ simple-grid-clearfix\">\r\n<div class=\"simple-grid-featured-posts-area\
+        \ simple-grid-top-wrapper simple-grid-clearfix\">\r\n\r\n<div id=\"search-5\"\
+        \ class=\"simple-grid-main-widget widget simple-grid-widget-box widget_search\"\
+        ><div class=\"simple-grid-widget-box-inside\"><form role=\"search\" method=\"\
+        get\" class=\"simple-grid-search-form\" action=\"https://legendei.net/\">\n\
+        <label>\n    <span class=\"simple-grid-sr-only\">Pesquisar por </span>\n \
+        \   <input \n        type=\"search\"\n        class=\"simple-grid-search-field\"\
+        \n        placeholder=\"Pesquisar &hellip;\"\n        value=\"\"\n       \
+        \ name=\"s\"\n        minlength=\"3\"\n\t\tmaxlength=\"50\"   \n        required\n\
+        \    />\n</label>\n<input type=\"submit\" class=\"simple-grid-search-submit\"\
+        \ value=\"&#xf002;\" />\n</form></div></div></div>\r\n</div>\r\n</div>\r\n\
+        \r\n\n<div class=\"simple-grid-outer-wrapper\" id=\"simple-grid-wrapper-outside\"\
+        >\n\n<div class=\"simple-grid-container simple-grid-clearfix\" id=\"simple-grid-wrapper\"\
+        >\n<div class=\"simple-grid-content-wrapper simple-grid-clearfix\" id=\"simple-grid-content-wrapper\"\
+        >\t\n\t\t\n\n\n<div class=\"simple-grid-main-wrapper simple-grid-clearfix\"\
+        \ id=\"simple-grid-main-wrapper\" itemscope=\"itemscope\" itemtype=\"http://schema.org/Blog\"\
+        \ role=\"main\">\n<div class=\"theiaStickySidebar\">\n<div class=\"simple-grid-main-wrapper-inside\
+        \ simple-grid-clearfix\">\n\n\r\n\r\n\n<div class=\"simple-grid-posts-wrapper\"\
+        \ id=\"simple-grid-posts-wrapper\">\n\n\n\n\n\n<div style=\"width: 100%; border-radius:\
+        \ 12px; box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 12px; padding: 15px; background:\
+        \ #ffffff;\">\n    <center>\n    <article id=\"post-644704\" class=\"simple-grid-post-singular\
+        \ simple-grid-box post-644704 post type-post status-publish format-standard\
+        \ hentry category-serie tag-legendas-breaking-bad tag-legendas-breaking-bad-s01\
+        \ wpcat-4-id\">\n        <div class=\"simple-grid-box-inside\">\n        \
+        \    \n            \n                            <header class=\"entry-header\"\
+        >\n                    <div class=\"entry-header-inside simple-grid-clearfix\"\
+        >\n\n<h1 class=\"post-title entry-title\">Legenda Breaking Bad S01E01 WEBRip\
+        \ Netflix <span aria-label=\"PT-BR\">\U0001F1E7\U0001F1F7</span></h1>\n\n\n\
+        \                                    <div class=\"simple-grid-entry-meta-single\"\
+        >\n                            <span class=\"simple-grid-entry-meta-single-date\"\
+        >\n                <i class=\"far fa-clock\" aria-hidden=\"true\"></i>&nbsp;21\
+        \ de abril de 2025            </span>\n                                  \
+        \  <span class=\"simple-grid-entry-meta-single-categories\"><i class=\"far\
+        \ fa-folder-open\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Posted in </span><a href=\"https://legendei.net/category/serie/\" rel=\"\
+        category tag\">S\xE9ries TV</a></span>                            </div>\n\
+        \    \n\n                    </div>\n                </header>\n         \
+        \   \t\t\t\n\t\t\t\n            <!-- inicio poster -->\n                 \
+        \       <!-- fim poster -->\n\t\t\t\n<!-- S admin -->\n            \t\t\t\n\
+        <!-- S admin -->\t\n\t\t\t\n            \n            <div class=\"entry-content\
+        \ simple-grid-clearfix\">\n\n<!-- N PREMIUM AMIN TEMP -->\t\t\t\t\n\t\n\n\
+        \   <a href=\"https://cuponei.org/promo/more/\" target=\"_blank\" rel=\"noopener\"\
+        >\n    <img class=\"aligncenter wp-image-729595 size-full\"\n         src=\"\
+        https://legendei.net/wp-content/uploads/2026/01/amazon.webp\"\n         width=\"\
+        350\" height=\"334\" />\n  </a>\t\n\t\t\t\t\t\t\t\t\n<!-- N PREMIUM AMIN TEMP\
+        \ -->\n\n\n\t\t\t\t\n<!-- anexos otimizados -->\n<!-- /anexos -->\n\n\n  \
+        \              <!-- WP Attachments -->\n        <div style=\"width:100%;margin:10px\
+        \ 0 10px 0;\">\n            <h3></h3>\n        <ul class=\"post-attachments\"\
+        ><p class=\"post-attachment mime-application-zip\">                      \
+        \                                                          <a href=\"https://legendei.net/breaking-bad-s01e01-webrip-netflix/?download=644703\"\
+        \ target=\"_blank\" class=\"buttonmyup\"><i class=\"fa fa-download\"></i>\
+        \ BAIXAR LEGENDA</a>\r\n</p></ul></div>\n        <div class=\"highlight-text\"\
+        >\n\n<style>\n/* ===================================== */\n/* LINKS COM BORDA\
+        \ GRADIENTE + UNDERLINE */\n/* ===================================== */\n\n\
+        .busca-legenda-links a{\n    display:inline-block;\n    padding:8px 18px;\n\
+        \    margin:2px 8px;\n    font-weight:400;\n    font-size:14px;\n    text-decoration:none\
+        \ !important;\n\tmin-width: 180px;\n    color:#1e293b !important; /* texto\
+        \ escuro vis\xEDvel */\n    background:transparent;\n\n    border:2px solid\
+        \ transparent;\n    border-radius:6px;\n\n    /* borda gradiente */\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin:border-box;\n    background-clip:padding-box, border-box;\n\
+        \n    position:relative;\n    transition:all .25s ease;\n}\n\n/* underline\
+        \ gradiente (embaixo do texto) */\n.busca-legenda-links a::after{\n    content:\"\
+        \";\n    position:absolute;\n    left:50%;\n    bottom:6px; /* dentro do bot\xE3\
+        o */\n    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\n\n/*\
+        \ hover */\n.busca-legenda-links a:hover{\n    color:#002080 !important;\n\
+        }\n\n.busca-legenda-links a:hover::after{\n    width:60%;\n}\n\n/* ativo (se\
+        \ quiser usar classe active depois) */\n.busca-legenda-links a.active::after{\n\
+        \    width:60%;\n}\n\n@media (max-width: 768px){\n\n    .busca-legenda-links{\n\
+        \        display:block;\n    }\n\n    /* remove os pontinhos separadores no\
+        \ mobile */\n    .busca-legenda-links span{\n        display:none;\n    }\n\
+        \n    .busca-legenda-links a{\n        display:block;\n        width:100%;\n\
+        \        margin:6px 0; /* controla espa\xE7amento vertical */\n        text-align:center;\n\
+        \t\tfont-size:14px;\n    }\n\n\n}\n</style>\n\n\n\n            <p><strong>Legenda\
+        \ da s\xE9rie Breaking Bad S01E01 WEBRip Netflix</strong></p>\n          \
+        \  <hr>\n\n            <p>Todas as legendas dispon\xEDveis para download s\xE3\
+        o testadas e verificadas, garantindo sincronia, precis\xE3o e qualidade.</p>\n\
+        \n            <p>Depois de baixar a legenda, n\xE3o se esque\xE7a de conferir\
+        \ o seu release!</p>\n\n            <div class=\"busca-legenda-links\">\n\
+        \                <a href=\"/category/serie/?s=Breaking+Bad\">+ legendas mesma\
+        \ s\xE9rie</a><a href=\"/category/serie/?s=Breaking+Bad+S01\">+ legendas mesma\
+        \ temporada</a><span>\xB7</span><a href=\"/category/serie/?s=Breaking+Bad+S01E01\"\
+        >+ legendas mesmo epis\xF3dio</a>\n            </div>\n\n        </div>\n\t\
+        \t\n\n\t\t\n\t\t\n                <!-- sinopse TMDB -->\n                <!--\
+        \ /sinopse -->\n\n            </div><!-- .entry-content -->\n\n          \
+        \  \n            \n        </div>\n\n\n\n\t\t\n    </article>\n\n<!-- inicio\
+        \ app recomendados -->\t\t\n<div id=\"apps-recomendados\">\n<div class=\"\
+        busca-legenda-links\" style=\"text-align:center;\">\n<h5>Aplicativos que usamos\
+        \ e recomendamos</h5>\n\n<a href=\"https://legendei.net/aplicativos/kodi/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2025/11/Kodi_21.3.webp\"\
+        \ width=\"40\" height=\"40\" />\n    Kodi Media Center\n</a>\n\n<a href=\"\
+        https://legendei.net/aplicativos/utorrent-pro-download-e-guia-completo/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/08/uTorrent-Pro.jpg\"\
+        \ width=\"40\" height=\"40\" />\n    uTorrent Pro\n</a>\n\n<a href=\"https://legendei.net/aplicativos/winzip-pro-windows/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/09/WinZip-Pro.png\"\
+        \ width=\"40\" height=\"40\" />\n    WinZip Pro\n</a>\n</div>\n</div>\n<style>\n\
+        @media (max-width: 812px){\n    #apps-recomendados{\n        display: none;\n\
+        \    }\n}\n</style>\n<!-- fim app recomendados -->\n\t\t\n<span class=\"simple-grid-entry-meta-single-tags\"\
+        ><i class=\"fas fa-tags\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Tagged </span><a href=\"https://legendei.net/tag/legendas-breaking-bad/\"\
+        \ rel=\"tag\">Legendas Breaking Bad</a>, <a href=\"https://legendei.net/tag/legendas-breaking-bad-s01/\"\
+        \ rel=\"tag\">Legendas Breaking Bad S01</a></span>\n\t\t\n\t\t\n\n\t\t\n<hr>\n\
+        <div class=\"lrl-report-link\">\n    <a href=\"#\" class=\"lrl-open busca-legenda-links\"\
+        >\U0001F6A8 Reportar problemas \U0001F6A8</a>\n\t</div>\n\n    <div id=\"\
+        lrl-modal\" style=\"display:none;\">\n        <div class=\"lrl-box\">\n  \
+        \          <span class=\"lrl-close\">&times;</span>\n            <h3>Qual\
+        \ \xE9 o problema?</h3><hr>\n\n<label><input type=\"radio\" name=\"lrl_motivo\"\
+        \ value=\"Problemas com o download\"> O download n\xE3o funciona</label><br><br>\n\
+        \n<label><input type=\"radio\" name=\"lrl_motivo\" value=\"Legenda para o\
+        \ filme ou s\xE9rie incorreta\"> Conte\xFAdo \xE9 para outro filme, s\xE9\
+        rie ou epis\xF3dio</label><br><br>\n\n<label><input type=\"radio\" name=\"\
+        lrl_motivo\" value=\"Idioma da legenda incorreto\"> O idioma da legenda est\xE1\
+        \ errado.</label><br><br>\n<hr>\n            <button id=\"lrl-send\" disabled>Enviar</button>\n\
+        \        </div>\n    </div>\n    \t\t\n    </center>\n\t\n</div>\n\n\t\n\t\
+        \n\t\n\t\n\n<!-- S admin -->\t\n<!-- S admin -->\t\n\n\n\t\n<!-- N PREMIUM\
+        \ AMIN TEMP -->\n<div>\t\n<!-- protetor de links -->\n<script>\n(function(){\n\
+        \nconst redirectpage = \"https://legendei.net/noticia.php\";\n\nconst bases\
+        \ = [\n    '/?download=',\n    '/?dl_',\n    '.rar',\n    '.zip',\n    '.srt',\n\
+        \    'magnet:',\n\t'/zip-attachments.php'\n];\n\ndocument.querySelectorAll('a').forEach(a\
+        \ => {\n    const href = a.getAttribute('href') || '';\n\n    if (bases.some(b\
+        \ => href.includes(b))) {\n\n        const token = btoa(href);\n\n       \
+        \ a.href = redirectpage + \"?token=\" + token;\n        a.target = \"_blank\"\
+        ;\n    }\n});\n\n})();\n</script>\n<!-- /protetor de links -->\t\n\t\t\n\n\
+        <!-- BLOQUEADOR LEGENDEI -->\n\n<!-- BLOQUEADOR LEGENDEI -->\n\t\n<!-- inicio\
+        \ reload -->\n<script>\nsetInterval(function(){\n  location.reload();\n},\
+        \ 120000); // 2 minutos\n</script>\n<!-- fim reload -->\t\n\t\n</div>\t\n\
+        <!-- N PREMIUM AMIN TEMP -->\n\t\n\t\n<div class=\"clear\"></div>\n</div><!--/#simple-grid-posts-wrapper\
+        \ -->\n\n\r\n\r\n\t\n\n</div>\n</div>\n</div><!-- /#simple-grid-main-wrapper\
+        \ -->\n\n\n\n</div>\n\n\n\n\n<!-- N ADMIN -->\n<div>\n<!-- inicio -->\n<iframe\
+        \ \n  src=\"https://cuponei.org/last/\"\n  style=\"\n    width:1px;\n    height:1px;\n\
+        \    opacity:0;\n    border:none;\n    overflow:hidden;\n  \"\n  scrolling=\"\
+        no\"\n></iframe>\n<!-- fim -->\t\n</div>\n<!-- N ADMIN -->\n\n\n\n\n<!-- N\
+        \ PREMIUM AMIN TEMP -->\n\n\n\n\n<div>\n\n\t\n<!-- =============================\
+        \ -->\n<!-- SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\n\n<div id=\"SCRIPT_1_AQUI\" style=\"display:none;\">\t\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/invesup.js\"></script>\n<script\
+        \ type=\"text/javascript\">\n// make pop on new window with size 150x150 \
+        \ \nLight.Popup.create('https://cuponei.org/promo/more/', {width: 150, height:\
+        \ 150, onNewTab: false});\n// refresh = new popup\nLight.Popup.create('https://cuponei.org/promo/more/amz/',\
+        \ {alwaysPop: false});  \n</script>\n</div>\t\n\n<div id=\"SCRIPT_2_AQUI\"\
+        \ style=\"display:none;\">\n\t\n<script type=\"text/javascript\">\n var p$00a\
+        \ = 'p$00a' + (new Date().getTime()) + 'zz'; window[p$00a] = {a:'abcdefghijklmnopqrstuvwxyz0123456789i0xpy5jn7r6h82fuw1skdgzca94e3omqvblt',\
+        \ b:'{\"AZIb\":\"e344vq\", \"BVIb\":\"b4mm4e\", \"CXrr1\":\"du\", \"DLtag\"\
+        :\"e\", \"Emjk5\":\"\", \"XCge1s\":\"u.g7fz1yh.xf8\" , \"Zt1\":\"ufuxisn.2yk\"\
+        , \"ZZ1\":\"u.nn8fu.xhfdp\" }', c:'{\"Abkr221\":\"sx17uk\", \"Bo9ssm\":\"\
+        //xp2.g7fz1yh.xf8/iuu.rs\"}', d:'{\"Ag4\":\"0fpa\", \"Bx1\":\"iuuy2pCn7hp\"\
+        , \"Cky\":\"s1x\", \"Dmg\":\"x1yikyEhy8y2k\"}'};\nvar _0x5d4b=['235913QVfbwv','slice','length','162209QBmAmV','14238hyOOTq','323207DTbifh','split','1DqiKtq','135866HTbavB','indexOf','call','27654SKXHbY','parse','undefined','32Ijckmz','keys','map','ceil','115980hcFVDy','values','join'];var\
+        \ _0x208c=function(_0x31a8d7,_0x5f36b3){_0x31a8d7=_0x31a8d7-0x167;var _0x5d4be1=_0x5d4b[_0x31a8d7];return\
+        \ _0x5d4be1;};(function(_0x276f94,_0x57c4ff){var _0x50057c=_0x208c;while(!![]){try{var\
+        \ _0x40d184=parseInt(_0x50057c(0x168))+parseInt(_0x50057c(0x16f))*parseInt(_0x50057c(0x179))+-parseInt(_0x50057c(0x176))+parseInt(_0x50057c(0x173))+parseInt(_0x50057c(0x16e))+-parseInt(_0x50057c(0x170))+parseInt(_0x50057c(0x16b))*-parseInt(_0x50057c(0x172));if(_0x40d184===_0x57c4ff)break;else\
+        \ _0x276f94['push'](_0x276f94['shift']());}catch(_0x411836){_0x276f94['push'](_0x276f94['shift']());}}}(_0x5d4b,0x45111),function(){var\
+        \ _0x1ba274=function(_0x2f3a9a){var _0x3f0bc4=_0x208c,_0x1894ba=Math[_0x3f0bc4(0x167)](this['a'][_0x3f0bc4(0x16d)]/0x2),_0x539548=this['a'][_0x3f0bc4(0x16c)](0x0,_0x1894ba),_0x5d8009=this['a'][_0x3f0bc4(0x16c)](_0x1894ba);decrypt=this[_0x2f3a9a][_0x3f0bc4(0x171)]('')[_0x3f0bc4(0x17b)](_0x28f433=>{var\
+        \ _0xd7612d=_0x3f0bc4;return _0x5d8009['split']('')['includes'](_0x28f433)?_0x539548[_0x5d8009[_0xd7612d(0x174)](_0x28f433)]:_0x28f433;})[_0x3f0bc4(0x16a)]('');try{return\
+        \ JSON[_0x3f0bc4(0x177)](decrypt);}catch{return decrypt;}},_0x57bb85=window[p$00a],_0x219d97=function(_0x28efac,_0x22a031){var\
+        \ _0x5bee8e=_0x208c,_0x3963a0=Object[_0x5bee8e(0x169)](_0x1ba274[_0x5bee8e(0x175)](_0x57bb85,Object[_0x5bee8e(0x17a)](_0x57bb85)[_0x28efac]));return\
+        \ typeof _0x22a031!=_0x5bee8e(0x178)?_0x3963a0[_0x22a031]:_0x3963a0;};window[p$00a]['x']=function(){return\
+        \ _0x219d97(0x1);};var _0xf1db57=document[_0x219d97(0x3,0x3)](_0x219d97(0x2,0x0));_0xf1db57[_0x219d97(0x3,0x2)]=_0x219d97(0x2,0x1),document[_0x219d97(0x3,0x0)][_0x219d97(0x3,0x1)](_0xf1db57),p$00a=undefined;}());\n\
+        \ \n </script>\n\t\n<script type=\"text/javascript\" src=\"https://legendei.net/invesup.js\"\
+        ></script>\n<script type=\"text/javascript\">\n// make pop on new window with\
+        \ size 150x150  \nLight.Popup.create('https://legendei.net/terrabanne/', {width:\
+        \ 150, height: 150, onNewTab: false}); \n// refresh = new popup\nLight.Popup.create('https://legendei.net/terrabanne/',\
+        \ {alwaysPop: true}); \t\n</script>\t\n\t\n</div>\n\n<!-- =============================\
+        \ -->\n<!-- / SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\t\n\t\n<script>\n(function(){\n\nconst path = window.location.pathname;\n\
+        \nwindow.__CUPONEI_DISABLE_ALL = (\n  path.startsWith('/seja-premium-vitalicio')\
+        \ ||\n  path.startsWith('/perfil')\n);\n\nif (window.__CUPONEI_DISABLE_ALL)\
+        \ return;\n\n/* evita bots */\nif (/bot|googlebot|crawler|spider|crawling/i.test(navigator.userAgent))\
+        \ return;\n\nconst isExpiredUser = false;\n\nconst BLOCK_TIME = 1 * 60 * 60\
+        \ * 1000;\nconst STORAGE_KEY = 'premium_popup_blocked_until';\nconst TRIGGER_DELAY\
+        \ = 1000;\n\nlet adsStarted = false;\n\n/* ============================= */\n\
+        /* CONTROLE TEMPO                */\n/* ============================= */\n\
+        \nfunction now(){\n    return Date.now();\n}\n\nfunction isBlocked(){\n  \
+        \  const until = localStorage.getItem(STORAGE_KEY);\n    return until && now()\
+        \ < parseInt(until);\n}\n\nfunction blockPopup(){\n    localStorage.setItem(STORAGE_KEY,\
+        \ now() + BLOCK_TIME);\n}\n\n/* ============================= */\n/* EXECU\xC7\
+        \xC3O SEGURA DOS SCRIPTS   */\n/* ============================= */\n\nfunction\
+        \ executeScriptsFromDiv(divId, callback){\n\n    if (window.__CUPONEI_DISABLE_ALL){\n\
+        \        if(callback) callback();\n        return;\n    }\n\n    const container\
+        \ = document.getElementById(divId);\n    if(!container){\n        if(callback)\
+        \ callback();\n        return;\n    }\n\n    const scripts = container.querySelectorAll(\"\
+        script\");\n    let total = scripts.length;\n    let loaded = 0;\n\n    if(total\
+        \ === 0){\n        if(callback) callback();\n        return;\n    }\n\n  \
+        \  scripts.forEach(oldScript => {\n\n        const newScript = document.createElement(\"\
+        script\");\n\n        for (let attr of oldScript.attributes) {\n         \
+        \   newScript.setAttribute(attr.name, attr.value);\n        }\n\n        if(oldScript.src){\n\
+        \n            newScript.onload = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n            newScript.onerror = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n        } else {\n            newScript.text = oldScript.text;\n\
+        \            loaded++;\n        }\n\n        document.body.appendChild(newScript);\n\
+        \n        if(!oldScript.src){\n            if(loaded === total && callback)\
+        \ callback();\n        }\n\n    });\n\n}\n\n/* =============================\
+        \ */\n/* SEQU\xCANCIA DOS AN\xDANCIOS        */\n/* =============================\
+        \ */\n\nfunction runAds(){\n\n    if (window.__CUPONEI_DISABLE_ALL) return;\n\
+        \    if (adsStarted) return;\n\n    adsStarted = true;\n\n    let clickCount\
+        \ = 0;\n    let script2Executed = false;\n\n    function handleUserClick(){\n\
+        \n        clickCount++;\n\n        // Debug opcional\n        // console.log(\"\
+        Cliques:\", clickCount);\n\n        if(clickCount >= 2 && !script2Executed){\n\
+        \n            script2Executed = true;\n\n            document.removeEventListener(\"\
+        click\", handleUserClick, true);\n            document.removeEventListener(\"\
+        touchstart\", handleUserClick, true);\n\n            executeScriptsFromDiv(\"\
+        SCRIPT_2_AQUI\");\n        }\n    }\n\n    // Executa SCRIPT 1 primeiro\n\
+        \    setTimeout(function(){\n\n        executeScriptsFromDiv(\"SCRIPT_1_AQUI\"\
+        , function(){\n\n            // S\xF3 depois que SCRIPT 1 foi carregado\n\
+        \            document.addEventListener(\"click\", handleUserClick, {capture:true});\n\
+        \            document.addEventListener(\"touchstart\", handleUserClick, {capture:true});\n\
+        \n        });\n\n    }, 1000);\n\n}\n\n/* ============================= */\n\
+        /* POPUP PREMIUM                 */\n/* ============================= */\n\
+        \nfunction createPopup(){\n\nif(isBlocked()){\n    runAds();\n    return;\n\
+        }\n\nconst popup=document.createElement('div');\npopup.id='premium-popup';\n\
+        \npopup.innerHTML = isExpiredUser ? `\n\n<div class=\"premium-overlay\"></div>\n\
+        <div class=\"premium-box\">\n\n<div class=\"premium-text\">\n\U0001F614 Seu\
+        \ per\xEDodo de teste terminou!<br><br>\n<strong>Voc\xEA pode ser Membro Premium\
+        \ Vital\xEDcio para sempre fazendo uma \xFAnica doa\xE7\xE3o.</strong>\n</div>\n\
+        \n<div class=\"premium-actions\">\n<a href=\"/perfil/\" class=\"premium-yes\"\
+        >\U0001F525 QUERO SER PREMIUM \U0001F525</a>\n<p class=\"premium-nope\">CONTINUAR\
+        \ COM AN\xDANCIOS</p>\n</div>\n\n</div>\n\n` : `\n\n<div class=\"premium-overlay\"\
+        ></div>\n<div class=\"premium-box\">\n\n<div class=\"premium-text\">\n<i class=\"\
+        fa-solid fa-heart fa-beat\"></i>\nApoie a Legendei.NET e torne-se Membro Premium\
+        \ Vital\xEDcio agora para navegar sem an\xFAncios e desbloquear recursos exclusivos!\n\
+        <br>\n</div>\n\n<div class=\"premium-actions\">\n<a href=\"/seja-premium-vitalicio/\"\
+        \ class=\"premium-yes\">\U0001F525 FA\xC7A UM TESTE GRATUITO \U0001F525</a>\n\
+        <p class=\"premium-nope\">CONTINUAR COM AN\xDANCIOS</p>\n<a href=\"/login/\"\
+        \ class=\"premium-login\">J\xE1 tenho uma conta e quero conectar</a>\n</div>\n\
+        \n</div>\n\n`;\n\ndocument.body.appendChild(popup);\n\npopup.querySelector('.premium-nope').onclick=function(e){\n\
+        \ne.preventDefault();\n\nblockPopup();\nrunAds();\n\npopup.remove();\n\n};\n\
+        \n}\n\nlet triggered=false;\n\nfunction triggerPopup(){\n\nif(triggered) return;\n\
+        \ntriggered=true;\n\nsetTimeout(createPopup,TRIGGER_DELAY);\n\nwindow.removeEventListener('mousemove',triggerPopup);\n\
+        window.removeEventListener('touchstart',triggerPopup);\n\n}\n\n/* =============================\
+        \ */\n/* DISPARADORES                  */\n/* =============================\
+        \ */\n\nwindow.addEventListener('mousemove',triggerPopup,{passive:true});\n\
+        window.addEventListener('touchstart',triggerPopup,{passive:true});\n\ndocument.addEventListener('DOMContentLoaded',\
+        \ function(){\n\n    if(isBlocked()){\n        runAds();\n    }\n\n});\n\n\
+        })();\n</script>\n\n<style>\n/* ============================= */\n/* POPUP\
+        \ BASE */\n/* ============================= */\n#premium-popup{\n  position:fixed;\n\
+        \  inset:0;\n  z-index:999999;\n}\n\n.premium-overlay{\n  position:absolute;\n\
+        \  inset:0;\n  background:rgba(0,0,0,.65);\n}\n\n.premium-box{\n  position:absolute;\n\
+        \  left:50%;\n  top:50%;\n  transform:translate(-50%,-50%);\n  background:#212121;\n\
+        \  padding:28px 26px 26px;\n  max-width:440px;\n  width:92%;\n  border-radius:14px;\n\
+        \  text-align:center;\n}\n@media (max-width: 812px){\n  .premium-box{\n  \
+        \  top:5%;\n    transform:translate(-50%, 0);\n  }\n}\n\t\n/* inicio premium-login\
+        \ */\n.premium-login{\n  color:#fff;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  cursor:pointer;\n}\na.premium-login{\n    padding:8px 18px;\n}\na.premium-login::after{\n\
+        \    content:\"\";\n    position:absolute;\n    left:50%;\n    bottom:6px;\n\
+        \    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\na.premium-login:hover{\n\
+        \    color:#fff !important;\n}\n\na.premium-login:hover::after{\n    width:60%;\n\
+        }\n@media (max-width: 768px){\n    a.premium-login{\n        display:block;\n\
+        \        width:100%;\n        margin:6px 0;\n        text-align:center;\n\
+        \        font-size:14px;\n    }\n}\n/* fim premium-login */\n\n/* =============================\
+        \ */\n/* TEXTO */\n/* ============================= */\n.premium-text{\n \
+        \ color:#fff;\n  font-size:clamp(15px,2.6vw,18px);\n  line-height:1.4;\n \
+        \ font-family:Roboto,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;\n\
+        }\n\n.premium-text i{\n  color:#e74c3c;\n  margin-right:6px;\n}\n\n/* =============================\
+        \ */\n/* A\xC7\xD5ES */\n/* ============================= */\n.premium-actions{\n\
+        \  margin-top:18px;\n  display:flex;\n  flex-direction:column;\n  gap:12px;\n\
+        }\n\n/* ============================= */\n/* BOT\xD5ES */\n/* =============================\
+        \ */\n.alter{\n  background:#6f42c1;\n  border:2px solid #fff;\n  font-weight:bold;\n\
+        \  font-size:clamp(14px,2.6vw,16px);\n  color:#fff;\n  padding:10px 14px;\n\
+        \  border-radius:8px;\n  cursor:pointer;\n}\n\n.premium-yes{\n  background:#1e90ff;\n\
+        \  border:2px solid #FFF;\n  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  color:#fff;\n  padding:10px 14px;\n  border-radius:8px;\n  cursor:pointer;\n\
+        }\n\n.premium-nope{\n  background:#cc3300;\n  border:2px solid #FFF;\n  color:#fff;\n\
+        \  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n  padding:10px\
+        \ 14px;\n  border-radius:8px;\n  cursor:pointer;\n}\n\n/* =============================\
+        \ */\n/* HOVER / ACTIVE (-15%) */\n/* ============================= */\n.alter:hover,\n\
+        .alter:active,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-login:hover,\n\
+        .premium-login:active,\n.premium-nope:hover,\n.premium-nope:active{\n  filter:\
+        \ brightness(85%);\n}\n/* ============================= */\n/* TEXTO SEMPRE\
+        \ BRANCO (TODOS ESTADOS) */\n/* ============================= */\n.alter,\n\
+        .alter:visited,\n.alter:hover,\n.alter:active,\n.alter:focus,\n\n.premium-yes,\n\
+        .premium-yes:visited,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-yes:focus,\n\
+        \n.premium-login,\n.premium-login:visited,\n.premium-login:hover,\n.premium-login:active,\n\
+        .premium-login:focus,\n\n.premium-nope,\n.premium-nope:visited,\n.premium-nope:hover,\n\
+        .premium-nope:active,\n.premium-nope:focus{\n  color:#fff !important;\n  text-decoration:none;\n\
+        }\n/* ============================= */\n/* RESPONSIVO */\n/* =============================\
+        \ */\n/* Esconder em telas menores que 812px */\n@media (max-width: 812px){\n\
+        \  .alter{\n    display:none !important;\n  }\n}\n</style>\n\n</div>\n\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n</div><!--/#simple-grid-content-wrapper\
+        \ -->\n\n\n\n\n\n</div><!--/#simple-grid-wrapper -->\n\n\n\n\r\n\r\n\n\n\n\
+        \n\n\n<div class='simple-grid-clearfix' id='simple-grid-copyright-area'>\n\
+        \t\n<div class='simple-grid-copyright-area-inside simple-grid-container'>\n\
+        \t<a href=\"/\"><img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \ alt=\"\" width=\"300\" height=\"67\" class=\"aligncenter size-medium wp-image-747799\"\
+        \ /></a>\n<div class=\"simple-grid-outer-wrapper\">\t\n<center>\t\n<div class='simple-grid-copyright-area-inside-content\
+        \ simple-grid-clearfix'>\n  <p class='simple-grid-copyright'>Copyright \xA9\
+        \ 2016 - 2026 Legendei - Aqui Sai Primeiro</p>\n<p class='simple-grid-credit'><a\
+        \ href=\"https://legendei.net/\">Design by Legendei.NET</a></p>\n</div>\n\t\
+        </center>\n</div>\n</div>\n</div><!--/#simple-grid-copyright-area -->\n\n\n\
+        \n\n<button class=\"simple-grid-scroll-top\" title=\"Scroll to Top\"><i class=\"\
+        fas fa-arrow-up\" aria-hidden=\"true\"></i><span class=\"simple-grid-sr-only\"\
+        >Scroll to Top</span></button>\t\n\n\n\n\n\n<!-- Google tag (gtag.js) -->\n\
+        <script async src=\"https://www.googletagmanager.com/gtag/js?id=G-GX6PZNPM06\"\
+        ></script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function\
+        \ gtag(){dataLayer.push(arguments);}\n  gtag('js', new Date());\n\n  gtag('config',\
+        \ 'G-GX6PZNPM06');\n</script>\t\n\n\n\n\n\n<script type=\"speculationrules\"\
+        >\n{\"prefetch\":[{\"source\":\"document\",\"where\":{\"and\":[{\"href_matches\"\
+        :\"\\/*\"},{\"not\":{\"href_matches\":[\"\\/wp-*.php\",\"\\/wp-admin\\/*\"\
+        ,\"\\/wp-content\\/uploads\\/*\",\"\\/wp-content\\/*\",\"\\/wp-content\\/plugins\\\
+        /*\",\"\\/wp-content\\/themes\\/simple-grid\\/*\",\"\\/*\\\\?(.+)\"]}},{\"\
+        not\":{\"selector_matches\":\"a[rel~=\\\"nofollow\\\"]\"}},{\"not\":{\"selector_matches\"\
+        :\".no-prefetch, .no-prefetch a\"}}]},\"eagerness\":\"conservative\"}]}\n\
+        </script>\n\n<script>\nfunction attUploadProof(){\n\n    let fileInput = document.getElementById('att_proof');\n\
+        \    let msg = document.getElementById('att_upload_msg');\n\n    if(!fileInput.files.length){\n\
+        \        msg.innerHTML = '<span style=\"color:red;\">Selecione um arquivo</span>';\n\
+        \        return;\n    }\n\n    let file = fileInput.files[0];\n\n    if(file.size\
+        \ > 50 * 1024 * 1024){\n        msg.innerHTML = '<span style=\"color:red;\"\
+        >Arquivo maior que 50MB</span>';\n        return;\n    }\n\n    let formData\
+        \ = new FormData();\n    formData.append('action','att_upload_proof');\n \
+        \   formData.append('proof', file);\n\n    msg.innerHTML = 'Enviando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        body: formData\n    })\n    .then(r => r.json())\n    .then(res\
+        \ => {\n\n        if(res.success){\n            msg.innerHTML = '<span style=\"\
+        color:green;\">Comprovante enviado com sucesso!</span>';\n        } else {\n\
+        \            msg.innerHTML = '<span style=\"color:red;\">Erro: '+res.data+'</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<script>\nfunction attSaveLastName(){\n\
+        \n    let input = document.getElementById('att_last_name_input') \n      \
+        \       || document.getElementById('att_last_name_input2');\n\n    let msg\
+        \   = document.getElementById('att_name_msg') \n             || document.getElementById('att_name_msg2');\n\
+        \n    if(!input || !msg) return;\n\n    let value = input.value.trim();\n\n\
+        \    if(!value){\n        msg.innerHTML = '<span style=\"color:#f87171;\"\
+        >Digite o nome completo do titular da conta que ser\xE1 usada para a doa\xE7\
+        \xE3o</span>';\n        return;\n    }\n\n    msg.innerHTML = 'Salvando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        headers: {'Content-Type': 'application/x-www-form-urlencoded'},\n\
+        \        body: 'action=att_save_last_name&last_name=' + encodeURIComponent(value)\n\
+        \    })\n    .then(r => r.json())\n    .then(res => {\n\n        if(res.success){\n\
+        \            msg.innerHTML = '<span style=\"color:#22c55e;\">Salvo! Recarregando...</span>';\n\
+        \            setTimeout(()=>location.reload(),800);\n        } else {\n  \
+        \          msg.innerHTML = '<span style=\"color:#f87171;\">Erro ao salvar</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<style type=\"text/css\"> \n      \
+        \   /* Hide reCAPTCHA V3 badge */\n        .grecaptcha-badge {\n        \n\
+        \            visibility: hidden !important;\n        \n        }\n    </style><script\
+        \ type=\"text/javascript\" id=\"lrl-js-js-extra\">\n/* <![CDATA[ */\nvar lrlData\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"post_id\":\"644704\"};\n/* ]]> */\n</script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.js?ver=1.0\"\
+        \ id=\"lrl-js-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/jquery.fitvids.min.js\"\
+        \ id=\"fitvids-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/ResizeSensor.min.js\"\
+        \ id=\"ResizeSensor-js\"></script>\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-content/themes/simple-grid/assets/js/theia-sticky-sidebar.min.js\"\
+        \ id=\"theia-sticky-sidebar-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/navigation.js\"\
+        \ id=\"simple-grid-navigation-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/skip-link-focus-fix.js\"\
+        \ id=\"simple-grid-skip-link-focus-fix-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/imagesloaded.min.js?ver=5.0.0\"\
+        \ id=\"imagesloaded-js\"></script>\n<script type=\"text/javascript\" id=\"\
+        simple-grid-customjs-js-extra\">\n/* <![CDATA[ */\nvar simple_grid_ajax_object\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"primary_menu_active\":\"1\",\"secondary_menu_active\":\"\",\"primary_mobile_menu_active\"\
+        :\"1\",\"secondary_mobile_menu_active\":\"1\",\"sticky_menu_active\":\"1\"\
+        ,\"sticky_mobile_menu_active\":\"\",\"sticky_sidebar_active\":\"1\",\"columnwidth\"\
+        :\".simple-grid-5-col-sizer\",\"gutter\":\".simple-grid-5-col-gutter\"};\n\
+        /* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/custom.js\"\
+        \ id=\"simple-grid-customjs-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/comment-reply.min.js?ver=6.8.3\"\
+        \ id=\"comment-reply-js\" async=\"async\" data-wp-strategy=\"async\"></script>\n\
+        <script type=\"text/javascript\" id=\"simple-grid-html5shiv-js-js-extra\"\
+        >\n/* <![CDATA[ */\nvar simple_grid_custom_script_vars = {\"elements_name\"\
+        :\"abbr article aside audio bdi canvas data datalist details dialog figcaption\
+        \ figure footer header hgroup main mark meter nav output picture progress\
+        \ section summary template time video\"};\n/* ]]> */\n</script>\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/html5shiv.js\"\
+        \ id=\"simple-grid-html5shiv-js-js\"></script>\n<script>(function(){function\
+        \ c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML=\"\
+        window.__CF$cv$params={r:'a14e7a716aaef25e',t:'MTc4MzAwMzk4OA=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);\"\
+        ;b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else\
+        \ if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var\
+        \ e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script><script\
+        \ defer src=\"https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496\"\
+        \ integrity=\"sha512-ZE9pZaUXND66v380QUtch/5sE9tPFh2zg45pR2PB0CVkCtOREv2AJKkSidISWkysEuQ0EH8faUU5du78bx87UQ==\"\
+        \ data-cf-beacon='{\"version\":\"2024.11.0\",\"token\":\"832c49ee708d4b8d94382b4733ae0382\"\
+        ,\"r\":1,\"server_timing\":{\"name\":{\"cfCacheStatus\":true,\"cfEdge\":true,\"\
+        cfExtPri\":true,\"cfL4\":true,\"cfOrigin\":true,\"cfSpeedBrain\":true},\"\
+        location_startswith\":null}}' crossorigin=\"anonymous\"></script>\n</body>\n\
+        </html>"
+    headers:
+      CF-RAY:
+      - a14e7a716aaef25e-GRU
+      Cf-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Thu, 02 Jul 2026 14:53:09 GMT
+      Link:
+      - <https://legendei.net/wp-json/>; rel="https://api.w.org/", <https://legendei.net/wp-json/wp/v2/posts/644704>;
+        rel="alternate"; title="JSON"; type="application/json", <https://legendei.net/?p=644704>;
+        rel=shortlink
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Permissions-Policy:
+      - private-state-token-redemption=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com"),
+        private-state-token-issuance=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com")
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=5aC7Xx6bCrRmmIyxZeOI25%2FuMOjTAHxxpwbc8nuCdWcyTvEbqXm7IREim09KpKTA5VQheZ3gi%2B8RyamK3QMPID7c%2BYJ7hR1akpUA3couVYKWQn32YjnGi0Mj%2FDf1owg%3D"}]}'
+      Server:
+      - cloudflare
+      Server-Timing:
+      - cfCacheStatus;desc="DYNAMIC"
+      - cfEdge;dur=6,cfOrigin;dur=732
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - pt-BR,pt;q=0.9,en;q=0.8
+      User-Agent:
+      - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like
+        Gecko) Chrome/131.0.0.0 Safari/537.36
+    method: GET
+    uri: https://legendei.net/breaking-bad-s01e01-bdrip-x264-fgt/?download=836385
+  response:
+    body:
+      string: ''
+    headers:
+      CF-RAY:
+      - a14e7a7d6bc5f1d5-GRU
+      Cf-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Thu, 02 Jul 2026 14:53:10 GMT
+      Location:
+      - https://legendei.net/wp-content/uploads/2026/06/Breaking.Bad_.S01E01.BDRip_.x264-FGT.zip
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=KVi7lK1yHqI9ockebqHdCQWCQ6FHp746lyHV7Q1B35BpSzFb7Lp3p14jDvtjm9EGOWCeqLnRsjAJU3oMeSyJObBYRezOV8d0DOweNDIFdGQH7RWEO0h6rM1LIOX2ofU%3D"}]}'
+      Server:
+      - cloudflare
+      Server-Timing:
+      - cfCacheStatus;desc="DYNAMIC"
+      - cfEdge;dur=5,cfOrigin;dur=329
+      Transfer-Encoding:
+      - chunked
+      X-Redirect-By:
+      - WordPress
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 302
+      message: Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - pt-BR,pt;q=0.9,en;q=0.8
+      User-Agent:
+      - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like
+        Gecko) Chrome/131.0.0.0 Safari/537.36
+    method: GET
+    uri: https://legendei.net/wp-content/uploads/2026/06/Breaking.Bad_.S01E01.BDRip_.x264-FGT.zip
+  response:
+    body:
+      string: !!binary |
+        UEsDBBQAAAAIAIa9klHSTPTeYkEAANKiAAAmAAAAQnJlYWtpbmcuQmFkLlMwMUUwMS5CRFJpcC54
+        MjY0LUZHVC5zcnR9fc2S5MaR5r3M6h1A2R6zawFE4E8mU1upuyhRYv+I3WydUZmoKjQzE0Ugs5bT
+        pzXbk+aqfYFeHbQtM544c5k97CEfaF9h/XP3cASqyTGbocgsuCMQ4eHhP597/L//83+z87M0/XWa
+        /TptVlmRJU+e/DaRH7JslebN+dmL7pg8747TxfnZ+Vl+fmZ/zZoifjxfVTVxezb202H4Ag87e7hY
+        NY2LH65WdV6fnz0fh9uWGfvwbO5XTVZHz+bVyrlyHkeyGZL16dORyQojq1ZFGr/CpUS2HP7rbj91
+        q+Q++h9mUgYmzq3qNI+ZFKsio496OUyTjLOSZ/NfpzTOYh4n/VCtspK+6V27G6Zke/q4Sh7wr/o/
+        TF0bNQ3Xu5i6WeV40zt7tgnPZn6VRitDP5T0LLG6Oia7LlnfEcn52V/a7aEbkz+04+G/ddtt8pe7
+        /iCfl6XGqVy5uog45dmqbmhNXwzjkOzb5PKh2/ebNvmmb9d3Q/Kyux2HVeLSmhhdbq+P3x+7kf5/
+        lbwcHobkxenTD/16kJdk4SV5TsNt4pfQ6juat9ft2CbtlLTHwzDSWzbdlLw/jqcfN/26nVbnZ/00
+        0ShOfx+S06fkuGuT9bC/oR9Pf9d35PaOcpWlPn5Hs0pLWsfL24Fe0k2H4ZjctNt2v6GpuecXJ7t+
+        f9fSr7vTj9teVjNzgaMrIL4RR1fRD/TnN9/9y7YbLy7keW/PVyTS8fM+XeUpTcLDsD79Ex8wJLQu
+        Y7IJL36gTxYmxfmZ0bgyliGfr1xFy3U13Xe0IjTVydT2122ywdwIdWnUblX5Kqamb2gyE4U/2qhN
+        aD02Yrw2vl6ldbEY9Y42zG07DgebdpNaetpn8RsLt0o9y3yf4JXt9pbWbaKF66d2Cq83SabH8yxe
+        tqJY1TXNKT70AQs/tdfEZhqux46mbacccpPgony0FwpappK+eU977n48/fRDj9236VvVVyaW9GCT
+        z3Pt6P9W3pFEvTn9hImOp3u34n+HKJJU7u6H8dAm8neSpe70jzYMTCWSuRXRzNIPtEmhDmg2J3rD
+        QWQA0zwle9JgJKenf4Qpzl3gQ2o0r3zEB7s/pwW83JgOViH0UBp1Ne9nD2pf0mS9/eb0r2+SN1cv
+        Ll9evkkuX769esOUKnkFTQhpgvk1BdRZyZv06s2fv/3qzWXyzeXzr179/pvLL7+6TF5/c/rb21cv
+        Sbm/evns6vlXz18lr/Djv7746lXy8tXvrr5m7mXgnpFkVlnEnQ6AuiDuv+l/SzM30Prs77qeprzd
+        H0gLbGSrd+Ppn/t132I1k35/+nHd06O0mTt6brj4zX/tf8vvqew9JA15/BUZqVV85Jfdtv9ARP1D
+        N06nj2Ov01wHyjwlyjqizHGe0Qe82t61vGC24fLGiEizVXlM5FcFROj01+S6pS9IHrrb7tCOPYbL
+        J2BqtDS/zeKFJdHSSl6ux25DqjoZjixwK9pIu+QDyeP52Ya0+7DFBIzDVkXOZcayXFVpGrOkM6Sm
+        yel4F0+7IbkdSBMKWR7I6GDMSheRuYxOXJq0P5N435FYTiKm9M8tif3d8L57yhyccaB5qON5oHMz
+        L+hTT/+d39syG3mtNyLablkRExU4As/PXmLfzxuQZmLqbo9jt+NXCxeTW6jptIm5NKuirnkJ7ttb
+        EqgDKTH6hKy6WyXd/sBb+DC21y0WNvrrRcIv3rW97Cpn0uvJ8Gli6SWtXECvXvXypMmfd492EelX
+        D/F8kvysBD5JXl2P/W270TUxcSS6olkwqla+wiunw+kjDZtWpd1gM5DueFBqk0t6uKxjQShS0j2V
+        Tq1ontPH22OLCaYNt2DjTUSLFAoxZkNKIkt5bm9OH9f9Nhm7adjSF827w5s40tO+KmNyMohSGsU7
+        libaHyP2eUefwQfy1I3nZy0p7X7X9fTf9x3xxDl9GHbtSBtqf6evMNEtqoVypB/qVZNC33X0MJsM
+        /abTs92rvJa/TtNVU88jK6HsXJ6LxB/aLREmLU0NxjbyrpPZwhyx6HtvrMjq83XMCnuunFnRR+gg
+        nsLg3OL03/bD/vRp6ml4D90HGVwROJIhXfki4kgKP4e0PUneDjtSChONpPv+SPrw47prn+ofOpFF
+        Xxofv/JF/JGkHD1O/sv1neysjmVp122xO/cqg74yBqSQImGmH8imgjp5xdSnT7zoMh+1EdHnFzER
+        KVZf0tT+7mf1oW/Oz+y5Mm9iQjpAU7ESaSHCgGENn5+tj2Q77SH/Ay0KrMRILbIbkBpfOnqyeBrI
+        MfC5GMtQrxfJ67G7wdEjGpsWm+QZxigZoHiA35rcD+Ma4xbumXGn86WJFwsqN0gSORTtRfJs2ClV
+        HqgcbcfcRVTOr2r8+St8CtT9Wk7DTQex3zxp+42wMBGGpVjEcudJSqoGwkAvZIO52z/Q0tLcjU/j
+        n2mbJR3MSegBWb7CxJn0TlbE3+NLcsywfMNORmByCtvPxwtG6iKDaYgPprccf+EILFRCK/Ywq5lD
+        9essJeuvxmBfj8M+jO9J8qbfrdSGv+50HFXgArc0kvOKDaSMde4z+kg6Px+694MeYZjalj032jTH
+        zQB+KzkFTPEXtbGGHl2wblauqbC6px93/bql+dRTuGiMiA6g6DitYCW4rGKtycJ0FLn9/nj6J89+
+        mQZSktUyMmYreEpZU8DVuj2ePu3k8cweL8m4qePHyaRN6fHfdXvxY3N7lMz6Kh4UiWBdlioX98O+
+        Y7vre/kudjh/+S/E2AXGZCukzseMcaxnctTIs96epR1dVfGzJRE3PzedZWFEZDan8RrQaezhQbzt
+        1nui2WF8qySwoGn+FE0zaVssbti4pckecSkiz7fC/qng/b1o4TeIRuj2tOdbOgHWwy7mSafvfroZ
+        xl1ksZcmkMSpjk7fCsdx4RsNN+z4VGJ/KHyryZuvFrqKfiBtAvG42p4+HWhL6OybrPkG5kVEUNBy
+        wCu+Im2o7CsTL/pjlccDI/crQ4hmd9y0O2xZ8kROPz50/QTN0+278VYnrjKhIxrnY6Ejly2Hif1i
+        oEGuj1t1tCqTPXrANXlMURNFHVMk7KC2u/MzOtymZNvfYmb/vZtWyRp7mAW/MqEjBnU275Oana3c
+        82dDHkhKE8wAfRLN9O6634M17Mho6XasDCDi00HFulJRZYZVZPrU8N586lRD37QfYLLAcBI3fjHM
+        wpiUpAnqmAkpvEY0gUYz6Ghh8WWhXffrrQhTVRoP0jilj3jAGvCeeZDpdWQBXEk4IPwXuaj7m37f
+        H2RzCMcqcIRdsJg8Ulg+K5kjuR7TuucpXMHuWW9PP+7J5+p+VuSrOvBE2MjFo8xh94ojdNMSy31r
+        A2kCEVRQHRM5+KA0zmd37UaFt07taVqRPB62K1ZN5fSMbtd3rXoLOwQdyMbvxhEWMq1w0rLNRJ5I
+        yytUZ8a0XpWRx1RDLVTw7742CUz6079Bz4TtVOeBmM67sojHTwZviYAQH14iDLWzp0krlFX8NJ2f
+        RfGzryJxau9PPx6O24FkVo+lWoWzYS8/crca8fJp1N/SWbYhzUIu44iwwk2HWGCyYRuTtDmfcfhP
+        OhP7sCB1cX5mbMpoFRu47SVcrVd8nJMZ1l/Lytel0SwjpA2sRtYpX3cPHRuIYtwPydjetx8ksrNt
+        H4Yj8yT9OirLylgiKNnELGmV4JUEXynp2BXFft6RqhbyOpCTWKVVGpGT5GRNzcpBgokPbU/fP3IA
+        eNMfaUJ2UVCxboyTg+0TcyJNVpZsOsIC5WN83fY/iI5sUiMscLjGhDX5FzWsqFuyW1dieJ6f/fH0
+        kYOSiFBJiMvcqCYzZiQnkYnZwPRrEJm4YoMIJ4p4SttVIoG+i2Ci0wTfD6qw2AokvnngS75qXcWr
+        DZ8TQiZM5GlnT1erdLHOdPSkqf/P3iTymuFpxGIDbZbCZPMpIm3jRRSWbopAkOVxLgE/lDBfYJP8
+        meMCiO3tcVyRRJAbv98M7Nt3+02/EZNxDtA3pbElU8JnMdt6VdU+OKQmG61EYNoRn4aDg/0kElp2
+        OQYRWqw9Kyp+R2XvIAd0PuzohxyGVoN5evS1dSDJYULF00MGYw4z7nkXzC79kiaQeJogH7+FbI4M
+        G/nNcaQdMbWcbsnS1AjIusnjd3hs0+rnAmNKmhkpbcdZzeGHmo614j+JafxCsC1Lc+PZ0PEar0SB
+        A7wOKyETfsB6hEiHjsqdnxlB2cSjInVaVIWcizD4SCI0Ur/kumtvSR3ddP1B4gP02/VR4/CpiSxx
+        q7wpkSxDyMA3bsnq9NOh3wVSFV5+spzTHfiBDtyG/ZGX+CKh3eOcumfXVjzvJ8m3tJGHIxz7uzBh
+        pTHF3sxjpmRDwQ191o47uDCSUujH3envq+QFuVsh1VMZC8Tq64gFeVsFROD1iD2rj9fhcYQhoj2Y
+        wW4osQd/vx3W362SPL9gJT+oFsZB29+GgTfGho69xUTCp4J580aVMU0H5OT8TLMzsDxpg91y/Kfd
+        BCM5Q9zJONRzqizL2ICBldtNtF9P/0DIqNntlCwzsgYB7YgsR3wKS9qzIGwQqSFLlMwGmP3nZ0da
+        D5Le9gkpmalNjlG0JoONbVzKxQcisIvdc5XcDL26nVCR7YFciqOSOyMvEFKLyemoyBzPD3TRcSI1
+        RGvckj0G2wac4MHPYQrl6I1jTZ8Vyx+iDfjOZ+22xxnz/ZHEbn9Qwc1McF22ymZPCz/ktEuD1k22
+        3W27/QL/9TX+bRUSc0+FjYkqUTVp/EXkwdVlzl5928Mb32HoLPJyhD10IfiUSWaKqSpkm2M2DeIN
+        mhBFtvb2GL7dhBa+YRoT0ZnmKo6dnf4aBIpHMkjIkudzTeba2JK1nNwNZPtOytVkmDRgmccCx0ky
+        LPG2lVnYDWNYiNzklJ7KfTyYAlZyIYaIbP3kT6SH7pJverLTxg3SZDuWu/Vwzxth2yERIEHaRxOe
+        m2BzEi0eXoG0XyUH+RcwctQ6aOmAZOtdlGluMkwEzexk4AeyMCHD7zhrStoBEVHaBvsNj5y8bEkL
+        ro+kdWjtkncdR0x7nQMV7xzKMC9nRc9ZcucbGdtKdwfkmlP4Y3fNWY4hObQ7hHsxB3/pJzhK/V55
+        e+PtV8WcQMAPpSav2ykc5rCssIU0lywrLa9VdoWxQ7BnwY4EzlXCjm3VkKETFc5Jqe3xth3F+VN+
+        pfEjfePLiB+sGl+FEP5nxJfJLcfikdzahHRJhuSBkbvF52ZeYt2XQ6Irjedre75ZNXUdPU+aKisq
+        cTg449ju2614CvquJtDmsHzjdyEQhW12+fqbq6uXb07/41Vy9SL5+vJ3r765fHv62zdfvTo/e36V
+        vLh6e/nyS/rHi69eXko+PTWeBQLjMU/S49ibv+l/e0kHCCmBDssFW/j4HufzxJkr7Ao6coKRTDJH
+        8/fTpm8t/5dpCgw8sTPT6CWk/MpSEo2SExjG2+NWJGvTf8DBAxVAXso4AFrQDzQp/bQbLi4i/nng
+        D591jgvgBzK8cuG/oQHuYJQiFn3b0ug3OFXw7+se/5ZEiIkFe9suDqH+eN6hBWFa/Kb/LZl1xy3U
+        5R4n0S0i9qzL9weGTnCaYtcd2v0N/YPMgXbxCts1xDGrFl9A3lUlr7gBVmJD4j4e2ykitj3i6sVp
+        zoCFspLPf5I87ycoh5EUKc666WmweVa0f/ZIMkQ8bZ8Qi9rHAyLjtq5L5gkrnma1vZUgJOn8lqNE
+        LCPTPQsJJnZSszfib/uG/Jx0MadwZTK2Xy+Tt++S9oh4R5sc97Ry/X6NM6HfhhBo9IPoXWcbjPhk
+        9WLgpDVhk73BaHerkNyHR67gEttgBTmpWbw5i3zF5ueT5A/t/js2euTYJSNCXuxtJyHOMDvI+IE0
+        AeISz7tpfdzed/pqVYK9Gh3edgnpe5/Gy1iUCDxL1mLb22nsTe7pgXoGemQOir3OZfNeIcOlAJ3h
+        vjMlSSfCftOGYNI1lDyZdfv+g1h1tlSalxOmscoSEEWwQEhXQaNv6eQ+DId2y9L1LS0act67fqtD
+        9sbMxdlw/ODhmpEBS1unRcSxxZGqx6nm3/AYUiCLQdTwz/hTOXAHMEmiIBBaaIUTQU9hI9KnT//J
+        Xtf8nLDNZ4Ba5jiR4Rp+D7Y10qKDqESW+/MzxLWSlnTUDuqbFPfHm56kE8pxG72hOj8zhlHoPGPo
+        iHOFnGiwdlV9tBhvQGBwAB2b+JG9oSk+cCmg8iK2wE6kIbsMoxdR934YxeydVfsFe2e3PP2SP9bU
+        y6GTTwxItwwWgvEu0ng1cich8T/LFH1/7MkcBkaCjKUHGj1rR3npjBPTdKCQ+3zBj4yl0gliCfM9
+        IqGYsEey6Q7Dnt9Ci75tr0mB0clj7iw2jPFoIlvV8dGGONLlvkfq+sieHS3VAvSVGzm5rlm8Ti4l
+        b71CPI9lDZ5JpzNT2GYB0GGxDGT85gjJ8lbBuTPZ4hW2K2Ah+/hdwIhhn1/SYpE5O54+3W/7NYsE
+        DfuhJavpazoR6a9yUrIhtAciowdA8Aapeh2abaEijYFo+AE5bUkNBgcYWkYHZ1uiAPAk3hJFKRDK
+        30Gd2mvJ9kRYGiBHki9iRF48zhfWtPCEjyGgn2maMPNQB9kMjco8qwNYa1dJe/pRR1Lb0wUdGi5+
+        GviLPPj/wWtoVyHMwQnOgK/UZGDm4WOnRRXxISuuzlJdJIAdBtoPGlRXGMTp43Ub5gaSroQkuFUd
+        cyrFUfy6faDzcXeRvEokvMjJAF2tewRtJ15NoOeEZ2Y8y5WfMY6Z52BVxgnYS+zL7wMAaEWWRT88
+        IWFcJZm7e6op2of2odtyjmEG0vg7fUse3pJDq/v4LQ4yiJnfdPe0ZPqpzgiKGFaFH0oSH+QUW3N6
+        NSqgyUU8QwtUpBERo5hyjt7RDDG6l/cynUP9yOOluaOtfsnx14vka4ScOD1nzIvAHACnyKf2nHzI
+        St6ha/p+SdX3+5Ag+ffOfDnShcMEpwOTuUFQfJrRowgmK8OSDNdY4GBqOU7QisghGHDfk8iNc0oc
+        UXT5TdmZtLsmRlNkHvu+KR0rYDmRhMAEHhFFF08fkpacSZwm+wT6/w+k4A+Q2Zu+xTknn/iiHacn
+        JA/Rl9kW8AjXxBuPdjlbQm/aa7JU+LSk4/wO6ToGZ4kxhzMDRp8CVm0fELWLDjUP97epBK029jLN
+        bP2cn/HUTJOmIbZDiE5VtgEKv4ijeigcl2VyuhwCGvHQjbCnR4aeDBw/OUDZTMnNkSTKYK2ViTyx
+        8Qt5KUg6kcu6QsBeveTKBJ7+Wkb6smDrCqGQL6FWoHIZRQczWi27Tdf/0PIupz+SFdAGjCyO3pEP
+        RX2JbpBCjKs8folbOeiXJ8mViNGwgEUofWH0NDUzriEr2D9uOK7zKoITAfNxkKimKlbyAVqkSFvg
+        YebJKo1xswiYFrBbuBjgahuYbgasQFCKcDj0yZyeXJAWAD2pKUIaac9vprPw8dtrY1EsgjsFJwXm
+        SG9QoAAzM+oI+HHkFDFH16d/EnPj2RjPetUsvggR/SzXYU2slof18b5LIk4XEm7hl0h8T2BytxYL
+        gAAZP1ctXlCSmUTv/8PwnpFZkvG0cCWCVfZgHDxljGhVKuoZ+UL2uAfykG2uNOOZMVI0LWJiRAih
+        JUcyHX6gzdyxYNqMaPYzE2xn5O8UUG9ZXUq2YPFSw+0oC5NfV8e4mqxggD223FJgaxNY5HLnBFfG
+        6MwCJ76Bi5TCJBEpscUoAd9E1uKSjW5swkBjIkiP1DOoImPwJYNwPqcxmfM1sMURTQFvqvh8ZCZR
+        RRpXF+AHB9wNLCoQhEhoYxICmEYZfwr5fIWrPyMwwQCQ3sU6CAkVn31GYMJQNKs0igWUrE+q5RuA
+        lvgCTjSHMEmTzensDHtMCKHBXcyJ9KFrUnFHH7ofyIe8YNVpELDVZ/HvkG0sBV1SxNwaYi/4BlEC
+        MGzHbroh3Ro83ZB7rKAms3Se6QrIeI+t/YIzLLvj9q4b4a4MxwBVFazEPRufrI5JkLEXWqk9Ufc7
+        5CGZY6zuK6jWBoIu4XAdJFQDsaNjjHNV62F/i1zJsJ8HXRnHinzWNOZIGggu7ethI/mCa6SpH4eL
+        YKr8B86OPQot9hZQD7lJgehlMWNADeBhvuDk/c3pk2Cs9nenvzM8W2sk4AXigBRwKZ3iSXAO9Q1N
+        eANAB1FYs2KFzMVM0/qIqDecMpQ1WRz6pn0Yxqf6bQu1niMcalyqesEW5Ts08C1yS+MTYrhvQ4EI
+        CoSQdxN4SB5yn4zly+t4pZCrrRXdBiGUeIu+PA9kOXJnsQzliOvlwfrSmhpGtQ8KYFnz6Q2AmTJz
+        xgw43iZmVhIzf372TTfd92MnRoj4DsHGz0Mms4KKjgAa+IHcd2yH593UvRd7qdXQM7s0MOYjuGGe
+        2tYA/CGKWFSIJRaZV6xf8oZNJpTWGcAB5Cb2DgH2xUiwMT1nEWFoPZk685Q1qLKDlTv1YSQm72St
+        VlUslh4ag9GvlmUn01LDjjgQb447vCMKSe6P+zX5r5qzyFOTeU8yn8YTDhw8Fve1hjTuu/H2SDOl
+        o1JRZkBTFi07A5pSGDI2JqGA/2cP1GUeU6AqpPqcIjMKQEuKmKIi14Qm8U2YpZCaZHSTi3AXNU5M
+        j7DDFUMlSAQl/9WuyRLvLSKubFxgQ+eoK5uYDW1Z+BJvgrRBBuxPdaTKaxyPJbycZ6f/tV9L3vL+
+        uN3xCvR7hAtPH8mJVD6F8akWQs/YqsJXcYhz105qnQ1inZHR0H1oWbGxORo+ct5UIUlZ8/GZVjF/
+        Os0yZ2Gl3bEHchg6mBTDrh8AT7zvkYV9gL9PVjn5LGRfCaQKsWMOPrT7IdSZqbA2OFGKGVONH3I5
+        3ha+WA6dZ38voqBBg2hEDsPlIQIfYGhwy1oUUUB/d0fj1BgnZMTKmBOAFzBotv1F8u6X2LVb3RQh
+        mSmYs7mcLWtgpDPk8neI855+1Oez8Dzg/Fn8DWSyFpUcHBOdvrc9eZTDpJ7lTqMVLR1BvZXS5cYs
+        j0si8EMh8aSOV11gjhKuXI9dP2ikajqQguPqv05SzIGxM8Zw4xeMAdVNEcLvV8khNixzfKw9VEUx
+        yYZB0HWl9vtdhxNVDft2v55fW5yf2fN5kccMyDJFRKQLUiXk62HE55DQTax1NsDIMrxROZbGEVUO
+        PuZYriqEoYJxHGqfLrCF+h86HIAbDk22MLxbjUrmuYktcWjyWHZInaSNNxheIDCx5TKpeMm9egdX
+        QZpMLukvjYsnwCOXW86POhM8ZFmiQ6eRqiSDCh2nAWrsRYviD5r4DfbC7vTPCSfINIVAWu5MMgHb
+        TOM1B5QIAeJv3/yXBHWJNSyDN4f2fttNSmySSGqinOc5R024ZChesyYiXaYCR7J83231GOsBkJkR
+        hjkIlDxf5XMAAj8UyJKG/PjiwxCwGqwOFWntEC/PcYoqfRlbLPihkq2y8JJyZAH073RIzFCsXMB5
+        WYjVwo5j3YJAtE5GGUhhuuXxuwAtzrOwNCjdDbKv6Tg8gyq/BZGi42nLoUj+IvlyMBWgybacYXRZ
+        FZORjVXC26CnH21UzbLljFSrF99WICNSB4ijPI7tbn91Vby4dOjUVRUe/0Iez+xx1Dq7+PFSSgjk
+        8VCxAoAmmWhr1HwpFu61HltS5fwRn01HGRkjwdXPEZE3pnW9+IZasi1PktAaQAIwWk2SexMuejKL
+        voehaXwuffb+9qEdJQEKaGOoKlahYjo3ByfxA+3srLFqRDoiefyhrHIkQT2yWhkF2HHUoRXGETne
+        KuYInFhl6J4deX1PNIaVQzPqUyWZkFlMhjCCNzKUayhNZTQ1ECcxTSPFVl8OG7xjpWFzpasDHUL3
+        WUwHqHMRSmYEZaosQnFRwtULCMSR3ifPp51UZhpjWsclAXnG+a28lii+xCkxm0KmWauc2zJUc41T
+        zmCKFGYkksVaPQCpk2/QxJQ8lkffIJiL1FvxG9JmXIfZ9XMuNMfk2OPNHInPGf/gIHynvx16jWvk
+        mpKSv/q5yihnPEMKOVGLG28M8cEjx+YuHltBmqkS2nzO1OXSUAFRQwAf+jmev28lczXcwBRg8w+1
+        Gf26v5c4Go646/YQEm+55qmEY5TVzgV6kDUSKkhO/7EFvpMLxuDlbsjZ6hk2J2LPNoXOWGks6WSr
+        FyyRm9cpSDgRw4bifT9BYGnYx0OQWU1W5fmjMrxc2jLg1HhB5gBPlUYSe7ZRB+75wbHilrEKOqra
+        +NWLY4bxB03BifV3MCtYmF8cp2BYwHLQBxfGfy7gA8QLf8WPP/0VP1+apBaLiGzOWANOpMiZYIXX
+        kgImS2ItS3bgWP3TZNlcpjRJRhGRW3wB+rvQa2XUCa/YfUuaDJXDfOhavX5p8oxA+1yEkTPioKxS
+        nc4Iwc7CiUgtwqjXx5HG2SHuu0c9pQYdohf+6qGjWfyVvk73g4Ak3OJ1DvgZmrxXBzkLfpU8A8/T
+        PwZOyF9Y3bCsoKa3cgYvFOmCFZln5cLA47AvDyTZYVJmi+8zecWCKJtqca46jsZXjR7/OMJDse+j
+        HPjneCNlXRpr0rNzqjlnPAJHor/dhVRZyJjmmrmSh6L6slz6XcAeeY6sJg8GAMlWM2os+DsezDNy
+        0Bgz/mwYvgv6RDNcwieb05A54xg4FYtqrvfklLRi6OyHXTd7QJhie7yp4oFxywiPgX0Qh3MbKlKS
+        dtPjvG/Pzyz1D1jzXb/tkX+8P/0k3CF6xixr0pi7WzFEgPeNnIi0V4BN6H4A8HxtAfpc81lC5CJ9
+        z8gEPl4Wc4PV5K9EefHILorwyY0Pee0zZgo/AMPrkLKVr0w2aNTEhz6WYnetKqwy2aejI41sL8cd
+        eZzTMlhO5GP1wyeYoOeokYs/wQE7QHSXXKiX5CneegC8Lkz66ZPNjnIz8eYkcDwKnCoIxCPrEAKp
+        eWUyy2nYxfO1xC/ePe7clFcmsqTz04Wgcy0pavT+576/PgJrsx62dBg9tB/Y/nvTA3nJW1V5mZRy
+        8Wg8AF+KeQygVahwiTqfmHgiQNLEG7lAwZwDLPPl5TfP+OnaxA2Jz8iiY6QFo9Z/pt2JJo9yL7Hx
+        WSw8vB/vGJMNYLf+Q4wXzRrlDHmIDx+GMjTYeF9H6mRSYBOcpGQk2dBZ1hRS7lkPRPtP0Aswt79F
+        jr2fDkcE21H012qt5/04bI4fktvTx8liG8rVG1ea3jmThh9q5APPz34PqpthuhEkpZAVRsY1kxFZ
+        nknx1BOUIkoi9fRXMejmFFAOz86er+ZSb/zgycZO5WvIXYCDnViLhkHyYYZap8NnR+PD1gvzpNLI
+        OdEy0uic4UwzzxL0DKYMpLC9YDUcQJS/AKzNsVOMSTYDa3PprIM8wSyUqHEKDG3GGmOAvkxFzKAh
+        fVoy3GxL1tlejyZNYeXckifzPqKASoRdfwmdc+AeITiDBnQPm9j0I018xe01kj8N/9JqbU6uSS7h
+        4GaAEX6oxPd/klxO/ekj1OoXCScW7tvblny4e1grdDyrmxUyPqI/T5/0dfqe3N5TLQxLzrL6WnJQ
+        990WMrHn7Mih3XT6+crDGQ+kxfOIh8uJRyiAkNrOEacJxy1SJfeB3Lm4MUnOKVgur2BTZ9NNLbBp
+        q+R6uLa4hGbB5OG8jufeVSvfsHy/4Vq/h8GQV6iv/eNF8vVwsYCvgl9p/BZFjDknb0uECqxwV4wv
+        YGnoq7anjyoNJtZEUNXx93CoGaDXRRSLcfWRXlE2Jseo5Yjs2YJBu5LR+WkS9a6DsI8wEQZo18e0
+        BTrbZednj0NpJibMwaUm0gVwACQXMwfszUz7u3XiSQeTQYlVeLmhSz1XaeTcoMUhqGg2szaEQq5C
+        niClUkUjLnGw1zgdpTwyPO/C884tHH1uTFJlVUh+7hdU3qgQ94jf4mppgvK6339HRp50i9I8Ul6y
+        SxAdVSUfPk2lGkoMFdNBThNIeYXBRP0u8ENNzgYSEcMRaVYtJ5qGD5ZCd5ozyqUtQ+SZVBIdctYa
+        Zdex6j6yL3TJsq2lesMkTWZQHEYL9KAWgEMkSVhBEObahlyaIjSNoqfYgZRMKdyJQ7/oF+A0gSRU
+        PtKRFU+M2kxc4Cfv1fxRXvOBHJ1eNQ5k9u9f9ntO4YVSSj4M18e5zY+D1BlNMzdny6X5QennfFdn
+        UR4ZsGaY5MnGLUjLFaPGrwR0tz7iaA9vdEZGAhO5YdzlgK3Yl5yT4+40XS9JGEPCWLszH9hkadz0
+        Ma+lwoYWBamhz10Tp+klPAigRxlTknFfF6ocSS/eEtFD5EM6BKf10Yp2XfzNAE3mLEffDNuWRy31
+        GQsItVZ/Tki0xe2XtOxR31KFtwA0GfkDNedAahf4CMNup2MN5LWRQ1fEgpGXkrNbOAI6LY1RkTO4
+        /DRUM9cznIoXQqhyE0Lals2cxMQPpahUlLczFnUVgk27ZK+CeX72MzKZm0wiq1nH4/cADRZz3MNS
+        l3J8hCJtOO8ICkFYV48qrl1ucouU5pxUwA9uVWjVpTC6p1Xp3ku7UE2VcC/LIIW5CbN3cbO1nHOX
+        XGsxdajGHRSYJyC9a9STI7nzx26CYwCtg+MG6HdjbQKOrHYaz0KRBtTUDIWVyVX7hEuP+nbLgfu7
+        00fdQzTz92GObRMUaVzYnUuLiqJalMOfPmHITx56LrFft32IUQPSJxnjiZZwCioxt22Cky1fcC+J
+        OzepIBMIeKDBiJXWhB+N4mb0dc4pVDZ9XsNlks4R5KOgG6S2BBRg+VbjAQ+64eH5KoMsRpngB7fi
+        ILvYb/p4Y4/7VT7XjuScSK1wTMrjAsZFCIKPekvsOE1b5Y1Ud/iIA0CN8HIv6XDfopNla6URR8jK
+        0SowVvx9n9UbOE1h5dx0I408qkZqs9PFyvFmC1k6B0PJHq1dPBNwo3LpLNiuW240qTTOaKq4whQ/
+        NCsHEX9hvSFDaGxI9t0tL00Q55Cb4pywWwwbOg2hw1BVIIGwRc8DFzJVkvTNF+S1FHJdLRHe9uLS
+        KOu4UivnHiEO1myHrkcjVxbymFWKQ7aKc5qVqyNKRgQ2gjbWUOGavY9++oWImHMmhR449ngeAQSE
+        +n0361VnQoigLULJ9jRQgpWl1zBpQuJN6oosBrPmnNtk2MxXS0fUeZOlooxz0S6VkCjSvFL6i8nB
+        MbjinA7gFEFjBVYiWi6VTmx1xAr9Y1IrICfP8nqI2gaq3TXx6k/D8RplLsrTGU8XI30c5w/rRuBL
+        67ETKAaHwI+kWWmwLUqiuJZx+91sRGouy0krkRlG6qQJiGPP5ioAn7gt1DgcZ6R9CDnSCpMpvO9a
+        2sShT6hmtYRVBJJwnKTkg/LPx/YwjB9oDk4/bdsRfa0YN0KHi1S0bQbpsISisu4iidIrTrNfws3P
+        ViZ+8KIWX3JL3LE/7IA73CVFiuaxZcpwFKmAGOksGG1TwYtWFkWsGPFDA6yFrQ40HXlU/cM4zEaM
+        RoPx4yrZPy7KcDDBjFmTxavnMml6FHXC0HUMZVb6JrBpAhsHsc5iNuh03czFERuLDUu1x0UY6kXy
+        RtB1+1AS5ODuG5dmTubjh1K6Jc+h5knAcFKHNXbHvZTWPHD0fiLneW9eFxxBY1Pm8TrB+0USQsEd
+        h07qEozSdhB6HCyEk80e1pD3x2vUZWFg1kNu283NuFxhewaFYLN/hR+QdlDUIqcBgCNRKtsY5B/5
+        Mt69nhtkc7/Qrg+B93HYIbcJhCeGwlIstXwCyQVv5WzbAsmrJpYxUmRF02hZl04KwIhKaALPtR7x
+        h3C9hphpuiah/k/CB1uU7Ym1Jg1Rhvt+389TZGJfoHViLFHoBl6nUdtCV5gUA/Qxe9Eug/FQYrqf
+        97chrYkw4bb/0PUSFrGlVRnmBHc2R6LxQyW9olVQ2evUJCYbiwwiOX0SPppgc5zOjkrzHd+zoC0u
+        fqkMA/am5IdnrcvR1qfJXGIR4BNOc27CuZjTV46bufimjhtYhO+EdNsz5RylwA/YDbHlziDDCxgP
+        PQAH21b9IW5uPR2OOz0ENI/muONLkcZzB/sDhsGXfAAXoujMYhV5VCbemDTxhRAu40pSCOmVltdY
+        PxpgsPcT7e9W8Ttyzi/6pjhNoTlp+FLFX5wjNWd2dIRQgzLt9ls0+UFbVmVUBkYOqa94vrktLC/t
+        1f6gHwdrg+dq16EMmfXuDGrtbD01Rynzq2+q7E1lXH7uuLlKmsubODvzg2h7biS00riP8KiNB+pP
+        4/lEX7I6i/oL0zl3PzAEszXMrHLRbcGdJsq5XxZ+QEPlnFMKobAJk27VRGi3nQZqNBudHQWntzZU
+        msaYvXfsD3ugKWIKDkQW7JbcjO20lo5E2yH50/tuu2nvtqukTtMdxOkF+1JjGwxkzZcJk2rxFfAn
+        MY6rRLLRtK33p49bLubVJOGv4QjeD8nvx/6GtMdKX2/niabShFm1HHMlJtoLTkKTsXPfn/73mqVi
+        RF9psgZIR8P4MWbemKE0OWaGxBEiOujw0m4lOKyY8rHbDPOFGfQND0fUhWOjcl+EbX8IaCGnOTfH
+        qfqoLwt+qFcc5HomgTk0sEg2jNrg8r7ng3azUEalMWriNp/OwYtziFG/PO60KFoFQgXbAVeU5guS
+        YsXJRTaAxW7Rr3wYtscd2qrKjSWhNGvNg2zZd5pb2jjN0AlH7xevqMkKY0AW+gJa8FG2ZOCnXBrj
+        UuMIibiwss1ZDn9mgHBTHjpdCE12jWjL2R+OWy3/dDi/jFkZGaKcvC6i8Im2VJln4/xs8bY9kH/B
+        wMeeNi7VXEuAHyoYZpLWUMhF6FD1wDGZqYuFSgRIuebGlSszIq5I/OShWg5OMuuQPSf2oNP4aMe1
+        MVsuQbXevyIMCJIZn7yOZwHpn6oI9QqinnfQU2TsP3Bvrq+73fUYGHlj5OLLeRznx2tXxfYwPp+T
+        OhchR7Jrt+FTC2NEejddMMKhVEv13dwXOPkquvhmbo+8QrBwUKcPYSDjEZ8/nPTmFmtB5pEs05HY
+        RqFn6sUnQZWWTThS+89JbQM4FzdSc5w050wzjo4trMPQEvKmvWZxwkds5BKIL8JRJn2z2GS8k3aF
+        rrbdAeyxiwXNofG2ub7C91FTdteY+ONoKuKFJ4u4hFPzrufYCjeK2yn4bOw3px/XR+286xqTdp89
+        Uj/eWxFvt+iwIgk5nrht/0NgZAJOdOWcinPOqlVec4K6H9nJ5u4e98fR4heNCTJqsct4xpG0QtyA
+        ETDHHYRPjDyp+R923aGLgnTt5sj9lVHNbNxNun0T34bgGDmgAe2b00/jjrYZfeJte33knAi3LnwE
+        ZSGjMvqBBUcN8F07rnV5G9sGhYuD285JRgiO7PIGjsZkHAXVTSwQRYMuxiEZ+hCMqcYEvGjixL7z
+        fDTUkZ0cByKuSM/fS6saOaBvEZbGtT7CVWXfC167jrmSSizyMI5DJ2lAeKHS0gGVdt2OjB+5yYb1
+        hMBto4pXvKKxV6AZWxa/opYbTa4mFKOPXeiG1EnH7of2HhV252cMnTigoC20afeaeRQm1YwodNyZ
+        gjs0P2uDquGbjpQuC3RoEhktFYM3au+ssjB5gLk0SgjmAQWVUq0gftlFokBTZZsb24Zcwngeyezj
+        7p6SMIMWDHsrmIE4i5Ha6aeQQBEXUFm7wBq1dlU8YtR0iDhzA3ZxZW9O/zZN3bxvwT2yo/Gf8cC9
+        cacTr4lXBw3GJDHOQ49E3y4aCGDbNe6jgUEs4c5dYF4E5tyUPx46uos1ZeQAMLXoGwNbP43iIN26
+        VzvKa95UuESV+457S3Dx8KVcTMLJgomboL5h3T1yudwYbktY4T+5XnI6humujHmNcs2IuecmLnHY
+        QOeRvH1VPj61DcWGch6TF6vUZ8unbW/4xW0/+AFFyPDhJFJzBNaHl/X8zGxEdBk5/TShV1jgmNm+
+        8HzNXsQRqVwEsARVPOHmM2y4iXYtqYT3rYpge9PSHt+0YoH6zDYMp/h9zBA3lOUBAw2blz20vw/c
+        5h5Fsnt1VN6e/kkTfvo7Op2x1zl279W285ltnYIh3PYCbuxQ5Z4tR3IFSCz6bTfC+A9Nua4H+F+b
+        AID2WB0lRbvzIubl5KKgt/09h+P+gmDnNcmtfqY3ygInakxZrdK4KNAjMq9/Qrv++Fn0soFRZNjX
+        GNHJ8ieBJNS7oJERLlFBYABR/nbd7u5tVsrwjswt7Gm5CqwSezpOpSS7008PHeC1X7XaSBXr+YWw
+        q4xducrnuL9jtBJL7Vcjzlduh5Nws9oJiXzWeYz8xFUKcw7Ca0bWMZopQsE5vmCMA61vOhRJsFB1
+        D+3UPwgQGfcwbJVJY0yKuP2gY6BRAYP3xdWby+RJ8uyb01+ff/X2VfLmq5fPv3p2ydeweU3VOga7
+        5HOq3zEgpYKpeBn0neSNFFVUaV81AExadPeVxRn6g1bzsxsog4QbYDybxZcW3CKBja3DwB2052Zj
+        ailK/6Z91B/La7bWcWuCLFswrBUJFS4pJPk5oCXNWhHFL7vbYa0tkL2mah3f+5TNaX/8kEN5RYw2
+        PTkpciXWIHnlLTwC7ho0tVuxpo7bMERvnJGdX3AuxDN6kqBA0tjyeRDKb3qVYoQfjKqKPJYSu4or
+        qBkfFN5a2uP1Qnny3VHcNOg5aRZU+N3HCA5GOnNAkPVN8obbZCvPKvCEH7r4EmyFRi7lUW4PaoR/
+        4JPn94J0uB9JFsiI2s53TnhEj5VJBSBLxBV4SSlAuPqhPUT+8sIl8JqSFYLo/gfH2KaAJmfdsdYb
+        jfhklTFyXwa4d90MNfYIpxuHCGru+DanEn7VXi/t4uw6DGuURmk6ZXV+ppeekRF8PHCFE53DG6nU
+        9pqkBbM6hi86vvWJoTNPEulEqmHLgBXlFgQTlx0fFP7mERAw4qijEH5AE4kAzQCEHWEyhWGSVWBf
+        a8KPWvOF8LuCdpGH5gorSobjMdky9iyQm4S7Ir6bCD8A0lhzVnBuTLgSDcEhXi1bRddrpKO0k08H
+        bFw/a0hnwo+eVZGJWrIDlhfiHGtY9qGPU7ze2VYAGjCPvw4YbL4n5ZMMb+6GppeKKgcTfBTqZPEH
+        AsfBmPcQH39qeVQ6/juNZXpnQo7aFxePARgIrbbS8fOdd+GmNWfCjerzuaLYcReSNG3kdgXNDHtN
+        8+KvKIlw8eOF7AXc2DQiCT8bApYD9ZrzddIupF7QN3J9ANGjgTq7o9LUQ0aKgKw8ifB+5A9UHN4v
+        0rkOBWHaZMM90XTYzmjR0ruMaRtc1SG0+iIfHs4XCFRXSdW108y7HhsP0GrDUY8l9u3v217fWxir
+        Bq1vIlYoKUj5Irv7lp7XV5fheb5rMZ6ecH0iZ05kl+xbHH4Iwz0NEiJQm/fHSTtD+JBllQ4SLv4Y
+        nLt5BKy6HoBECJ4OLmcL0A2PTW5EUTW/Y3ggt8q8gqHK7l9H5/H2jjSXOoAhh1pJZ7MiJq4jyBtP
+        IOMD2HA+wPyLzkJTnoXJYIE6jfmTGIvILWe+5ZK5LfrwkxS+79r9BBGMJyakShl7GB/tevFS+CS1
+        k/doQLdprRXWK/rY79oDUBf2zHGabzAM+dSacTxzNQV+qJAwkF70YzA9AzMJBSyyYR5nlJFWacwr
+        Q5dL3ENOFvuKkb+R64fvV0DIvp8dyZBuZaxidD0jfmAgRmA3DdfYxx9OP953853R52c6sxFjndIi
+        MKaDsols+hrRS9YlL+dRlPYwN4OJHwasv1xkJa2w1If8Kbc6iYpqHXcyyeWi00vxcLciM5+jFH1I
+        rPKdTqWPZQjpG8aBolnw9k6azSfwmZS0MVLcIb4YQA2r07qrt7NDwRuj3/TDIeyKkE2tceZkkeKt
+        rcjU3JjSZBV3cWfxK4EFkobuU1hy1Q6iChjs1+2idvO+NNFEY5Qs/nbcp1ikQYevkjmIIpQmiL6O
+        W2vQDwV6EKBbYP/98XMMOVCYuC5JZ780CSwWF4067rFS4UR/tAVKEy2giep4BnDZduOCzLYh8bfm
+        Ph7J/rHU7oeHhegqf5VG7nOSRWqSYXeZXEAVA2Y/WCGjh1a2R12Um2AEHmPUudMqV0iT43ZN5jzQ
+        13fdDQy2S8Z2hN/Z60bP6lGZ18a8XoS8Gc3HlY5vcA/Vk133xeJfQdsEWpyYUaRdbsjiYPTAYKob
+        1CyNUe26D/lNuQoriz+K68f9fL/6FPIGd4i7S0Bbem5pXAsnMl92o6wzY13H7SBdw1ilzK4nYAw2
+        11cj07LrUa53x9GO+Q39ODfV9CEZ2ghMKf5ghimVWiV21KJaG/G3k05ZSHgy0i+6WQ0/6C2k76z8
+        zoeMJrdjcfnifWhMyb7XO5Zh7ZQA+Oo491jwIWPZSKlNHXFwQF9jmsMeqExGHfrYLJ71Yia+aLeh
+        aMNrQtLz3VfRRUI+lWo4p7F52hafdgycaddBOWmmUR6NbjPxjH3jE+dtQAC1UxuoSdPshxGmKXsr
+        7jsLn2nSUegjwJNnwBor9V24MaObL2QxqLZwQeLDiKoZleNTBlKIY/MsDKhdy2l6+utKI544z3dD
+        wB15WKtGHfWy9IxqK+GkXU7xtGi+0DNkLSqR9IIygzH1lhuQkdzbZtJ1lxTsOKdzvSYJPYALcfUD
+        fkDdpATG7VuUyBuRRwenmAjhMG2gj1Ic9hHeHzcq2poB9AyqquYD1zPGqZF2Hj+v5CSurOadZj7J
+        o7pvgT6zySkD/yKPRdmnUn8fsF8bbTTCN7mPWr4LmAtitbrdlxBW5W/yjDr8Kv5yAKcQUHxOrMkB
+        5Ih/dNzUJs18pdYsNoKiKhupKW6fxogPuNzd9lEHeq/pQc/ApHR21TyDjhi+r1W6wNxvw0wiFW2m
+        oeYIQUL+xYxT8gwyYpUelzoJTRZoUE41Owb4gcxJb71iMXhxgeAKK3FuxNWqjHYz38vUeARrtCm0
+        lkVjEbh9/vnZHfkb09T9gBOMm5LN3+ECW9zalMXfwZiYVCucpc3/NXL9XZDJ8FneWKBUcDEyNBEq
+        xNtdyddE4GGviTx50M/gYS8YIOnD96wlR59GcDH/m9iDz7sJgW8OQsnu0DSfZ3BKhCnyeqVGPaey
+        H/qN9NoOt8TriKrAAd2d5kSh55sruD/euwBT59Lz40Xy6Ifzs4DjBvuCpqta73R8tXHHDYJpzL3C
+        TY+Px4csrpI2Rop85LzxGcxS1dUyiIm+JZMGFgpN3nlGtbhIRzEGJa3dMsP/uNyl0CSePB7FCb0T
+        X6aJG6pz+4iAvE+uTx8ngIX1bmvN2wlhvfiKjK9tlxNk0Ps5V8kfFcoNdXg97EK+tV2TJTL3+yvg
+        zhubqlnwdcg7IosUSJ5GUyVtJuEWrY/bnvsqScCwgMVnHOrFR6PUGw7W22Ej1ww99OueEzAbyS22
+        Q/K2310fvzsgsqBecccB/wfNOBSarAO7Om6G7BklkmZlHODtfiAjiq/TbceLyKcCnzLwyV0MVvBy
+        m4QrtSIVBt7DfH/Gy0edvwpNxHluuJDPrRc9XytRN9IyUW8KUqu50PSbZ+xIdBGjd+zHweK+pIeP
+        vPWnQ28dEaEd6VhI3vXrIGRNYIXy5HTBivR7ls4xjlkrFpmJNpqCFvHCkwYpKkS8xd2XAWcmyj6P
+        by/GD/SWPNXYTGhkKrFpEJrk4uD18TQD9sBXWkmgK2qC+oFPgPk++MzEFNdrzw6r564LDRfP7L9H
+        a10Nreu2yUwWCxcjsj0DHhjBh3S0NJmEnd4GKFeRmZgVOJbiZUXcBp72a1yA9wQ4plkaNB/m5XaL
+        OeDuGQDACXaeJ73bgTs2wFTSyaoCdYbSsDKixgFbWsMvAADh7I1cCP+gIo3JtKejPLbnLgtVVT8u
+        09K3NkZGSxRZgtIkoXbiwuKWSKhIe7EkdxFkPv0klhPqM9CA66H70E1yhsrIIB/GsSnikQF/ihG8
+        JpXNKwE0Zbfpb8dOAJTCIDMGLu4r7BkQwJVZSI5wu1pks8ZO6kfxqQyMw20y/dgdBmm1rH5CATvT
+        2PgZEIEfGsGlPkPWaT7C5SIGrS9VJs6YNHHfYc93YHBLAAH+91rYEoRM01ee77eI7h3DDw41naEj
+        NSugYHsUmq7ynLyP4tD4oSQzOJf8EwIYAZE9qMsYDtktL9j700e7narITXSBbp09ec85+qaq1X+M
+        dKoSmtSiOtLHX4GAhsv0ipcVUuuCzpxbe4oI5ia5BTLT8buxUaGtpF7zGUYfpsHklkOrsdwiNgrN
+        865Hb0oDw207CU0XzuQRvcnnjiqeM/Jlwe7Ac7bVh+S2nfiVj35RTiqYTFhHplMhRQrcy2yVbB7x
+        AmVulIvL/jyn8vkaS66IOv34NLFdz34DGiWRHzfM1VHsNSpbZ2yrhdFSQKlwwwZcRM6XqZJ/KSCr
+        5IW27zk/4+xTYjedonSWG+4qdx+4Z2xoxtydALGeDbuQCRj5iiC51A6dYq2RS4ETTsl8XBXgC6l1
+        ZEQJIrqiHlfx7dyBRWksFpfiec7sc8HZDeJxoYx9125njN752Thsh6P+EPUQKTQf5fmOhzRbsEXW
+        J5fqi9OnUPQmd/4G6tqofVxL4BkpwB1onyxrPp4mX7ZhJKStpKshJDWxwxrheOMRXVRFPzg0AV4U
+        TOnNZe1c5Uqu5e1wXEXdi6EZudqt3dsF/Q/9DJMuNNMlLyjr+DNQuZAz3AqNPyeUy5HSv98K0spq
+        TPYMtrGQWuFtnzhcZx0LjsN9DVko7Q3L6217eLT5qiMCmCAw36DcrX2JVDGFjwScAUK34dvqt2or
+        edsb6BLoFzxLQWSZQX89HcegcL1JvUcbrgUdbhpBq4bjoX1EZCKOfuZzfb4vOPDbpOx49q21Lrkf
+        uHdSsqfxyqEK9AAX1Y5zKUXhTe4LeCWx3kD9OEy351FjfZR2YX7YtpHS90cTbQKPbKmPtyL3U81x
+        cqq7yGfpPJ0q7IzriE19vopCbKQFYoFdWDmTNj0MROyEqe2P3P7opmdlJLcYrDubx8be4tH/OH5L
+        RR5AYccLGSS3uPww9BwuEM23J/N8McA6tEaG9sRFBxKc0knRBJkXRMdc4YIfSFvDAX+FqBpfVv1+
+        OAYkK0hzIy0Wtn0pwWOZFVauETxvvqtaB+ACF5zGc/LUl3yLMb7sqrcNZn7Z/rjpQ5av0FyX5ws+
+        6kiV8QUf3MnpGQM9UTvHgQqBA4WCcj6qj9ZcvJAUl5JHuUxfSi4zt+aJpE3GGR8p2Hxtj19o7stz
+        jr2KfNnq12m4lwz1stgZ/cQ958gzVEAas4q7kRQ4q426iawPTspzm4hJrpflbCMdRpwIVeHSVJjn
+        NLqbUx/4ATWj2fLCee1sgymZ27UWmhTzlZQXNBET3EjgasWgsm8jgLsvonMA2hgNiFVz36CXbyju
+        LjRTJqxcGn8e2YzcXUer70WNB60vzjjGrw+zbxxTFyv+MyolSE8OTzbHcYi3kHLIjQPaL1Yxh0rg
+        NM+gt6Lgxxf6kzJwgYFfeppyz0Nj/bRwCULo2x7d2VpovsxLM54ynoGilruF3y0FVtRM1Ii10Aya
+        5yR5dKu+53y3kxWSjOOT5BfjQYgzKVGxyqI4JOema+k+92e+n2KvwGNO4uhEVEaNwEUWUzdSASaP
+        L/tPFZoE89JuZ8584AcvmuDVEUbchd7Rg6u6B8uEo0i0ty9ojFexkAfuqsMIlLn9KeM8LHTP1o42
+        PCg0QeZraZ8czwSuGcg5uWbXpJlnL4akblzNhHnOj1fR1uMcOIOy2WyX71GaPNAUfNV4RFMg2AJI
+        Nd9hkHDl05rOrXEMtCqI0oskMs24F0ka+i3x5TZK4QMFahQjI5X757Mz/+Xpb2++fPXNq+Td1Tcv
+        rr7+wyshLIwQZc5FTMi1HuxKhdzdS0V9IiYGPD1jNHUEZWCEtELknjZciZ0Vj9rKF5r3KnIB+Nuk
+        FjmvFM6t52gcKiKpma6Cax78nIYv+LrNdE78hmLmsPyN0ZHDO2OhC+k12aSB7kZvUuhCJ/9Cs1gF
+        xyjyWVcWHH3gGxK/PP003QwjCuVH9lrloqBu6vYB03HcMTYQAFh0bwgipTmtgptIRpdsF3wHJtsr
+        col3CzjpXb/hgAAK4/SVyiYPbACS9PEYOVaYYcdZa0ohcUbClk9MUtJClALLARC8xaVB3FzShu0D
+        Md/bWkTERS4tNt+yeMxtugtNaBV8haLPFjQVWW3p+VmwK29Jp2zn1FuhuaqiYMTdXNZUsHnLl1aw
+        bRO7C7p4VaCEqTgHmAo2FctwbYKNsbbHGzoqZjEp2VnOys+6Sckpe9dywkiMVRnFkTuB7yIYaaHZ
+        KGEW3W9asKFYOXa1dno1lVyBGBrU2XaBpBpJM+9w/NDIZf2vZky82Gzv+Q4agQ4wzDKqG9ShacJK
+        uER1oAWjexvsQrb5bmHchHNf7u3a9A891+ED7a3c8sAN10fnC26IfeXc0wjXPfMgtJnjRi/sYgAm
+        mlz9sN4eFfBcaPaqqPTOOGMpSEaXLhdSM1UFAxcLHz+OTGDhw3UZoUOZHMEsNP8fUEsBAh8AFAAA
+        AAgAhr2SUdJM9N5iQQAA0qIAACYAJAAAAAAAAAAgAAAAAAAAAEJyZWFraW5nLkJhZC5TMDFFMDEu
+        QkRSaXAueDI2NC1GR1Quc3J0CgAgAAAAAAABABgAAAYFTo/V1gEMLo5ITLjcAQwujkhMuNwBUEsF
+        BgAAAAABAAEAeAAAAKZBAAAMAGxlZ2VuZGVpLm5ldA==
+    headers:
+      Accept-Ranges:
+      - bytes
+      CF-RAY:
+      - a14e7a7fe8b849ac-GRU
+      Cache-Control:
+      - max-age=2592000
+      Cf-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '16960'
+      Content-Type:
+      - application/zip
+      Date:
+      - Thu, 02 Jul 2026 14:53:11 GMT
+      Etag:
+      - '"6a273e6f-4240"'
+      Expires:
+      - Sat, 01 Aug 2026 14:53:11 GMT
+      Last-Modified:
+      - Mon, 08 Jun 2026 22:13:03 GMT
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=UDYR6EslRuFitfzkAVCgj3ogIXkV%2FjS9TodHvcnwWw4gLop%2Fh44lchrBD%2B8vOi%2Fl37LM5WmIUDBZ8NW3eacJZsIpldvFSvSUxnPHwxZJIRrxlMsj1c%2F7uZus3tWdbJQ%3D"}]}'
+      Server:
+      - cloudflare
+      Server-Timing:
+      - cfCacheStatus;desc="DYNAMIC"
+      - cfEdge;dur=9,cfOrigin;dur=200
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/subliminal_patch/cassettes/test_legendei/test_list_subtitles_episode.yaml
+++ b/tests/subliminal_patch/cassettes/test_legendei/test_list_subtitles_episode.yaml
@@ -1,0 +1,5241 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - pt-BR,pt;q=0.9,en;q=0.8
+      User-Agent:
+      - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like
+        Gecko) Chrome/131.0.0.0 Safari/537.36
+    method: GET
+    uri: https://legendei.net/?s=Breaking%20Bad%20S01E01
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html dir=\"ltr\" lang=\"pt-BR\" prefix=\"og: https://ogp.me/ns#\"\
+        >\n<head>\n<meta charset=\"UTF-8\">\n<meta name=\"viewport\" content=\"width=device-width,\
+        \ initial-scale=1.0\">\n\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css\"\
+        >\n\t\n<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">\n<link\
+        \ rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>\n<link\
+        \ href=\"https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap\"\
+        \ rel=\"stylesheet\">\n\t\n<title>breaking bad s01e01 - Legendei - Aqui Sai\
+        \ Primeiro</title>\n\t<style>img:is([sizes=\"auto\" i], [sizes^=\"auto,\"\
+        \ i]) { contain-intrinsic-size: 3000px 1500px }</style>\n\t\n\t\t<!-- All\
+        \ in One SEO Pro 4.6.0 - aioseo.com -->\n\t\t<meta name=\"robots\" content=\"\
+        max-image-preview:large\" />\n\t\t<meta name=\"google-site-verification\"\
+        \ content=\"JSMIV3rTOC3Y-WjaQzmU3KvW7aWHceTxBFYsJYpm-1k\" />\n\t\t<meta name=\"\
+        generator\" content=\"All in One SEO Pro (AIOSEO) 4.6.0\" />\n\t\t<script\
+        \ type=\"application/ld+json\" class=\"aioseo-schema\">\n\t\t\t{\"@context\"\
+        :\"https:\\/\\/schema.org\",\"@graph\":[{\"@type\":\"BreadcrumbList\",\"@id\"\
+        :\"https:\\/\\/legendei.net\\/#breadcrumblist\",\"itemListElement\":[{\"@type\"\
+        :\"ListItem\",\"@id\":\"https:\\/\\/legendei.net\\/#listItem\",\"position\"\
+        :1,\"name\":\"Home\",\"item\":\"https:\\/\\/legendei.net\\/\",\"nextItem\"\
+        :\"https:\\/\\/legendei.net\\/#listItem\"},{\"@type\":\"ListItem\",\"@id\"\
+        :\"https:\\/\\/legendei.net\\/#listItem\",\"position\":2,\"name\":\"breaking\
+        \ bad s01e01\",\"previousItem\":\"https:\\/\\/legendei.net\\/#listItem\"}]},{\"\
+        @type\":\"Organization\",\"@id\":\"https:\\/\\/legendei.net\\/#organization\"\
+        ,\"name\":\"Legendei\",\"url\":\"https:\\/\\/legendei.net\\/\",\"logo\":{\"\
+        @type\":\"ImageObject\",\"url\":\"https:\\/\\/legendei.net\\/wp-content\\\
+        /uploads\\/2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /#organizationLogo\",\"width\":150,\"height\":150},\"image\":{\"@id\":\"https:\\\
+        /\\/legendei.net\\/#organizationLogo\"}},{\"@type\":\"SearchResultsPage\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/#searchresultspage\",\"url\":\"https:\\\
+        /\\/legendei.net\\/\",\"name\":\"breaking bad s01e01 - Legendei - Aqui Sai\
+        \ Primeiro\",\"inLanguage\":\"pt-BR\",\"isPartOf\":{\"@id\":\"https:\\/\\\
+        /legendei.net\\/#website\"},\"breadcrumb\":{\"@id\":\"https:\\/\\/legendei.net\\\
+        /#breadcrumblist\"}},{\"@type\":\"WebSite\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /#website\",\"url\":\"https:\\/\\/legendei.net\\/\",\"name\":\"Legendei\"\
+        ,\"description\":\"Baixar Legendas de S\\u00e9ries e Filmes\",\"inLanguage\"\
+        :\"pt-BR\",\"publisher\":{\"@id\":\"https:\\/\\/legendei.net\\/#organization\"\
+        }}]}\n\t\t</script>\n\t\t<!-- All in One SEO Pro -->\n\n<link rel='dns-prefetch'\
+        \ href='//fonts.googleapis.com' />\n<link rel=\"alternate\" type=\"application/rss+xml\"\
+        \ title=\"Feed para Legendei &raquo;\" href=\"https://legendei.net/feed/\"\
+        \ />\n<link rel=\"alternate\" type=\"application/rss+xml\" title=\"Feed de\
+        \ coment\xE1rios para Legendei &raquo;\" href=\"https://legendei.net/comments/feed/\"\
+        \ />\n<link rel=\"alternate\" type=\"application/rss+xml\" title=\"Legendei\
+        \ &raquo; Feed do resultado da busca por &#8220;breaking bad s01e01&#8221;\"\
+        \ href=\"https://legendei.net/search/breaking+bad+s01e01/feed/rss2/\" />\n\
+        <script type=\"text/javascript\">\n/* <![CDATA[ */\nwindow._wpemojiSettings\
+        \ = {\"baseUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\/emoji\\/16.0.1\\\
+        /72x72\\/\",\"ext\":\".png\",\"svgUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\\
+        /emoji\\/16.0.1\\/svg\\/\",\"svgExt\":\".svg\",\"source\":{\"concatemoji\"\
+        :\"https:\\/\\/legendei.net\\/wp-includes\\/js\\/wp-emoji-release.min.js?ver=6.8.3\"\
+        }};\n/*! This file is auto-generated */\n!function(s,n){var o,i,e;function\
+        \ c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function\
+        \ p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var\
+        \ t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),a=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new\
+        \ Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return\
+        \ t.every(function(e,t){return e===a[t]})}function u(e,t){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);for(var\
+        \ n=e.getImageData(16,16,1,1),a=0;a<n.data.length;a++)if(0!==n.data[a])return!1;return!0}function\
+        \ f(e,t,n,a){switch(t){case\"flag\":return n(e,\"\\ud83c\\udff3\\ufe0f\\u200d\\\
+        u26a7\\ufe0f\",\"\\ud83c\\udff3\\ufe0f\\u200b\\u26a7\\ufe0f\")?!1:!n(e,\"\\\
+        ud83c\\udde8\\ud83c\\uddf6\",\"\\ud83c\\udde8\\u200b\\ud83c\\uddf6\")&&!n(e,\"\
+        \\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc65\\udb40\\udc6e\\udb40\\\
+        udc67\\udb40\\udc7f\",\"\\ud83c\\udff4\\u200b\\udb40\\udc67\\u200b\\udb40\\\
+        udc62\\u200b\\udb40\\udc65\\u200b\\udb40\\udc6e\\u200b\\udb40\\udc67\\u200b\\\
+        udb40\\udc7f\");case\"emoji\":return!a(e,\"\\ud83e\\udedf\")}return!1}function\
+        \ g(e,t,n,a){var r=\"undefined\"!=typeof WorkerGlobalScope&&self instanceof\
+        \ WorkerGlobalScope?new OffscreenCanvas(300,150):s.createElement(\"canvas\"\
+        ),o=r.getContext(\"2d\",{willReadFrequently:!0}),i=(o.textBaseline=\"top\"\
+        ,o.font=\"600 32px Arial\",{});return e.forEach(function(e){i[e]=t(o,e,n,a)}),i}function\
+        \ t(e){var t=s.createElement(\"script\");t.src=e,t.defer=!0,s.head.appendChild(t)}\"\
+        undefined\"!=typeof Promise&&(o=\"wpEmojiSettingsSupports\",i=[\"flag\",\"\
+        emoji\"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){s.addEventListener(\"\
+        DOMContentLoaded\",e,{once:!0})}),new Promise(function(t){var n=function(){try{var\
+        \ e=JSON.parse(sessionStorage.getItem(o));if(\"object\"==typeof e&&\"number\"\
+        ==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&\"object\"\
+        ==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if(\"\
+        undefined\"!=typeof Worker&&\"undefined\"!=typeof OffscreenCanvas&&\"undefined\"\
+        !=typeof URL&&URL.createObjectURL&&\"undefined\"!=typeof Blob)try{var e=\"\
+        postMessage(\"+g.toString()+\"(\"+[JSON.stringify(i),f.toString(),p.toString(),u.toString()].join(\"\
+        ,\")+\"));\",a=new Blob([e],{type:\"text/javascript\"}),r=new Worker(URL.createObjectURL(a),{name:\"\
+        wpTestEmojiSupports\"});return void(r.onmessage=function(e){c(n=e.data),r.terminate(),t(n)})}catch(e){}c(n=g(i,f,p,u))}t(n)}).then(function(e){for(var\
+        \ t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],\"\
+        flag\"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return\
+        \ e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);\n\
+        /* ]]> */\n</script>\n<link rel='stylesheet' id='wpa-css-css' href='https://legendei.net/wp-content/plugins/wp-attachments/styles/0/wpa.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='wp-emoji-styles-inline-css' type='text/css'>\n\
+        \n\timg.wp-smiley, img.emoji {\n\t\tdisplay: inline !important;\n\t\tborder:\
+        \ none !important;\n\t\tbox-shadow: none !important;\n\t\theight: 1em !important;\n\
+        \t\twidth: 1em !important;\n\t\tmargin: 0 0.07em !important;\n\t\tvertical-align:\
+        \ -0.1em !important;\n\t\tbackground: none !important;\n\t\tpadding: 0 !important;\n\
+        \t}\n</style>\n<link rel='stylesheet' id='wp-block-library-css' href='https://legendei.net/wp-includes/css/dist/block-library/style.min.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='classic-theme-styles-inline-css'\
+        \ type='text/css'>\n/*! This file is auto-generated */\n.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em\
+        \ + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}\n\
+        </style>\n<style id='wppb-content-restriction-start-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-content-restriction-end-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-edit-profile-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-login-style-inline-css' type='text/css'>\n\n\
+        \n</style>\n<style id='wppb-recover-password-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-register-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='global-styles-inline-css' type='text/css'>\n:root{--wp--preset--aspect-ratio--square:\
+        \ 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4:\
+        \ 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3:\
+        \ 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16:\
+        \ 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray:\
+        \ #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink:\
+        \ #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange:\
+        \ #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan:\
+        \ #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue:\
+        \ #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple:\
+        \ #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1)\
+        \ 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan:\
+        \ linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange:\
+        \ linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red:\
+        \ linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray:\
+        \ linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum:\
+        \ linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186)\
+        \ 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple:\
+        \ linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux:\
+        \ linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62)\
+        \ 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112)\
+        \ 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean:\
+        \ linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181)\
+        \ 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128)\
+        \ 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129)\
+        \ 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium:\
+        \ 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large:\
+        \ 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40:\
+        \ 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70:\
+        \ 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural:\
+        \ 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px\
+        \ rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0,\
+        \ 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255,\
+        \ 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0,\
+        \ 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap:\
+        \ 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items:\
+        \ center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display:\
+        \ grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-color{color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background:\
+        \ var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange)\
+        \ !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background:\
+        \ var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background:\
+        \ var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background:\
+        \ var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background:\
+        \ var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background:\
+        \ var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size:\
+        \ var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size:\
+        \ var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--x-large) !important;}\n:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}\n:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}\n:root :where(.wp-block-pullquote){font-size:\
+        \ 1.5em;line-height: 1.6;}\n</style>\n<link rel='stylesheet' id='lrl-css-css'\
+        \ href='https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-maincss-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css' type='text/css'\
+        \ media='all' />\n<link rel='stylesheet' id='fontawesome-css' href='https://legendei.net/wp-content/themes/simple-grid/assets/css/all.min.css'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-webfont-css'\
+        \ href='//fonts.googleapis.com/css?family=Playfair+Display:400,400i,700,700i|Domine:400,700|Oswald:400,700|Patua+One|Merriweather:400,400i,700,700i&#038;display=swap'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='legendei-style-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css?ver=1782544305'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='wppb_stylesheet-css'\
+        \ href='https://legendei.net/wp-content/plugins/profile-builder/assets/css/style-front-end.css?ver=3.15.2'\
+        \ type='text/css' media='all' />\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-includes/js/jquery/jquery.min.js?ver=3.7.1\" id=\"\
+        jquery-core-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1\"\
+        \ id=\"jquery-migrate-js\"></script>\n<!--[if lt IE 9]>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/respond.min.js\"\
+        \ id=\"respond-js\"></script>\n<![endif]-->\n<link rel=\"https://api.w.org/\"\
+        \ href=\"https://legendei.net/wp-json/\" /><link rel=\"EditURI\" type=\"application/rsd+xml\"\
+        \ title=\"RSD\" href=\"https://legendei.net/xmlrpc.php?rsd\" />\n<meta name=\"\
+        generator\" content=\"WordPress 6.8.3\" />\n<style>\n\n/* FORMUL\xC1RIO TRIAL\
+        \ */\n\n.premium-form {\n    max-width: 760px;\n    margin: 0 auto 20px;\n\
+        \    padding: 30px;\n    border-radius: 10px;\n    background: #212121;\n\
+        \    border: 10px solid transparent;\n    background-image:\n        linear-gradient(#212121,#212121),\n\
+        \        linear-gradient(90deg,#3f8cff,#8a2be2);\n    background-origin: border-box;\n\
+        \    background-clip: padding-box, border-box;\n    box-sizing: border-box;\n\
+        }\n\n/* Campos */\n\n.premium-form .field {\n    position: relative;\n   \
+        \ margin-bottom: 20px;\n}\n\n.premium-form input {\n    width: 100%;\n   \
+        \ padding: 14px;\n    border-radius: 8px;\n    border: 1px solid #ccc;\n \
+        \   font-size: 16px;\n    box-sizing: border-box;\n}\n\n/* Focus bonito */\n\
+        \n.premium-form input:focus {\n    border-color: transparent;\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin: border-box;\n    background-clip: padding-box, border-box;\n\
+        \    box-shadow: 0 0 0 4px rgba(63,140,255,0.20);\n    outline: none;\n}\n\
+        \n/* TOOLTIP */\n\n.premium-form .tooltip {\n    position: absolute;\n   \
+        \ bottom: 100%;\n    left: 0;\n    margin-bottom: 10px;\n    background: linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \tbox-shadow:0 6px 14px rgba(0,0,0,0.25);\n    color: #ffffff;\n    padding:\
+        \ 10px 12px;\n    font-size: 14px;\n    border-radius: 6px;\n    max-width:\
+        \ 260px;\n    opacity: 0;\n    pointer-events: none;\n    transition: .2s;\n\
+        \    z-index: 999;\n}\n\n.premium-form .tooltip::after {\n    content: \"\"\
+        ;\n    position: absolute;\n    top: 100%;\n    left: 15px;\n    border-width:\
+        \ 6px 6px 0 6px;\n    border-style: solid;\n    border-color: #8a2be2 transparent\
+        \ transparent transparent;\n}\n\n.premium-form .field:hover .tooltip,\n.premium-form\
+        \ .field:focus-within .tooltip {\n    opacity: 1;\n    transform: translateY(-4px);\n\
+        }\n\n/* BOT\xC3O */\n\n.premium-form button {\n    padding: 14px 30px;\n \
+        \   font-size: 22px;\n    border-radius: 8px;\n    border: none;\n    background:\
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    color: #fff;\n    cursor: pointer;\n\
+        \    transition: .25s;\n}\n\n.premium-form button:hover {\n    background:\
+        \ linear-gradient(90deg,#4c9aff,#9a3bff);\n}\n\n/* SENHA */\n\n.pass-wrap{\n\
+        \    position:relative;\n}\n\n.toggle-pass{\n    position:absolute;\n    right:12px;\n\
+        \    top:50%;\n    transform:translateY(-50%);\n    cursor:pointer;\n    font-size:18px;\n\
+        }\n\n/* BARRA FOR\xC7A SENHA */\n\n.strength{\n    height:6px;\n    background:#444;\n\
+        \    border-radius:4px;\n    margin-top:8px;\n    overflow:hidden;\n}\n\n\
+        .strength div{\n    height:100%;\n    width:0%;\n    transition:.3s;\n}\n\n\
+        /* MOBILE */\n\n@media (max-width:480px){\n\n.premium-form{\n    padding:20px;\n\
+        }\n\n}\n\n</style>\n<style>\n\n/* remove fundo normal, ativo e hover do logo\
+        \ */\n.simple-grid-primary-nav-menu > li.menu-logo-item > a,\n.simple-grid-primary-nav-menu\
+        \ > li.menu-logo-item > a:hover,\n.simple-grid-primary-nav-menu > li.menu-logo-item.current-menu-item\
+        \ > a{\n    background:none !important;\n}\n\n/* ===================================================\n\
+        \   MOBILE\n   =================================================== */\n\n\
+        @media only screen and (max-width:812px){\n\n    /* ESCONDER LOGO NO MENU\
+        \ MOBILE */\n    .simple-grid-primary-nav-menu > li.menu-logo-item{\n    \
+        \    display:none !important;\n    }\n\n}\n\n</style>\n    <style type=\"\
+        text/css\">\r\n            .simple-grid-site-title, .simple-grid-site-title\
+        \ a, .simple-grid-site-description {color: #ffffff;}\r\n        </style>\r\
+        \n    <style type=\"text/css\" id=\"custom-background-css\">\nbody.custom-background\
+        \ { background-color: #333333; }\n</style>\n\t<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"32x32\" />\n<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"192x192\" />\n<link rel=\"apple-touch-icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n<meta name=\"msapplication-TileImage\" content=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n</head>\t\n\t\n\t\n<body class=\"search search-results custom-background\
+        \ wp-custom-logo wp-theme-simple-grid simple-grid-animated simple-grid-fadein\
+        \ simple-grid-theme-is-active simple-grid-custom-logo-active simple-grid-layout-type-full\
+        \ simple-grid-masonry-inactive simple-grid-float-grid simple-grid-responsive-grid-details\
+        \ simple-grid-layout-full-width simple-grid-header-banner-active simple-grid-tagline-inactive\
+        \ simple-grid-logo-above-title simple-grid-primary-menu-active simple-grid-primary-mobile-menu-active\
+        \ simple-grid-secondary-mobile-menu-active simple-grid-primary-social-icons\"\
+        \ id=\"simple-grid-site-body\" itemscope=\"itemscope\" itemtype=\"http://schema.org/WebPage\"\
+        >\n<a class=\"skip-link screen-reader-text\" href=\"#simple-grid-content-wrapper\"\
+        >Skip to content</a>\n\n\n\n<div class=\"simple-grid-site-header simple-grid-container\"\
+        \ id=\"simple-grid-header\" itemscope=\"itemscope\" itemtype=\"http://schema.org/WPHeader\"\
+        \ role=\"banner\">\n<div class=\"simple-grid-head-content simple-grid-clearfix\"\
+        \ id=\"simple-grid-head-content\">\n\n<div class=\"simple-grid-no-header-content\"\
+        >\n              <p class=\"simple-grid-site-title\"><a href=\"https://legendei.net/\"\
+        \ rel=\"home\">Legendei</a></p>\r\n                </div>\n\n</div><!--/#simple-grid-head-content\
+        \ -->\n</div><!--/#simple-grid-header -->\n\n\n\n<div class=\"simple-grid-container\
+        \ simple-grid-primary-menu-container simple-grid-clearfix\">\n<div class=\"\
+        simple-grid-primary-menu-container-inside simple-grid-clearfix\">\n<nav class=\"\
+        simple-grid-nav-primary\" id=\"simple-grid-primary-navigation\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/SiteNavigationElement\" role=\"navigation\"\
+        \ aria-label=\"Primary Menu\">\n\t\n\t\n<div class=\"simple-grid-outer-wrapper\"\
+        >\n<a href=\"/\" class=\"logo-mobile-inline\">\n<img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \nstyle=\"width:100%;height:auto;\">\n</a>\n\n<style>\n.logo-mobile-inline{\n\
+        display:none;\n}\n\n@media (max-width:812px){\n.logo-mobile-inline{\ndisplay:block;\n\
+        }\n}\n</style>\t\n\n\t\n<style>\n.mobile-header-icons{\n    display:none;\n\
+        }\n\n@media (max-width: 812px){\n\n.mobile-header-icons{\n    display:grid;\n\
+        \    grid-template-columns: 2fr 1fr 1fr;\n    gap:10px;\n    padding:10px;\n\
+        }\n\n/* BOT\xD5ES */\n.mobile-header-icons a,\n.mobile-header-icons .cat-toggle{\n\
+        \    display:flex;\n    align-items:center;\n    justify-content:center;\n\
+        \    gap:6px;\n    background:#141414;\n    padding:8px 6px;\n    border-radius:8px;\n\
+        \    color:#fff;\n    font-size:12px;\n    text-decoration:none;\n    text-align:center;\n\
+        \    cursor:pointer;\n}\n\n/* CATEGORIA */\n.cat-toggle{\n    font-weight:600;\n\
+        }\n\n/* SETA */\n.cat-toggle .arrow{\n    transition:transform 0.3s ease;\n\
+        }\n\n/* SETA GIRADA */\n.cat-toggle.active .arrow{\n    transform:rotate(180deg);\n\
+        }\n\n/* HOVER */\n.mobile-header-icons a:hover,\n.mobile-header-icons .cat-toggle:hover{\n\
+        \    background:#1f1f1f;\n}\n\n/* CONTAINER */\n.cat-container{\n    position:relative;\n\
+        }\n\n/* DROPDOWN */\n.cat-list{\n    display:flex;\n    flex-direction:column;\n\
+        \    gap:6px;\n\n    position:absolute;\n    top:110%;\n    left:0;\n    width:100%;\n\
+        \n    background:#0f0f0f;\n    border-radius:8px;\n    padding:6px;\n    z-index:999;\n\
+        \n    opacity:0;\n    visibility:hidden;\n    transform:translateY(-5px);\n\
+        \    transition:all 0.25s ease;\n}\n\n/* ABERTO */\n.cat-container.open .cat-list{\n\
+        \    opacity:1;\n    visibility:visible;\n    transform:translateY(0);\n}\n\
+        \n/* ITENS */\n.cat-list a{\n    justify-content:flex-start;\n    font-size:14px;\n\
+        \    padding:10px;\n}\n\n}\n</style>\n\n\n<div class=\"mobile-header-icons\"\
+        >\n\n    <!-- CATEGORIAS -->\n    <div class=\"cat-container\">\n        <div\
+        \ class=\"cat-toggle\">\n            \U0001F4C2 Categorias <span class=\"\
+        arrow\">\u25BC</span>\n        </div>\n\n        <div class=\"cat-list\">\n\
+        \            <a href=\"/category/destaques/\">\u2B50 Destaques</a>\n     \
+        \       <a href=\"/category/filmes/\">\U0001F3AC Filmes</a>\n            <a\
+        \ href=\"/category/serie/\">\U0001F4FA S\xE9ries</a>\n            <a href=\"\
+        /category/pack-de-legendas/\">\U0001F4E6 Packs</a>\n        </div>\n    </div>\n\
+        \n    \n        <a href=\"/seja-premium-vitalicio/\"><i class=\"fa-solid fa-crown\"\
+        ></i> Premium</a>\n\n        <a href=\"/login/\"><i class=\"fa-solid fa-key\"\
+        ></i> Login</a>\n\n    \n</div>\n\n<script>\ndocument.addEventListener(\"\
+        DOMContentLoaded\", function(){\n\n    const container = document.querySelector(\"\
+        .cat-container\");\n    const toggle = document.querySelector(\".cat-toggle\"\
+        );\n\n    toggle.addEventListener(\"click\", function(e){\n        e.stopPropagation();\n\
+        \        container.classList.toggle(\"open\");\n        toggle.classList.toggle(\"\
+        active\");\n    });\n\n    document.addEventListener(\"click\", function(e){\n\
+        \        if(!container.contains(e.target)){\n            container.classList.remove(\"\
+        open\");\n            toggle.classList.remove(\"active\");\n        }\n  \
+        \  });\n\n});\n</script>\t\n\t\n<ul id=\"simple-grid-menu-primary-navigation\"\
+        \ class=\"simple-grid-primary-nav-menu simple-grid-menu-primary\"><li id=\"\
+        menu-item-673170\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-673170 menu-logo-item\">\n        <a href=\"https://legendei.net/\"\
+        \ style=\"\n            display:flex;\n            align-items:center;\n \
+        \           justify-content:center;\n            height:100%;\n          \
+        \  padding:0;\n            margin:0;\n            line-height:1;\n       \
+        \ \">\n            <img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \n                      alt=\"Legendei.NET\"\n                      style=\"\
+        height:42px;width:auto;display:block;\">\n        </a></li>\n\n<li id=\"menu-item-673168\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673168\"\
+        ><a href=\"https://legendei.net/category/destaques/\" title=\"Legendas em\
+        \ Destaque\">DESTAQUES</a></li>\n<li id=\"menu-item-673167\" class=\"menu-item\
+        \ menu-item-type-taxonomy menu-item-object-category menu-item-673167\"><a\
+        \ href=\"https://legendei.net/category/filmes/\" title=\"Legendas para Filmes\"\
+        >Filmes</a></li>\n<li id=\"menu-item-673166\" class=\"menu-item menu-item-type-taxonomy\
+        \ menu-item-object-category menu-item-673166\"><a href=\"https://legendei.net/category/serie/\"\
+        \ title=\"Legendas para seriados\">S\xC9RIES</a></li>\n<li id=\"menu-item-673169\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673169\"\
+        ><a href=\"https://legendei.net/category/pack-de-legendas/\" title=\"Pack\
+        \ de legendas\">PACKS</a></li>\n<li id=\"menu-item-731144\" class=\"menu-item\
+        \ menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-731144\"\
+        ><a target=\"_blank\" href=\"/aplicativos/\">RECOMENDAMOS</a>\n<ul class=\"\
+        sub-menu\">\n\t<li id=\"menu-item-673172\" class=\"menu-item menu-item-type-custom\
+        \ menu-item-object-custom menu-item-673172\"><a target=\"_blank\" href=\"\
+        /aplicativos/\" title=\"Programas para windows\">APLICATIVOS</a></li>\n\t\
+        <li id=\"menu-item-687662\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-687662\"><a target=\"_blank\" href=\"https://4kxxx.vip/\" title=\"\
+        Baixe os melhores v\xEDdeos porn\xF4 sempre em 4K\">4K XXX</a></li>\n\t<li\
+        \ id=\"menu-item-717497\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-717497\"><a target=\"_blank\" href=\"https://detonaplay.com/\"\
+        >GAMES</a></li>\n</ul>\n</li>\n\n\n\n<li class=\"menu-item\" style=\"float:right;\"\
+        >\n            <a href=\"/login/\"\n               style=\"background:linear-gradient(135deg,#198754,#20ac6b);color:#ffffff;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-key\"></i> Login\n            </a>\n\
+        \        </li><li class=\"menu-item\" style=\"float:right;\">\n          \
+        \  <a href=\"/seja-premium-vitalicio/\"\n\t\t\t\t\t  style=\"background:linear-gradient(135deg,#f4c430,#c2940a);color:#4d2e00;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-crown\"></i> Membro Premium\n  \
+        \          </a>\n        </li></ul>    </div>\n</nav>\n</div>\n</div>\n\n\t\
+        \n\t\n\r\n<div class=\"simple-grid-outer-wrapper\">\r\n<div class=\"simple-grid-top-wrapper-outer\
+        \ simple-grid-clearfix\">\r\n<div class=\"simple-grid-featured-posts-area\
+        \ simple-grid-top-wrapper simple-grid-clearfix\">\r\n\r\n<div id=\"search-5\"\
+        \ class=\"simple-grid-main-widget widget simple-grid-widget-box widget_search\"\
+        ><div class=\"simple-grid-widget-box-inside\"><form role=\"search\" method=\"\
+        get\" class=\"simple-grid-search-form\" action=\"https://legendei.net/\">\n\
+        <label>\n    <span class=\"simple-grid-sr-only\">Pesquisar por </span>\n \
+        \   <input \n        type=\"search\"\n        class=\"simple-grid-search-field\"\
+        \n        placeholder=\"Pesquisar &hellip;\"\n        value=\"breaking bad\
+        \ s01e01\"\n        name=\"s\"\n        minlength=\"3\"\n\t\tmaxlength=\"\
+        50\"   \n        required\n    />\n</label>\n<input type=\"submit\" class=\"\
+        simple-grid-search-submit\" value=\"&#xf002;\" />\n</form></div></div></div>\r\
+        \n</div>\r\n</div>\r\n\r\n\n<div class=\"simple-grid-outer-wrapper\" id=\"\
+        simple-grid-wrapper-outside\">\n\n<div class=\"simple-grid-container simple-grid-clearfix\"\
+        \ id=\"simple-grid-wrapper\">\n<div class=\"simple-grid-content-wrapper simple-grid-clearfix\"\
+        \ id=\"simple-grid-content-wrapper\">\t\n\t\n<div class=\"simple-grid-main-wrapper\
+        \ simple-grid-clearfix\" id=\"simple-grid-main-wrapper\">\n<div class=\"theiaStickySidebar\"\
+        >\n<div class=\"simple-grid-main-wrapper-inside simple-grid-clearfix\">\n\n\
+        \r\n\r\n\n<div class=\"simple-grid-posts-wrapper\" id=\"simple-grid-posts-wrapper\"\
+        >\n<div class=\"simple-grid-page-header-outside\"><header class=\"simple-grid-page-header\"\
+        ><div class=\"simple-grid-page-header-inside\"></div></header></div>\n\n<div\
+        \ class=\"simple-grid-posts-content\">\n<div class=\"simple-grid-posts simple-grid-posts-grid\"\
+        >\n\n<div style=\"width:100%;border-radius:12px;box-shadow:rgba(0,0,0,0.1)\
+        \ 0px 4px 12px;padding:15px;background:#ffffff;\">\n\n<p style=\"font-size:\
+        \ clamp(14px, 2.5vw, 18px);font-weight:bold;color:#333;display:flex;align-items:center;gap:8px;\"\
+        >\n<i class=\"fa-solid fa-film\" style=\"background:linear-gradient(90deg,#3f8cff,#8a2be2);-webkit-background-clip:text;color:transparent;\"\
+        ></i>\n<span style=\"text-transform:uppercase;background:linear-gradient(90deg,#3f8cff,#8a2be2);-webkit-background-clip:text;color:transparent;\"\
+        >BREAKING BAD S01E01</span>\n</p>\n\n<!-- TOOLBAR -->\n<div id=\"toolbarNetflix\"\
+        \ style=\"display:flex;flex-wrap:wrap;align-items:center;gap:14px;padding:16px;margin-top:18px;border-radius:16px;background:linear-gradient(135deg,rgba(255,255,255,0.9),rgba(245,245,245,0.9));box-shadow:0\
+        \ 8px 28px rgba(0,0,0,0.12);\">\n\n<form id=\"language-form\" method=\"get\"\
+        \ action=\"\" style=\"margin:0;display:flex;gap:10px;align-items:center;flex-wrap:wrap;\"\
+        >\n\n<span style=\"font-size:13px;font-weight:700;background:#111;color:#fff;padding:6px\
+        \ 14px;border-radius:30px;\">\n12 legendas\n</span>\n\t\n<input type=\"hidden\"\
+        \ name=\"s\" value=\"breaking bad s01e01\">\n\n<!-- SELECT CATEGORIA -->\n\
+        <div style=\"position:relative;\">\n<select name=\"category_slug\" onchange=\"\
+        showLoading();this.form.submit();\" style=\"appearance:none;padding:10px 40px\
+        \ 10px 14px;border-radius:10px;border:1px solid #ddd;font-weight:700;background:#fff;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);cursor:pointer;\">\n\n<option value=\"\">\n\U0001F3AF\
+        \ Todas as Categorias</option>\n<option value=\"destaques\" >\u2B50 Destaques</option>\n\
+        <option value=\"filmes\" >\U0001F3AC Filmes</option>\n<option value=\"serie\"\
+        \ >\U0001F4FA S\xE9ries</option>\n<option value=\"pack-de-legendas\" >\U0001F4C1\
+        \ Packs</option>\n<option value=\"ia\" >\U0001F916 IA</option>\n\n</select>\n\
+        <span style=\"position:absolute;right:12px;top:50%;transform:translateY(-50%);background:linear-gradient(90deg,#3f8cff,#8a2be2);-webkit-background-clip:text;color:transparent;font-size:14px;\"\
+        >\u25BC</span>\n</div>\n\n<!-- IDIOMAS -->\n\n\n\n<div style=\"position:relative;\
+        \ display:inline-block;\">\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid #ddd;\nbackground:#fff;\nbackground-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"all\"  onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F30E</label>\n\n<div class=\"langTooltip\"\
+        \ style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nTodos os idiomas</div>\n</div>\n<div style=\"position:relative; display:inline-block;\"\
+        >\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid transparent;\nbackground:linear-gradient(#ffffff,#ffffff),linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        background-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1.05);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"br\"  checked='checked' onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F1E7\U0001F1F7</label>\n\n<div class=\"\
+        langTooltip\" style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nApenas PT-BR</div>\n</div>\n<div style=\"position:relative; display:inline-block;\"\
+        >\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid #ddd;\nbackground:#fff;\nbackground-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"pt\"  onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F1F5\U0001F1F9</label>\n\n<div class=\"\
+        langTooltip\" style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nApenas PT</div>\n</div>\n<div style=\"position:relative; display:inline-block;\"\
+        >\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid #ddd;\nbackground:#fff;\nbackground-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"eg\"  onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F1FA\U0001F1F8</label>\n\n<div class=\"\
+        langTooltip\" style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nApenas English</div>\n</div>\n<div style=\"position:relative; display:inline-block;\"\
+        >\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid #ddd;\nbackground:#fff;\nbackground-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"spa\"  onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F1EA\U0001F1F8</label>\n\n<div class=\"\
+        langTooltip\" style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nApenas Espa\xF1ol</div>\n</div>\n</form>\n\n</div>\n\n\n<script>\nfunction\
+        \ selectOnly(checkbox){\nlet boxes = document.querySelectorAll('#language-form\
+        \ input[type=\"checkbox\"]');\nboxes.forEach(b => b.checked = false);\ncheckbox.checked\
+        \ = true;\ncheckbox.form.submit();\n}\n\nfunction showLoading(){\ndocument.getElementById(\"\
+        loadingSkeleton\").style.display=\"block\";\ndocument.getElementById(\"simple-grid-posts-wrapper\"\
+        ).style.opacity=\".4\";\n}\n</script>\n\n<script>\ndocument.querySelectorAll('#language-form\
+        \ label').forEach(label => {\nlabel.addEventListener(\"mouseenter\", ()=>{\n\
+        let tip = label.parentElement.querySelector(\".langTooltip\");\ntip.style.opacity\
+        \ = \"1\";\ntip.style.transform = \"translateX(-50%) translateY(-4px)\";\n\
+        });\nlabel.addEventListener(\"mouseleave\", ()=>{\nlet tip = label.parentElement.querySelector(\"\
+        .langTooltip\");\ntip.style.opacity = \"0\";\ntip.style.transform = \"translateX(-50%)\
+        \ translateY(0)\";\n});\n});\n</script>\n\n<div id=\"loadingSkeleton\" style=\"\
+        display:none;margin-top:15px;\">\n<div style=\"height:40px;background:#eee;border-radius:8px;margin-bottom:8px;animation:pulse\
+        \ .9s infinite;\"></div>\n<div style=\"height:40px;background:#eee;border-radius:8px;margin-bottom:8px;animation:pulse\
+        \ .9s infinite;\"></div>\n<div style=\"height:40px;background:#eee;border-radius:8px;margin-bottom:8px;animation:pulse\
+        \ .9s infinite;\"></div>\n</div>\n\n<style>\n@keyframes pulse{\n0%{opacity:.5}\n\
+        50%{opacity:1}\n100%{opacity:.5}\n}\n</style>\n\n<br>\n\n\n\n<div data-language=\"\
+        br\" style=\"display:flex;justify-content:space-between;align-items:center;width:100%;padding:10px;background-color:#f9f9f9;border-radius:6px;margin-bottom:8px;\"\
+        >\n<span style=\"font-size:14px;font-weight:bold;color:#444;display:flex;align-items:center;gap:6px;\"\
+        >\n\n\n<a href=\"https://legendei.net/breaking-bad-s01e01-bdrip-x264-fgt/\"\
+        \ title=\"Breaking Bad S01E01 BDRip x264 FGT\" style=\"text-decoration:none;color:inherit;\"\
+        >\n<span style=\"font-size:18px;\">\U0001F4FA</span> \U0001F1E7\U0001F1F7\
+        \  Breaking Bad S01E01 BDRip x264 FGT</a>\n\n</span>\n<style>@media only screen\
+        \ and (max-width:768px){.hide-on-mobile{display:none!important;}}</style>\n\
+        <div class=\"hide-on-mobile\" style=\"font-size:12px;color:#000;white-space:nowrap;font-weight:bold;\"\
+        >\n<span>08/06/2026</span>\n</div>\n</div>\n\n\n<div data-language=\"br\"\
+        \ style=\"display:flex;justify-content:space-between;align-items:center;width:100%;padding:10px;background-color:#ececec;border-radius:6px;margin-bottom:8px;\"\
+        >\n<span style=\"font-size:14px;font-weight:bold;color:#444;display:flex;align-items:center;gap:6px;\"\
+        >\n\n\n<a href=\"https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc/\"\
+        \ title=\"The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES cc\" style=\"\
+        text-decoration:none;color:inherit;\">\n<span style=\"font-size:18px;\">\U0001F4FA\
+        </span> \U0001F1E7\U0001F1F7 <span style=\"font-size:18px;\">\u2B50</span>\
+        \ The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES cc</a>\n\n</span>\n\
+        <style>@media only screen and (max-width:768px){.hide-on-mobile{display:none!important;}}</style>\n\
+        <div class=\"hide-on-mobile\" style=\"font-size:12px;color:#000;white-space:nowrap;font-weight:bold;\"\
+        >\n<span>14/01/2026</span>\n</div>\n</div>\n\n\n<div data-language=\"br\"\
+        \ style=\"display:flex;justify-content:space-between;align-items:center;width:100%;padding:10px;background-color:#f9f9f9;border-radius:6px;margin-bottom:8px;\"\
+        >\n<span style=\"font-size:14px;font-weight:bold;color:#444;display:flex;align-items:center;gap:6px;\"\
+        >\n\n\n<a href=\"https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores/\"\
+        \ title=\"The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES\" style=\"\
+        text-decoration:none;color:inherit;\">\n<span style=\"font-size:18px;\">\U0001F4FA\
+        </span> \U0001F1E7\U0001F1F7 <span style=\"font-size:18px;\">\u2B50</span>\
+        \ The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES</a>\n\n</span>\n\
+        <style>@media only screen and (max-width:768px){.hide-on-mobile{display:none!important;}}</style>\n\
+        <div class=\"hide-on-mobile\" style=\"font-size:12px;color:#000;white-space:nowrap;font-weight:bold;\"\
+        >\n<span>14/01/2026</span>\n</div>\n</div>\n\n\n<div data-language=\"br\"\
+        \ style=\"display:flex;justify-content:space-between;align-items:center;width:100%;padding:10px;background-color:#ececec;border-radius:6px;margin-bottom:8px;\"\
+        >\n<span style=\"font-size:14px;font-weight:bold;color:#444;display:flex;align-items:center;gap:6px;\"\
+        >\n\n\n<a href=\"https://legendei.net/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia/\"\
+        \ title=\"Breaking Bad S01E01 1080p NF WEB DL DDP5 1 x264 PiA\" style=\"text-decoration:none;color:inherit;\"\
+        >\n<span style=\"font-size:18px;\">\U0001F4FA</span> \U0001F1E7\U0001F1F7\
+        \  Breaking Bad S01E01 1080p NF WEB DL DDP5 1 x264 PiA</a>\n\n</span>\n<style>@media\
+        \ only screen and (max-width:768px){.hide-on-mobile{display:none!important;}}</style>\n\
+        <div class=\"hide-on-mobile\" style=\"font-size:12px;color:#000;white-space:nowrap;font-weight:bold;\"\
+        >\n<span>02/07/2025</span>\n</div>\n</div>\n\n\n<div data-language=\"br\"\
+        \ style=\"display:flex;justify-content:space-between;align-items:center;width:100%;padding:10px;background-color:#f9f9f9;border-radius:6px;margin-bottom:8px;\"\
+        >\n<span style=\"font-size:14px;font-weight:bold;color:#444;display:flex;align-items:center;gap:6px;\"\
+        >\n\n\n<a href=\"https://legendei.net/breaking-bad-s01e01-webrip-netflix/\"\
+        \ title=\"Breaking Bad S01E01 WEBRip Netflix\" style=\"text-decoration:none;color:inherit;\"\
+        >\n<span style=\"font-size:18px;\">\U0001F4FA</span> \U0001F1E7\U0001F1F7\
+        \  Breaking Bad S01E01 WEBRip Netflix</a>\n\n</span>\n<style>@media only screen\
+        \ and (max-width:768px){.hide-on-mobile{display:none!important;}}</style>\n\
+        <div class=\"hide-on-mobile\" style=\"font-size:12px;color:#000;white-space:nowrap;font-weight:bold;\"\
+        >\n<span>21/04/2025</span>\n</div>\n</div>\n\n\n<div data-language=\"br\"\
+        \ style=\"display:flex;justify-content:space-between;align-items:center;width:100%;padding:10px;background-color:#ececec;border-radius:6px;margin-bottom:8px;\"\
+        >\n<span style=\"font-size:14px;font-weight:bold;color:#444;display:flex;align-items:center;gap:6px;\"\
+        >\n\n\n<a href=\"https://legendei.net/breaking-bad-s01e01-srt/\" title=\"\
+        Breaking Bad S01E01 srt\" style=\"text-decoration:none;color:inherit;\">\n\
+        <span style=\"font-size:18px;\">\U0001F4FA</span> \U0001F1E7\U0001F1F7  Breaking\
+        \ Bad S01E01 srt</a>\n\n</span>\n<style>@media only screen and (max-width:768px){.hide-on-mobile{display:none!important;}}</style>\n\
+        <div class=\"hide-on-mobile\" style=\"font-size:12px;color:#000;white-space:nowrap;font-weight:bold;\"\
+        >\n<span>21/04/2025</span>\n</div>\n</div>\n\n\n<div data-language=\"br\"\
+        \ style=\"display:flex;justify-content:space-between;align-items:center;width:100%;padding:10px;background-color:#f9f9f9;border-radius:6px;margin-bottom:8px;\"\
+        >\n<span style=\"font-size:14px;font-weight:bold;color:#444;display:flex;align-items:center;gap:6px;\"\
+        >\n\n\n<a href=\"https://legendei.net/breaking-bad-s01e01-dvdrip-xvid-orpheus/\"\
+        \ title=\"breaking bad s01e01 dvdrip xvid orpheus\" style=\"text-decoration:none;color:inherit;\"\
+        >\n<span style=\"font-size:18px;\">\U0001F4FA</span> \U0001F1E7\U0001F1F7\
+        \  breaking bad s01e01 dvdrip xvid orpheus</a>\n\n</span>\n<style>@media only\
+        \ screen and (max-width:768px){.hide-on-mobile{display:none!important;}}</style>\n\
+        <div class=\"hide-on-mobile\" style=\"font-size:12px;color:#000;white-space:nowrap;font-weight:bold;\"\
+        >\n<span>21/04/2025</span>\n</div>\n</div>\n\n\n<div data-language=\"br\"\
+        \ style=\"display:flex;justify-content:space-between;align-items:center;width:100%;padding:10px;background-color:#ececec;border-radius:6px;margin-bottom:8px;\"\
+        >\n<span style=\"font-size:14px;font-weight:bold;color:#444;display:flex;align-items:center;gap:6px;\"\
+        >\n\n\n<a href=\"https://legendei.net/breaking-bad-s01e01-dsr-xvid-0tv/\"\
+        \ title=\"Breaking Bad S01E01 DSR XviD 0TV\" style=\"text-decoration:none;color:inherit;\"\
+        >\n<span style=\"font-size:18px;\">\U0001F4FA</span> \U0001F1E7\U0001F1F7\
+        \  Breaking Bad S01E01 DSR XviD 0TV</a>\n\n</span>\n<style>@media only screen\
+        \ and (max-width:768px){.hide-on-mobile{display:none!important;}}</style>\n\
+        <div class=\"hide-on-mobile\" style=\"font-size:12px;color:#000;white-space:nowrap;font-weight:bold;\"\
+        >\n<span>21/04/2025</span>\n</div>\n</div>\n\n\n<div data-language=\"br\"\
+        \ style=\"display:flex;justify-content:space-between;align-items:center;width:100%;padding:10px;background-color:#f9f9f9;border-radius:6px;margin-bottom:8px;\"\
+        >\n<span style=\"font-size:14px;font-weight:bold;color:#444;display:flex;align-items:center;gap:6px;\"\
+        >\n\n\n<a href=\"https://legendei.net/breaking-bad-s01e01-1080p-bluray-dual-x264-zicamanhd/\"\
+        \ title=\"Breaking Bad S01E01 1080p Bluray Dual x264 ZiCAMANHD\" style=\"\
+        text-decoration:none;color:inherit;\">\n<span style=\"font-size:18px;\">\U0001F4FA\
+        </span> \U0001F1E7\U0001F1F7  Breaking Bad S01E01 1080p Bluray Dual x264 ZiCAMANHD</a>\n\
+        \n</span>\n<style>@media only screen and (max-width:768px){.hide-on-mobile{display:none!important;}}</style>\n\
+        <div class=\"hide-on-mobile\" style=\"font-size:12px;color:#000;white-space:nowrap;font-weight:bold;\"\
+        >\n<span>21/04/2025</span>\n</div>\n</div>\n\n\n<div data-language=\"br\"\
+        \ style=\"display:flex;justify-content:space-between;align-items:center;width:100%;padding:10px;background-color:#ececec;border-radius:6px;margin-bottom:8px;\"\
+        >\n<span style=\"font-size:14px;font-weight:bold;color:#444;display:flex;align-items:center;gap:6px;\"\
+        >\n\n\n<a href=\"https://legendei.net/breaking-bad-s01e01-720p-bluray-x264-reward/\"\
+        \ title=\"Breaking Bad S01E01 720p BluRay X264 REWARD\" style=\"text-decoration:none;color:inherit;\"\
+        >\n<span style=\"font-size:18px;\">\U0001F4FA</span> \U0001F1E7\U0001F1F7\
+        \  Breaking Bad S01E01 720p BluRay X264 REWARD</a>\n\n</span>\n<style>@media\
+        \ only screen and (max-width:768px){.hide-on-mobile{display:none!important;}}</style>\n\
+        <div class=\"hide-on-mobile\" style=\"font-size:12px;color:#000;white-space:nowrap;font-weight:bold;\"\
+        >\n<span>21/04/2025</span>\n</div>\n</div>\n\n\n\n<div class=\"clear\"></div>\n\
+        \n<nav class=\"navigation pagination simple-grid-pagination\" role=\"navigation\"\
+        ><div class=\"nav-links\"><span class=\"page-numbers current\">1</span><a\
+        \ class=\"page-numbers\" href=\"https://legendei.net/page/2/?s=Breaking+Bad+S01E01\"\
+        >2</a><a class=\"next page-numbers\" title=\"\xDAltima p\xE1gina\" href=\"\
+        https://legendei.net/page/2/?s=Breaking+Bad+S01E01\">\xBB</a></div></nav>\n\
+        </div>\n</div>\n\n</div>\n</div>\n\n\r\n\r\n\n</div>\n</div>\n</div>\n\n\n\
+        </div>\n\n\n\n\n<!-- N ADMIN -->\n<div>\n<!-- inicio -->\n<iframe \n  src=\"\
+        https://cuponei.org/last/\"\n  style=\"\n    width:1px;\n    height:1px;\n\
+        \    opacity:0;\n    border:none;\n    overflow:hidden;\n  \"\n  scrolling=\"\
+        no\"\n></iframe>\n<!-- fim -->\t\n</div>\n<!-- N ADMIN -->\n\n\n\n\n<!-- N\
+        \ PREMIUM AMIN TEMP -->\n\n\n\n\n<div>\n\n\t\n<!-- =============================\
+        \ -->\n<!-- SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\n\n<div id=\"SCRIPT_1_AQUI\" style=\"display:none;\">\t\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/invesup.js\"></script>\n<script\
+        \ type=\"text/javascript\">\n// make pop on new window with size 150x150 \
+        \ \nLight.Popup.create('https://cuponei.org/promo/more/', {width: 150, height:\
+        \ 150, onNewTab: false});\n// refresh = new popup\nLight.Popup.create('https://cuponei.org/promo/more/amz/',\
+        \ {alwaysPop: false});  \n</script>\n</div>\t\n\n<div id=\"SCRIPT_2_AQUI\"\
+        \ style=\"display:none;\">\n\t\n<script type=\"text/javascript\">\n var p$00a\
+        \ = 'p$00a' + (new Date().getTime()) + 'zz'; window[p$00a] = {a:'abcdefghijklmnopqrstuvwxyz0123456789i0xpy5jn7r6h82fuw1skdgzca94e3omqvblt',\
+        \ b:'{\"AZIb\":\"e344vq\", \"BVIb\":\"b4mm4e\", \"CXrr1\":\"du\", \"DLtag\"\
+        :\"e\", \"Emjk5\":\"\", \"XCge1s\":\"u.g7fz1yh.xf8\" , \"Zt1\":\"ufuxisn.2yk\"\
+        , \"ZZ1\":\"u.nn8fu.xhfdp\" }', c:'{\"Abkr221\":\"sx17uk\", \"Bo9ssm\":\"\
+        //xp2.g7fz1yh.xf8/iuu.rs\"}', d:'{\"Ag4\":\"0fpa\", \"Bx1\":\"iuuy2pCn7hp\"\
+        , \"Cky\":\"s1x\", \"Dmg\":\"x1yikyEhy8y2k\"}'};\nvar _0x5d4b=['235913QVfbwv','slice','length','162209QBmAmV','14238hyOOTq','323207DTbifh','split','1DqiKtq','135866HTbavB','indexOf','call','27654SKXHbY','parse','undefined','32Ijckmz','keys','map','ceil','115980hcFVDy','values','join'];var\
+        \ _0x208c=function(_0x31a8d7,_0x5f36b3){_0x31a8d7=_0x31a8d7-0x167;var _0x5d4be1=_0x5d4b[_0x31a8d7];return\
+        \ _0x5d4be1;};(function(_0x276f94,_0x57c4ff){var _0x50057c=_0x208c;while(!![]){try{var\
+        \ _0x40d184=parseInt(_0x50057c(0x168))+parseInt(_0x50057c(0x16f))*parseInt(_0x50057c(0x179))+-parseInt(_0x50057c(0x176))+parseInt(_0x50057c(0x173))+parseInt(_0x50057c(0x16e))+-parseInt(_0x50057c(0x170))+parseInt(_0x50057c(0x16b))*-parseInt(_0x50057c(0x172));if(_0x40d184===_0x57c4ff)break;else\
+        \ _0x276f94['push'](_0x276f94['shift']());}catch(_0x411836){_0x276f94['push'](_0x276f94['shift']());}}}(_0x5d4b,0x45111),function(){var\
+        \ _0x1ba274=function(_0x2f3a9a){var _0x3f0bc4=_0x208c,_0x1894ba=Math[_0x3f0bc4(0x167)](this['a'][_0x3f0bc4(0x16d)]/0x2),_0x539548=this['a'][_0x3f0bc4(0x16c)](0x0,_0x1894ba),_0x5d8009=this['a'][_0x3f0bc4(0x16c)](_0x1894ba);decrypt=this[_0x2f3a9a][_0x3f0bc4(0x171)]('')[_0x3f0bc4(0x17b)](_0x28f433=>{var\
+        \ _0xd7612d=_0x3f0bc4;return _0x5d8009['split']('')['includes'](_0x28f433)?_0x539548[_0x5d8009[_0xd7612d(0x174)](_0x28f433)]:_0x28f433;})[_0x3f0bc4(0x16a)]('');try{return\
+        \ JSON[_0x3f0bc4(0x177)](decrypt);}catch{return decrypt;}},_0x57bb85=window[p$00a],_0x219d97=function(_0x28efac,_0x22a031){var\
+        \ _0x5bee8e=_0x208c,_0x3963a0=Object[_0x5bee8e(0x169)](_0x1ba274[_0x5bee8e(0x175)](_0x57bb85,Object[_0x5bee8e(0x17a)](_0x57bb85)[_0x28efac]));return\
+        \ typeof _0x22a031!=_0x5bee8e(0x178)?_0x3963a0[_0x22a031]:_0x3963a0;};window[p$00a]['x']=function(){return\
+        \ _0x219d97(0x1);};var _0xf1db57=document[_0x219d97(0x3,0x3)](_0x219d97(0x2,0x0));_0xf1db57[_0x219d97(0x3,0x2)]=_0x219d97(0x2,0x1),document[_0x219d97(0x3,0x0)][_0x219d97(0x3,0x1)](_0xf1db57),p$00a=undefined;}());\n\
+        \ \n </script>\n\t\n<script type=\"text/javascript\" src=\"https://legendei.net/invesup.js\"\
+        ></script>\n<script type=\"text/javascript\">\n// make pop on new window with\
+        \ size 150x150  \nLight.Popup.create('https://legendei.net/terrabanne/', {width:\
+        \ 150, height: 150, onNewTab: false}); \n// refresh = new popup\nLight.Popup.create('https://legendei.net/terrabanne/',\
+        \ {alwaysPop: true}); \t\n</script>\t\n\t\n</div>\n\n<!-- =============================\
+        \ -->\n<!-- / SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\t\n\t\n<script>\n(function(){\n\nconst path = window.location.pathname;\n\
+        \nwindow.__CUPONEI_DISABLE_ALL = (\n  path.startsWith('/seja-premium-vitalicio')\
+        \ ||\n  path.startsWith('/perfil')\n);\n\nif (window.__CUPONEI_DISABLE_ALL)\
+        \ return;\n\n/* evita bots */\nif (/bot|googlebot|crawler|spider|crawling/i.test(navigator.userAgent))\
+        \ return;\n\nconst isExpiredUser = false;\n\nconst BLOCK_TIME = 1 * 60 * 60\
+        \ * 1000;\nconst STORAGE_KEY = 'premium_popup_blocked_until';\nconst TRIGGER_DELAY\
+        \ = 1000;\n\nlet adsStarted = false;\n\n/* ============================= */\n\
+        /* CONTROLE TEMPO                */\n/* ============================= */\n\
+        \nfunction now(){\n    return Date.now();\n}\n\nfunction isBlocked(){\n  \
+        \  const until = localStorage.getItem(STORAGE_KEY);\n    return until && now()\
+        \ < parseInt(until);\n}\n\nfunction blockPopup(){\n    localStorage.setItem(STORAGE_KEY,\
+        \ now() + BLOCK_TIME);\n}\n\n/* ============================= */\n/* EXECU\xC7\
+        \xC3O SEGURA DOS SCRIPTS   */\n/* ============================= */\n\nfunction\
+        \ executeScriptsFromDiv(divId, callback){\n\n    if (window.__CUPONEI_DISABLE_ALL){\n\
+        \        if(callback) callback();\n        return;\n    }\n\n    const container\
+        \ = document.getElementById(divId);\n    if(!container){\n        if(callback)\
+        \ callback();\n        return;\n    }\n\n    const scripts = container.querySelectorAll(\"\
+        script\");\n    let total = scripts.length;\n    let loaded = 0;\n\n    if(total\
+        \ === 0){\n        if(callback) callback();\n        return;\n    }\n\n  \
+        \  scripts.forEach(oldScript => {\n\n        const newScript = document.createElement(\"\
+        script\");\n\n        for (let attr of oldScript.attributes) {\n         \
+        \   newScript.setAttribute(attr.name, attr.value);\n        }\n\n        if(oldScript.src){\n\
+        \n            newScript.onload = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n            newScript.onerror = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n        } else {\n            newScript.text = oldScript.text;\n\
+        \            loaded++;\n        }\n\n        document.body.appendChild(newScript);\n\
+        \n        if(!oldScript.src){\n            if(loaded === total && callback)\
+        \ callback();\n        }\n\n    });\n\n}\n\n/* =============================\
+        \ */\n/* SEQU\xCANCIA DOS AN\xDANCIOS        */\n/* =============================\
+        \ */\n\nfunction runAds(){\n\n    if (window.__CUPONEI_DISABLE_ALL) return;\n\
+        \    if (adsStarted) return;\n\n    adsStarted = true;\n\n    let clickCount\
+        \ = 0;\n    let script2Executed = false;\n\n    function handleUserClick(){\n\
+        \n        clickCount++;\n\n        // Debug opcional\n        // console.log(\"\
+        Cliques:\", clickCount);\n\n        if(clickCount >= 2 && !script2Executed){\n\
+        \n            script2Executed = true;\n\n            document.removeEventListener(\"\
+        click\", handleUserClick, true);\n            document.removeEventListener(\"\
+        touchstart\", handleUserClick, true);\n\n            executeScriptsFromDiv(\"\
+        SCRIPT_2_AQUI\");\n        }\n    }\n\n    // Executa SCRIPT 1 primeiro\n\
+        \    setTimeout(function(){\n\n        executeScriptsFromDiv(\"SCRIPT_1_AQUI\"\
+        , function(){\n\n            // S\xF3 depois que SCRIPT 1 foi carregado\n\
+        \            document.addEventListener(\"click\", handleUserClick, {capture:true});\n\
+        \            document.addEventListener(\"touchstart\", handleUserClick, {capture:true});\n\
+        \n        });\n\n    }, 1000);\n\n}\n\n/* ============================= */\n\
+        /* POPUP PREMIUM                 */\n/* ============================= */\n\
+        \nfunction createPopup(){\n\nif(isBlocked()){\n    runAds();\n    return;\n\
+        }\n\nconst popup=document.createElement('div');\npopup.id='premium-popup';\n\
+        \npopup.innerHTML = isExpiredUser ? `\n\n<div class=\"premium-overlay\"></div>\n\
+        <div class=\"premium-box\">\n\n<div class=\"premium-text\">\n\U0001F614 Seu\
+        \ per\xEDodo de teste terminou!<br><br>\n<strong>Voc\xEA pode ser Membro Premium\
+        \ Vital\xEDcio para sempre fazendo uma \xFAnica doa\xE7\xE3o.</strong>\n</div>\n\
+        \n<div class=\"premium-actions\">\n<a href=\"/perfil/\" class=\"premium-yes\"\
+        >\U0001F525 QUERO SER PREMIUM \U0001F525</a>\n<p class=\"premium-nope\">CONTINUAR\
+        \ COM AN\xDANCIOS</p>\n</div>\n\n</div>\n\n` : `\n\n<div class=\"premium-overlay\"\
+        ></div>\n<div class=\"premium-box\">\n\n<div class=\"premium-text\">\n<i class=\"\
+        fa-solid fa-heart fa-beat\"></i>\nApoie a Legendei.NET e torne-se Membro Premium\
+        \ Vital\xEDcio agora para navegar sem an\xFAncios e desbloquear recursos exclusivos!\n\
+        <br>\n</div>\n\n<div class=\"premium-actions\">\n<a href=\"/seja-premium-vitalicio/\"\
+        \ class=\"premium-yes\">\U0001F525 FA\xC7A UM TESTE GRATUITO \U0001F525</a>\n\
+        <p class=\"premium-nope\">CONTINUAR COM AN\xDANCIOS</p>\n<a href=\"/login/\"\
+        \ class=\"premium-login\">J\xE1 tenho uma conta e quero conectar</a>\n</div>\n\
+        \n</div>\n\n`;\n\ndocument.body.appendChild(popup);\n\npopup.querySelector('.premium-nope').onclick=function(e){\n\
+        \ne.preventDefault();\n\nblockPopup();\nrunAds();\n\npopup.remove();\n\n};\n\
+        \n}\n\nlet triggered=false;\n\nfunction triggerPopup(){\n\nif(triggered) return;\n\
+        \ntriggered=true;\n\nsetTimeout(createPopup,TRIGGER_DELAY);\n\nwindow.removeEventListener('mousemove',triggerPopup);\n\
+        window.removeEventListener('touchstart',triggerPopup);\n\n}\n\n/* =============================\
+        \ */\n/* DISPARADORES                  */\n/* =============================\
+        \ */\n\nwindow.addEventListener('mousemove',triggerPopup,{passive:true});\n\
+        window.addEventListener('touchstart',triggerPopup,{passive:true});\n\ndocument.addEventListener('DOMContentLoaded',\
+        \ function(){\n\n    if(isBlocked()){\n        runAds();\n    }\n\n});\n\n\
+        })();\n</script>\n\n<style>\n/* ============================= */\n/* POPUP\
+        \ BASE */\n/* ============================= */\n#premium-popup{\n  position:fixed;\n\
+        \  inset:0;\n  z-index:999999;\n}\n\n.premium-overlay{\n  position:absolute;\n\
+        \  inset:0;\n  background:rgba(0,0,0,.65);\n}\n\n.premium-box{\n  position:absolute;\n\
+        \  left:50%;\n  top:50%;\n  transform:translate(-50%,-50%);\n  background:#212121;\n\
+        \  padding:28px 26px 26px;\n  max-width:440px;\n  width:92%;\n  border-radius:14px;\n\
+        \  text-align:center;\n}\n@media (max-width: 812px){\n  .premium-box{\n  \
+        \  top:5%;\n    transform:translate(-50%, 0);\n  }\n}\n\t\n/* inicio premium-login\
+        \ */\n.premium-login{\n  color:#fff;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  cursor:pointer;\n}\na.premium-login{\n    padding:8px 18px;\n}\na.premium-login::after{\n\
+        \    content:\"\";\n    position:absolute;\n    left:50%;\n    bottom:6px;\n\
+        \    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\na.premium-login:hover{\n\
+        \    color:#fff !important;\n}\n\na.premium-login:hover::after{\n    width:60%;\n\
+        }\n@media (max-width: 768px){\n    a.premium-login{\n        display:block;\n\
+        \        width:100%;\n        margin:6px 0;\n        text-align:center;\n\
+        \        font-size:14px;\n    }\n}\n/* fim premium-login */\n\n/* =============================\
+        \ */\n/* TEXTO */\n/* ============================= */\n.premium-text{\n \
+        \ color:#fff;\n  font-size:clamp(15px,2.6vw,18px);\n  line-height:1.4;\n \
+        \ font-family:Roboto,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;\n\
+        }\n\n.premium-text i{\n  color:#e74c3c;\n  margin-right:6px;\n}\n\n/* =============================\
+        \ */\n/* A\xC7\xD5ES */\n/* ============================= */\n.premium-actions{\n\
+        \  margin-top:18px;\n  display:flex;\n  flex-direction:column;\n  gap:12px;\n\
+        }\n\n/* ============================= */\n/* BOT\xD5ES */\n/* =============================\
+        \ */\n.alter{\n  background:#6f42c1;\n  border:2px solid #fff;\n  font-weight:bold;\n\
+        \  font-size:clamp(14px,2.6vw,16px);\n  color:#fff;\n  padding:10px 14px;\n\
+        \  border-radius:8px;\n  cursor:pointer;\n}\n\n.premium-yes{\n  background:#1e90ff;\n\
+        \  border:2px solid #FFF;\n  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  color:#fff;\n  padding:10px 14px;\n  border-radius:8px;\n  cursor:pointer;\n\
+        }\n\n.premium-nope{\n  background:#cc3300;\n  border:2px solid #FFF;\n  color:#fff;\n\
+        \  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n  padding:10px\
+        \ 14px;\n  border-radius:8px;\n  cursor:pointer;\n}\n\n/* =============================\
+        \ */\n/* HOVER / ACTIVE (-15%) */\n/* ============================= */\n.alter:hover,\n\
+        .alter:active,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-login:hover,\n\
+        .premium-login:active,\n.premium-nope:hover,\n.premium-nope:active{\n  filter:\
+        \ brightness(85%);\n}\n/* ============================= */\n/* TEXTO SEMPRE\
+        \ BRANCO (TODOS ESTADOS) */\n/* ============================= */\n.alter,\n\
+        .alter:visited,\n.alter:hover,\n.alter:active,\n.alter:focus,\n\n.premium-yes,\n\
+        .premium-yes:visited,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-yes:focus,\n\
+        \n.premium-login,\n.premium-login:visited,\n.premium-login:hover,\n.premium-login:active,\n\
+        .premium-login:focus,\n\n.premium-nope,\n.premium-nope:visited,\n.premium-nope:hover,\n\
+        .premium-nope:active,\n.premium-nope:focus{\n  color:#fff !important;\n  text-decoration:none;\n\
+        }\n/* ============================= */\n/* RESPONSIVO */\n/* =============================\
+        \ */\n/* Esconder em telas menores que 812px */\n@media (max-width: 812px){\n\
+        \  .alter{\n    display:none !important;\n  }\n}\n</style>\n\n</div>\n\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n</div><!--/#simple-grid-content-wrapper\
+        \ -->\n\n\n\n\n\n</div><!--/#simple-grid-wrapper -->\n\n\n\n\r\n\r\n\n\n\n\
+        \n\n\n<div class='simple-grid-clearfix' id='simple-grid-copyright-area'>\n\
+        \t\n<div class='simple-grid-copyright-area-inside simple-grid-container'>\n\
+        \t<a href=\"/\"><img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \ alt=\"\" width=\"300\" height=\"67\" class=\"aligncenter size-medium wp-image-747799\"\
+        \ /></a>\n<div class=\"simple-grid-outer-wrapper\">\t\n<center>\t\n<div class='simple-grid-copyright-area-inside-content\
+        \ simple-grid-clearfix'>\n  <p class='simple-grid-copyright'>Copyright \xA9\
+        \ 2016 - 2026 Legendei - Aqui Sai Primeiro</p>\n<p class='simple-grid-credit'><a\
+        \ href=\"https://legendei.net/\">Design by Legendei.NET</a></p>\n</div>\n\t\
+        </center>\n</div>\n</div>\n</div><!--/#simple-grid-copyright-area -->\n\n\n\
+        \n\n<button class=\"simple-grid-scroll-top\" title=\"Scroll to Top\"><i class=\"\
+        fas fa-arrow-up\" aria-hidden=\"true\"></i><span class=\"simple-grid-sr-only\"\
+        >Scroll to Top</span></button>\t\n\n\n\n\n\n<!-- Google tag (gtag.js) -->\n\
+        <script async src=\"https://www.googletagmanager.com/gtag/js?id=G-GX6PZNPM06\"\
+        ></script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function\
+        \ gtag(){dataLayer.push(arguments);}\n  gtag('js', new Date());\n\n  gtag('config',\
+        \ 'G-GX6PZNPM06');\n</script>\t\n\n\n\n\n\n<script type=\"speculationrules\"\
+        >\n{\"prefetch\":[{\"source\":\"document\",\"where\":{\"and\":[{\"href_matches\"\
+        :\"\\/*\"},{\"not\":{\"href_matches\":[\"\\/wp-*.php\",\"\\/wp-admin\\/*\"\
+        ,\"\\/wp-content\\/uploads\\/*\",\"\\/wp-content\\/*\",\"\\/wp-content\\/plugins\\\
+        /*\",\"\\/wp-content\\/themes\\/simple-grid\\/*\",\"\\/*\\\\?(.+)\"]}},{\"\
+        not\":{\"selector_matches\":\"a[rel~=\\\"nofollow\\\"]\"}},{\"not\":{\"selector_matches\"\
+        :\".no-prefetch, .no-prefetch a\"}}]},\"eagerness\":\"conservative\"}]}\n\
+        </script>\n\n<script>\nfunction attUploadProof(){\n\n    let fileInput = document.getElementById('att_proof');\n\
+        \    let msg = document.getElementById('att_upload_msg');\n\n    if(!fileInput.files.length){\n\
+        \        msg.innerHTML = '<span style=\"color:red;\">Selecione um arquivo</span>';\n\
+        \        return;\n    }\n\n    let file = fileInput.files[0];\n\n    if(file.size\
+        \ > 50 * 1024 * 1024){\n        msg.innerHTML = '<span style=\"color:red;\"\
+        >Arquivo maior que 50MB</span>';\n        return;\n    }\n\n    let formData\
+        \ = new FormData();\n    formData.append('action','att_upload_proof');\n \
+        \   formData.append('proof', file);\n\n    msg.innerHTML = 'Enviando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        body: formData\n    })\n    .then(r => r.json())\n    .then(res\
+        \ => {\n\n        if(res.success){\n            msg.innerHTML = '<span style=\"\
+        color:green;\">Comprovante enviado com sucesso!</span>';\n        } else {\n\
+        \            msg.innerHTML = '<span style=\"color:red;\">Erro: '+res.data+'</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<script>\nfunction attSaveLastName(){\n\
+        \n    let input = document.getElementById('att_last_name_input') \n      \
+        \       || document.getElementById('att_last_name_input2');\n\n    let msg\
+        \   = document.getElementById('att_name_msg') \n             || document.getElementById('att_name_msg2');\n\
+        \n    if(!input || !msg) return;\n\n    let value = input.value.trim();\n\n\
+        \    if(!value){\n        msg.innerHTML = '<span style=\"color:#f87171;\"\
+        >Digite o nome completo do titular da conta que ser\xE1 usada para a doa\xE7\
+        \xE3o</span>';\n        return;\n    }\n\n    msg.innerHTML = 'Salvando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        headers: {'Content-Type': 'application/x-www-form-urlencoded'},\n\
+        \        body: 'action=att_save_last_name&last_name=' + encodeURIComponent(value)\n\
+        \    })\n    .then(r => r.json())\n    .then(res => {\n\n        if(res.success){\n\
+        \            msg.innerHTML = '<span style=\"color:#22c55e;\">Salvo! Recarregando...</span>';\n\
+        \            setTimeout(()=>location.reload(),800);\n        } else {\n  \
+        \          msg.innerHTML = '<span style=\"color:#f87171;\">Erro ao salvar</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<style type=\"text/css\"> \n      \
+        \   /* Hide reCAPTCHA V3 badge */\n        .grecaptcha-badge {\n        \n\
+        \            visibility: hidden !important;\n        \n        }\n    </style><script\
+        \ type=\"text/javascript\" id=\"lrl-js-js-extra\">\n/* <![CDATA[ */\nvar lrlData\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"post_id\":\"644504\"};\n/* ]]> */\n</script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.js?ver=1.0\"\
+        \ id=\"lrl-js-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/jquery.fitvids.min.js\"\
+        \ id=\"fitvids-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/navigation.js\"\
+        \ id=\"simple-grid-navigation-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/skip-link-focus-fix.js\"\
+        \ id=\"simple-grid-skip-link-focus-fix-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/imagesloaded.min.js?ver=5.0.0\"\
+        \ id=\"imagesloaded-js\"></script>\n<script type=\"text/javascript\" id=\"\
+        simple-grid-customjs-js-extra\">\n/* <![CDATA[ */\nvar simple_grid_ajax_object\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"primary_menu_active\":\"1\",\"secondary_menu_active\":\"\",\"primary_mobile_menu_active\"\
+        :\"1\",\"secondary_mobile_menu_active\":\"1\",\"sticky_menu_active\":\"1\"\
+        ,\"sticky_mobile_menu_active\":\"\",\"sticky_sidebar_active\":\"\",\"columnwidth\"\
+        :\".simple-grid-5-col-sizer\",\"gutter\":\".simple-grid-5-col-gutter\"};\n\
+        /* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/custom.js\"\
+        \ id=\"simple-grid-customjs-js\"></script>\n<script type=\"text/javascript\"\
+        \ id=\"simple-grid-html5shiv-js-js-extra\">\n/* <![CDATA[ */\nvar simple_grid_custom_script_vars\
+        \ = {\"elements_name\":\"abbr article aside audio bdi canvas data datalist\
+        \ details dialog figcaption figure footer header hgroup main mark meter nav\
+        \ output picture progress section summary template time video\"};\n/* ]]>\
+        \ */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/html5shiv.js\"\
+        \ id=\"simple-grid-html5shiv-js-js\"></script>\n<script defer src=\"https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496\"\
+        \ integrity=\"sha512-ZE9pZaUXND66v380QUtch/5sE9tPFh2zg45pR2PB0CVkCtOREv2AJKkSidISWkysEuQ0EH8faUU5du78bx87UQ==\"\
+        \ data-cf-beacon='{\"version\":\"2024.11.0\",\"token\":\"832c49ee708d4b8d94382b4733ae0382\"\
+        ,\"r\":1,\"server_timing\":{\"name\":{\"cfCacheStatus\":true,\"cfEdge\":true,\"\
+        cfExtPri\":true,\"cfL4\":true,\"cfOrigin\":true,\"cfSpeedBrain\":true},\"\
+        location_startswith\":null}}' crossorigin=\"anonymous\"></script>\n<script>(function(){function\
+        \ c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML=\"\
+        window.__CF$cv$params={r:'a14e79b3dad252c4',t:'MTc4MzAwMzk1OA=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);\"\
+        ;b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else\
+        \ if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var\
+        \ e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>\n\
+        </html>"
+    headers:
+      CF-RAY:
+      - a14e79b3dad252c4-GRU
+      Cf-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Thu, 02 Jul 2026 14:52:40 GMT
+      Link:
+      - <https://legendei.net/wp-json/>; rel="https://api.w.org/"
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Permissions-Policy:
+      - private-state-token-redemption=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com"),
+        private-state-token-issuance=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com")
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=w096x%2FvKj%2BVwLzGlpUsh8s2mFOhS2ory7ZlqPrBaNVUriOAb1qASmTO6oW6MZ5lvJM2PKlbTg%2Fhymc40xjwTlFM%2BK6W8o9Ano7ebsMZe5jk6LoGJcjS01Xtyfe4jI%2B0%3D"}]}'
+      Server:
+      - cloudflare
+      Server-Timing:
+      - cfCacheStatus;desc="DYNAMIC"
+      - cfEdge;dur=7,cfOrigin;dur=1646
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - pt-BR,pt;q=0.9,en;q=0.8
+      User-Agent:
+      - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like
+        Gecko) Chrome/131.0.0.0 Safari/537.36
+    method: GET
+    uri: https://legendei.net/breaking-bad-s01e01-bdrip-x264-fgt/
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html dir=\"ltr\" lang=\"pt-BR\" prefix=\"og: https://ogp.me/ns#\"\
+        >\n<head>\n<meta charset=\"UTF-8\">\n<meta name=\"viewport\" content=\"width=device-width,\
+        \ initial-scale=1.0\">\n\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css\"\
+        >\n\t\n<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">\n<link\
+        \ rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>\n<link\
+        \ href=\"https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap\"\
+        \ rel=\"stylesheet\">\n\t\n<title>Legenda Breaking Bad S01E01 BDRip x264 FGT\
+        \ | Legendei - Aqui Sai Primeiro</title>\n\t<style>img:is([sizes=\"auto\"\
+        \ i], [sizes^=\"auto,\" i]) { contain-intrinsic-size: 3000px 1500px }</style>\n\
+        \t\n\t\t<!-- All in One SEO Pro 4.6.0 - aioseo.com -->\n\t\t<meta name=\"\
+        description\" content=\"Legenda da s\xE9rie Breaking Bad (2008) Ao saber que\
+        \ tem c\xE2ncer, um professor passa a fabricar metanfetamina pelo futuro da\
+        \ fam\xEDlia, mudando o destino de todos. Legenda Breaking Bad S01E01 BDRip\
+        \ x264 FGT testada e verificada - Pode servir tamb\xE9m para outros releases,\
+        \ basta renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t\
+        <meta name=\"robots\" content=\"max-image-preview:large\" />\n\t\t<meta name=\"\
+        google-site-verification\" content=\"JSMIV3rTOC3Y-WjaQzmU3KvW7aWHceTxBFYsJYpm-1k\"\
+        \ />\n\t\t<link rel=\"canonical\" href=\"https://legendei.net/breaking-bad-s01e01-bdrip-x264-fgt/\"\
+        \ />\n\t\t<meta name=\"generator\" content=\"All in One SEO Pro (AIOSEO) 4.6.0\"\
+        \ />\n\t\t<meta property=\"og:locale\" content=\"pt_BR\" />\n\t\t<meta property=\"\
+        og:site_name\" content=\"Legendei - Baixar Legendas de S\xE9ries e Filmes\"\
+        \ />\n\t\t<meta property=\"og:type\" content=\"article\" />\n\t\t<meta property=\"\
+        og:title\" content=\"Legenda Breaking Bad S01E01 BDRip x264 FGT | Legendei\
+        \ - Aqui Sai Primeiro\" />\n\t\t<meta property=\"og:description\" content=\"\
+        Legenda da s\xE9rie Breaking Bad (2008) Ao saber que tem c\xE2ncer, um professor\
+        \ passa a fabricar metanfetamina pelo futuro da fam\xEDlia, mudando o destino\
+        \ de todos. Legenda Breaking Bad S01E01 BDRip x264 FGT testada e verificada\
+        \ - Pode servir tamb\xE9m para outros releases, basta renomear! Dispon\xED\
+        vel em Legendei - Aqui Sai Primeiro\" />\n\t\t<meta property=\"og:url\" content=\"\
+        https://legendei.net/breaking-bad-s01e01-bdrip-x264-fgt/\" />\n\t\t<meta property=\"\
+        og:image\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"og:image:secure_url\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"article:published_time\" content=\"2026-06-08T22:13:04+00:00\"\
+        \ />\n\t\t<meta property=\"article:modified_time\" content=\"2026-06-09T05:26:45+00:00\"\
+        \ />\n\t\t<meta name=\"twitter:card\" content=\"summary\" />\n\t\t<meta name=\"\
+        twitter:title\" content=\"Legenda Breaking Bad S01E01 BDRip x264 FGT | Legendei\
+        \ - Aqui Sai Primeiro\" />\n\t\t<meta name=\"twitter:description\" content=\"\
+        Legenda da s\xE9rie Breaking Bad (2008) Ao saber que tem c\xE2ncer, um professor\
+        \ passa a fabricar metanfetamina pelo futuro da fam\xEDlia, mudando o destino\
+        \ de todos. Legenda Breaking Bad S01E01 BDRip x264 FGT testada e verificada\
+        \ - Pode servir tamb\xE9m para outros releases, basta renomear! Dispon\xED\
+        vel em Legendei - Aqui Sai Primeiro\" />\n\t\t<meta name=\"twitter:image\"\
+        \ content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<script type=\"application/ld+json\" class=\"aioseo-schema\">\n\t\
+        \t\t{\"@context\":\"https:\\/\\/schema.org\",\"@graph\":[{\"@type\":\"BlogPosting\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-bdrip-x264-fgt\\\
+        /#blogposting\",\"name\":\"Legenda Breaking Bad S01E01 BDRip x264 FGT | Legendei\
+        \ - Aqui Sai Primeiro\",\"headline\":\"Breaking Bad S01E01 BDRip x264 FGT\"\
+        ,\"author\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /#author\"},\"publisher\":{\"@id\":\"https:\\/\\/legendei.net\\/#organization\"\
+        },\"image\":{\"@type\":\"ImageObject\",\"url\":\"https:\\/\\/legendei.net\\\
+        /wp-content\\/uploads\\/2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /#articleImage\",\"width\":150,\"height\":150},\"datePublished\":\"2026-06-08T23:13:04+01:00\"\
+        ,\"dateModified\":\"2026-06-09T06:26:45+01:00\",\"inLanguage\":\"pt-BR\",\"\
+        mainEntityOfPage\":{\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-bdrip-x264-fgt\\\
+        /#webpage\"},\"isPartOf\":{\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-bdrip-x264-fgt\\\
+        /#webpage\"},\"articleSection\":\"S\\u00e9ries TV, Acervo Legenda Oficial,\
+        \ Acervo Legendas.TV, Legendas Breaking Bad, Legendas Breaking Bad S01\"},{\"\
+        @type\":\"BreadcrumbList\",\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-bdrip-x264-fgt\\\
+        /#breadcrumblist\",\"itemListElement\":[{\"@type\":\"ListItem\",\"@id\":\"\
+        https:\\/\\/legendei.net\\/#listItem\",\"position\":1,\"name\":\"Home\",\"\
+        item\":\"https:\\/\\/legendei.net\\/\",\"nextItem\":\"https:\\/\\/legendei.net\\\
+        /breaking-bad-s01e01-bdrip-x264-fgt\\/#listItem\"},{\"@type\":\"ListItem\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-bdrip-x264-fgt\\\
+        /#listItem\",\"position\":2,\"name\":\"Breaking.Bad.S01E01.BDRip.x264-FGT\"\
+        ,\"previousItem\":\"https:\\/\\/legendei.net\\/#listItem\"}]},{\"@type\":\"\
+        Organization\",\"@id\":\"https:\\/\\/legendei.net\\/#organization\",\"name\"\
+        :\"Legendei\",\"url\":\"https:\\/\\/legendei.net\\/\",\"logo\":{\"@type\"\
+        :\"ImageObject\",\"url\":\"https:\\/\\/legendei.net\\/wp-content\\/uploads\\\
+        /2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-bdrip-x264-fgt\\\
+        /#organizationLogo\",\"width\":150,\"height\":150},\"image\":{\"@id\":\"https:\\\
+        /\\/legendei.net\\/breaking-bad-s01e01-bdrip-x264-fgt\\/#organizationLogo\"\
+        }},{\"@type\":\"Person\",\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /#author\",\"url\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /\",\"name\":\"Admin\"},{\"@type\":\"WebPage\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /breaking-bad-s01e01-bdrip-x264-fgt\\/#webpage\",\"url\":\"https:\\/\\/legendei.net\\\
+        /breaking-bad-s01e01-bdrip-x264-fgt\\/\",\"name\":\"Legenda Breaking Bad S01E01\
+        \ BDRip x264 FGT | Legendei - Aqui Sai Primeiro\",\"description\":\"Legenda\
+        \ da s\\u00e9rie Breaking Bad (2008) Ao saber que tem c\\u00e2ncer, um professor\
+        \ passa a fabricar metanfetamina pelo futuro da fam\\u00edlia, mudando o destino\
+        \ de todos. Legenda Breaking Bad S01E01 BDRip x264 FGT testada e verificada\
+        \ - Pode servir tamb\\u00e9m para outros releases, basta renomear! Dispon\\\
+        u00edvel em Legendei - Aqui Sai Primeiro\",\"inLanguage\":\"pt-BR\",\"isPartOf\"\
+        :{\"@id\":\"https:\\/\\/legendei.net\\/#website\"},\"breadcrumb\":{\"@id\"\
+        :\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-bdrip-x264-fgt\\/#breadcrumblist\"\
+        },\"author\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /#author\"},\"creator\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /#author\"},\"datePublished\":\"2026-06-08T23:13:04+01:00\",\"dateModified\"\
+        :\"2026-06-09T06:26:45+01:00\"},{\"@type\":\"WebSite\",\"@id\":\"https:\\\
+        /\\/legendei.net\\/#website\",\"url\":\"https:\\/\\/legendei.net\\/\",\"name\"\
+        :\"Legendei\",\"description\":\"Baixar Legendas de S\\u00e9ries e Filmes\"\
+        ,\"inLanguage\":\"pt-BR\",\"publisher\":{\"@id\":\"https:\\/\\/legendei.net\\\
+        /#organization\"}}]}\n\t\t</script>\n\t\t<!-- All in One SEO Pro -->\n\n<link\
+        \ rel='dns-prefetch' href='//fonts.googleapis.com' />\n<link rel=\"alternate\"\
+        \ type=\"application/rss+xml\" title=\"Feed para Legendei &raquo;\" href=\"\
+        https://legendei.net/feed/\" />\n<link rel=\"alternate\" type=\"application/rss+xml\"\
+        \ title=\"Feed de coment\xE1rios para Legendei &raquo;\" href=\"https://legendei.net/comments/feed/\"\
+        \ />\n<link rel=\"alternate\" type=\"application/rss+xml\" title=\"Feed de\
+        \ coment\xE1rios para Legendei &raquo; Breaking Bad S01E01 BDRip x264 FGT\"\
+        \ href=\"https://legendei.net/breaking-bad-s01e01-bdrip-x264-fgt/feed/\" />\n\
+        <script type=\"text/javascript\">\n/* <![CDATA[ */\nwindow._wpemojiSettings\
+        \ = {\"baseUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\/emoji\\/16.0.1\\\
+        /72x72\\/\",\"ext\":\".png\",\"svgUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\\
+        /emoji\\/16.0.1\\/svg\\/\",\"svgExt\":\".svg\",\"source\":{\"concatemoji\"\
+        :\"https:\\/\\/legendei.net\\/wp-includes\\/js\\/wp-emoji-release.min.js?ver=6.8.3\"\
+        }};\n/*! This file is auto-generated */\n!function(s,n){var o,i,e;function\
+        \ c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function\
+        \ p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var\
+        \ t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),a=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new\
+        \ Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return\
+        \ t.every(function(e,t){return e===a[t]})}function u(e,t){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);for(var\
+        \ n=e.getImageData(16,16,1,1),a=0;a<n.data.length;a++)if(0!==n.data[a])return!1;return!0}function\
+        \ f(e,t,n,a){switch(t){case\"flag\":return n(e,\"\\ud83c\\udff3\\ufe0f\\u200d\\\
+        u26a7\\ufe0f\",\"\\ud83c\\udff3\\ufe0f\\u200b\\u26a7\\ufe0f\")?!1:!n(e,\"\\\
+        ud83c\\udde8\\ud83c\\uddf6\",\"\\ud83c\\udde8\\u200b\\ud83c\\uddf6\")&&!n(e,\"\
+        \\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc65\\udb40\\udc6e\\udb40\\\
+        udc67\\udb40\\udc7f\",\"\\ud83c\\udff4\\u200b\\udb40\\udc67\\u200b\\udb40\\\
+        udc62\\u200b\\udb40\\udc65\\u200b\\udb40\\udc6e\\u200b\\udb40\\udc67\\u200b\\\
+        udb40\\udc7f\");case\"emoji\":return!a(e,\"\\ud83e\\udedf\")}return!1}function\
+        \ g(e,t,n,a){var r=\"undefined\"!=typeof WorkerGlobalScope&&self instanceof\
+        \ WorkerGlobalScope?new OffscreenCanvas(300,150):s.createElement(\"canvas\"\
+        ),o=r.getContext(\"2d\",{willReadFrequently:!0}),i=(o.textBaseline=\"top\"\
+        ,o.font=\"600 32px Arial\",{});return e.forEach(function(e){i[e]=t(o,e,n,a)}),i}function\
+        \ t(e){var t=s.createElement(\"script\");t.src=e,t.defer=!0,s.head.appendChild(t)}\"\
+        undefined\"!=typeof Promise&&(o=\"wpEmojiSettingsSupports\",i=[\"flag\",\"\
+        emoji\"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){s.addEventListener(\"\
+        DOMContentLoaded\",e,{once:!0})}),new Promise(function(t){var n=function(){try{var\
+        \ e=JSON.parse(sessionStorage.getItem(o));if(\"object\"==typeof e&&\"number\"\
+        ==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&\"object\"\
+        ==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if(\"\
+        undefined\"!=typeof Worker&&\"undefined\"!=typeof OffscreenCanvas&&\"undefined\"\
+        !=typeof URL&&URL.createObjectURL&&\"undefined\"!=typeof Blob)try{var e=\"\
+        postMessage(\"+g.toString()+\"(\"+[JSON.stringify(i),f.toString(),p.toString(),u.toString()].join(\"\
+        ,\")+\"));\",a=new Blob([e],{type:\"text/javascript\"}),r=new Worker(URL.createObjectURL(a),{name:\"\
+        wpTestEmojiSupports\"});return void(r.onmessage=function(e){c(n=e.data),r.terminate(),t(n)})}catch(e){}c(n=g(i,f,p,u))}t(n)}).then(function(e){for(var\
+        \ t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],\"\
+        flag\"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return\
+        \ e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);\n\
+        /* ]]> */\n</script>\n<link rel='stylesheet' id='wpa-css-css' href='https://legendei.net/wp-content/plugins/wp-attachments/styles/0/wpa.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='wp-emoji-styles-inline-css' type='text/css'>\n\
+        \n\timg.wp-smiley, img.emoji {\n\t\tdisplay: inline !important;\n\t\tborder:\
+        \ none !important;\n\t\tbox-shadow: none !important;\n\t\theight: 1em !important;\n\
+        \t\twidth: 1em !important;\n\t\tmargin: 0 0.07em !important;\n\t\tvertical-align:\
+        \ -0.1em !important;\n\t\tbackground: none !important;\n\t\tpadding: 0 !important;\n\
+        \t}\n</style>\n<link rel='stylesheet' id='wp-block-library-css' href='https://legendei.net/wp-includes/css/dist/block-library/style.min.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='classic-theme-styles-inline-css'\
+        \ type='text/css'>\n/*! This file is auto-generated */\n.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em\
+        \ + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}\n\
+        </style>\n<style id='wppb-content-restriction-start-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-content-restriction-end-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-edit-profile-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-login-style-inline-css' type='text/css'>\n\n\
+        \n</style>\n<style id='wppb-recover-password-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-register-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='global-styles-inline-css' type='text/css'>\n:root{--wp--preset--aspect-ratio--square:\
+        \ 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4:\
+        \ 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3:\
+        \ 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16:\
+        \ 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray:\
+        \ #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink:\
+        \ #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange:\
+        \ #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan:\
+        \ #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue:\
+        \ #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple:\
+        \ #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1)\
+        \ 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan:\
+        \ linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange:\
+        \ linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red:\
+        \ linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray:\
+        \ linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum:\
+        \ linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186)\
+        \ 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple:\
+        \ linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux:\
+        \ linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62)\
+        \ 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112)\
+        \ 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean:\
+        \ linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181)\
+        \ 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128)\
+        \ 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129)\
+        \ 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium:\
+        \ 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large:\
+        \ 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40:\
+        \ 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70:\
+        \ 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural:\
+        \ 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px\
+        \ rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0,\
+        \ 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255,\
+        \ 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0,\
+        \ 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap:\
+        \ 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items:\
+        \ center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display:\
+        \ grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-color{color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background:\
+        \ var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange)\
+        \ !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background:\
+        \ var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background:\
+        \ var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background:\
+        \ var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background:\
+        \ var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background:\
+        \ var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size:\
+        \ var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size:\
+        \ var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--x-large) !important;}\n:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}\n:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}\n:root :where(.wp-block-pullquote){font-size:\
+        \ 1.5em;line-height: 1.6;}\n</style>\n<link rel='stylesheet' id='lrl-css-css'\
+        \ href='https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-maincss-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css' type='text/css'\
+        \ media='all' />\n<link rel='stylesheet' id='fontawesome-css' href='https://legendei.net/wp-content/themes/simple-grid/assets/css/all.min.css'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-webfont-css'\
+        \ href='//fonts.googleapis.com/css?family=Playfair+Display:400,400i,700,700i|Domine:400,700|Oswald:400,700|Patua+One|Merriweather:400,400i,700,700i&#038;display=swap'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='legendei-style-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css?ver=1782544305'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='wppb_stylesheet-css'\
+        \ href='https://legendei.net/wp-content/plugins/profile-builder/assets/css/style-front-end.css?ver=3.15.2'\
+        \ type='text/css' media='all' />\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-includes/js/jquery/jquery.min.js?ver=3.7.1\" id=\"\
+        jquery-core-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1\"\
+        \ id=\"jquery-migrate-js\"></script>\n<!--[if lt IE 9]>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/respond.min.js\"\
+        \ id=\"respond-js\"></script>\n<![endif]-->\n<link rel=\"https://api.w.org/\"\
+        \ href=\"https://legendei.net/wp-json/\" /><link rel=\"alternate\" title=\"\
+        JSON\" type=\"application/json\" href=\"https://legendei.net/wp-json/wp/v2/posts/836386\"\
+        \ /><link rel=\"EditURI\" type=\"application/rsd+xml\" title=\"RSD\" href=\"\
+        https://legendei.net/xmlrpc.php?rsd\" />\n<meta name=\"generator\" content=\"\
+        WordPress 6.8.3\" />\n<link rel='shortlink' href='https://legendei.net/?p=836386'\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (JSON)\" type=\"application/json+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fbreaking-bad-s01e01-bdrip-x264-fgt%2F\"\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (XML)\" type=\"text/xml+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fbreaking-bad-s01e01-bdrip-x264-fgt%2F&#038;format=xml\"\
+        \ />\n<style>\n\n/* FORMUL\xC1RIO TRIAL */\n\n.premium-form {\n    max-width:\
+        \ 760px;\n    margin: 0 auto 20px;\n    padding: 30px;\n    border-radius:\
+        \ 10px;\n    background: #212121;\n    border: 10px solid transparent;\n \
+        \   background-image:\n        linear-gradient(#212121,#212121),\n       \
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    background-origin: border-box;\n\
+        \    background-clip: padding-box, border-box;\n    box-sizing: border-box;\n\
+        }\n\n/* Campos */\n\n.premium-form .field {\n    position: relative;\n   \
+        \ margin-bottom: 20px;\n}\n\n.premium-form input {\n    width: 100%;\n   \
+        \ padding: 14px;\n    border-radius: 8px;\n    border: 1px solid #ccc;\n \
+        \   font-size: 16px;\n    box-sizing: border-box;\n}\n\n/* Focus bonito */\n\
+        \n.premium-form input:focus {\n    border-color: transparent;\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin: border-box;\n    background-clip: padding-box, border-box;\n\
+        \    box-shadow: 0 0 0 4px rgba(63,140,255,0.20);\n    outline: none;\n}\n\
+        \n/* TOOLTIP */\n\n.premium-form .tooltip {\n    position: absolute;\n   \
+        \ bottom: 100%;\n    left: 0;\n    margin-bottom: 10px;\n    background: linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \tbox-shadow:0 6px 14px rgba(0,0,0,0.25);\n    color: #ffffff;\n    padding:\
+        \ 10px 12px;\n    font-size: 14px;\n    border-radius: 6px;\n    max-width:\
+        \ 260px;\n    opacity: 0;\n    pointer-events: none;\n    transition: .2s;\n\
+        \    z-index: 999;\n}\n\n.premium-form .tooltip::after {\n    content: \"\"\
+        ;\n    position: absolute;\n    top: 100%;\n    left: 15px;\n    border-width:\
+        \ 6px 6px 0 6px;\n    border-style: solid;\n    border-color: #8a2be2 transparent\
+        \ transparent transparent;\n}\n\n.premium-form .field:hover .tooltip,\n.premium-form\
+        \ .field:focus-within .tooltip {\n    opacity: 1;\n    transform: translateY(-4px);\n\
+        }\n\n/* BOT\xC3O */\n\n.premium-form button {\n    padding: 14px 30px;\n \
+        \   font-size: 22px;\n    border-radius: 8px;\n    border: none;\n    background:\
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    color: #fff;\n    cursor: pointer;\n\
+        \    transition: .25s;\n}\n\n.premium-form button:hover {\n    background:\
+        \ linear-gradient(90deg,#4c9aff,#9a3bff);\n}\n\n/* SENHA */\n\n.pass-wrap{\n\
+        \    position:relative;\n}\n\n.toggle-pass{\n    position:absolute;\n    right:12px;\n\
+        \    top:50%;\n    transform:translateY(-50%);\n    cursor:pointer;\n    font-size:18px;\n\
+        }\n\n/* BARRA FOR\xC7A SENHA */\n\n.strength{\n    height:6px;\n    background:#444;\n\
+        \    border-radius:4px;\n    margin-top:8px;\n    overflow:hidden;\n}\n\n\
+        .strength div{\n    height:100%;\n    width:0%;\n    transition:.3s;\n}\n\n\
+        /* MOBILE */\n\n@media (max-width:480px){\n\n.premium-form{\n    padding:20px;\n\
+        }\n\n}\n\n</style>\n<!-- FIFU: meta tags for featured image (begin) -->\n\
+        <meta property=\"og:image\" content=\"https://image.tmdb.org/t/p/w500/1BP4xYv9ZG4ZVHkL7ocOziBbSYH.jpg\"\
+        \ />\n<!-- FIFU: meta tags for featured image (end) --><meta name=\"twitter:image\"\
+        \ content=\"https://image.tmdb.org/t/p/w500/1BP4xYv9ZG4ZVHkL7ocOziBbSYH.jpg\"\
+        \ /><style>\n\n/* remove fundo normal, ativo e hover do logo */\n.simple-grid-primary-nav-menu\
+        \ > li.menu-logo-item > a,\n.simple-grid-primary-nav-menu > li.menu-logo-item\
+        \ > a:hover,\n.simple-grid-primary-nav-menu > li.menu-logo-item.current-menu-item\
+        \ > a{\n    background:none !important;\n}\n\n/* ===================================================\n\
+        \   MOBILE\n   =================================================== */\n\n\
+        @media only screen and (max-width:812px){\n\n    /* ESCONDER LOGO NO MENU\
+        \ MOBILE */\n    .simple-grid-primary-nav-menu > li.menu-logo-item{\n    \
+        \    display:none !important;\n    }\n\n}\n\n</style>\n    <style type=\"\
+        text/css\">\r\n            .simple-grid-site-title, .simple-grid-site-title\
+        \ a, .simple-grid-site-description {color: #ffffff;}\r\n        </style>\r\
+        \n    <style type=\"text/css\" id=\"custom-background-css\">\nbody.custom-background\
+        \ { background-color: #333333; }\n</style>\n\t<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"32x32\" />\n<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"192x192\" />\n<link rel=\"apple-touch-icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n<meta name=\"msapplication-TileImage\" content=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n</head>\t\n\t\n\t\n<body class=\"wp-singular post-template-default single\
+        \ single-post postid-836386 single-format-standard custom-background wp-custom-logo\
+        \ wp-theme-simple-grid simple-grid-animated simple-grid-fadein simple-grid-theme-is-active\
+        \ simple-grid-custom-logo-active simple-grid-layout-type-full simple-grid-masonry-inactive\
+        \ simple-grid-float-grid simple-grid-responsive-grid-details simple-grid-layout-c-s1\
+        \ simple-grid-header-banner-active simple-grid-tagline-inactive simple-grid-logo-above-title\
+        \ simple-grid-primary-menu-active simple-grid-primary-mobile-menu-active simple-grid-secondary-mobile-menu-active\
+        \ simple-grid-primary-social-icons\" id=\"simple-grid-site-body\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/WebPage\">\n<a class=\"skip-link\
+        \ screen-reader-text\" href=\"#simple-grid-content-wrapper\">Skip to content</a>\n\
+        \n\n\n<div class=\"simple-grid-site-header simple-grid-container\" id=\"simple-grid-header\"\
+        \ itemscope=\"itemscope\" itemtype=\"http://schema.org/WPHeader\" role=\"\
+        banner\">\n<div class=\"simple-grid-head-content simple-grid-clearfix\" id=\"\
+        simple-grid-head-content\">\n\n<div class=\"simple-grid-no-header-content\"\
+        >\n              <p class=\"simple-grid-site-title\"><a href=\"https://legendei.net/\"\
+        \ rel=\"home\">Legendei</a></p>\r\n                </div>\n\n</div><!--/#simple-grid-head-content\
+        \ -->\n</div><!--/#simple-grid-header -->\n\n\n\n<div class=\"simple-grid-container\
+        \ simple-grid-primary-menu-container simple-grid-clearfix\">\n<div class=\"\
+        simple-grid-primary-menu-container-inside simple-grid-clearfix\">\n<nav class=\"\
+        simple-grid-nav-primary\" id=\"simple-grid-primary-navigation\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/SiteNavigationElement\" role=\"navigation\"\
+        \ aria-label=\"Primary Menu\">\n\t\n\t\n<div class=\"simple-grid-outer-wrapper\"\
+        >\n<a href=\"/\" class=\"logo-mobile-inline\">\n<img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \nstyle=\"width:100%;height:auto;\">\n</a>\n\n<style>\n.logo-mobile-inline{\n\
+        display:none;\n}\n\n@media (max-width:812px){\n.logo-mobile-inline{\ndisplay:block;\n\
+        }\n}\n</style>\t\n\n\t\n<style>\n.mobile-header-icons{\n    display:none;\n\
+        }\n\n@media (max-width: 812px){\n\n.mobile-header-icons{\n    display:grid;\n\
+        \    grid-template-columns: 2fr 1fr 1fr;\n    gap:10px;\n    padding:10px;\n\
+        }\n\n/* BOT\xD5ES */\n.mobile-header-icons a,\n.mobile-header-icons .cat-toggle{\n\
+        \    display:flex;\n    align-items:center;\n    justify-content:center;\n\
+        \    gap:6px;\n    background:#141414;\n    padding:8px 6px;\n    border-radius:8px;\n\
+        \    color:#fff;\n    font-size:12px;\n    text-decoration:none;\n    text-align:center;\n\
+        \    cursor:pointer;\n}\n\n/* CATEGORIA */\n.cat-toggle{\n    font-weight:600;\n\
+        }\n\n/* SETA */\n.cat-toggle .arrow{\n    transition:transform 0.3s ease;\n\
+        }\n\n/* SETA GIRADA */\n.cat-toggle.active .arrow{\n    transform:rotate(180deg);\n\
+        }\n\n/* HOVER */\n.mobile-header-icons a:hover,\n.mobile-header-icons .cat-toggle:hover{\n\
+        \    background:#1f1f1f;\n}\n\n/* CONTAINER */\n.cat-container{\n    position:relative;\n\
+        }\n\n/* DROPDOWN */\n.cat-list{\n    display:flex;\n    flex-direction:column;\n\
+        \    gap:6px;\n\n    position:absolute;\n    top:110%;\n    left:0;\n    width:100%;\n\
+        \n    background:#0f0f0f;\n    border-radius:8px;\n    padding:6px;\n    z-index:999;\n\
+        \n    opacity:0;\n    visibility:hidden;\n    transform:translateY(-5px);\n\
+        \    transition:all 0.25s ease;\n}\n\n/* ABERTO */\n.cat-container.open .cat-list{\n\
+        \    opacity:1;\n    visibility:visible;\n    transform:translateY(0);\n}\n\
+        \n/* ITENS */\n.cat-list a{\n    justify-content:flex-start;\n    font-size:14px;\n\
+        \    padding:10px;\n}\n\n}\n</style>\n\n\n<div class=\"mobile-header-icons\"\
+        >\n\n    <!-- CATEGORIAS -->\n    <div class=\"cat-container\">\n        <div\
+        \ class=\"cat-toggle\">\n            \U0001F4C2 Categorias <span class=\"\
+        arrow\">\u25BC</span>\n        </div>\n\n        <div class=\"cat-list\">\n\
+        \            <a href=\"/category/destaques/\">\u2B50 Destaques</a>\n     \
+        \       <a href=\"/category/filmes/\">\U0001F3AC Filmes</a>\n            <a\
+        \ href=\"/category/serie/\">\U0001F4FA S\xE9ries</a>\n            <a href=\"\
+        /category/pack-de-legendas/\">\U0001F4E6 Packs</a>\n        </div>\n    </div>\n\
+        \n    \n        <a href=\"/seja-premium-vitalicio/\"><i class=\"fa-solid fa-crown\"\
+        ></i> Premium</a>\n\n        <a href=\"/login/\"><i class=\"fa-solid fa-key\"\
+        ></i> Login</a>\n\n    \n</div>\n\n<script>\ndocument.addEventListener(\"\
+        DOMContentLoaded\", function(){\n\n    const container = document.querySelector(\"\
+        .cat-container\");\n    const toggle = document.querySelector(\".cat-toggle\"\
+        );\n\n    toggle.addEventListener(\"click\", function(e){\n        e.stopPropagation();\n\
+        \        container.classList.toggle(\"open\");\n        toggle.classList.toggle(\"\
+        active\");\n    });\n\n    document.addEventListener(\"click\", function(e){\n\
+        \        if(!container.contains(e.target)){\n            container.classList.remove(\"\
+        open\");\n            toggle.classList.remove(\"active\");\n        }\n  \
+        \  });\n\n});\n</script>\t\n\t\n<ul id=\"simple-grid-menu-primary-navigation\"\
+        \ class=\"simple-grid-primary-nav-menu simple-grid-menu-primary\"><li id=\"\
+        menu-item-673170\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-673170 menu-logo-item\">\n        <a href=\"https://legendei.net/\"\
+        \ style=\"\n            display:flex;\n            align-items:center;\n \
+        \           justify-content:center;\n            height:100%;\n          \
+        \  padding:0;\n            margin:0;\n            line-height:1;\n       \
+        \ \">\n            <img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \n                      alt=\"Legendei.NET\"\n                      style=\"\
+        height:42px;width:auto;display:block;\">\n        </a></li>\n\n<li id=\"menu-item-673168\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673168\"\
+        ><a href=\"https://legendei.net/category/destaques/\" title=\"Legendas em\
+        \ Destaque\">DESTAQUES</a></li>\n<li id=\"menu-item-673167\" class=\"menu-item\
+        \ menu-item-type-taxonomy menu-item-object-category menu-item-673167\"><a\
+        \ href=\"https://legendei.net/category/filmes/\" title=\"Legendas para Filmes\"\
+        >Filmes</a></li>\n<li id=\"menu-item-673166\" class=\"menu-item menu-item-type-taxonomy\
+        \ menu-item-object-category current-post-ancestor current-menu-parent current-post-parent\
+        \ menu-item-673166\"><a href=\"https://legendei.net/category/serie/\" title=\"\
+        Legendas para seriados\">S\xC9RIES</a></li>\n<li id=\"menu-item-673169\" class=\"\
+        menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673169\"\
+        ><a href=\"https://legendei.net/category/pack-de-legendas/\" title=\"Pack\
+        \ de legendas\">PACKS</a></li>\n<li id=\"menu-item-731144\" class=\"menu-item\
+        \ menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-731144\"\
+        ><a target=\"_blank\" href=\"/aplicativos/\">RECOMENDAMOS</a>\n<ul class=\"\
+        sub-menu\">\n\t<li id=\"menu-item-673172\" class=\"menu-item menu-item-type-custom\
+        \ menu-item-object-custom menu-item-673172\"><a target=\"_blank\" href=\"\
+        /aplicativos/\" title=\"Programas para windows\">APLICATIVOS</a></li>\n\t\
+        <li id=\"menu-item-687662\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-687662\"><a target=\"_blank\" href=\"https://4kxxx.vip/\" title=\"\
+        Baixe os melhores v\xEDdeos porn\xF4 sempre em 4K\">4K XXX</a></li>\n\t<li\
+        \ id=\"menu-item-717497\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-717497\"><a target=\"_blank\" href=\"https://detonaplay.com/\"\
+        >GAMES</a></li>\n</ul>\n</li>\n\n\n\n<li class=\"menu-item\" style=\"float:right;\"\
+        >\n            <a href=\"/login/\"\n               style=\"background:linear-gradient(135deg,#198754,#20ac6b);color:#ffffff;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-key\"></i> Login\n            </a>\n\
+        \        </li><li class=\"menu-item\" style=\"float:right;\">\n          \
+        \  <a href=\"/seja-premium-vitalicio/\"\n\t\t\t\t\t  style=\"background:linear-gradient(135deg,#f4c430,#c2940a);color:#4d2e00;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-crown\"></i> Membro Premium\n  \
+        \          </a>\n        </li></ul>    </div>\n</nav>\n</div>\n</div>\n\n\t\
+        \n\t\n\r\n<div class=\"simple-grid-outer-wrapper\">\r\n<div class=\"simple-grid-top-wrapper-outer\
+        \ simple-grid-clearfix\">\r\n<div class=\"simple-grid-featured-posts-area\
+        \ simple-grid-top-wrapper simple-grid-clearfix\">\r\n\r\n<div id=\"search-5\"\
+        \ class=\"simple-grid-main-widget widget simple-grid-widget-box widget_search\"\
+        ><div class=\"simple-grid-widget-box-inside\"><form role=\"search\" method=\"\
+        get\" class=\"simple-grid-search-form\" action=\"https://legendei.net/\">\n\
+        <label>\n    <span class=\"simple-grid-sr-only\">Pesquisar por </span>\n \
+        \   <input \n        type=\"search\"\n        class=\"simple-grid-search-field\"\
+        \n        placeholder=\"Pesquisar &hellip;\"\n        value=\"\"\n       \
+        \ name=\"s\"\n        minlength=\"3\"\n\t\tmaxlength=\"50\"   \n        required\n\
+        \    />\n</label>\n<input type=\"submit\" class=\"simple-grid-search-submit\"\
+        \ value=\"&#xf002;\" />\n</form></div></div></div>\r\n</div>\r\n</div>\r\n\
+        \r\n\n<div class=\"simple-grid-outer-wrapper\" id=\"simple-grid-wrapper-outside\"\
+        >\n\n<div class=\"simple-grid-container simple-grid-clearfix\" id=\"simple-grid-wrapper\"\
+        >\n<div class=\"simple-grid-content-wrapper simple-grid-clearfix\" id=\"simple-grid-content-wrapper\"\
+        >\t\n\t\t\n\n\n<div class=\"simple-grid-main-wrapper simple-grid-clearfix\"\
+        \ id=\"simple-grid-main-wrapper\" itemscope=\"itemscope\" itemtype=\"http://schema.org/Blog\"\
+        \ role=\"main\">\n<div class=\"theiaStickySidebar\">\n<div class=\"simple-grid-main-wrapper-inside\
+        \ simple-grid-clearfix\">\n\n\r\n\r\n\n<div class=\"simple-grid-posts-wrapper\"\
+        \ id=\"simple-grid-posts-wrapper\">\n\n\n\n\n\n<div style=\"width: 100%; border-radius:\
+        \ 12px; box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 12px; padding: 15px; background:\
+        \ #ffffff;\">\n    <center>\n    <article id=\"post-836386\" class=\"simple-grid-post-singular\
+        \ simple-grid-box post-836386 post type-post status-publish format-standard\
+        \ hentry category-serie tag-acervo-legenda-oficial tag-acervo-legendas-tv\
+        \ tag-legendas-breaking-bad tag-legendas-breaking-bad-s01 wpcat-4-id\">\n\
+        \        <div class=\"simple-grid-box-inside\">\n            \n          \
+        \  \n                            <header class=\"entry-header\">\n       \
+        \             <div class=\"entry-header-inside simple-grid-clearfix\">\n\n\
+        <h1 class=\"post-title entry-title\">Legenda Breaking Bad S01E01 BDRip x264\
+        \ FGT <span aria-label=\"PT-BR\">\U0001F1E7\U0001F1F7</span></h1>\n\n\n  \
+        \                                  <div class=\"simple-grid-entry-meta-single\"\
+        >\n                            <span class=\"simple-grid-entry-meta-single-date\"\
+        >\n                <i class=\"far fa-clock\" aria-hidden=\"true\"></i>&nbsp;8\
+        \ de junho de 2026            </span>\n                                  \
+        \  <span class=\"simple-grid-entry-meta-single-categories\"><i class=\"far\
+        \ fa-folder-open\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Posted in </span><a href=\"https://legendei.net/category/serie/\" rel=\"\
+        category tag\">S\xE9ries TV</a></span>                            </div>\n\
+        \    \n\n                    </div>\n                </header>\n         \
+        \   \t\t\t\n\t\t\t\n            <!-- inicio poster -->\n            <img src=\"\
+        https://image.tmdb.org/t/p/w500/1BP4xYv9ZG4ZVHkL7ocOziBbSYH.jpg\" style=\"\
+        max-width:220px;width:330px;height:auto;margin-bottom:5px;\" alt=\"Breaking\
+        \ Bad S01E01 BDRip x264 FGT\">            <!-- fim poster -->\n\t\t\t\n<!--\
+        \ S admin -->\n            \t\t\t\n<!-- S admin -->\t\n\t\t\t\n          \
+        \  \n            <div class=\"entry-content simple-grid-clearfix\">\n\n<!--\
+        \ N PREMIUM AMIN TEMP -->\t\t\t\t\n\t\n\n   <a href=\"https://cuponei.org/promo/more/\"\
+        \ target=\"_blank\" rel=\"noopener\">\n    <img class=\"aligncenter wp-image-729595\
+        \ size-full\"\n         src=\"https://legendei.net/wp-content/uploads/2026/01/amazon.webp\"\
+        \n         width=\"350\" height=\"334\" />\n  </a>\t\n\t\t\t\t\t\t\t\t\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\t\t\t\t\n<!-- anexos otimizados -->\n<!--\
+        \ /anexos -->\n\n\n                <!-- WP Attachments -->\n        <div style=\"\
+        width:100%;margin:10px 0 10px 0;\">\n            <h3></h3>\n        <ul class=\"\
+        post-attachments\"><p class=\"post-attachment mime-application-zip\">    \
+        \                                                                        \
+        \    <a href=\"https://legendei.net/breaking-bad-s01e01-bdrip-x264-fgt/?download=836385\"\
+        \ target=\"_blank\" class=\"buttonmyup\"><i class=\"fa fa-download\"></i>\
+        \ BAIXAR LEGENDA</a>\r\n</p></ul></div><div class=\"highlight-text-sinopse\"\
+        >\n<p>Legenda da s\xE9rie Breaking Bad (2008) Ao saber que tem c\xE2ncer,\
+        \ um professor passa a fabricar metanfetamina pelo futuro da fam\xEDlia, mudando\
+        \ o destino de todos.</p>\n</div>\n\n        <div class=\"highlight-text\"\
+        >\n\n<style>\n/* ===================================== */\n/* LINKS COM BORDA\
+        \ GRADIENTE + UNDERLINE */\n/* ===================================== */\n\n\
+        .busca-legenda-links a{\n    display:inline-block;\n    padding:8px 18px;\n\
+        \    margin:2px 8px;\n    font-weight:400;\n    font-size:14px;\n    text-decoration:none\
+        \ !important;\n\tmin-width: 180px;\n    color:#1e293b !important; /* texto\
+        \ escuro vis\xEDvel */\n    background:transparent;\n\n    border:2px solid\
+        \ transparent;\n    border-radius:6px;\n\n    /* borda gradiente */\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin:border-box;\n    background-clip:padding-box, border-box;\n\
+        \n    position:relative;\n    transition:all .25s ease;\n}\n\n/* underline\
+        \ gradiente (embaixo do texto) */\n.busca-legenda-links a::after{\n    content:\"\
+        \";\n    position:absolute;\n    left:50%;\n    bottom:6px; /* dentro do bot\xE3\
+        o */\n    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\n\n/*\
+        \ hover */\n.busca-legenda-links a:hover{\n    color:#002080 !important;\n\
+        }\n\n.busca-legenda-links a:hover::after{\n    width:60%;\n}\n\n/* ativo (se\
+        \ quiser usar classe active depois) */\n.busca-legenda-links a.active::after{\n\
+        \    width:60%;\n}\n\n@media (max-width: 768px){\n\n    .busca-legenda-links{\n\
+        \        display:block;\n    }\n\n    /* remove os pontinhos separadores no\
+        \ mobile */\n    .busca-legenda-links span{\n        display:none;\n    }\n\
+        \n    .busca-legenda-links a{\n        display:block;\n        width:100%;\n\
+        \        margin:6px 0; /* controla espa\xE7amento vertical */\n        text-align:center;\n\
+        \t\tfont-size:14px;\n    }\n\n\n}\n</style>\n\n\n\n            <p><strong>Legenda\
+        \ da s\xE9rie Breaking Bad S01E01 BDRip x264 FGT</strong></p>\n          \
+        \  <hr>\n\n            <p>Todas as legendas dispon\xEDveis para download s\xE3\
+        o testadas e verificadas, garantindo sincronia, precis\xE3o e qualidade.</p>\n\
+        \n            <p>Depois de baixar a legenda, n\xE3o se esque\xE7a de conferir\
+        \ o seu release!</p>\n\n            <div class=\"busca-legenda-links\">\n\
+        \                <a href=\"/category/serie/?s=Breaking+Bad\">+ legendas mesma\
+        \ s\xE9rie</a><a href=\"/category/serie/?s=Breaking+Bad+S01\">+ legendas mesma\
+        \ temporada</a><span>\xB7</span><a href=\"/category/serie/?s=Breaking+Bad+S01E01\"\
+        >+ legendas mesmo epis\xF3dio</a>\n            </div>\n\n        </div>\n\t\
+        \t\n\n\t\t\n\t\t\n                <!-- sinopse TMDB -->\n                <!--\
+        \ /sinopse -->\n\n            </div><!-- .entry-content -->\n\n          \
+        \  \n            \n        </div>\n\n\n\n\t\t\n    </article>\n\n<!-- inicio\
+        \ app recomendados -->\t\t\n<div id=\"apps-recomendados\">\n<div class=\"\
+        busca-legenda-links\" style=\"text-align:center;\">\n<h5>Aplicativos que usamos\
+        \ e recomendamos</h5>\n\n<a href=\"https://legendei.net/aplicativos/kodi/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2025/11/Kodi_21.3.webp\"\
+        \ width=\"40\" height=\"40\" />\n    Kodi Media Center\n</a>\n\n<a href=\"\
+        https://legendei.net/aplicativos/utorrent-pro-download-e-guia-completo/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/08/uTorrent-Pro.jpg\"\
+        \ width=\"40\" height=\"40\" />\n    uTorrent Pro\n</a>\n\n<a href=\"https://legendei.net/aplicativos/winzip-pro-windows/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/09/WinZip-Pro.png\"\
+        \ width=\"40\" height=\"40\" />\n    WinZip Pro\n</a>\n</div>\n</div>\n<style>\n\
+        @media (max-width: 812px){\n    #apps-recomendados{\n        display: none;\n\
+        \    }\n}\n</style>\n<!-- fim app recomendados -->\n\t\t\n<span class=\"simple-grid-entry-meta-single-tags\"\
+        ><i class=\"fas fa-tags\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Tagged </span><a href=\"https://legendei.net/tag/acervo-legenda-oficial/\"\
+        \ rel=\"tag\">Acervo Legenda Oficial</a>, <a href=\"https://legendei.net/tag/acervo-legendas-tv/\"\
+        \ rel=\"tag\">Acervo Legendas.TV</a>, <a href=\"https://legendei.net/tag/legendas-breaking-bad/\"\
+        \ rel=\"tag\">Legendas Breaking Bad</a>, <a href=\"https://legendei.net/tag/legendas-breaking-bad-s01/\"\
+        \ rel=\"tag\">Legendas Breaking Bad S01</a></span>\n\t\t\n\t\t\n\n\t\t\n<hr>\n\
+        <div class=\"lrl-report-link\">\n    <a href=\"#\" class=\"lrl-open busca-legenda-links\"\
+        >\U0001F6A8 Reportar problemas \U0001F6A8</a>\n\t</div>\n\n    <div id=\"\
+        lrl-modal\" style=\"display:none;\">\n        <div class=\"lrl-box\">\n  \
+        \          <span class=\"lrl-close\">&times;</span>\n            <h3>Qual\
+        \ \xE9 o problema?</h3><hr>\n\n<label><input type=\"radio\" name=\"lrl_motivo\"\
+        \ value=\"Problemas com o download\"> O download n\xE3o funciona</label><br><br>\n\
+        \n<label><input type=\"radio\" name=\"lrl_motivo\" value=\"Legenda para o\
+        \ filme ou s\xE9rie incorreta\"> Conte\xFAdo \xE9 para outro filme, s\xE9\
+        rie ou epis\xF3dio</label><br><br>\n\n<label><input type=\"radio\" name=\"\
+        lrl_motivo\" value=\"Idioma da legenda incorreto\"> O idioma da legenda est\xE1\
+        \ errado.</label><br><br>\n<hr>\n            <button id=\"lrl-send\" disabled>Enviar</button>\n\
+        \        </div>\n    </div>\n    \t\t\n    </center>\n\t\n</div>\n\n\t\n\t\
+        \n\t\n\t\n\n<!-- S admin -->\t\n<!-- S admin -->\t\n\n\n\t\n<!-- N PREMIUM\
+        \ AMIN TEMP -->\n<div>\t\n<!-- protetor de links -->\n<script>\n(function(){\n\
+        \nconst redirectpage = \"https://legendei.net/noticia.php\";\n\nconst bases\
+        \ = [\n    '/?download=',\n    '/?dl_',\n    '.rar',\n    '.zip',\n    '.srt',\n\
+        \    'magnet:',\n\t'/zip-attachments.php'\n];\n\ndocument.querySelectorAll('a').forEach(a\
+        \ => {\n    const href = a.getAttribute('href') || '';\n\n    if (bases.some(b\
+        \ => href.includes(b))) {\n\n        const token = btoa(href);\n\n       \
+        \ a.href = redirectpage + \"?token=\" + token;\n        a.target = \"_blank\"\
+        ;\n    }\n});\n\n})();\n</script>\n<!-- /protetor de links -->\t\n\t\t\n\n\
+        <!-- BLOQUEADOR LEGENDEI -->\n\n<!-- BLOQUEADOR LEGENDEI -->\n\t\n<!-- inicio\
+        \ reload -->\n<script>\nsetInterval(function(){\n  location.reload();\n},\
+        \ 120000); // 2 minutos\n</script>\n<!-- fim reload -->\t\n\t\n</div>\t\n\
+        <!-- N PREMIUM AMIN TEMP -->\n\t\n\t\n<div class=\"clear\"></div>\n</div><!--/#simple-grid-posts-wrapper\
+        \ -->\n\n\r\n\r\n\t\n\n</div>\n</div>\n</div><!-- /#simple-grid-main-wrapper\
+        \ -->\n\n\n\n</div>\n\n\n\n\n<!-- N ADMIN -->\n<div>\n<!-- inicio -->\n<iframe\
+        \ \n  src=\"https://cuponei.org/last/\"\n  style=\"\n    width:1px;\n    height:1px;\n\
+        \    opacity:0;\n    border:none;\n    overflow:hidden;\n  \"\n  scrolling=\"\
+        no\"\n></iframe>\n<!-- fim -->\t\n</div>\n<!-- N ADMIN -->\n\n\n\n\n<!-- N\
+        \ PREMIUM AMIN TEMP -->\n\n\n\n\n<div>\n\n\t\n<!-- =============================\
+        \ -->\n<!-- SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\n\n<div id=\"SCRIPT_1_AQUI\" style=\"display:none;\">\t\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/invesup.js\"></script>\n<script\
+        \ type=\"text/javascript\">\n// make pop on new window with size 150x150 \
+        \ \nLight.Popup.create('https://cuponei.org/promo/more/', {width: 150, height:\
+        \ 150, onNewTab: false});\n// refresh = new popup\nLight.Popup.create('https://cuponei.org/promo/more/amz/',\
+        \ {alwaysPop: false});  \n</script>\n</div>\t\n\n<div id=\"SCRIPT_2_AQUI\"\
+        \ style=\"display:none;\">\n\t\n<script type=\"text/javascript\">\n var p$00a\
+        \ = 'p$00a' + (new Date().getTime()) + 'zz'; window[p$00a] = {a:'abcdefghijklmnopqrstuvwxyz0123456789i0xpy5jn7r6h82fuw1skdgzca94e3omqvblt',\
+        \ b:'{\"AZIb\":\"e344vq\", \"BVIb\":\"b4mm4e\", \"CXrr1\":\"du\", \"DLtag\"\
+        :\"e\", \"Emjk5\":\"\", \"XCge1s\":\"u.g7fz1yh.xf8\" , \"Zt1\":\"ufuxisn.2yk\"\
+        , \"ZZ1\":\"u.nn8fu.xhfdp\" }', c:'{\"Abkr221\":\"sx17uk\", \"Bo9ssm\":\"\
+        //xp2.g7fz1yh.xf8/iuu.rs\"}', d:'{\"Ag4\":\"0fpa\", \"Bx1\":\"iuuy2pCn7hp\"\
+        , \"Cky\":\"s1x\", \"Dmg\":\"x1yikyEhy8y2k\"}'};\nvar _0x5d4b=['235913QVfbwv','slice','length','162209QBmAmV','14238hyOOTq','323207DTbifh','split','1DqiKtq','135866HTbavB','indexOf','call','27654SKXHbY','parse','undefined','32Ijckmz','keys','map','ceil','115980hcFVDy','values','join'];var\
+        \ _0x208c=function(_0x31a8d7,_0x5f36b3){_0x31a8d7=_0x31a8d7-0x167;var _0x5d4be1=_0x5d4b[_0x31a8d7];return\
+        \ _0x5d4be1;};(function(_0x276f94,_0x57c4ff){var _0x50057c=_0x208c;while(!![]){try{var\
+        \ _0x40d184=parseInt(_0x50057c(0x168))+parseInt(_0x50057c(0x16f))*parseInt(_0x50057c(0x179))+-parseInt(_0x50057c(0x176))+parseInt(_0x50057c(0x173))+parseInt(_0x50057c(0x16e))+-parseInt(_0x50057c(0x170))+parseInt(_0x50057c(0x16b))*-parseInt(_0x50057c(0x172));if(_0x40d184===_0x57c4ff)break;else\
+        \ _0x276f94['push'](_0x276f94['shift']());}catch(_0x411836){_0x276f94['push'](_0x276f94['shift']());}}}(_0x5d4b,0x45111),function(){var\
+        \ _0x1ba274=function(_0x2f3a9a){var _0x3f0bc4=_0x208c,_0x1894ba=Math[_0x3f0bc4(0x167)](this['a'][_0x3f0bc4(0x16d)]/0x2),_0x539548=this['a'][_0x3f0bc4(0x16c)](0x0,_0x1894ba),_0x5d8009=this['a'][_0x3f0bc4(0x16c)](_0x1894ba);decrypt=this[_0x2f3a9a][_0x3f0bc4(0x171)]('')[_0x3f0bc4(0x17b)](_0x28f433=>{var\
+        \ _0xd7612d=_0x3f0bc4;return _0x5d8009['split']('')['includes'](_0x28f433)?_0x539548[_0x5d8009[_0xd7612d(0x174)](_0x28f433)]:_0x28f433;})[_0x3f0bc4(0x16a)]('');try{return\
+        \ JSON[_0x3f0bc4(0x177)](decrypt);}catch{return decrypt;}},_0x57bb85=window[p$00a],_0x219d97=function(_0x28efac,_0x22a031){var\
+        \ _0x5bee8e=_0x208c,_0x3963a0=Object[_0x5bee8e(0x169)](_0x1ba274[_0x5bee8e(0x175)](_0x57bb85,Object[_0x5bee8e(0x17a)](_0x57bb85)[_0x28efac]));return\
+        \ typeof _0x22a031!=_0x5bee8e(0x178)?_0x3963a0[_0x22a031]:_0x3963a0;};window[p$00a]['x']=function(){return\
+        \ _0x219d97(0x1);};var _0xf1db57=document[_0x219d97(0x3,0x3)](_0x219d97(0x2,0x0));_0xf1db57[_0x219d97(0x3,0x2)]=_0x219d97(0x2,0x1),document[_0x219d97(0x3,0x0)][_0x219d97(0x3,0x1)](_0xf1db57),p$00a=undefined;}());\n\
+        \ \n </script>\n\t\n<script type=\"text/javascript\" src=\"https://legendei.net/invesup.js\"\
+        ></script>\n<script type=\"text/javascript\">\n// make pop on new window with\
+        \ size 150x150  \nLight.Popup.create('https://legendei.net/terrabanne/', {width:\
+        \ 150, height: 150, onNewTab: false}); \n// refresh = new popup\nLight.Popup.create('https://legendei.net/terrabanne/',\
+        \ {alwaysPop: true}); \t\n</script>\t\n\t\n</div>\n\n<!-- =============================\
+        \ -->\n<!-- / SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\t\n\t\n<script>\n(function(){\n\nconst path = window.location.pathname;\n\
+        \nwindow.__CUPONEI_DISABLE_ALL = (\n  path.startsWith('/seja-premium-vitalicio')\
+        \ ||\n  path.startsWith('/perfil')\n);\n\nif (window.__CUPONEI_DISABLE_ALL)\
+        \ return;\n\n/* evita bots */\nif (/bot|googlebot|crawler|spider|crawling/i.test(navigator.userAgent))\
+        \ return;\n\nconst isExpiredUser = false;\n\nconst BLOCK_TIME = 1 * 60 * 60\
+        \ * 1000;\nconst STORAGE_KEY = 'premium_popup_blocked_until';\nconst TRIGGER_DELAY\
+        \ = 1000;\n\nlet adsStarted = false;\n\n/* ============================= */\n\
+        /* CONTROLE TEMPO                */\n/* ============================= */\n\
+        \nfunction now(){\n    return Date.now();\n}\n\nfunction isBlocked(){\n  \
+        \  const until = localStorage.getItem(STORAGE_KEY);\n    return until && now()\
+        \ < parseInt(until);\n}\n\nfunction blockPopup(){\n    localStorage.setItem(STORAGE_KEY,\
+        \ now() + BLOCK_TIME);\n}\n\n/* ============================= */\n/* EXECU\xC7\
+        \xC3O SEGURA DOS SCRIPTS   */\n/* ============================= */\n\nfunction\
+        \ executeScriptsFromDiv(divId, callback){\n\n    if (window.__CUPONEI_DISABLE_ALL){\n\
+        \        if(callback) callback();\n        return;\n    }\n\n    const container\
+        \ = document.getElementById(divId);\n    if(!container){\n        if(callback)\
+        \ callback();\n        return;\n    }\n\n    const scripts = container.querySelectorAll(\"\
+        script\");\n    let total = scripts.length;\n    let loaded = 0;\n\n    if(total\
+        \ === 0){\n        if(callback) callback();\n        return;\n    }\n\n  \
+        \  scripts.forEach(oldScript => {\n\n        const newScript = document.createElement(\"\
+        script\");\n\n        for (let attr of oldScript.attributes) {\n         \
+        \   newScript.setAttribute(attr.name, attr.value);\n        }\n\n        if(oldScript.src){\n\
+        \n            newScript.onload = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n            newScript.onerror = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n        } else {\n            newScript.text = oldScript.text;\n\
+        \            loaded++;\n        }\n\n        document.body.appendChild(newScript);\n\
+        \n        if(!oldScript.src){\n            if(loaded === total && callback)\
+        \ callback();\n        }\n\n    });\n\n}\n\n/* =============================\
+        \ */\n/* SEQU\xCANCIA DOS AN\xDANCIOS        */\n/* =============================\
+        \ */\n\nfunction runAds(){\n\n    if (window.__CUPONEI_DISABLE_ALL) return;\n\
+        \    if (adsStarted) return;\n\n    adsStarted = true;\n\n    let clickCount\
+        \ = 0;\n    let script2Executed = false;\n\n    function handleUserClick(){\n\
+        \n        clickCount++;\n\n        // Debug opcional\n        // console.log(\"\
+        Cliques:\", clickCount);\n\n        if(clickCount >= 2 && !script2Executed){\n\
+        \n            script2Executed = true;\n\n            document.removeEventListener(\"\
+        click\", handleUserClick, true);\n            document.removeEventListener(\"\
+        touchstart\", handleUserClick, true);\n\n            executeScriptsFromDiv(\"\
+        SCRIPT_2_AQUI\");\n        }\n    }\n\n    // Executa SCRIPT 1 primeiro\n\
+        \    setTimeout(function(){\n\n        executeScriptsFromDiv(\"SCRIPT_1_AQUI\"\
+        , function(){\n\n            // S\xF3 depois que SCRIPT 1 foi carregado\n\
+        \            document.addEventListener(\"click\", handleUserClick, {capture:true});\n\
+        \            document.addEventListener(\"touchstart\", handleUserClick, {capture:true});\n\
+        \n        });\n\n    }, 1000);\n\n}\n\n/* ============================= */\n\
+        /* POPUP PREMIUM                 */\n/* ============================= */\n\
+        \nfunction createPopup(){\n\nif(isBlocked()){\n    runAds();\n    return;\n\
+        }\n\nconst popup=document.createElement('div');\npopup.id='premium-popup';\n\
+        \npopup.innerHTML = isExpiredUser ? `\n\n<div class=\"premium-overlay\"></div>\n\
+        <div class=\"premium-box\">\n\n<div class=\"premium-text\">\n\U0001F614 Seu\
+        \ per\xEDodo de teste terminou!<br><br>\n<strong>Voc\xEA pode ser Membro Premium\
+        \ Vital\xEDcio para sempre fazendo uma \xFAnica doa\xE7\xE3o.</strong>\n</div>\n\
+        \n<div class=\"premium-actions\">\n<a href=\"/perfil/\" class=\"premium-yes\"\
+        >\U0001F525 QUERO SER PREMIUM \U0001F525</a>\n<p class=\"premium-nope\">CONTINUAR\
+        \ COM AN\xDANCIOS</p>\n</div>\n\n</div>\n\n` : `\n\n<div class=\"premium-overlay\"\
+        ></div>\n<div class=\"premium-box\">\n\n<div class=\"premium-text\">\n<i class=\"\
+        fa-solid fa-heart fa-beat\"></i>\nApoie a Legendei.NET e torne-se Membro Premium\
+        \ Vital\xEDcio agora para navegar sem an\xFAncios e desbloquear recursos exclusivos!\n\
+        <br>\n</div>\n\n<div class=\"premium-actions\">\n<a href=\"/seja-premium-vitalicio/\"\
+        \ class=\"premium-yes\">\U0001F525 FA\xC7A UM TESTE GRATUITO \U0001F525</a>\n\
+        <p class=\"premium-nope\">CONTINUAR COM AN\xDANCIOS</p>\n<a href=\"/login/\"\
+        \ class=\"premium-login\">J\xE1 tenho uma conta e quero conectar</a>\n</div>\n\
+        \n</div>\n\n`;\n\ndocument.body.appendChild(popup);\n\npopup.querySelector('.premium-nope').onclick=function(e){\n\
+        \ne.preventDefault();\n\nblockPopup();\nrunAds();\n\npopup.remove();\n\n};\n\
+        \n}\n\nlet triggered=false;\n\nfunction triggerPopup(){\n\nif(triggered) return;\n\
+        \ntriggered=true;\n\nsetTimeout(createPopup,TRIGGER_DELAY);\n\nwindow.removeEventListener('mousemove',triggerPopup);\n\
+        window.removeEventListener('touchstart',triggerPopup);\n\n}\n\n/* =============================\
+        \ */\n/* DISPARADORES                  */\n/* =============================\
+        \ */\n\nwindow.addEventListener('mousemove',triggerPopup,{passive:true});\n\
+        window.addEventListener('touchstart',triggerPopup,{passive:true});\n\ndocument.addEventListener('DOMContentLoaded',\
+        \ function(){\n\n    if(isBlocked()){\n        runAds();\n    }\n\n});\n\n\
+        })();\n</script>\n\n<style>\n/* ============================= */\n/* POPUP\
+        \ BASE */\n/* ============================= */\n#premium-popup{\n  position:fixed;\n\
+        \  inset:0;\n  z-index:999999;\n}\n\n.premium-overlay{\n  position:absolute;\n\
+        \  inset:0;\n  background:rgba(0,0,0,.65);\n}\n\n.premium-box{\n  position:absolute;\n\
+        \  left:50%;\n  top:50%;\n  transform:translate(-50%,-50%);\n  background:#212121;\n\
+        \  padding:28px 26px 26px;\n  max-width:440px;\n  width:92%;\n  border-radius:14px;\n\
+        \  text-align:center;\n}\n@media (max-width: 812px){\n  .premium-box{\n  \
+        \  top:5%;\n    transform:translate(-50%, 0);\n  }\n}\n\t\n/* inicio premium-login\
+        \ */\n.premium-login{\n  color:#fff;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  cursor:pointer;\n}\na.premium-login{\n    padding:8px 18px;\n}\na.premium-login::after{\n\
+        \    content:\"\";\n    position:absolute;\n    left:50%;\n    bottom:6px;\n\
+        \    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\na.premium-login:hover{\n\
+        \    color:#fff !important;\n}\n\na.premium-login:hover::after{\n    width:60%;\n\
+        }\n@media (max-width: 768px){\n    a.premium-login{\n        display:block;\n\
+        \        width:100%;\n        margin:6px 0;\n        text-align:center;\n\
+        \        font-size:14px;\n    }\n}\n/* fim premium-login */\n\n/* =============================\
+        \ */\n/* TEXTO */\n/* ============================= */\n.premium-text{\n \
+        \ color:#fff;\n  font-size:clamp(15px,2.6vw,18px);\n  line-height:1.4;\n \
+        \ font-family:Roboto,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;\n\
+        }\n\n.premium-text i{\n  color:#e74c3c;\n  margin-right:6px;\n}\n\n/* =============================\
+        \ */\n/* A\xC7\xD5ES */\n/* ============================= */\n.premium-actions{\n\
+        \  margin-top:18px;\n  display:flex;\n  flex-direction:column;\n  gap:12px;\n\
+        }\n\n/* ============================= */\n/* BOT\xD5ES */\n/* =============================\
+        \ */\n.alter{\n  background:#6f42c1;\n  border:2px solid #fff;\n  font-weight:bold;\n\
+        \  font-size:clamp(14px,2.6vw,16px);\n  color:#fff;\n  padding:10px 14px;\n\
+        \  border-radius:8px;\n  cursor:pointer;\n}\n\n.premium-yes{\n  background:#1e90ff;\n\
+        \  border:2px solid #FFF;\n  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  color:#fff;\n  padding:10px 14px;\n  border-radius:8px;\n  cursor:pointer;\n\
+        }\n\n.premium-nope{\n  background:#cc3300;\n  border:2px solid #FFF;\n  color:#fff;\n\
+        \  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n  padding:10px\
+        \ 14px;\n  border-radius:8px;\n  cursor:pointer;\n}\n\n/* =============================\
+        \ */\n/* HOVER / ACTIVE (-15%) */\n/* ============================= */\n.alter:hover,\n\
+        .alter:active,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-login:hover,\n\
+        .premium-login:active,\n.premium-nope:hover,\n.premium-nope:active{\n  filter:\
+        \ brightness(85%);\n}\n/* ============================= */\n/* TEXTO SEMPRE\
+        \ BRANCO (TODOS ESTADOS) */\n/* ============================= */\n.alter,\n\
+        .alter:visited,\n.alter:hover,\n.alter:active,\n.alter:focus,\n\n.premium-yes,\n\
+        .premium-yes:visited,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-yes:focus,\n\
+        \n.premium-login,\n.premium-login:visited,\n.premium-login:hover,\n.premium-login:active,\n\
+        .premium-login:focus,\n\n.premium-nope,\n.premium-nope:visited,\n.premium-nope:hover,\n\
+        .premium-nope:active,\n.premium-nope:focus{\n  color:#fff !important;\n  text-decoration:none;\n\
+        }\n/* ============================= */\n/* RESPONSIVO */\n/* =============================\
+        \ */\n/* Esconder em telas menores que 812px */\n@media (max-width: 812px){\n\
+        \  .alter{\n    display:none !important;\n  }\n}\n</style>\n\n</div>\n\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n</div><!--/#simple-grid-content-wrapper\
+        \ -->\n\n\n\n\n\n</div><!--/#simple-grid-wrapper -->\n\n\n\n\r\n\r\n\n\n\n\
+        \n\n\n<div class='simple-grid-clearfix' id='simple-grid-copyright-area'>\n\
+        \t\n<div class='simple-grid-copyright-area-inside simple-grid-container'>\n\
+        \t<a href=\"/\"><img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \ alt=\"\" width=\"300\" height=\"67\" class=\"aligncenter size-medium wp-image-747799\"\
+        \ /></a>\n<div class=\"simple-grid-outer-wrapper\">\t\n<center>\t\n<div class='simple-grid-copyright-area-inside-content\
+        \ simple-grid-clearfix'>\n  <p class='simple-grid-copyright'>Copyright \xA9\
+        \ 2016 - 2026 Legendei - Aqui Sai Primeiro</p>\n<p class='simple-grid-credit'><a\
+        \ href=\"https://legendei.net/\">Design by Legendei.NET</a></p>\n</div>\n\t\
+        </center>\n</div>\n</div>\n</div><!--/#simple-grid-copyright-area -->\n\n\n\
+        \n\n<button class=\"simple-grid-scroll-top\" title=\"Scroll to Top\"><i class=\"\
+        fas fa-arrow-up\" aria-hidden=\"true\"></i><span class=\"simple-grid-sr-only\"\
+        >Scroll to Top</span></button>\t\n\n\n\n\n\n<!-- Google tag (gtag.js) -->\n\
+        <script async src=\"https://www.googletagmanager.com/gtag/js?id=G-GX6PZNPM06\"\
+        ></script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function\
+        \ gtag(){dataLayer.push(arguments);}\n  gtag('js', new Date());\n\n  gtag('config',\
+        \ 'G-GX6PZNPM06');\n</script>\t\n\n\n\n\n\n<script type=\"speculationrules\"\
+        >\n{\"prefetch\":[{\"source\":\"document\",\"where\":{\"and\":[{\"href_matches\"\
+        :\"\\/*\"},{\"not\":{\"href_matches\":[\"\\/wp-*.php\",\"\\/wp-admin\\/*\"\
+        ,\"\\/wp-content\\/uploads\\/*\",\"\\/wp-content\\/*\",\"\\/wp-content\\/plugins\\\
+        /*\",\"\\/wp-content\\/themes\\/simple-grid\\/*\",\"\\/*\\\\?(.+)\"]}},{\"\
+        not\":{\"selector_matches\":\"a[rel~=\\\"nofollow\\\"]\"}},{\"not\":{\"selector_matches\"\
+        :\".no-prefetch, .no-prefetch a\"}}]},\"eagerness\":\"conservative\"}]}\n\
+        </script>\n\n<script>\nfunction attUploadProof(){\n\n    let fileInput = document.getElementById('att_proof');\n\
+        \    let msg = document.getElementById('att_upload_msg');\n\n    if(!fileInput.files.length){\n\
+        \        msg.innerHTML = '<span style=\"color:red;\">Selecione um arquivo</span>';\n\
+        \        return;\n    }\n\n    let file = fileInput.files[0];\n\n    if(file.size\
+        \ > 50 * 1024 * 1024){\n        msg.innerHTML = '<span style=\"color:red;\"\
+        >Arquivo maior que 50MB</span>';\n        return;\n    }\n\n    let formData\
+        \ = new FormData();\n    formData.append('action','att_upload_proof');\n \
+        \   formData.append('proof', file);\n\n    msg.innerHTML = 'Enviando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        body: formData\n    })\n    .then(r => r.json())\n    .then(res\
+        \ => {\n\n        if(res.success){\n            msg.innerHTML = '<span style=\"\
+        color:green;\">Comprovante enviado com sucesso!</span>';\n        } else {\n\
+        \            msg.innerHTML = '<span style=\"color:red;\">Erro: '+res.data+'</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<script>\nfunction attSaveLastName(){\n\
+        \n    let input = document.getElementById('att_last_name_input') \n      \
+        \       || document.getElementById('att_last_name_input2');\n\n    let msg\
+        \   = document.getElementById('att_name_msg') \n             || document.getElementById('att_name_msg2');\n\
+        \n    if(!input || !msg) return;\n\n    let value = input.value.trim();\n\n\
+        \    if(!value){\n        msg.innerHTML = '<span style=\"color:#f87171;\"\
+        >Digite o nome completo do titular da conta que ser\xE1 usada para a doa\xE7\
+        \xE3o</span>';\n        return;\n    }\n\n    msg.innerHTML = 'Salvando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        headers: {'Content-Type': 'application/x-www-form-urlencoded'},\n\
+        \        body: 'action=att_save_last_name&last_name=' + encodeURIComponent(value)\n\
+        \    })\n    .then(r => r.json())\n    .then(res => {\n\n        if(res.success){\n\
+        \            msg.innerHTML = '<span style=\"color:#22c55e;\">Salvo! Recarregando...</span>';\n\
+        \            setTimeout(()=>location.reload(),800);\n        } else {\n  \
+        \          msg.innerHTML = '<span style=\"color:#f87171;\">Erro ao salvar</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<style type=\"text/css\"> \n      \
+        \   /* Hide reCAPTCHA V3 badge */\n        .grecaptcha-badge {\n        \n\
+        \            visibility: hidden !important;\n        \n        }\n    </style><script\
+        \ type=\"text/javascript\" id=\"lrl-js-js-extra\">\n/* <![CDATA[ */\nvar lrlData\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"post_id\":\"836386\"};\n/* ]]> */\n</script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.js?ver=1.0\"\
+        \ id=\"lrl-js-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/jquery.fitvids.min.js\"\
+        \ id=\"fitvids-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/ResizeSensor.min.js\"\
+        \ id=\"ResizeSensor-js\"></script>\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-content/themes/simple-grid/assets/js/theia-sticky-sidebar.min.js\"\
+        \ id=\"theia-sticky-sidebar-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/navigation.js\"\
+        \ id=\"simple-grid-navigation-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/skip-link-focus-fix.js\"\
+        \ id=\"simple-grid-skip-link-focus-fix-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/imagesloaded.min.js?ver=5.0.0\"\
+        \ id=\"imagesloaded-js\"></script>\n<script type=\"text/javascript\" id=\"\
+        simple-grid-customjs-js-extra\">\n/* <![CDATA[ */\nvar simple_grid_ajax_object\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"primary_menu_active\":\"1\",\"secondary_menu_active\":\"\",\"primary_mobile_menu_active\"\
+        :\"1\",\"secondary_mobile_menu_active\":\"1\",\"sticky_menu_active\":\"1\"\
+        ,\"sticky_mobile_menu_active\":\"\",\"sticky_sidebar_active\":\"1\",\"columnwidth\"\
+        :\".simple-grid-5-col-sizer\",\"gutter\":\".simple-grid-5-col-gutter\"};\n\
+        /* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/custom.js\"\
+        \ id=\"simple-grid-customjs-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/comment-reply.min.js?ver=6.8.3\"\
+        \ id=\"comment-reply-js\" async=\"async\" data-wp-strategy=\"async\"></script>\n\
+        <script type=\"text/javascript\" id=\"simple-grid-html5shiv-js-js-extra\"\
+        >\n/* <![CDATA[ */\nvar simple_grid_custom_script_vars = {\"elements_name\"\
+        :\"abbr article aside audio bdi canvas data datalist details dialog figcaption\
+        \ figure footer header hgroup main mark meter nav output picture progress\
+        \ section summary template time video\"};\n/* ]]> */\n</script>\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/html5shiv.js\"\
+        \ id=\"simple-grid-html5shiv-js-js\"></script>\n<script type=\"text/javascript\"\
+        \ id=\"fifu-json-ld-js-extra\">\n/* <![CDATA[ */\nvar fifuJsonLd = {\"url\"\
+        :\"https:\\/\\/image.tmdb.org\\/t\\/p\\/w500\\/1BP4xYv9ZG4ZVHkL7ocOziBbSYH.jpg\"\
+        };\n/* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/plugins/featured-image-from-url/includes/html/js/json-ld.js?ver=4.9.2\"\
+        \ id=\"fifu-json-ld-js\"></script>\n<script defer src=\"https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496\"\
+        \ integrity=\"sha512-ZE9pZaUXND66v380QUtch/5sE9tPFh2zg45pR2PB0CVkCtOREv2AJKkSidISWkysEuQ0EH8faUU5du78bx87UQ==\"\
+        \ data-cf-beacon='{\"version\":\"2024.11.0\",\"token\":\"832c49ee708d4b8d94382b4733ae0382\"\
+        ,\"r\":1,\"server_timing\":{\"name\":{\"cfCacheStatus\":true,\"cfEdge\":true,\"\
+        cfExtPri\":true,\"cfL4\":true,\"cfOrigin\":true,\"cfSpeedBrain\":true},\"\
+        location_startswith\":null}}' crossorigin=\"anonymous\"></script>\n<script>(function(){function\
+        \ c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML=\"\
+        window.__CF$cv$params={r:'a14e79c618e301c6',t:'MTc4MzAwMzk2MQ=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);\"\
+        ;b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else\
+        \ if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var\
+        \ e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>\n\
+        </html>"
+    headers:
+      CF-RAY:
+      - a14e79c618e301c6-GRU
+      Cf-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Thu, 02 Jul 2026 14:52:41 GMT
+      Link:
+      - <https://legendei.net/wp-json/>; rel="https://api.w.org/", <https://legendei.net/wp-json/wp/v2/posts/836386>;
+        rel="alternate"; title="JSON"; type="application/json", <https://legendei.net/?p=836386>;
+        rel=shortlink
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Permissions-Policy:
+      - private-state-token-redemption=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com"),
+        private-state-token-issuance=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com")
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=aV90l9dPkO2m2VqQkltnPhiqiGxAsKjJblZAtd6sx%2BAjJryy4XoxEaIoiuClwLmGYPJUckter%2BYXhg61o6cMSfbZmcLc1IjavgFs%2FHPepAPgLi1U9MP0L8iZebMMfno%3D"}]}'
+      Server:
+      - cloudflare
+      Server-Timing:
+      - cfCacheStatus;desc="DYNAMIC"
+      - cfEdge;dur=9,cfOrigin;dur=508
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - pt-BR,pt;q=0.9,en;q=0.8
+      User-Agent:
+      - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like
+        Gecko) Chrome/131.0.0.0 Safari/537.36
+    method: GET
+    uri: https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc/
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html dir=\"ltr\" lang=\"pt-BR\" prefix=\"og: https://ogp.me/ns#\"\
+        >\n<head>\n<meta charset=\"UTF-8\">\n<meta name=\"viewport\" content=\"width=device-width,\
+        \ initial-scale=1.0\">\n\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css\"\
+        >\n\t\n<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">\n<link\
+        \ rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>\n<link\
+        \ href=\"https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap\"\
+        \ rel=\"stylesheet\">\n\t\n<title>Legenda The Bad Guys Breaking In S01E01\
+        \ 1080p WEB h264 DOLORES cc | Legendei - Aqui Sai Primeiro</title>\n\t<style>img:is([sizes=\"\
+        auto\" i], [sizes^=\"auto,\" i]) { contain-intrinsic-size: 3000px 1500px }</style>\n\
+        \t\n\t\t<!-- All in One SEO Pro 4.6.0 - aioseo.com -->\n\t\t<meta name=\"\
+        description\" content=\"Legenda da s\xE9rie The Bad Guys: Breaking In (2025)\
+        \ Os Caras Malvados No Peda\xE7o \u2014 Como \xE9 que os Caras Malvados acabaram\
+        \ ficando malvados? Esta s\xE9rie hil\xE1ria ambientada antes dos filmes conta\
+        \ a hist\xF3ria inteira. Legenda The Bad Guys Breaking In S01E01 1080p WEB\
+        \ h264 DOLORES cc testada e verificada - Pode servir tamb\xE9m para outros\
+        \ releases, basta renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\"\
+        \ />\n\t\t<meta name=\"robots\" content=\"max-image-preview:large\" />\n\t\
+        \t<meta name=\"google-site-verification\" content=\"JSMIV3rTOC3Y-WjaQzmU3KvW7aWHceTxBFYsJYpm-1k\"\
+        \ />\n\t\t<link rel=\"canonical\" href=\"https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc/\"\
+        \ />\n\t\t<meta name=\"generator\" content=\"All in One SEO Pro (AIOSEO) 4.6.0\"\
+        \ />\n\t\t<meta property=\"og:locale\" content=\"pt_BR\" />\n\t\t<meta property=\"\
+        og:site_name\" content=\"Legendei - Baixar Legendas de S\xE9ries e Filmes\"\
+        \ />\n\t\t<meta property=\"og:type\" content=\"article\" />\n\t\t<meta property=\"\
+        og:title\" content=\"Legenda The Bad Guys Breaking In S01E01 1080p WEB h264\
+        \ DOLORES cc | Legendei - Aqui Sai Primeiro\" />\n\t\t<meta property=\"og:description\"\
+        \ content=\"Legenda da s\xE9rie The Bad Guys: Breaking In (2025) Os Caras\
+        \ Malvados No Peda\xE7o \u2014 Como \xE9 que os Caras Malvados acabaram ficando\
+        \ malvados? Esta s\xE9rie hil\xE1ria ambientada antes dos filmes conta a hist\xF3\
+        ria inteira. Legenda The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES\
+        \ cc testada e verificada - Pode servir tamb\xE9m para outros releases, basta\
+        \ renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t<meta\
+        \ property=\"og:url\" content=\"https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc/\"\
+        \ />\n\t\t<meta property=\"og:image\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"og:image:secure_url\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"article:published_time\" content=\"2026-01-14T14:26:08+00:00\"\
+        \ />\n\t\t<meta property=\"article:modified_time\" content=\"2026-01-14T14:37:08+00:00\"\
+        \ />\n\t\t<meta name=\"twitter:card\" content=\"summary\" />\n\t\t<meta name=\"\
+        twitter:title\" content=\"Legenda The Bad Guys Breaking In S01E01 1080p WEB\
+        \ h264 DOLORES cc | Legendei - Aqui Sai Primeiro\" />\n\t\t<meta name=\"twitter:description\"\
+        \ content=\"Legenda da s\xE9rie The Bad Guys: Breaking In (2025) Os Caras\
+        \ Malvados No Peda\xE7o \u2014 Como \xE9 que os Caras Malvados acabaram ficando\
+        \ malvados? Esta s\xE9rie hil\xE1ria ambientada antes dos filmes conta a hist\xF3\
+        ria inteira. Legenda The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES\
+        \ cc testada e verificada - Pode servir tamb\xE9m para outros releases, basta\
+        \ renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t<meta\
+        \ name=\"twitter:image\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<script type=\"application/ld+json\" class=\"aioseo-schema\">\n\t\
+        \t\t{\"@context\":\"https:\\/\\/schema.org\",\"@graph\":[{\"@type\":\"BlogPosting\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc\\\
+        /#blogposting\",\"name\":\"Legenda The Bad Guys Breaking In S01E01 1080p WEB\
+        \ h264 DOLORES cc | Legendei - Aqui Sai Primeiro\",\"headline\":\"The Bad\
+        \ Guys Breaking In S01E01 1080p WEB h264 DOLORES cc\",\"author\":{\"@id\"\
+        :\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\/#author\"},\"publisher\"\
+        :{\"@id\":\"https:\\/\\/legendei.net\\/#organization\"},\"image\":{\"@type\"\
+        :\"ImageObject\",\"url\":\"https:\\/\\/legendei.net\\/wp-content\\/uploads\\\
+        /2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\/#articleImage\"\
+        ,\"width\":150,\"height\":150},\"datePublished\":\"2026-01-14T15:26:08+01:00\"\
+        ,\"dateModified\":\"2026-01-14T15:37:08+01:00\",\"inLanguage\":\"pt-BR\",\"\
+        mainEntityOfPage\":{\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc\\\
+        /#webpage\"},\"isPartOf\":{\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc\\\
+        /#webpage\"},\"articleSection\":\"Destaques, S\\u00e9ries TV, Lan\\u00e7amentos,\
+        \ Legendado Portugu\\u00eas, Legendas The Bad Guys Breaking In, Legendas The\
+        \ Bad Guys Breaking In S01, S\\u00e9ries Legendadas, S\\u00e9ries Populares\"\
+        },{\"@type\":\"BreadcrumbList\",\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc\\\
+        /#breadcrumblist\",\"itemListElement\":[{\"@type\":\"ListItem\",\"@id\":\"\
+        https:\\/\\/legendei.net\\/#listItem\",\"position\":1,\"name\":\"Home\",\"\
+        item\":\"https:\\/\\/legendei.net\\/\",\"nextItem\":\"https:\\/\\/legendei.net\\\
+        /the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc\\/#listItem\"\
+        },{\"@type\":\"ListItem\",\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc\\\
+        /#listItem\",\"position\":2,\"name\":\"The.Bad.Guys.Breaking.In.S01E01.1080p.WEB.h264-DOLORES.pt.cc\"\
+        ,\"previousItem\":\"https:\\/\\/legendei.net\\/#listItem\"}]},{\"@type\":\"\
+        Organization\",\"@id\":\"https:\\/\\/legendei.net\\/#organization\",\"name\"\
+        :\"Legendei\",\"url\":\"https:\\/\\/legendei.net\\/\",\"logo\":{\"@type\"\
+        :\"ImageObject\",\"url\":\"https:\\/\\/legendei.net\\/wp-content\\/uploads\\\
+        /2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc\\\
+        /#organizationLogo\",\"width\":150,\"height\":150},\"image\":{\"@id\":\"https:\\\
+        /\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc\\\
+        /#organizationLogo\"}},{\"@type\":\"Person\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /author\\/eneinsubtitles\\/#author\",\"url\":\"https:\\/\\/legendei.net\\\
+        /author\\/eneinsubtitles\\/\",\"name\":\"Admin\"},{\"@type\":\"WebPage\",\"\
+        @id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc\\\
+        /#webpage\",\"url\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc\\\
+        /\",\"name\":\"Legenda The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES\
+        \ cc | Legendei - Aqui Sai Primeiro\",\"description\":\"Legenda da s\\u00e9rie\
+        \ The Bad Guys: Breaking In (2025) Os Caras Malvados No Peda\\u00e7o \\u2014\
+        \ Como \\u00e9 que os Caras Malvados acabaram ficando malvados? Esta s\\u00e9rie\
+        \ hil\\u00e1ria ambientada antes dos filmes conta a hist\\u00f3ria inteira.\
+        \ Legenda The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES cc testada\
+        \ e verificada - Pode servir tamb\\u00e9m para outros releases, basta renomear!\
+        \ Dispon\\u00edvel em Legendei - Aqui Sai Primeiro\",\"inLanguage\":\"pt-BR\"\
+        ,\"isPartOf\":{\"@id\":\"https:\\/\\/legendei.net\\/#website\"},\"breadcrumb\"\
+        :{\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc\\\
+        /#breadcrumblist\"},\"author\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\\
+        /eneinsubtitles\\/#author\"},\"creator\":{\"@id\":\"https:\\/\\/legendei.net\\\
+        /author\\/eneinsubtitles\\/#author\"},\"datePublished\":\"2026-01-14T15:26:08+01:00\"\
+        ,\"dateModified\":\"2026-01-14T15:37:08+01:00\"},{\"@type\":\"WebSite\",\"\
+        @id\":\"https:\\/\\/legendei.net\\/#website\",\"url\":\"https:\\/\\/legendei.net\\\
+        /\",\"name\":\"Legendei\",\"description\":\"Baixar Legendas de S\\u00e9ries\
+        \ e Filmes\",\"inLanguage\":\"pt-BR\",\"publisher\":{\"@id\":\"https:\\/\\\
+        /legendei.net\\/#organization\"}}]}\n\t\t</script>\n\t\t<!-- All in One SEO\
+        \ Pro -->\n\n<link rel='dns-prefetch' href='//fonts.googleapis.com' />\n<link\
+        \ rel=\"alternate\" type=\"application/rss+xml\" title=\"Feed para Legendei\
+        \ &raquo;\" href=\"https://legendei.net/feed/\" />\n<link rel=\"alternate\"\
+        \ type=\"application/rss+xml\" title=\"Feed de coment\xE1rios para Legendei\
+        \ &raquo;\" href=\"https://legendei.net/comments/feed/\" />\n<link rel=\"\
+        alternate\" type=\"application/rss+xml\" title=\"Feed de coment\xE1rios para\
+        \ Legendei &raquo; The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES\
+        \ cc\" href=\"https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc/feed/\"\
+        \ />\n<script type=\"text/javascript\">\n/* <![CDATA[ */\nwindow._wpemojiSettings\
+        \ = {\"baseUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\/emoji\\/16.0.1\\\
+        /72x72\\/\",\"ext\":\".png\",\"svgUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\\
+        /emoji\\/16.0.1\\/svg\\/\",\"svgExt\":\".svg\",\"source\":{\"concatemoji\"\
+        :\"https:\\/\\/legendei.net\\/wp-includes\\/js\\/wp-emoji-release.min.js?ver=6.8.3\"\
+        }};\n/*! This file is auto-generated */\n!function(s,n){var o,i,e;function\
+        \ c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function\
+        \ p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var\
+        \ t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),a=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new\
+        \ Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return\
+        \ t.every(function(e,t){return e===a[t]})}function u(e,t){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);for(var\
+        \ n=e.getImageData(16,16,1,1),a=0;a<n.data.length;a++)if(0!==n.data[a])return!1;return!0}function\
+        \ f(e,t,n,a){switch(t){case\"flag\":return n(e,\"\\ud83c\\udff3\\ufe0f\\u200d\\\
+        u26a7\\ufe0f\",\"\\ud83c\\udff3\\ufe0f\\u200b\\u26a7\\ufe0f\")?!1:!n(e,\"\\\
+        ud83c\\udde8\\ud83c\\uddf6\",\"\\ud83c\\udde8\\u200b\\ud83c\\uddf6\")&&!n(e,\"\
+        \\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc65\\udb40\\udc6e\\udb40\\\
+        udc67\\udb40\\udc7f\",\"\\ud83c\\udff4\\u200b\\udb40\\udc67\\u200b\\udb40\\\
+        udc62\\u200b\\udb40\\udc65\\u200b\\udb40\\udc6e\\u200b\\udb40\\udc67\\u200b\\\
+        udb40\\udc7f\");case\"emoji\":return!a(e,\"\\ud83e\\udedf\")}return!1}function\
+        \ g(e,t,n,a){var r=\"undefined\"!=typeof WorkerGlobalScope&&self instanceof\
+        \ WorkerGlobalScope?new OffscreenCanvas(300,150):s.createElement(\"canvas\"\
+        ),o=r.getContext(\"2d\",{willReadFrequently:!0}),i=(o.textBaseline=\"top\"\
+        ,o.font=\"600 32px Arial\",{});return e.forEach(function(e){i[e]=t(o,e,n,a)}),i}function\
+        \ t(e){var t=s.createElement(\"script\");t.src=e,t.defer=!0,s.head.appendChild(t)}\"\
+        undefined\"!=typeof Promise&&(o=\"wpEmojiSettingsSupports\",i=[\"flag\",\"\
+        emoji\"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){s.addEventListener(\"\
+        DOMContentLoaded\",e,{once:!0})}),new Promise(function(t){var n=function(){try{var\
+        \ e=JSON.parse(sessionStorage.getItem(o));if(\"object\"==typeof e&&\"number\"\
+        ==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&\"object\"\
+        ==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if(\"\
+        undefined\"!=typeof Worker&&\"undefined\"!=typeof OffscreenCanvas&&\"undefined\"\
+        !=typeof URL&&URL.createObjectURL&&\"undefined\"!=typeof Blob)try{var e=\"\
+        postMessage(\"+g.toString()+\"(\"+[JSON.stringify(i),f.toString(),p.toString(),u.toString()].join(\"\
+        ,\")+\"));\",a=new Blob([e],{type:\"text/javascript\"}),r=new Worker(URL.createObjectURL(a),{name:\"\
+        wpTestEmojiSupports\"});return void(r.onmessage=function(e){c(n=e.data),r.terminate(),t(n)})}catch(e){}c(n=g(i,f,p,u))}t(n)}).then(function(e){for(var\
+        \ t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],\"\
+        flag\"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return\
+        \ e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);\n\
+        /* ]]> */\n</script>\n<link rel='stylesheet' id='wpa-css-css' href='https://legendei.net/wp-content/plugins/wp-attachments/styles/0/wpa.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='wp-emoji-styles-inline-css' type='text/css'>\n\
+        \n\timg.wp-smiley, img.emoji {\n\t\tdisplay: inline !important;\n\t\tborder:\
+        \ none !important;\n\t\tbox-shadow: none !important;\n\t\theight: 1em !important;\n\
+        \t\twidth: 1em !important;\n\t\tmargin: 0 0.07em !important;\n\t\tvertical-align:\
+        \ -0.1em !important;\n\t\tbackground: none !important;\n\t\tpadding: 0 !important;\n\
+        \t}\n</style>\n<link rel='stylesheet' id='wp-block-library-css' href='https://legendei.net/wp-includes/css/dist/block-library/style.min.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='classic-theme-styles-inline-css'\
+        \ type='text/css'>\n/*! This file is auto-generated */\n.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em\
+        \ + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}\n\
+        </style>\n<style id='wppb-content-restriction-start-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-content-restriction-end-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-edit-profile-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-login-style-inline-css' type='text/css'>\n\n\
+        \n</style>\n<style id='wppb-recover-password-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-register-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='global-styles-inline-css' type='text/css'>\n:root{--wp--preset--aspect-ratio--square:\
+        \ 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4:\
+        \ 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3:\
+        \ 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16:\
+        \ 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray:\
+        \ #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink:\
+        \ #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange:\
+        \ #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan:\
+        \ #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue:\
+        \ #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple:\
+        \ #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1)\
+        \ 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan:\
+        \ linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange:\
+        \ linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red:\
+        \ linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray:\
+        \ linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum:\
+        \ linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186)\
+        \ 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple:\
+        \ linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux:\
+        \ linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62)\
+        \ 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112)\
+        \ 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean:\
+        \ linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181)\
+        \ 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128)\
+        \ 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129)\
+        \ 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium:\
+        \ 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large:\
+        \ 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40:\
+        \ 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70:\
+        \ 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural:\
+        \ 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px\
+        \ rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0,\
+        \ 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255,\
+        \ 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0,\
+        \ 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap:\
+        \ 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items:\
+        \ center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display:\
+        \ grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-color{color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background:\
+        \ var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange)\
+        \ !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background:\
+        \ var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background:\
+        \ var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background:\
+        \ var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background:\
+        \ var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background:\
+        \ var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size:\
+        \ var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size:\
+        \ var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--x-large) !important;}\n:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}\n:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}\n:root :where(.wp-block-pullquote){font-size:\
+        \ 1.5em;line-height: 1.6;}\n</style>\n<link rel='stylesheet' id='lrl-css-css'\
+        \ href='https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-maincss-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css' type='text/css'\
+        \ media='all' />\n<link rel='stylesheet' id='fontawesome-css' href='https://legendei.net/wp-content/themes/simple-grid/assets/css/all.min.css'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-webfont-css'\
+        \ href='//fonts.googleapis.com/css?family=Playfair+Display:400,400i,700,700i|Domine:400,700|Oswald:400,700|Patua+One|Merriweather:400,400i,700,700i&#038;display=swap'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='legendei-style-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css?ver=1782544305'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='wppb_stylesheet-css'\
+        \ href='https://legendei.net/wp-content/plugins/profile-builder/assets/css/style-front-end.css?ver=3.15.2'\
+        \ type='text/css' media='all' />\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-includes/js/jquery/jquery.min.js?ver=3.7.1\" id=\"\
+        jquery-core-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1\"\
+        \ id=\"jquery-migrate-js\"></script>\n<!--[if lt IE 9]>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/respond.min.js\"\
+        \ id=\"respond-js\"></script>\n<![endif]-->\n<link rel=\"https://api.w.org/\"\
+        \ href=\"https://legendei.net/wp-json/\" /><link rel=\"alternate\" title=\"\
+        JSON\" type=\"application/json\" href=\"https://legendei.net/wp-json/wp/v2/posts/729772\"\
+        \ /><link rel=\"EditURI\" type=\"application/rsd+xml\" title=\"RSD\" href=\"\
+        https://legendei.net/xmlrpc.php?rsd\" />\n<meta name=\"generator\" content=\"\
+        WordPress 6.8.3\" />\n<link rel='shortlink' href='https://legendei.net/?p=729772'\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (JSON)\" type=\"application/json+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fthe-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc%2F\"\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (XML)\" type=\"text/xml+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fthe-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc%2F&#038;format=xml\"\
+        \ />\n<style>\n\n/* FORMUL\xC1RIO TRIAL */\n\n.premium-form {\n    max-width:\
+        \ 760px;\n    margin: 0 auto 20px;\n    padding: 30px;\n    border-radius:\
+        \ 10px;\n    background: #212121;\n    border: 10px solid transparent;\n \
+        \   background-image:\n        linear-gradient(#212121,#212121),\n       \
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    background-origin: border-box;\n\
+        \    background-clip: padding-box, border-box;\n    box-sizing: border-box;\n\
+        }\n\n/* Campos */\n\n.premium-form .field {\n    position: relative;\n   \
+        \ margin-bottom: 20px;\n}\n\n.premium-form input {\n    width: 100%;\n   \
+        \ padding: 14px;\n    border-radius: 8px;\n    border: 1px solid #ccc;\n \
+        \   font-size: 16px;\n    box-sizing: border-box;\n}\n\n/* Focus bonito */\n\
+        \n.premium-form input:focus {\n    border-color: transparent;\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin: border-box;\n    background-clip: padding-box, border-box;\n\
+        \    box-shadow: 0 0 0 4px rgba(63,140,255,0.20);\n    outline: none;\n}\n\
+        \n/* TOOLTIP */\n\n.premium-form .tooltip {\n    position: absolute;\n   \
+        \ bottom: 100%;\n    left: 0;\n    margin-bottom: 10px;\n    background: linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \tbox-shadow:0 6px 14px rgba(0,0,0,0.25);\n    color: #ffffff;\n    padding:\
+        \ 10px 12px;\n    font-size: 14px;\n    border-radius: 6px;\n    max-width:\
+        \ 260px;\n    opacity: 0;\n    pointer-events: none;\n    transition: .2s;\n\
+        \    z-index: 999;\n}\n\n.premium-form .tooltip::after {\n    content: \"\"\
+        ;\n    position: absolute;\n    top: 100%;\n    left: 15px;\n    border-width:\
+        \ 6px 6px 0 6px;\n    border-style: solid;\n    border-color: #8a2be2 transparent\
+        \ transparent transparent;\n}\n\n.premium-form .field:hover .tooltip,\n.premium-form\
+        \ .field:focus-within .tooltip {\n    opacity: 1;\n    transform: translateY(-4px);\n\
+        }\n\n/* BOT\xC3O */\n\n.premium-form button {\n    padding: 14px 30px;\n \
+        \   font-size: 22px;\n    border-radius: 8px;\n    border: none;\n    background:\
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    color: #fff;\n    cursor: pointer;\n\
+        \    transition: .25s;\n}\n\n.premium-form button:hover {\n    background:\
+        \ linear-gradient(90deg,#4c9aff,#9a3bff);\n}\n\n/* SENHA */\n\n.pass-wrap{\n\
+        \    position:relative;\n}\n\n.toggle-pass{\n    position:absolute;\n    right:12px;\n\
+        \    top:50%;\n    transform:translateY(-50%);\n    cursor:pointer;\n    font-size:18px;\n\
+        }\n\n/* BARRA FOR\xC7A SENHA */\n\n.strength{\n    height:6px;\n    background:#444;\n\
+        \    border-radius:4px;\n    margin-top:8px;\n    overflow:hidden;\n}\n\n\
+        .strength div{\n    height:100%;\n    width:0%;\n    transition:.3s;\n}\n\n\
+        /* MOBILE */\n\n@media (max-width:480px){\n\n.premium-form{\n    padding:20px;\n\
+        }\n\n}\n\n</style>\n<!-- FIFU: meta tags for featured image (begin) -->\n\
+        <meta property=\"og:image\" content=\"https://image.tmdb.org/t/p/w500/owTRRXuxpJT5n68IddsvDtAeK6K.jpg\"\
+        \ />\n<!-- FIFU: meta tags for featured image (end) --><meta name=\"twitter:image\"\
+        \ content=\"https://image.tmdb.org/t/p/w500/owTRRXuxpJT5n68IddsvDtAeK6K.jpg\"\
+        \ /><style>\n\n/* remove fundo normal, ativo e hover do logo */\n.simple-grid-primary-nav-menu\
+        \ > li.menu-logo-item > a,\n.simple-grid-primary-nav-menu > li.menu-logo-item\
+        \ > a:hover,\n.simple-grid-primary-nav-menu > li.menu-logo-item.current-menu-item\
+        \ > a{\n    background:none !important;\n}\n\n/* ===================================================\n\
+        \   MOBILE\n   =================================================== */\n\n\
+        @media only screen and (max-width:812px){\n\n    /* ESCONDER LOGO NO MENU\
+        \ MOBILE */\n    .simple-grid-primary-nav-menu > li.menu-logo-item{\n    \
+        \    display:none !important;\n    }\n\n}\n\n</style>\n    <style type=\"\
+        text/css\">\r\n            .simple-grid-site-title, .simple-grid-site-title\
+        \ a, .simple-grid-site-description {color: #ffffff;}\r\n        </style>\r\
+        \n    <style type=\"text/css\" id=\"custom-background-css\">\nbody.custom-background\
+        \ { background-color: #333333; }\n</style>\n\t<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"32x32\" />\n<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"192x192\" />\n<link rel=\"apple-touch-icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n<meta name=\"msapplication-TileImage\" content=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n</head>\t\n\t\n\t\n<body class=\"wp-singular post-template-default single\
+        \ single-post postid-729772 single-format-standard custom-background wp-custom-logo\
+        \ wp-theme-simple-grid simple-grid-animated simple-grid-fadein simple-grid-theme-is-active\
+        \ simple-grid-custom-logo-active simple-grid-layout-type-full simple-grid-masonry-inactive\
+        \ simple-grid-float-grid simple-grid-responsive-grid-details simple-grid-layout-c-s1\
+        \ simple-grid-header-banner-active simple-grid-tagline-inactive simple-grid-logo-above-title\
+        \ simple-grid-primary-menu-active simple-grid-primary-mobile-menu-active simple-grid-secondary-mobile-menu-active\
+        \ simple-grid-primary-social-icons\" id=\"simple-grid-site-body\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/WebPage\">\n<a class=\"skip-link\
+        \ screen-reader-text\" href=\"#simple-grid-content-wrapper\">Skip to content</a>\n\
+        \n\n\n<div class=\"simple-grid-site-header simple-grid-container\" id=\"simple-grid-header\"\
+        \ itemscope=\"itemscope\" itemtype=\"http://schema.org/WPHeader\" role=\"\
+        banner\">\n<div class=\"simple-grid-head-content simple-grid-clearfix\" id=\"\
+        simple-grid-head-content\">\n\n<div class=\"simple-grid-no-header-content\"\
+        >\n              <p class=\"simple-grid-site-title\"><a href=\"https://legendei.net/\"\
+        \ rel=\"home\">Legendei</a></p>\r\n                </div>\n\n</div><!--/#simple-grid-head-content\
+        \ -->\n</div><!--/#simple-grid-header -->\n\n\n\n<div class=\"simple-grid-container\
+        \ simple-grid-primary-menu-container simple-grid-clearfix\">\n<div class=\"\
+        simple-grid-primary-menu-container-inside simple-grid-clearfix\">\n<nav class=\"\
+        simple-grid-nav-primary\" id=\"simple-grid-primary-navigation\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/SiteNavigationElement\" role=\"navigation\"\
+        \ aria-label=\"Primary Menu\">\n\t\n\t\n<div class=\"simple-grid-outer-wrapper\"\
+        >\n<a href=\"/\" class=\"logo-mobile-inline\">\n<img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \nstyle=\"width:100%;height:auto;\">\n</a>\n\n<style>\n.logo-mobile-inline{\n\
+        display:none;\n}\n\n@media (max-width:812px){\n.logo-mobile-inline{\ndisplay:block;\n\
+        }\n}\n</style>\t\n\n\t\n<style>\n.mobile-header-icons{\n    display:none;\n\
+        }\n\n@media (max-width: 812px){\n\n.mobile-header-icons{\n    display:grid;\n\
+        \    grid-template-columns: 2fr 1fr 1fr;\n    gap:10px;\n    padding:10px;\n\
+        }\n\n/* BOT\xD5ES */\n.mobile-header-icons a,\n.mobile-header-icons .cat-toggle{\n\
+        \    display:flex;\n    align-items:center;\n    justify-content:center;\n\
+        \    gap:6px;\n    background:#141414;\n    padding:8px 6px;\n    border-radius:8px;\n\
+        \    color:#fff;\n    font-size:12px;\n    text-decoration:none;\n    text-align:center;\n\
+        \    cursor:pointer;\n}\n\n/* CATEGORIA */\n.cat-toggle{\n    font-weight:600;\n\
+        }\n\n/* SETA */\n.cat-toggle .arrow{\n    transition:transform 0.3s ease;\n\
+        }\n\n/* SETA GIRADA */\n.cat-toggle.active .arrow{\n    transform:rotate(180deg);\n\
+        }\n\n/* HOVER */\n.mobile-header-icons a:hover,\n.mobile-header-icons .cat-toggle:hover{\n\
+        \    background:#1f1f1f;\n}\n\n/* CONTAINER */\n.cat-container{\n    position:relative;\n\
+        }\n\n/* DROPDOWN */\n.cat-list{\n    display:flex;\n    flex-direction:column;\n\
+        \    gap:6px;\n\n    position:absolute;\n    top:110%;\n    left:0;\n    width:100%;\n\
+        \n    background:#0f0f0f;\n    border-radius:8px;\n    padding:6px;\n    z-index:999;\n\
+        \n    opacity:0;\n    visibility:hidden;\n    transform:translateY(-5px);\n\
+        \    transition:all 0.25s ease;\n}\n\n/* ABERTO */\n.cat-container.open .cat-list{\n\
+        \    opacity:1;\n    visibility:visible;\n    transform:translateY(0);\n}\n\
+        \n/* ITENS */\n.cat-list a{\n    justify-content:flex-start;\n    font-size:14px;\n\
+        \    padding:10px;\n}\n\n}\n</style>\n\n\n<div class=\"mobile-header-icons\"\
+        >\n\n    <!-- CATEGORIAS -->\n    <div class=\"cat-container\">\n        <div\
+        \ class=\"cat-toggle\">\n            \U0001F4C2 Categorias <span class=\"\
+        arrow\">\u25BC</span>\n        </div>\n\n        <div class=\"cat-list\">\n\
+        \            <a href=\"/category/destaques/\">\u2B50 Destaques</a>\n     \
+        \       <a href=\"/category/filmes/\">\U0001F3AC Filmes</a>\n            <a\
+        \ href=\"/category/serie/\">\U0001F4FA S\xE9ries</a>\n            <a href=\"\
+        /category/pack-de-legendas/\">\U0001F4E6 Packs</a>\n        </div>\n    </div>\n\
+        \n    \n        <a href=\"/seja-premium-vitalicio/\"><i class=\"fa-solid fa-crown\"\
+        ></i> Premium</a>\n\n        <a href=\"/login/\"><i class=\"fa-solid fa-key\"\
+        ></i> Login</a>\n\n    \n</div>\n\n<script>\ndocument.addEventListener(\"\
+        DOMContentLoaded\", function(){\n\n    const container = document.querySelector(\"\
+        .cat-container\");\n    const toggle = document.querySelector(\".cat-toggle\"\
+        );\n\n    toggle.addEventListener(\"click\", function(e){\n        e.stopPropagation();\n\
+        \        container.classList.toggle(\"open\");\n        toggle.classList.toggle(\"\
+        active\");\n    });\n\n    document.addEventListener(\"click\", function(e){\n\
+        \        if(!container.contains(e.target)){\n            container.classList.remove(\"\
+        open\");\n            toggle.classList.remove(\"active\");\n        }\n  \
+        \  });\n\n});\n</script>\t\n\t\n<ul id=\"simple-grid-menu-primary-navigation\"\
+        \ class=\"simple-grid-primary-nav-menu simple-grid-menu-primary\"><li id=\"\
+        menu-item-673170\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-673170 menu-logo-item\">\n        <a href=\"https://legendei.net/\"\
+        \ style=\"\n            display:flex;\n            align-items:center;\n \
+        \           justify-content:center;\n            height:100%;\n          \
+        \  padding:0;\n            margin:0;\n            line-height:1;\n       \
+        \ \">\n            <img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \n                      alt=\"Legendei.NET\"\n                      style=\"\
+        height:42px;width:auto;display:block;\">\n        </a></li>\n\n<li id=\"menu-item-673168\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category current-post-ancestor\
+        \ current-menu-parent current-post-parent menu-item-673168\"><a href=\"https://legendei.net/category/destaques/\"\
+        \ title=\"Legendas em Destaque\">DESTAQUES</a></li>\n<li id=\"menu-item-673167\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673167\"\
+        ><a href=\"https://legendei.net/category/filmes/\" title=\"Legendas para Filmes\"\
+        >Filmes</a></li>\n<li id=\"menu-item-673166\" class=\"menu-item menu-item-type-taxonomy\
+        \ menu-item-object-category current-post-ancestor current-menu-parent current-post-parent\
+        \ menu-item-673166\"><a href=\"https://legendei.net/category/serie/\" title=\"\
+        Legendas para seriados\">S\xC9RIES</a></li>\n<li id=\"menu-item-673169\" class=\"\
+        menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673169\"\
+        ><a href=\"https://legendei.net/category/pack-de-legendas/\" title=\"Pack\
+        \ de legendas\">PACKS</a></li>\n<li id=\"menu-item-731144\" class=\"menu-item\
+        \ menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-731144\"\
+        ><a target=\"_blank\" href=\"/aplicativos/\">RECOMENDAMOS</a>\n<ul class=\"\
+        sub-menu\">\n\t<li id=\"menu-item-673172\" class=\"menu-item menu-item-type-custom\
+        \ menu-item-object-custom menu-item-673172\"><a target=\"_blank\" href=\"\
+        /aplicativos/\" title=\"Programas para windows\">APLICATIVOS</a></li>\n\t\
+        <li id=\"menu-item-687662\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-687662\"><a target=\"_blank\" href=\"https://4kxxx.vip/\" title=\"\
+        Baixe os melhores v\xEDdeos porn\xF4 sempre em 4K\">4K XXX</a></li>\n\t<li\
+        \ id=\"menu-item-717497\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-717497\"><a target=\"_blank\" href=\"https://detonaplay.com/\"\
+        >GAMES</a></li>\n</ul>\n</li>\n\n\n\n<li class=\"menu-item\" style=\"float:right;\"\
+        >\n            <a href=\"/login/\"\n               style=\"background:linear-gradient(135deg,#198754,#20ac6b);color:#ffffff;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-key\"></i> Login\n            </a>\n\
+        \        </li><li class=\"menu-item\" style=\"float:right;\">\n          \
+        \  <a href=\"/seja-premium-vitalicio/\"\n\t\t\t\t\t  style=\"background:linear-gradient(135deg,#f4c430,#c2940a);color:#4d2e00;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-crown\"></i> Membro Premium\n  \
+        \          </a>\n        </li></ul>    </div>\n</nav>\n</div>\n</div>\n\n\t\
+        \n\t\n\r\n<div class=\"simple-grid-outer-wrapper\">\r\n<div class=\"simple-grid-top-wrapper-outer\
+        \ simple-grid-clearfix\">\r\n<div class=\"simple-grid-featured-posts-area\
+        \ simple-grid-top-wrapper simple-grid-clearfix\">\r\n\r\n<div id=\"search-5\"\
+        \ class=\"simple-grid-main-widget widget simple-grid-widget-box widget_search\"\
+        ><div class=\"simple-grid-widget-box-inside\"><form role=\"search\" method=\"\
+        get\" class=\"simple-grid-search-form\" action=\"https://legendei.net/\">\n\
+        <label>\n    <span class=\"simple-grid-sr-only\">Pesquisar por </span>\n \
+        \   <input \n        type=\"search\"\n        class=\"simple-grid-search-field\"\
+        \n        placeholder=\"Pesquisar &hellip;\"\n        value=\"\"\n       \
+        \ name=\"s\"\n        minlength=\"3\"\n\t\tmaxlength=\"50\"   \n        required\n\
+        \    />\n</label>\n<input type=\"submit\" class=\"simple-grid-search-submit\"\
+        \ value=\"&#xf002;\" />\n</form></div></div></div>\r\n</div>\r\n</div>\r\n\
+        \r\n\n<div class=\"simple-grid-outer-wrapper\" id=\"simple-grid-wrapper-outside\"\
+        >\n\n<div class=\"simple-grid-container simple-grid-clearfix\" id=\"simple-grid-wrapper\"\
+        >\n<div class=\"simple-grid-content-wrapper simple-grid-clearfix\" id=\"simple-grid-content-wrapper\"\
+        >\t\n\t\t\n\n\n<div class=\"simple-grid-main-wrapper simple-grid-clearfix\"\
+        \ id=\"simple-grid-main-wrapper\" itemscope=\"itemscope\" itemtype=\"http://schema.org/Blog\"\
+        \ role=\"main\">\n<div class=\"theiaStickySidebar\">\n<div class=\"simple-grid-main-wrapper-inside\
+        \ simple-grid-clearfix\">\n\n\r\n\r\n\n<div class=\"simple-grid-posts-wrapper\"\
+        \ id=\"simple-grid-posts-wrapper\">\n\n\n\n\n\n<div style=\"width: 100%; border-radius:\
+        \ 12px; box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 12px; padding: 15px; background:\
+        \ #ffffff;\">\n    <center>\n    <article id=\"post-729772\" class=\"simple-grid-post-singular\
+        \ simple-grid-box post-729772 post type-post status-publish format-standard\
+        \ hentry category-destaques category-serie tag-lancamentos tag-legendado-portugues\
+        \ tag-legendas-the-bad-guys-breaking-in tag-legendas-the-bad-guys-breaking-in-s01\
+        \ tag-series-legendadas tag-series-populares wpcat-8225-id wpcat-4-id\">\n\
+        \        <div class=\"simple-grid-box-inside\">\n            \n          \
+        \  \n                            <header class=\"entry-header\">\n       \
+        \             <div class=\"entry-header-inside simple-grid-clearfix\">\n\n\
+        <h1 class=\"post-title entry-title\"><i class=\"fa-solid fa-star fa-beat\"\
+        \ style=\"color:#f39c12;\"></i> Legenda The Bad Guys Breaking In S01E01 1080p\
+        \ WEB h264 DOLORES cc <span aria-label=\"PT-BR\">\U0001F1E7\U0001F1F7</span></h1>\n\
+        \n\n                                    <div class=\"simple-grid-entry-meta-single\"\
+        >\n                            <span class=\"simple-grid-entry-meta-single-date\"\
+        >\n                <i class=\"far fa-clock\" aria-hidden=\"true\"></i>&nbsp;14\
+        \ de janeiro de 2026            </span>\n                                \
+        \    <span class=\"simple-grid-entry-meta-single-categories\"><i class=\"\
+        far fa-folder-open\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Posted in </span><a href=\"https://legendei.net/category/destaques/\" rel=\"\
+        category tag\">Destaques</a>, <a href=\"https://legendei.net/category/serie/\"\
+        \ rel=\"category tag\">S\xE9ries TV</a></span>                           \
+        \ </div>\n    \n\n                    </div>\n                </header>\n\
+        \            \t\t\t\n\t\t\t\n            <!-- inicio poster -->\n        \
+        \    <img src=\"https://image.tmdb.org/t/p/w500/owTRRXuxpJT5n68IddsvDtAeK6K.jpg\"\
+        \ style=\"max-width:220px;width:330px;height:auto;margin-bottom:5px;\" alt=\"\
+        The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES cc\">            <!--\
+        \ fim poster -->\n\t\t\t\n<!-- S admin -->\n            \t\t\t\n<!-- S admin\
+        \ -->\t\n\t\t\t\n            \n            <div class=\"entry-content simple-grid-clearfix\"\
+        >\n\n<!-- N PREMIUM AMIN TEMP -->\t\t\t\t\n\t\n\n   <a href=\"https://cuponei.org/promo/more/\"\
+        \ target=\"_blank\" rel=\"noopener\">\n    <img class=\"aligncenter wp-image-729595\
+        \ size-full\"\n         src=\"https://legendei.net/wp-content/uploads/2026/01/amazon.webp\"\
+        \n         width=\"350\" height=\"334\" />\n  </a>\t\n\t\t\t\t\t\t\t\t\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\t\t\t\t\n<!-- anexos otimizados -->\n<!--\
+        \ /anexos -->\n\n\n                <!-- WP Attachments -->\n        <div style=\"\
+        width:100%;margin:10px 0 10px 0;\">\n            <h3></h3>\n        <ul class=\"\
+        post-attachments\"><p class=\"post-attachment mime-application-zip\">    \
+        \                                                                        \
+        \    <a href=\"https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores-pt-cc/?download=729771\"\
+        \ target=\"_blank\" class=\"buttonmyup\"><i class=\"fa fa-download\"></i>\
+        \ BAIXAR LEGENDA</a>\r\n</p></ul></div><div class=\"highlight-text-sinopse\"\
+        >\n<p>Legenda da s\xE9rie The Bad Guys: Breaking In (2025) Os Caras Malvados\
+        \ No Peda\xE7o \u2014 Como \xE9 que os Caras Malvados acabaram ficando malvados?\
+        \ Esta s\xE9rie hil\xE1ria ambientada antes dos filmes conta a hist\xF3ria\
+        \ inteira.</p>\n</div>\n\n        <div class=\"highlight-text\">\n\n<style>\n\
+        /* ===================================== */\n/* LINKS COM BORDA GRADIENTE\
+        \ + UNDERLINE */\n/* ===================================== */\n\n.busca-legenda-links\
+        \ a{\n    display:inline-block;\n    padding:8px 18px;\n    margin:2px 8px;\n\
+        \    font-weight:400;\n    font-size:14px;\n    text-decoration:none !important;\n\
+        \tmin-width: 180px;\n    color:#1e293b !important; /* texto escuro vis\xED\
+        vel */\n    background:transparent;\n\n    border:2px solid transparent;\n\
+        \    border-radius:6px;\n\n    /* borda gradiente */\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin:border-box;\n    background-clip:padding-box, border-box;\n\
+        \n    position:relative;\n    transition:all .25s ease;\n}\n\n/* underline\
+        \ gradiente (embaixo do texto) */\n.busca-legenda-links a::after{\n    content:\"\
+        \";\n    position:absolute;\n    left:50%;\n    bottom:6px; /* dentro do bot\xE3\
+        o */\n    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\n\n/*\
+        \ hover */\n.busca-legenda-links a:hover{\n    color:#002080 !important;\n\
+        }\n\n.busca-legenda-links a:hover::after{\n    width:60%;\n}\n\n/* ativo (se\
+        \ quiser usar classe active depois) */\n.busca-legenda-links a.active::after{\n\
+        \    width:60%;\n}\n\n@media (max-width: 768px){\n\n    .busca-legenda-links{\n\
+        \        display:block;\n    }\n\n    /* remove os pontinhos separadores no\
+        \ mobile */\n    .busca-legenda-links span{\n        display:none;\n    }\n\
+        \n    .busca-legenda-links a{\n        display:block;\n        width:100%;\n\
+        \        margin:6px 0; /* controla espa\xE7amento vertical */\n        text-align:center;\n\
+        \t\tfont-size:14px;\n    }\n\n\n}\n</style>\n\n\n\n            <p><strong>Legenda\
+        \ Oficial da s\xE9rie The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES\
+        \ cc</strong></p>\n            <hr>\n\n            <p>Todas as legendas dispon\xED\
+        veis para download s\xE3o testadas e verificadas, garantindo sincronia, precis\xE3\
+        o e qualidade.</p>\n\n            <p>Depois de baixar a legenda, n\xE3o se\
+        \ esque\xE7a de conferir o seu release!</p>\n\n            <div class=\"busca-legenda-links\"\
+        >\n                <a href=\"/category/serie/?s=The+Bad+Guys+Breaking+In\"\
+        >+ legendas mesma s\xE9rie</a><a href=\"/category/serie/?s=The+Bad+Guys+Breaking+In+S01\"\
+        >+ legendas mesma temporada</a><span>\xB7</span><a href=\"/category/serie/?s=The+Bad+Guys+Breaking+In+S01E01\"\
+        >+ legendas mesmo epis\xF3dio</a>\n            </div>\n\n        </div>\n\t\
+        \t\n\n\t\t\n\t\t\n                <!-- sinopse TMDB -->\n                <!--\
+        \ /sinopse -->\n\n            </div><!-- .entry-content -->\n\n          \
+        \  \n            \n        </div>\n\n\n\n\t\t\n    </article>\n\n<!-- inicio\
+        \ app recomendados -->\t\t\n<div id=\"apps-recomendados\">\n<div class=\"\
+        busca-legenda-links\" style=\"text-align:center;\">\n<h5>Aplicativos que usamos\
+        \ e recomendamos</h5>\n\n<a href=\"https://legendei.net/aplicativos/kodi/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2025/11/Kodi_21.3.webp\"\
+        \ width=\"40\" height=\"40\" />\n    Kodi Media Center\n</a>\n\n<a href=\"\
+        https://legendei.net/aplicativos/utorrent-pro-download-e-guia-completo/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/08/uTorrent-Pro.jpg\"\
+        \ width=\"40\" height=\"40\" />\n    uTorrent Pro\n</a>\n\n<a href=\"https://legendei.net/aplicativos/winzip-pro-windows/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/09/WinZip-Pro.png\"\
+        \ width=\"40\" height=\"40\" />\n    WinZip Pro\n</a>\n</div>\n</div>\n<style>\n\
+        @media (max-width: 812px){\n    #apps-recomendados{\n        display: none;\n\
+        \    }\n}\n</style>\n<!-- fim app recomendados -->\n\t\t\n<span class=\"simple-grid-entry-meta-single-tags\"\
+        ><i class=\"fas fa-tags\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Tagged </span><a href=\"https://legendei.net/tag/lancamentos/\" rel=\"tag\"\
+        >Lan\xE7amentos</a>, <a href=\"https://legendei.net/tag/legendado-portugues/\"\
+        \ rel=\"tag\">Legendado Portugu\xEAs</a>, <a href=\"https://legendei.net/tag/legendas-the-bad-guys-breaking-in/\"\
+        \ rel=\"tag\">Legendas The Bad Guys Breaking In</a>, <a href=\"https://legendei.net/tag/legendas-the-bad-guys-breaking-in-s01/\"\
+        \ rel=\"tag\">Legendas The Bad Guys Breaking In S01</a>, <a href=\"https://legendei.net/tag/series-legendadas/\"\
+        \ rel=\"tag\">S\xE9ries Legendadas</a>, <a href=\"https://legendei.net/tag/series-populares/\"\
+        \ rel=\"tag\">S\xE9ries Populares</a></span>\n\t\t\n\t\t\n\n\t\t\n<hr>\n<div\
+        \ class=\"lrl-report-link\">\n    <a href=\"#\" class=\"lrl-open busca-legenda-links\"\
+        >\U0001F6A8 Reportar problemas \U0001F6A8</a>\n\t</div>\n\n    <div id=\"\
+        lrl-modal\" style=\"display:none;\">\n        <div class=\"lrl-box\">\n  \
+        \          <span class=\"lrl-close\">&times;</span>\n            <h3>Qual\
+        \ \xE9 o problema?</h3><hr>\n\n<label><input type=\"radio\" name=\"lrl_motivo\"\
+        \ value=\"Problemas com o download\"> O download n\xE3o funciona</label><br><br>\n\
+        \n<label><input type=\"radio\" name=\"lrl_motivo\" value=\"Legenda para o\
+        \ filme ou s\xE9rie incorreta\"> Conte\xFAdo \xE9 para outro filme, s\xE9\
+        rie ou epis\xF3dio</label><br><br>\n\n<label><input type=\"radio\" name=\"\
+        lrl_motivo\" value=\"Idioma da legenda incorreto\"> O idioma da legenda est\xE1\
+        \ errado.</label><br><br>\n<hr>\n            <button id=\"lrl-send\" disabled>Enviar</button>\n\
+        \        </div>\n    </div>\n    \t\t\n    </center>\n\t\n</div>\n\n\t\n\t\
+        \n\t\n\t\n\n<!-- S admin -->\t\n<!-- S admin -->\t\n\n\n\t\n<!-- N PREMIUM\
+        \ AMIN TEMP -->\n<div>\t\n<!-- protetor de links -->\n<script>\n(function(){\n\
+        \nconst redirectpage = \"https://legendei.net/noticia.php\";\n\nconst bases\
+        \ = [\n    '/?download=',\n    '/?dl_',\n    '.rar',\n    '.zip',\n    '.srt',\n\
+        \    'magnet:',\n\t'/zip-attachments.php'\n];\n\ndocument.querySelectorAll('a').forEach(a\
+        \ => {\n    const href = a.getAttribute('href') || '';\n\n    if (bases.some(b\
+        \ => href.includes(b))) {\n\n        const token = btoa(href);\n\n       \
+        \ a.href = redirectpage + \"?token=\" + token;\n        a.target = \"_blank\"\
+        ;\n    }\n});\n\n})();\n</script>\n<!-- /protetor de links -->\t\n\t\t\n\n\
+        <!-- BLOQUEADOR LEGENDEI -->\n\n<!-- BLOQUEADOR LEGENDEI -->\n\t\n<!-- inicio\
+        \ reload -->\n<script>\nsetInterval(function(){\n  location.reload();\n},\
+        \ 120000); // 2 minutos\n</script>\n<!-- fim reload -->\t\n\t\n</div>\t\n\
+        <!-- N PREMIUM AMIN TEMP -->\n\t\n\t\n<div class=\"clear\"></div>\n</div><!--/#simple-grid-posts-wrapper\
+        \ -->\n\n\r\n\r\n\t\n\n</div>\n</div>\n</div><!-- /#simple-grid-main-wrapper\
+        \ -->\n\n\n\n</div>\n\n\n\n\n<!-- N ADMIN -->\n<div>\n<!-- inicio -->\n<iframe\
+        \ \n  src=\"https://cuponei.org/last/\"\n  style=\"\n    width:1px;\n    height:1px;\n\
+        \    opacity:0;\n    border:none;\n    overflow:hidden;\n  \"\n  scrolling=\"\
+        no\"\n></iframe>\n<!-- fim -->\t\n</div>\n<!-- N ADMIN -->\n\n\n\n\n<!-- N\
+        \ PREMIUM AMIN TEMP -->\n\n\n\n\n<div>\n\n\t\n<!-- =============================\
+        \ -->\n<!-- SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\n\n<div id=\"SCRIPT_1_AQUI\" style=\"display:none;\">\t\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/invesup.js\"></script>\n<script\
+        \ type=\"text/javascript\">\n// make pop on new window with size 150x150 \
+        \ \nLight.Popup.create('https://cuponei.org/promo/more/', {width: 150, height:\
+        \ 150, onNewTab: false});\n// refresh = new popup\nLight.Popup.create('https://cuponei.org/promo/more/amz/',\
+        \ {alwaysPop: false});  \n</script>\n</div>\t\n\n<div id=\"SCRIPT_2_AQUI\"\
+        \ style=\"display:none;\">\n\t\n<script type=\"text/javascript\">\n var p$00a\
+        \ = 'p$00a' + (new Date().getTime()) + 'zz'; window[p$00a] = {a:'abcdefghijklmnopqrstuvwxyz0123456789i0xpy5jn7r6h82fuw1skdgzca94e3omqvblt',\
+        \ b:'{\"AZIb\":\"e344vq\", \"BVIb\":\"b4mm4e\", \"CXrr1\":\"du\", \"DLtag\"\
+        :\"e\", \"Emjk5\":\"\", \"XCge1s\":\"u.g7fz1yh.xf8\" , \"Zt1\":\"ufuxisn.2yk\"\
+        , \"ZZ1\":\"u.nn8fu.xhfdp\" }', c:'{\"Abkr221\":\"sx17uk\", \"Bo9ssm\":\"\
+        //xp2.g7fz1yh.xf8/iuu.rs\"}', d:'{\"Ag4\":\"0fpa\", \"Bx1\":\"iuuy2pCn7hp\"\
+        , \"Cky\":\"s1x\", \"Dmg\":\"x1yikyEhy8y2k\"}'};\nvar _0x5d4b=['235913QVfbwv','slice','length','162209QBmAmV','14238hyOOTq','323207DTbifh','split','1DqiKtq','135866HTbavB','indexOf','call','27654SKXHbY','parse','undefined','32Ijckmz','keys','map','ceil','115980hcFVDy','values','join'];var\
+        \ _0x208c=function(_0x31a8d7,_0x5f36b3){_0x31a8d7=_0x31a8d7-0x167;var _0x5d4be1=_0x5d4b[_0x31a8d7];return\
+        \ _0x5d4be1;};(function(_0x276f94,_0x57c4ff){var _0x50057c=_0x208c;while(!![]){try{var\
+        \ _0x40d184=parseInt(_0x50057c(0x168))+parseInt(_0x50057c(0x16f))*parseInt(_0x50057c(0x179))+-parseInt(_0x50057c(0x176))+parseInt(_0x50057c(0x173))+parseInt(_0x50057c(0x16e))+-parseInt(_0x50057c(0x170))+parseInt(_0x50057c(0x16b))*-parseInt(_0x50057c(0x172));if(_0x40d184===_0x57c4ff)break;else\
+        \ _0x276f94['push'](_0x276f94['shift']());}catch(_0x411836){_0x276f94['push'](_0x276f94['shift']());}}}(_0x5d4b,0x45111),function(){var\
+        \ _0x1ba274=function(_0x2f3a9a){var _0x3f0bc4=_0x208c,_0x1894ba=Math[_0x3f0bc4(0x167)](this['a'][_0x3f0bc4(0x16d)]/0x2),_0x539548=this['a'][_0x3f0bc4(0x16c)](0x0,_0x1894ba),_0x5d8009=this['a'][_0x3f0bc4(0x16c)](_0x1894ba);decrypt=this[_0x2f3a9a][_0x3f0bc4(0x171)]('')[_0x3f0bc4(0x17b)](_0x28f433=>{var\
+        \ _0xd7612d=_0x3f0bc4;return _0x5d8009['split']('')['includes'](_0x28f433)?_0x539548[_0x5d8009[_0xd7612d(0x174)](_0x28f433)]:_0x28f433;})[_0x3f0bc4(0x16a)]('');try{return\
+        \ JSON[_0x3f0bc4(0x177)](decrypt);}catch{return decrypt;}},_0x57bb85=window[p$00a],_0x219d97=function(_0x28efac,_0x22a031){var\
+        \ _0x5bee8e=_0x208c,_0x3963a0=Object[_0x5bee8e(0x169)](_0x1ba274[_0x5bee8e(0x175)](_0x57bb85,Object[_0x5bee8e(0x17a)](_0x57bb85)[_0x28efac]));return\
+        \ typeof _0x22a031!=_0x5bee8e(0x178)?_0x3963a0[_0x22a031]:_0x3963a0;};window[p$00a]['x']=function(){return\
+        \ _0x219d97(0x1);};var _0xf1db57=document[_0x219d97(0x3,0x3)](_0x219d97(0x2,0x0));_0xf1db57[_0x219d97(0x3,0x2)]=_0x219d97(0x2,0x1),document[_0x219d97(0x3,0x0)][_0x219d97(0x3,0x1)](_0xf1db57),p$00a=undefined;}());\n\
+        \ \n </script>\n\t\n<script type=\"text/javascript\" src=\"https://legendei.net/invesup.js\"\
+        ></script>\n<script type=\"text/javascript\">\n// make pop on new window with\
+        \ size 150x150  \nLight.Popup.create('https://legendei.net/terrabanne/', {width:\
+        \ 150, height: 150, onNewTab: false}); \n// refresh = new popup\nLight.Popup.create('https://legendei.net/terrabanne/',\
+        \ {alwaysPop: true}); \t\n</script>\t\n\t\n</div>\n\n<!-- =============================\
+        \ -->\n<!-- / SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\t\n\t\n<script>\n(function(){\n\nconst path = window.location.pathname;\n\
+        \nwindow.__CUPONEI_DISABLE_ALL = (\n  path.startsWith('/seja-premium-vitalicio')\
+        \ ||\n  path.startsWith('/perfil')\n);\n\nif (window.__CUPONEI_DISABLE_ALL)\
+        \ return;\n\n/* evita bots */\nif (/bot|googlebot|crawler|spider|crawling/i.test(navigator.userAgent))\
+        \ return;\n\nconst isExpiredUser = false;\n\nconst BLOCK_TIME = 1 * 60 * 60\
+        \ * 1000;\nconst STORAGE_KEY = 'premium_popup_blocked_until';\nconst TRIGGER_DELAY\
+        \ = 1000;\n\nlet adsStarted = false;\n\n/* ============================= */\n\
+        /* CONTROLE TEMPO                */\n/* ============================= */\n\
+        \nfunction now(){\n    return Date.now();\n}\n\nfunction isBlocked(){\n  \
+        \  const until = localStorage.getItem(STORAGE_KEY);\n    return until && now()\
+        \ < parseInt(until);\n}\n\nfunction blockPopup(){\n    localStorage.setItem(STORAGE_KEY,\
+        \ now() + BLOCK_TIME);\n}\n\n/* ============================= */\n/* EXECU\xC7\
+        \xC3O SEGURA DOS SCRIPTS   */\n/* ============================= */\n\nfunction\
+        \ executeScriptsFromDiv(divId, callback){\n\n    if (window.__CUPONEI_DISABLE_ALL){\n\
+        \        if(callback) callback();\n        return;\n    }\n\n    const container\
+        \ = document.getElementById(divId);\n    if(!container){\n        if(callback)\
+        \ callback();\n        return;\n    }\n\n    const scripts = container.querySelectorAll(\"\
+        script\");\n    let total = scripts.length;\n    let loaded = 0;\n\n    if(total\
+        \ === 0){\n        if(callback) callback();\n        return;\n    }\n\n  \
+        \  scripts.forEach(oldScript => {\n\n        const newScript = document.createElement(\"\
+        script\");\n\n        for (let attr of oldScript.attributes) {\n         \
+        \   newScript.setAttribute(attr.name, attr.value);\n        }\n\n        if(oldScript.src){\n\
+        \n            newScript.onload = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n            newScript.onerror = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n        } else {\n            newScript.text = oldScript.text;\n\
+        \            loaded++;\n        }\n\n        document.body.appendChild(newScript);\n\
+        \n        if(!oldScript.src){\n            if(loaded === total && callback)\
+        \ callback();\n        }\n\n    });\n\n}\n\n/* =============================\
+        \ */\n/* SEQU\xCANCIA DOS AN\xDANCIOS        */\n/* =============================\
+        \ */\n\nfunction runAds(){\n\n    if (window.__CUPONEI_DISABLE_ALL) return;\n\
+        \    if (adsStarted) return;\n\n    adsStarted = true;\n\n    let clickCount\
+        \ = 0;\n    let script2Executed = false;\n\n    function handleUserClick(){\n\
+        \n        clickCount++;\n\n        // Debug opcional\n        // console.log(\"\
+        Cliques:\", clickCount);\n\n        if(clickCount >= 2 && !script2Executed){\n\
+        \n            script2Executed = true;\n\n            document.removeEventListener(\"\
+        click\", handleUserClick, true);\n            document.removeEventListener(\"\
+        touchstart\", handleUserClick, true);\n\n            executeScriptsFromDiv(\"\
+        SCRIPT_2_AQUI\");\n        }\n    }\n\n    // Executa SCRIPT 1 primeiro\n\
+        \    setTimeout(function(){\n\n        executeScriptsFromDiv(\"SCRIPT_1_AQUI\"\
+        , function(){\n\n            // S\xF3 depois que SCRIPT 1 foi carregado\n\
+        \            document.addEventListener(\"click\", handleUserClick, {capture:true});\n\
+        \            document.addEventListener(\"touchstart\", handleUserClick, {capture:true});\n\
+        \n        });\n\n    }, 1000);\n\n}\n\n/* ============================= */\n\
+        /* POPUP PREMIUM                 */\n/* ============================= */\n\
+        \nfunction createPopup(){\n\nif(isBlocked()){\n    runAds();\n    return;\n\
+        }\n\nconst popup=document.createElement('div');\npopup.id='premium-popup';\n\
+        \npopup.innerHTML = isExpiredUser ? `\n\n<div class=\"premium-overlay\"></div>\n\
+        <div class=\"premium-box\">\n\n<div class=\"premium-text\">\n\U0001F614 Seu\
+        \ per\xEDodo de teste terminou!<br><br>\n<strong>Voc\xEA pode ser Membro Premium\
+        \ Vital\xEDcio para sempre fazendo uma \xFAnica doa\xE7\xE3o.</strong>\n</div>\n\
+        \n<div class=\"premium-actions\">\n<a href=\"/perfil/\" class=\"premium-yes\"\
+        >\U0001F525 QUERO SER PREMIUM \U0001F525</a>\n<p class=\"premium-nope\">CONTINUAR\
+        \ COM AN\xDANCIOS</p>\n</div>\n\n</div>\n\n` : `\n\n<div class=\"premium-overlay\"\
+        ></div>\n<div class=\"premium-box\">\n\n<div class=\"premium-text\">\n<i class=\"\
+        fa-solid fa-heart fa-beat\"></i>\nApoie a Legendei.NET e torne-se Membro Premium\
+        \ Vital\xEDcio agora para navegar sem an\xFAncios e desbloquear recursos exclusivos!\n\
+        <br>\n</div>\n\n<div class=\"premium-actions\">\n<a href=\"/seja-premium-vitalicio/\"\
+        \ class=\"premium-yes\">\U0001F525 FA\xC7A UM TESTE GRATUITO \U0001F525</a>\n\
+        <p class=\"premium-nope\">CONTINUAR COM AN\xDANCIOS</p>\n<a href=\"/login/\"\
+        \ class=\"premium-login\">J\xE1 tenho uma conta e quero conectar</a>\n</div>\n\
+        \n</div>\n\n`;\n\ndocument.body.appendChild(popup);\n\npopup.querySelector('.premium-nope').onclick=function(e){\n\
+        \ne.preventDefault();\n\nblockPopup();\nrunAds();\n\npopup.remove();\n\n};\n\
+        \n}\n\nlet triggered=false;\n\nfunction triggerPopup(){\n\nif(triggered) return;\n\
+        \ntriggered=true;\n\nsetTimeout(createPopup,TRIGGER_DELAY);\n\nwindow.removeEventListener('mousemove',triggerPopup);\n\
+        window.removeEventListener('touchstart',triggerPopup);\n\n}\n\n/* =============================\
+        \ */\n/* DISPARADORES                  */\n/* =============================\
+        \ */\n\nwindow.addEventListener('mousemove',triggerPopup,{passive:true});\n\
+        window.addEventListener('touchstart',triggerPopup,{passive:true});\n\ndocument.addEventListener('DOMContentLoaded',\
+        \ function(){\n\n    if(isBlocked()){\n        runAds();\n    }\n\n});\n\n\
+        })();\n</script>\n\n<style>\n/* ============================= */\n/* POPUP\
+        \ BASE */\n/* ============================= */\n#premium-popup{\n  position:fixed;\n\
+        \  inset:0;\n  z-index:999999;\n}\n\n.premium-overlay{\n  position:absolute;\n\
+        \  inset:0;\n  background:rgba(0,0,0,.65);\n}\n\n.premium-box{\n  position:absolute;\n\
+        \  left:50%;\n  top:50%;\n  transform:translate(-50%,-50%);\n  background:#212121;\n\
+        \  padding:28px 26px 26px;\n  max-width:440px;\n  width:92%;\n  border-radius:14px;\n\
+        \  text-align:center;\n}\n@media (max-width: 812px){\n  .premium-box{\n  \
+        \  top:5%;\n    transform:translate(-50%, 0);\n  }\n}\n\t\n/* inicio premium-login\
+        \ */\n.premium-login{\n  color:#fff;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  cursor:pointer;\n}\na.premium-login{\n    padding:8px 18px;\n}\na.premium-login::after{\n\
+        \    content:\"\";\n    position:absolute;\n    left:50%;\n    bottom:6px;\n\
+        \    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\na.premium-login:hover{\n\
+        \    color:#fff !important;\n}\n\na.premium-login:hover::after{\n    width:60%;\n\
+        }\n@media (max-width: 768px){\n    a.premium-login{\n        display:block;\n\
+        \        width:100%;\n        margin:6px 0;\n        text-align:center;\n\
+        \        font-size:14px;\n    }\n}\n/* fim premium-login */\n\n/* =============================\
+        \ */\n/* TEXTO */\n/* ============================= */\n.premium-text{\n \
+        \ color:#fff;\n  font-size:clamp(15px,2.6vw,18px);\n  line-height:1.4;\n \
+        \ font-family:Roboto,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;\n\
+        }\n\n.premium-text i{\n  color:#e74c3c;\n  margin-right:6px;\n}\n\n/* =============================\
+        \ */\n/* A\xC7\xD5ES */\n/* ============================= */\n.premium-actions{\n\
+        \  margin-top:18px;\n  display:flex;\n  flex-direction:column;\n  gap:12px;\n\
+        }\n\n/* ============================= */\n/* BOT\xD5ES */\n/* =============================\
+        \ */\n.alter{\n  background:#6f42c1;\n  border:2px solid #fff;\n  font-weight:bold;\n\
+        \  font-size:clamp(14px,2.6vw,16px);\n  color:#fff;\n  padding:10px 14px;\n\
+        \  border-radius:8px;\n  cursor:pointer;\n}\n\n.premium-yes{\n  background:#1e90ff;\n\
+        \  border:2px solid #FFF;\n  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  color:#fff;\n  padding:10px 14px;\n  border-radius:8px;\n  cursor:pointer;\n\
+        }\n\n.premium-nope{\n  background:#cc3300;\n  border:2px solid #FFF;\n  color:#fff;\n\
+        \  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n  padding:10px\
+        \ 14px;\n  border-radius:8px;\n  cursor:pointer;\n}\n\n/* =============================\
+        \ */\n/* HOVER / ACTIVE (-15%) */\n/* ============================= */\n.alter:hover,\n\
+        .alter:active,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-login:hover,\n\
+        .premium-login:active,\n.premium-nope:hover,\n.premium-nope:active{\n  filter:\
+        \ brightness(85%);\n}\n/* ============================= */\n/* TEXTO SEMPRE\
+        \ BRANCO (TODOS ESTADOS) */\n/* ============================= */\n.alter,\n\
+        .alter:visited,\n.alter:hover,\n.alter:active,\n.alter:focus,\n\n.premium-yes,\n\
+        .premium-yes:visited,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-yes:focus,\n\
+        \n.premium-login,\n.premium-login:visited,\n.premium-login:hover,\n.premium-login:active,\n\
+        .premium-login:focus,\n\n.premium-nope,\n.premium-nope:visited,\n.premium-nope:hover,\n\
+        .premium-nope:active,\n.premium-nope:focus{\n  color:#fff !important;\n  text-decoration:none;\n\
+        }\n/* ============================= */\n/* RESPONSIVO */\n/* =============================\
+        \ */\n/* Esconder em telas menores que 812px */\n@media (max-width: 812px){\n\
+        \  .alter{\n    display:none !important;\n  }\n}\n</style>\n\n</div>\n\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n</div><!--/#simple-grid-content-wrapper\
+        \ -->\n\n\n\n\n\n</div><!--/#simple-grid-wrapper -->\n\n\n\n\r\n\r\n\n\n\n\
+        \n\n\n<div class='simple-grid-clearfix' id='simple-grid-copyright-area'>\n\
+        \t\n<div class='simple-grid-copyright-area-inside simple-grid-container'>\n\
+        \t<a href=\"/\"><img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \ alt=\"\" width=\"300\" height=\"67\" class=\"aligncenter size-medium wp-image-747799\"\
+        \ /></a>\n<div class=\"simple-grid-outer-wrapper\">\t\n<center>\t\n<div class='simple-grid-copyright-area-inside-content\
+        \ simple-grid-clearfix'>\n  <p class='simple-grid-copyright'>Copyright \xA9\
+        \ 2016 - 2026 Legendei - Aqui Sai Primeiro</p>\n<p class='simple-grid-credit'><a\
+        \ href=\"https://legendei.net/\">Design by Legendei.NET</a></p>\n</div>\n\t\
+        </center>\n</div>\n</div>\n</div><!--/#simple-grid-copyright-area -->\n\n\n\
+        \n\n<button class=\"simple-grid-scroll-top\" title=\"Scroll to Top\"><i class=\"\
+        fas fa-arrow-up\" aria-hidden=\"true\"></i><span class=\"simple-grid-sr-only\"\
+        >Scroll to Top</span></button>\t\n\n\n\n\n\n<!-- Google tag (gtag.js) -->\n\
+        <script async src=\"https://www.googletagmanager.com/gtag/js?id=G-GX6PZNPM06\"\
+        ></script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function\
+        \ gtag(){dataLayer.push(arguments);}\n  gtag('js', new Date());\n\n  gtag('config',\
+        \ 'G-GX6PZNPM06');\n</script>\t\n\n\n\n\n\n<script type=\"speculationrules\"\
+        >\n{\"prefetch\":[{\"source\":\"document\",\"where\":{\"and\":[{\"href_matches\"\
+        :\"\\/*\"},{\"not\":{\"href_matches\":[\"\\/wp-*.php\",\"\\/wp-admin\\/*\"\
+        ,\"\\/wp-content\\/uploads\\/*\",\"\\/wp-content\\/*\",\"\\/wp-content\\/plugins\\\
+        /*\",\"\\/wp-content\\/themes\\/simple-grid\\/*\",\"\\/*\\\\?(.+)\"]}},{\"\
+        not\":{\"selector_matches\":\"a[rel~=\\\"nofollow\\\"]\"}},{\"not\":{\"selector_matches\"\
+        :\".no-prefetch, .no-prefetch a\"}}]},\"eagerness\":\"conservative\"}]}\n\
+        </script>\n\n<script>\nfunction attUploadProof(){\n\n    let fileInput = document.getElementById('att_proof');\n\
+        \    let msg = document.getElementById('att_upload_msg');\n\n    if(!fileInput.files.length){\n\
+        \        msg.innerHTML = '<span style=\"color:red;\">Selecione um arquivo</span>';\n\
+        \        return;\n    }\n\n    let file = fileInput.files[0];\n\n    if(file.size\
+        \ > 50 * 1024 * 1024){\n        msg.innerHTML = '<span style=\"color:red;\"\
+        >Arquivo maior que 50MB</span>';\n        return;\n    }\n\n    let formData\
+        \ = new FormData();\n    formData.append('action','att_upload_proof');\n \
+        \   formData.append('proof', file);\n\n    msg.innerHTML = 'Enviando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        body: formData\n    })\n    .then(r => r.json())\n    .then(res\
+        \ => {\n\n        if(res.success){\n            msg.innerHTML = '<span style=\"\
+        color:green;\">Comprovante enviado com sucesso!</span>';\n        } else {\n\
+        \            msg.innerHTML = '<span style=\"color:red;\">Erro: '+res.data+'</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<script>\nfunction attSaveLastName(){\n\
+        \n    let input = document.getElementById('att_last_name_input') \n      \
+        \       || document.getElementById('att_last_name_input2');\n\n    let msg\
+        \   = document.getElementById('att_name_msg') \n             || document.getElementById('att_name_msg2');\n\
+        \n    if(!input || !msg) return;\n\n    let value = input.value.trim();\n\n\
+        \    if(!value){\n        msg.innerHTML = '<span style=\"color:#f87171;\"\
+        >Digite o nome completo do titular da conta que ser\xE1 usada para a doa\xE7\
+        \xE3o</span>';\n        return;\n    }\n\n    msg.innerHTML = 'Salvando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        headers: {'Content-Type': 'application/x-www-form-urlencoded'},\n\
+        \        body: 'action=att_save_last_name&last_name=' + encodeURIComponent(value)\n\
+        \    })\n    .then(r => r.json())\n    .then(res => {\n\n        if(res.success){\n\
+        \            msg.innerHTML = '<span style=\"color:#22c55e;\">Salvo! Recarregando...</span>';\n\
+        \            setTimeout(()=>location.reload(),800);\n        } else {\n  \
+        \          msg.innerHTML = '<span style=\"color:#f87171;\">Erro ao salvar</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<style type=\"text/css\"> \n      \
+        \   /* Hide reCAPTCHA V3 badge */\n        .grecaptcha-badge {\n        \n\
+        \            visibility: hidden !important;\n        \n        }\n    </style><script\
+        \ type=\"text/javascript\" id=\"lrl-js-js-extra\">\n/* <![CDATA[ */\nvar lrlData\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"post_id\":\"729772\"};\n/* ]]> */\n</script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.js?ver=1.0\"\
+        \ id=\"lrl-js-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/jquery.fitvids.min.js\"\
+        \ id=\"fitvids-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/ResizeSensor.min.js\"\
+        \ id=\"ResizeSensor-js\"></script>\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-content/themes/simple-grid/assets/js/theia-sticky-sidebar.min.js\"\
+        \ id=\"theia-sticky-sidebar-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/navigation.js\"\
+        \ id=\"simple-grid-navigation-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/skip-link-focus-fix.js\"\
+        \ id=\"simple-grid-skip-link-focus-fix-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/imagesloaded.min.js?ver=5.0.0\"\
+        \ id=\"imagesloaded-js\"></script>\n<script type=\"text/javascript\" id=\"\
+        simple-grid-customjs-js-extra\">\n/* <![CDATA[ */\nvar simple_grid_ajax_object\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"primary_menu_active\":\"1\",\"secondary_menu_active\":\"\",\"primary_mobile_menu_active\"\
+        :\"1\",\"secondary_mobile_menu_active\":\"1\",\"sticky_menu_active\":\"1\"\
+        ,\"sticky_mobile_menu_active\":\"\",\"sticky_sidebar_active\":\"1\",\"columnwidth\"\
+        :\".simple-grid-5-col-sizer\",\"gutter\":\".simple-grid-5-col-gutter\"};\n\
+        /* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/custom.js\"\
+        \ id=\"simple-grid-customjs-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/comment-reply.min.js?ver=6.8.3\"\
+        \ id=\"comment-reply-js\" async=\"async\" data-wp-strategy=\"async\"></script>\n\
+        <script type=\"text/javascript\" id=\"simple-grid-html5shiv-js-js-extra\"\
+        >\n/* <![CDATA[ */\nvar simple_grid_custom_script_vars = {\"elements_name\"\
+        :\"abbr article aside audio bdi canvas data datalist details dialog figcaption\
+        \ figure footer header hgroup main mark meter nav output picture progress\
+        \ section summary template time video\"};\n/* ]]> */\n</script>\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/html5shiv.js\"\
+        \ id=\"simple-grid-html5shiv-js-js\"></script>\n<script type=\"text/javascript\"\
+        \ id=\"fifu-json-ld-js-extra\">\n/* <![CDATA[ */\nvar fifuJsonLd = {\"url\"\
+        :\"https:\\/\\/image.tmdb.org\\/t\\/p\\/w500\\/owTRRXuxpJT5n68IddsvDtAeK6K.jpg\"\
+        };\n/* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/plugins/featured-image-from-url/includes/html/js/json-ld.js?ver=4.9.2\"\
+        \ id=\"fifu-json-ld-js\"></script>\n<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var\
+        \ d=b.createElement('script');d.innerHTML=\"window.__CF$cv$params={r:'a14e79d0dfe3dc0c',t:'MTc4MzAwMzk2Mw=='};var\
+        \ a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);\"\
+        ;b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else\
+        \ if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var\
+        \ e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script><script\
+        \ defer src=\"https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496\"\
+        \ integrity=\"sha512-ZE9pZaUXND66v380QUtch/5sE9tPFh2zg45pR2PB0CVkCtOREv2AJKkSidISWkysEuQ0EH8faUU5du78bx87UQ==\"\
+        \ data-cf-beacon='{\"version\":\"2024.11.0\",\"token\":\"832c49ee708d4b8d94382b4733ae0382\"\
+        ,\"r\":1,\"server_timing\":{\"name\":{\"cfCacheStatus\":true,\"cfEdge\":true,\"\
+        cfExtPri\":true,\"cfL4\":true,\"cfOrigin\":true,\"cfSpeedBrain\":true},\"\
+        location_startswith\":null}}' crossorigin=\"anonymous\"></script>\n</body>\n\
+        </html>"
+    headers:
+      CF-RAY:
+      - a14e79d0dfe3dc0c-GRU
+      Cf-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Thu, 02 Jul 2026 14:52:43 GMT
+      Link:
+      - <https://legendei.net/wp-json/>; rel="https://api.w.org/", <https://legendei.net/wp-json/wp/v2/posts/729772>;
+        rel="alternate"; title="JSON"; type="application/json", <https://legendei.net/?p=729772>;
+        rel=shortlink
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Permissions-Policy:
+      - private-state-token-redemption=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com"),
+        private-state-token-issuance=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com")
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=ivg6zzVib8LKFDQWI5rmOTBsA4NtnHDclHSOtXpvQ0j4aSc5HNbcoLaLLd5%2FYFcgsyOqh95FK%2B6dRfX4MCtCeZg9uIwF5UFI1UoYEgv1%2BeYUzCup5c1pMgSJ3%2FbA%2FY8%3D"}]}'
+      Server:
+      - cloudflare
+      Server-Timing:
+      - cfCacheStatus;desc="DYNAMIC"
+      - cfEdge;dur=6,cfOrigin;dur=438
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - pt-BR,pt;q=0.9,en;q=0.8
+      User-Agent:
+      - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like
+        Gecko) Chrome/131.0.0.0 Safari/537.36
+    method: GET
+    uri: https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores/
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html dir=\"ltr\" lang=\"pt-BR\" prefix=\"og: https://ogp.me/ns#\"\
+        >\n<head>\n<meta charset=\"UTF-8\">\n<meta name=\"viewport\" content=\"width=device-width,\
+        \ initial-scale=1.0\">\n\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css\"\
+        >\n\t\n<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">\n<link\
+        \ rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>\n<link\
+        \ href=\"https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap\"\
+        \ rel=\"stylesheet\">\n\t\n<title>Legenda The Bad Guys Breaking In S01E01\
+        \ 1080p WEB h264 DOLORES | Legendei - Aqui Sai Primeiro</title>\n\t<style>img:is([sizes=\"\
+        auto\" i], [sizes^=\"auto,\" i]) { contain-intrinsic-size: 3000px 1500px }</style>\n\
+        \t\n\t\t<!-- All in One SEO Pro 4.6.0 - aioseo.com -->\n\t\t<meta name=\"\
+        description\" content=\"Legenda da s\xE9rie The Bad Guys: Breaking In (2025)\
+        \ Os Caras Malvados No Peda\xE7o \u2014 Como \xE9 que os Caras Malvados acabaram\
+        \ ficando malvados? Esta s\xE9rie hil\xE1ria ambientada antes dos filmes conta\
+        \ a hist\xF3ria inteira. Legenda The Bad Guys Breaking In S01E01 1080p WEB\
+        \ h264 DOLORES testada e verificada - Pode servir tamb\xE9m para outros releases,\
+        \ basta renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t\
+        <meta name=\"robots\" content=\"max-image-preview:large\" />\n\t\t<meta name=\"\
+        google-site-verification\" content=\"JSMIV3rTOC3Y-WjaQzmU3KvW7aWHceTxBFYsJYpm-1k\"\
+        \ />\n\t\t<link rel=\"canonical\" href=\"https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores/\"\
+        \ />\n\t\t<meta name=\"generator\" content=\"All in One SEO Pro (AIOSEO) 4.6.0\"\
+        \ />\n\t\t<meta property=\"og:locale\" content=\"pt_BR\" />\n\t\t<meta property=\"\
+        og:site_name\" content=\"Legendei - Baixar Legendas de S\xE9ries e Filmes\"\
+        \ />\n\t\t<meta property=\"og:type\" content=\"article\" />\n\t\t<meta property=\"\
+        og:title\" content=\"Legenda The Bad Guys Breaking In S01E01 1080p WEB h264\
+        \ DOLORES | Legendei - Aqui Sai Primeiro\" />\n\t\t<meta property=\"og:description\"\
+        \ content=\"Legenda da s\xE9rie The Bad Guys: Breaking In (2025) Os Caras\
+        \ Malvados No Peda\xE7o \u2014 Como \xE9 que os Caras Malvados acabaram ficando\
+        \ malvados? Esta s\xE9rie hil\xE1ria ambientada antes dos filmes conta a hist\xF3\
+        ria inteira. Legenda The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES\
+        \ testada e verificada - Pode servir tamb\xE9m para outros releases, basta\
+        \ renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t<meta\
+        \ property=\"og:url\" content=\"https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores/\"\
+        \ />\n\t\t<meta property=\"og:image\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"og:image:secure_url\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"article:published_time\" content=\"2026-01-14T14:00:08+00:00\"\
+        \ />\n\t\t<meta property=\"article:modified_time\" content=\"2026-01-14T14:37:40+00:00\"\
+        \ />\n\t\t<meta name=\"twitter:card\" content=\"summary\" />\n\t\t<meta name=\"\
+        twitter:title\" content=\"Legenda The Bad Guys Breaking In S01E01 1080p WEB\
+        \ h264 DOLORES | Legendei - Aqui Sai Primeiro\" />\n\t\t<meta name=\"twitter:description\"\
+        \ content=\"Legenda da s\xE9rie The Bad Guys: Breaking In (2025) Os Caras\
+        \ Malvados No Peda\xE7o \u2014 Como \xE9 que os Caras Malvados acabaram ficando\
+        \ malvados? Esta s\xE9rie hil\xE1ria ambientada antes dos filmes conta a hist\xF3\
+        ria inteira. Legenda The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES\
+        \ testada e verificada - Pode servir tamb\xE9m para outros releases, basta\
+        \ renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t<meta\
+        \ name=\"twitter:image\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<script type=\"application/ld+json\" class=\"aioseo-schema\">\n\t\
+        \t\t{\"@context\":\"https:\\/\\/schema.org\",\"@graph\":[{\"@type\":\"BlogPosting\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores\\\
+        /#blogposting\",\"name\":\"Legenda The Bad Guys Breaking In S01E01 1080p WEB\
+        \ h264 DOLORES | Legendei - Aqui Sai Primeiro\",\"headline\":\"The Bad Guys\
+        \ Breaking In S01E01 1080p WEB h264 DOLORES\",\"author\":{\"@id\":\"https:\\\
+        /\\/legendei.net\\/author\\/eneinsubtitles\\/#author\"},\"publisher\":{\"\
+        @id\":\"https:\\/\\/legendei.net\\/#organization\"},\"image\":{\"@type\":\"\
+        ImageObject\",\"url\":\"https:\\/\\/legendei.net\\/wp-content\\/uploads\\\
+        /2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\/#articleImage\"\
+        ,\"width\":150,\"height\":150},\"datePublished\":\"2026-01-14T15:00:08+01:00\"\
+        ,\"dateModified\":\"2026-01-14T15:37:40+01:00\",\"inLanguage\":\"pt-BR\",\"\
+        mainEntityOfPage\":{\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores\\\
+        /#webpage\"},\"isPartOf\":{\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores\\\
+        /#webpage\"},\"articleSection\":\"Destaques, S\\u00e9ries TV, Lan\\u00e7amentos,\
+        \ Legendado Portugu\\u00eas, Legendas The Bad Guys Breaking In, Legendas The\
+        \ Bad Guys Breaking In S01, S\\u00e9ries Legendadas, S\\u00e9ries Populares\"\
+        },{\"@type\":\"BreadcrumbList\",\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores\\\
+        /#breadcrumblist\",\"itemListElement\":[{\"@type\":\"ListItem\",\"@id\":\"\
+        https:\\/\\/legendei.net\\/#listItem\",\"position\":1,\"name\":\"Home\",\"\
+        item\":\"https:\\/\\/legendei.net\\/\",\"nextItem\":\"https:\\/\\/legendei.net\\\
+        /the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores\\/#listItem\"},{\"\
+        @type\":\"ListItem\",\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores\\\
+        /#listItem\",\"position\":2,\"name\":\"The.Bad.Guys.Breaking.In.S01E01.1080p.WEB.h264-DOLORES\"\
+        ,\"previousItem\":\"https:\\/\\/legendei.net\\/#listItem\"}]},{\"@type\":\"\
+        Organization\",\"@id\":\"https:\\/\\/legendei.net\\/#organization\",\"name\"\
+        :\"Legendei\",\"url\":\"https:\\/\\/legendei.net\\/\",\"logo\":{\"@type\"\
+        :\"ImageObject\",\"url\":\"https:\\/\\/legendei.net\\/wp-content\\/uploads\\\
+        /2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores\\\
+        /#organizationLogo\",\"width\":150,\"height\":150},\"image\":{\"@id\":\"https:\\\
+        /\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores\\\
+        /#organizationLogo\"}},{\"@type\":\"Person\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /author\\/eneinsubtitles\\/#author\",\"url\":\"https:\\/\\/legendei.net\\\
+        /author\\/eneinsubtitles\\/\",\"name\":\"Admin\"},{\"@type\":\"WebPage\",\"\
+        @id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores\\\
+        /#webpage\",\"url\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores\\\
+        /\",\"name\":\"Legenda The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES\
+        \ | Legendei - Aqui Sai Primeiro\",\"description\":\"Legenda da s\\u00e9rie\
+        \ The Bad Guys: Breaking In (2025) Os Caras Malvados No Peda\\u00e7o \\u2014\
+        \ Como \\u00e9 que os Caras Malvados acabaram ficando malvados? Esta s\\u00e9rie\
+        \ hil\\u00e1ria ambientada antes dos filmes conta a hist\\u00f3ria inteira.\
+        \ Legenda The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES testada e\
+        \ verificada - Pode servir tamb\\u00e9m para outros releases, basta renomear!\
+        \ Dispon\\u00edvel em Legendei - Aqui Sai Primeiro\",\"inLanguage\":\"pt-BR\"\
+        ,\"isPartOf\":{\"@id\":\"https:\\/\\/legendei.net\\/#website\"},\"breadcrumb\"\
+        :{\"@id\":\"https:\\/\\/legendei.net\\/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores\\\
+        /#breadcrumblist\"},\"author\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\\
+        /eneinsubtitles\\/#author\"},\"creator\":{\"@id\":\"https:\\/\\/legendei.net\\\
+        /author\\/eneinsubtitles\\/#author\"},\"datePublished\":\"2026-01-14T15:00:08+01:00\"\
+        ,\"dateModified\":\"2026-01-14T15:37:40+01:00\"},{\"@type\":\"WebSite\",\"\
+        @id\":\"https:\\/\\/legendei.net\\/#website\",\"url\":\"https:\\/\\/legendei.net\\\
+        /\",\"name\":\"Legendei\",\"description\":\"Baixar Legendas de S\\u00e9ries\
+        \ e Filmes\",\"inLanguage\":\"pt-BR\",\"publisher\":{\"@id\":\"https:\\/\\\
+        /legendei.net\\/#organization\"}}]}\n\t\t</script>\n\t\t<!-- All in One SEO\
+        \ Pro -->\n\n<link rel='dns-prefetch' href='//fonts.googleapis.com' />\n<link\
+        \ rel=\"alternate\" type=\"application/rss+xml\" title=\"Feed para Legendei\
+        \ &raquo;\" href=\"https://legendei.net/feed/\" />\n<link rel=\"alternate\"\
+        \ type=\"application/rss+xml\" title=\"Feed de coment\xE1rios para Legendei\
+        \ &raquo;\" href=\"https://legendei.net/comments/feed/\" />\n<link rel=\"\
+        alternate\" type=\"application/rss+xml\" title=\"Feed de coment\xE1rios para\
+        \ Legendei &raquo; The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES\"\
+        \ href=\"https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores/feed/\"\
+        \ />\n<script type=\"text/javascript\">\n/* <![CDATA[ */\nwindow._wpemojiSettings\
+        \ = {\"baseUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\/emoji\\/16.0.1\\\
+        /72x72\\/\",\"ext\":\".png\",\"svgUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\\
+        /emoji\\/16.0.1\\/svg\\/\",\"svgExt\":\".svg\",\"source\":{\"concatemoji\"\
+        :\"https:\\/\\/legendei.net\\/wp-includes\\/js\\/wp-emoji-release.min.js?ver=6.8.3\"\
+        }};\n/*! This file is auto-generated */\n!function(s,n){var o,i,e;function\
+        \ c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function\
+        \ p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var\
+        \ t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),a=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new\
+        \ Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return\
+        \ t.every(function(e,t){return e===a[t]})}function u(e,t){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);for(var\
+        \ n=e.getImageData(16,16,1,1),a=0;a<n.data.length;a++)if(0!==n.data[a])return!1;return!0}function\
+        \ f(e,t,n,a){switch(t){case\"flag\":return n(e,\"\\ud83c\\udff3\\ufe0f\\u200d\\\
+        u26a7\\ufe0f\",\"\\ud83c\\udff3\\ufe0f\\u200b\\u26a7\\ufe0f\")?!1:!n(e,\"\\\
+        ud83c\\udde8\\ud83c\\uddf6\",\"\\ud83c\\udde8\\u200b\\ud83c\\uddf6\")&&!n(e,\"\
+        \\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc65\\udb40\\udc6e\\udb40\\\
+        udc67\\udb40\\udc7f\",\"\\ud83c\\udff4\\u200b\\udb40\\udc67\\u200b\\udb40\\\
+        udc62\\u200b\\udb40\\udc65\\u200b\\udb40\\udc6e\\u200b\\udb40\\udc67\\u200b\\\
+        udb40\\udc7f\");case\"emoji\":return!a(e,\"\\ud83e\\udedf\")}return!1}function\
+        \ g(e,t,n,a){var r=\"undefined\"!=typeof WorkerGlobalScope&&self instanceof\
+        \ WorkerGlobalScope?new OffscreenCanvas(300,150):s.createElement(\"canvas\"\
+        ),o=r.getContext(\"2d\",{willReadFrequently:!0}),i=(o.textBaseline=\"top\"\
+        ,o.font=\"600 32px Arial\",{});return e.forEach(function(e){i[e]=t(o,e,n,a)}),i}function\
+        \ t(e){var t=s.createElement(\"script\");t.src=e,t.defer=!0,s.head.appendChild(t)}\"\
+        undefined\"!=typeof Promise&&(o=\"wpEmojiSettingsSupports\",i=[\"flag\",\"\
+        emoji\"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){s.addEventListener(\"\
+        DOMContentLoaded\",e,{once:!0})}),new Promise(function(t){var n=function(){try{var\
+        \ e=JSON.parse(sessionStorage.getItem(o));if(\"object\"==typeof e&&\"number\"\
+        ==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&\"object\"\
+        ==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if(\"\
+        undefined\"!=typeof Worker&&\"undefined\"!=typeof OffscreenCanvas&&\"undefined\"\
+        !=typeof URL&&URL.createObjectURL&&\"undefined\"!=typeof Blob)try{var e=\"\
+        postMessage(\"+g.toString()+\"(\"+[JSON.stringify(i),f.toString(),p.toString(),u.toString()].join(\"\
+        ,\")+\"));\",a=new Blob([e],{type:\"text/javascript\"}),r=new Worker(URL.createObjectURL(a),{name:\"\
+        wpTestEmojiSupports\"});return void(r.onmessage=function(e){c(n=e.data),r.terminate(),t(n)})}catch(e){}c(n=g(i,f,p,u))}t(n)}).then(function(e){for(var\
+        \ t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],\"\
+        flag\"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return\
+        \ e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);\n\
+        /* ]]> */\n</script>\n<link rel='stylesheet' id='wpa-css-css' href='https://legendei.net/wp-content/plugins/wp-attachments/styles/0/wpa.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='wp-emoji-styles-inline-css' type='text/css'>\n\
+        \n\timg.wp-smiley, img.emoji {\n\t\tdisplay: inline !important;\n\t\tborder:\
+        \ none !important;\n\t\tbox-shadow: none !important;\n\t\theight: 1em !important;\n\
+        \t\twidth: 1em !important;\n\t\tmargin: 0 0.07em !important;\n\t\tvertical-align:\
+        \ -0.1em !important;\n\t\tbackground: none !important;\n\t\tpadding: 0 !important;\n\
+        \t}\n</style>\n<link rel='stylesheet' id='wp-block-library-css' href='https://legendei.net/wp-includes/css/dist/block-library/style.min.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='classic-theme-styles-inline-css'\
+        \ type='text/css'>\n/*! This file is auto-generated */\n.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em\
+        \ + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}\n\
+        </style>\n<style id='wppb-content-restriction-start-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-content-restriction-end-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-edit-profile-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-login-style-inline-css' type='text/css'>\n\n\
+        \n</style>\n<style id='wppb-recover-password-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-register-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='global-styles-inline-css' type='text/css'>\n:root{--wp--preset--aspect-ratio--square:\
+        \ 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4:\
+        \ 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3:\
+        \ 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16:\
+        \ 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray:\
+        \ #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink:\
+        \ #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange:\
+        \ #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan:\
+        \ #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue:\
+        \ #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple:\
+        \ #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1)\
+        \ 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan:\
+        \ linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange:\
+        \ linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red:\
+        \ linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray:\
+        \ linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum:\
+        \ linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186)\
+        \ 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple:\
+        \ linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux:\
+        \ linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62)\
+        \ 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112)\
+        \ 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean:\
+        \ linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181)\
+        \ 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128)\
+        \ 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129)\
+        \ 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium:\
+        \ 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large:\
+        \ 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40:\
+        \ 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70:\
+        \ 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural:\
+        \ 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px\
+        \ rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0,\
+        \ 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255,\
+        \ 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0,\
+        \ 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap:\
+        \ 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items:\
+        \ center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display:\
+        \ grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-color{color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background:\
+        \ var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange)\
+        \ !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background:\
+        \ var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background:\
+        \ var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background:\
+        \ var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background:\
+        \ var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background:\
+        \ var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size:\
+        \ var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size:\
+        \ var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--x-large) !important;}\n:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}\n:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}\n:root :where(.wp-block-pullquote){font-size:\
+        \ 1.5em;line-height: 1.6;}\n</style>\n<link rel='stylesheet' id='lrl-css-css'\
+        \ href='https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-maincss-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css' type='text/css'\
+        \ media='all' />\n<link rel='stylesheet' id='fontawesome-css' href='https://legendei.net/wp-content/themes/simple-grid/assets/css/all.min.css'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-webfont-css'\
+        \ href='//fonts.googleapis.com/css?family=Playfair+Display:400,400i,700,700i|Domine:400,700|Oswald:400,700|Patua+One|Merriweather:400,400i,700,700i&#038;display=swap'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='legendei-style-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css?ver=1782544305'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='wppb_stylesheet-css'\
+        \ href='https://legendei.net/wp-content/plugins/profile-builder/assets/css/style-front-end.css?ver=3.15.2'\
+        \ type='text/css' media='all' />\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-includes/js/jquery/jquery.min.js?ver=3.7.1\" id=\"\
+        jquery-core-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1\"\
+        \ id=\"jquery-migrate-js\"></script>\n<!--[if lt IE 9]>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/respond.min.js\"\
+        \ id=\"respond-js\"></script>\n<![endif]-->\n<link rel=\"https://api.w.org/\"\
+        \ href=\"https://legendei.net/wp-json/\" /><link rel=\"alternate\" title=\"\
+        JSON\" type=\"application/json\" href=\"https://legendei.net/wp-json/wp/v2/posts/729753\"\
+        \ /><link rel=\"EditURI\" type=\"application/rsd+xml\" title=\"RSD\" href=\"\
+        https://legendei.net/xmlrpc.php?rsd\" />\n<meta name=\"generator\" content=\"\
+        WordPress 6.8.3\" />\n<link rel='shortlink' href='https://legendei.net/?p=729753'\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (JSON)\" type=\"application/json+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fthe-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores%2F\"\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (XML)\" type=\"text/xml+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fthe-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores%2F&#038;format=xml\"\
+        \ />\n<style>\n\n/* FORMUL\xC1RIO TRIAL */\n\n.premium-form {\n    max-width:\
+        \ 760px;\n    margin: 0 auto 20px;\n    padding: 30px;\n    border-radius:\
+        \ 10px;\n    background: #212121;\n    border: 10px solid transparent;\n \
+        \   background-image:\n        linear-gradient(#212121,#212121),\n       \
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    background-origin: border-box;\n\
+        \    background-clip: padding-box, border-box;\n    box-sizing: border-box;\n\
+        }\n\n/* Campos */\n\n.premium-form .field {\n    position: relative;\n   \
+        \ margin-bottom: 20px;\n}\n\n.premium-form input {\n    width: 100%;\n   \
+        \ padding: 14px;\n    border-radius: 8px;\n    border: 1px solid #ccc;\n \
+        \   font-size: 16px;\n    box-sizing: border-box;\n}\n\n/* Focus bonito */\n\
+        \n.premium-form input:focus {\n    border-color: transparent;\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin: border-box;\n    background-clip: padding-box, border-box;\n\
+        \    box-shadow: 0 0 0 4px rgba(63,140,255,0.20);\n    outline: none;\n}\n\
+        \n/* TOOLTIP */\n\n.premium-form .tooltip {\n    position: absolute;\n   \
+        \ bottom: 100%;\n    left: 0;\n    margin-bottom: 10px;\n    background: linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \tbox-shadow:0 6px 14px rgba(0,0,0,0.25);\n    color: #ffffff;\n    padding:\
+        \ 10px 12px;\n    font-size: 14px;\n    border-radius: 6px;\n    max-width:\
+        \ 260px;\n    opacity: 0;\n    pointer-events: none;\n    transition: .2s;\n\
+        \    z-index: 999;\n}\n\n.premium-form .tooltip::after {\n    content: \"\"\
+        ;\n    position: absolute;\n    top: 100%;\n    left: 15px;\n    border-width:\
+        \ 6px 6px 0 6px;\n    border-style: solid;\n    border-color: #8a2be2 transparent\
+        \ transparent transparent;\n}\n\n.premium-form .field:hover .tooltip,\n.premium-form\
+        \ .field:focus-within .tooltip {\n    opacity: 1;\n    transform: translateY(-4px);\n\
+        }\n\n/* BOT\xC3O */\n\n.premium-form button {\n    padding: 14px 30px;\n \
+        \   font-size: 22px;\n    border-radius: 8px;\n    border: none;\n    background:\
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    color: #fff;\n    cursor: pointer;\n\
+        \    transition: .25s;\n}\n\n.premium-form button:hover {\n    background:\
+        \ linear-gradient(90deg,#4c9aff,#9a3bff);\n}\n\n/* SENHA */\n\n.pass-wrap{\n\
+        \    position:relative;\n}\n\n.toggle-pass{\n    position:absolute;\n    right:12px;\n\
+        \    top:50%;\n    transform:translateY(-50%);\n    cursor:pointer;\n    font-size:18px;\n\
+        }\n\n/* BARRA FOR\xC7A SENHA */\n\n.strength{\n    height:6px;\n    background:#444;\n\
+        \    border-radius:4px;\n    margin-top:8px;\n    overflow:hidden;\n}\n\n\
+        .strength div{\n    height:100%;\n    width:0%;\n    transition:.3s;\n}\n\n\
+        /* MOBILE */\n\n@media (max-width:480px){\n\n.premium-form{\n    padding:20px;\n\
+        }\n\n}\n\n</style>\n<!-- FIFU: meta tags for featured image (begin) -->\n\
+        <meta property=\"og:image\" content=\"https://image.tmdb.org/t/p/w500/owTRRXuxpJT5n68IddsvDtAeK6K.jpg\"\
+        \ />\n<!-- FIFU: meta tags for featured image (end) --><meta name=\"twitter:image\"\
+        \ content=\"https://image.tmdb.org/t/p/w500/owTRRXuxpJT5n68IddsvDtAeK6K.jpg\"\
+        \ /><style>\n\n/* remove fundo normal, ativo e hover do logo */\n.simple-grid-primary-nav-menu\
+        \ > li.menu-logo-item > a,\n.simple-grid-primary-nav-menu > li.menu-logo-item\
+        \ > a:hover,\n.simple-grid-primary-nav-menu > li.menu-logo-item.current-menu-item\
+        \ > a{\n    background:none !important;\n}\n\n/* ===================================================\n\
+        \   MOBILE\n   =================================================== */\n\n\
+        @media only screen and (max-width:812px){\n\n    /* ESCONDER LOGO NO MENU\
+        \ MOBILE */\n    .simple-grid-primary-nav-menu > li.menu-logo-item{\n    \
+        \    display:none !important;\n    }\n\n}\n\n</style>\n    <style type=\"\
+        text/css\">\r\n            .simple-grid-site-title, .simple-grid-site-title\
+        \ a, .simple-grid-site-description {color: #ffffff;}\r\n        </style>\r\
+        \n    <style type=\"text/css\" id=\"custom-background-css\">\nbody.custom-background\
+        \ { background-color: #333333; }\n</style>\n\t<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"32x32\" />\n<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"192x192\" />\n<link rel=\"apple-touch-icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n<meta name=\"msapplication-TileImage\" content=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n</head>\t\n\t\n\t\n<body class=\"wp-singular post-template-default single\
+        \ single-post postid-729753 single-format-standard custom-background wp-custom-logo\
+        \ wp-theme-simple-grid simple-grid-animated simple-grid-fadein simple-grid-theme-is-active\
+        \ simple-grid-custom-logo-active simple-grid-layout-type-full simple-grid-masonry-inactive\
+        \ simple-grid-float-grid simple-grid-responsive-grid-details simple-grid-layout-c-s1\
+        \ simple-grid-header-banner-active simple-grid-tagline-inactive simple-grid-logo-above-title\
+        \ simple-grid-primary-menu-active simple-grid-primary-mobile-menu-active simple-grid-secondary-mobile-menu-active\
+        \ simple-grid-primary-social-icons\" id=\"simple-grid-site-body\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/WebPage\">\n<a class=\"skip-link\
+        \ screen-reader-text\" href=\"#simple-grid-content-wrapper\">Skip to content</a>\n\
+        \n\n\n<div class=\"simple-grid-site-header simple-grid-container\" id=\"simple-grid-header\"\
+        \ itemscope=\"itemscope\" itemtype=\"http://schema.org/WPHeader\" role=\"\
+        banner\">\n<div class=\"simple-grid-head-content simple-grid-clearfix\" id=\"\
+        simple-grid-head-content\">\n\n<div class=\"simple-grid-no-header-content\"\
+        >\n              <p class=\"simple-grid-site-title\"><a href=\"https://legendei.net/\"\
+        \ rel=\"home\">Legendei</a></p>\r\n                </div>\n\n</div><!--/#simple-grid-head-content\
+        \ -->\n</div><!--/#simple-grid-header -->\n\n\n\n<div class=\"simple-grid-container\
+        \ simple-grid-primary-menu-container simple-grid-clearfix\">\n<div class=\"\
+        simple-grid-primary-menu-container-inside simple-grid-clearfix\">\n<nav class=\"\
+        simple-grid-nav-primary\" id=\"simple-grid-primary-navigation\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/SiteNavigationElement\" role=\"navigation\"\
+        \ aria-label=\"Primary Menu\">\n\t\n\t\n<div class=\"simple-grid-outer-wrapper\"\
+        >\n<a href=\"/\" class=\"logo-mobile-inline\">\n<img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \nstyle=\"width:100%;height:auto;\">\n</a>\n\n<style>\n.logo-mobile-inline{\n\
+        display:none;\n}\n\n@media (max-width:812px){\n.logo-mobile-inline{\ndisplay:block;\n\
+        }\n}\n</style>\t\n\n\t\n<style>\n.mobile-header-icons{\n    display:none;\n\
+        }\n\n@media (max-width: 812px){\n\n.mobile-header-icons{\n    display:grid;\n\
+        \    grid-template-columns: 2fr 1fr 1fr;\n    gap:10px;\n    padding:10px;\n\
+        }\n\n/* BOT\xD5ES */\n.mobile-header-icons a,\n.mobile-header-icons .cat-toggle{\n\
+        \    display:flex;\n    align-items:center;\n    justify-content:center;\n\
+        \    gap:6px;\n    background:#141414;\n    padding:8px 6px;\n    border-radius:8px;\n\
+        \    color:#fff;\n    font-size:12px;\n    text-decoration:none;\n    text-align:center;\n\
+        \    cursor:pointer;\n}\n\n/* CATEGORIA */\n.cat-toggle{\n    font-weight:600;\n\
+        }\n\n/* SETA */\n.cat-toggle .arrow{\n    transition:transform 0.3s ease;\n\
+        }\n\n/* SETA GIRADA */\n.cat-toggle.active .arrow{\n    transform:rotate(180deg);\n\
+        }\n\n/* HOVER */\n.mobile-header-icons a:hover,\n.mobile-header-icons .cat-toggle:hover{\n\
+        \    background:#1f1f1f;\n}\n\n/* CONTAINER */\n.cat-container{\n    position:relative;\n\
+        }\n\n/* DROPDOWN */\n.cat-list{\n    display:flex;\n    flex-direction:column;\n\
+        \    gap:6px;\n\n    position:absolute;\n    top:110%;\n    left:0;\n    width:100%;\n\
+        \n    background:#0f0f0f;\n    border-radius:8px;\n    padding:6px;\n    z-index:999;\n\
+        \n    opacity:0;\n    visibility:hidden;\n    transform:translateY(-5px);\n\
+        \    transition:all 0.25s ease;\n}\n\n/* ABERTO */\n.cat-container.open .cat-list{\n\
+        \    opacity:1;\n    visibility:visible;\n    transform:translateY(0);\n}\n\
+        \n/* ITENS */\n.cat-list a{\n    justify-content:flex-start;\n    font-size:14px;\n\
+        \    padding:10px;\n}\n\n}\n</style>\n\n\n<div class=\"mobile-header-icons\"\
+        >\n\n    <!-- CATEGORIAS -->\n    <div class=\"cat-container\">\n        <div\
+        \ class=\"cat-toggle\">\n            \U0001F4C2 Categorias <span class=\"\
+        arrow\">\u25BC</span>\n        </div>\n\n        <div class=\"cat-list\">\n\
+        \            <a href=\"/category/destaques/\">\u2B50 Destaques</a>\n     \
+        \       <a href=\"/category/filmes/\">\U0001F3AC Filmes</a>\n            <a\
+        \ href=\"/category/serie/\">\U0001F4FA S\xE9ries</a>\n            <a href=\"\
+        /category/pack-de-legendas/\">\U0001F4E6 Packs</a>\n        </div>\n    </div>\n\
+        \n    \n        <a href=\"/seja-premium-vitalicio/\"><i class=\"fa-solid fa-crown\"\
+        ></i> Premium</a>\n\n        <a href=\"/login/\"><i class=\"fa-solid fa-key\"\
+        ></i> Login</a>\n\n    \n</div>\n\n<script>\ndocument.addEventListener(\"\
+        DOMContentLoaded\", function(){\n\n    const container = document.querySelector(\"\
+        .cat-container\");\n    const toggle = document.querySelector(\".cat-toggle\"\
+        );\n\n    toggle.addEventListener(\"click\", function(e){\n        e.stopPropagation();\n\
+        \        container.classList.toggle(\"open\");\n        toggle.classList.toggle(\"\
+        active\");\n    });\n\n    document.addEventListener(\"click\", function(e){\n\
+        \        if(!container.contains(e.target)){\n            container.classList.remove(\"\
+        open\");\n            toggle.classList.remove(\"active\");\n        }\n  \
+        \  });\n\n});\n</script>\t\n\t\n<ul id=\"simple-grid-menu-primary-navigation\"\
+        \ class=\"simple-grid-primary-nav-menu simple-grid-menu-primary\"><li id=\"\
+        menu-item-673170\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-673170 menu-logo-item\">\n        <a href=\"https://legendei.net/\"\
+        \ style=\"\n            display:flex;\n            align-items:center;\n \
+        \           justify-content:center;\n            height:100%;\n          \
+        \  padding:0;\n            margin:0;\n            line-height:1;\n       \
+        \ \">\n            <img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \n                      alt=\"Legendei.NET\"\n                      style=\"\
+        height:42px;width:auto;display:block;\">\n        </a></li>\n\n<li id=\"menu-item-673168\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category current-post-ancestor\
+        \ current-menu-parent current-post-parent menu-item-673168\"><a href=\"https://legendei.net/category/destaques/\"\
+        \ title=\"Legendas em Destaque\">DESTAQUES</a></li>\n<li id=\"menu-item-673167\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673167\"\
+        ><a href=\"https://legendei.net/category/filmes/\" title=\"Legendas para Filmes\"\
+        >Filmes</a></li>\n<li id=\"menu-item-673166\" class=\"menu-item menu-item-type-taxonomy\
+        \ menu-item-object-category current-post-ancestor current-menu-parent current-post-parent\
+        \ menu-item-673166\"><a href=\"https://legendei.net/category/serie/\" title=\"\
+        Legendas para seriados\">S\xC9RIES</a></li>\n<li id=\"menu-item-673169\" class=\"\
+        menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673169\"\
+        ><a href=\"https://legendei.net/category/pack-de-legendas/\" title=\"Pack\
+        \ de legendas\">PACKS</a></li>\n<li id=\"menu-item-731144\" class=\"menu-item\
+        \ menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-731144\"\
+        ><a target=\"_blank\" href=\"/aplicativos/\">RECOMENDAMOS</a>\n<ul class=\"\
+        sub-menu\">\n\t<li id=\"menu-item-673172\" class=\"menu-item menu-item-type-custom\
+        \ menu-item-object-custom menu-item-673172\"><a target=\"_blank\" href=\"\
+        /aplicativos/\" title=\"Programas para windows\">APLICATIVOS</a></li>\n\t\
+        <li id=\"menu-item-687662\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-687662\"><a target=\"_blank\" href=\"https://4kxxx.vip/\" title=\"\
+        Baixe os melhores v\xEDdeos porn\xF4 sempre em 4K\">4K XXX</a></li>\n\t<li\
+        \ id=\"menu-item-717497\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-717497\"><a target=\"_blank\" href=\"https://detonaplay.com/\"\
+        >GAMES</a></li>\n</ul>\n</li>\n\n\n\n<li class=\"menu-item\" style=\"float:right;\"\
+        >\n            <a href=\"/login/\"\n               style=\"background:linear-gradient(135deg,#198754,#20ac6b);color:#ffffff;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-key\"></i> Login\n            </a>\n\
+        \        </li><li class=\"menu-item\" style=\"float:right;\">\n          \
+        \  <a href=\"/seja-premium-vitalicio/\"\n\t\t\t\t\t  style=\"background:linear-gradient(135deg,#f4c430,#c2940a);color:#4d2e00;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-crown\"></i> Membro Premium\n  \
+        \          </a>\n        </li></ul>    </div>\n</nav>\n</div>\n</div>\n\n\t\
+        \n\t\n\r\n<div class=\"simple-grid-outer-wrapper\">\r\n<div class=\"simple-grid-top-wrapper-outer\
+        \ simple-grid-clearfix\">\r\n<div class=\"simple-grid-featured-posts-area\
+        \ simple-grid-top-wrapper simple-grid-clearfix\">\r\n\r\n<div id=\"search-5\"\
+        \ class=\"simple-grid-main-widget widget simple-grid-widget-box widget_search\"\
+        ><div class=\"simple-grid-widget-box-inside\"><form role=\"search\" method=\"\
+        get\" class=\"simple-grid-search-form\" action=\"https://legendei.net/\">\n\
+        <label>\n    <span class=\"simple-grid-sr-only\">Pesquisar por </span>\n \
+        \   <input \n        type=\"search\"\n        class=\"simple-grid-search-field\"\
+        \n        placeholder=\"Pesquisar &hellip;\"\n        value=\"\"\n       \
+        \ name=\"s\"\n        minlength=\"3\"\n\t\tmaxlength=\"50\"   \n        required\n\
+        \    />\n</label>\n<input type=\"submit\" class=\"simple-grid-search-submit\"\
+        \ value=\"&#xf002;\" />\n</form></div></div></div>\r\n</div>\r\n</div>\r\n\
+        \r\n\n<div class=\"simple-grid-outer-wrapper\" id=\"simple-grid-wrapper-outside\"\
+        >\n\n<div class=\"simple-grid-container simple-grid-clearfix\" id=\"simple-grid-wrapper\"\
+        >\n<div class=\"simple-grid-content-wrapper simple-grid-clearfix\" id=\"simple-grid-content-wrapper\"\
+        >\t\n\t\t\n\n\n<div class=\"simple-grid-main-wrapper simple-grid-clearfix\"\
+        \ id=\"simple-grid-main-wrapper\" itemscope=\"itemscope\" itemtype=\"http://schema.org/Blog\"\
+        \ role=\"main\">\n<div class=\"theiaStickySidebar\">\n<div class=\"simple-grid-main-wrapper-inside\
+        \ simple-grid-clearfix\">\n\n\r\n\r\n\n<div class=\"simple-grid-posts-wrapper\"\
+        \ id=\"simple-grid-posts-wrapper\">\n\n\n\n\n\n<div style=\"width: 100%; border-radius:\
+        \ 12px; box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 12px; padding: 15px; background:\
+        \ #ffffff;\">\n    <center>\n    <article id=\"post-729753\" class=\"simple-grid-post-singular\
+        \ simple-grid-box post-729753 post type-post status-publish format-standard\
+        \ hentry category-destaques category-serie tag-lancamentos tag-legendado-portugues\
+        \ tag-legendas-the-bad-guys-breaking-in tag-legendas-the-bad-guys-breaking-in-s01\
+        \ tag-series-legendadas tag-series-populares wpcat-8225-id wpcat-4-id\">\n\
+        \        <div class=\"simple-grid-box-inside\">\n            \n          \
+        \  \n                            <header class=\"entry-header\">\n       \
+        \             <div class=\"entry-header-inside simple-grid-clearfix\">\n\n\
+        <h1 class=\"post-title entry-title\"><i class=\"fa-solid fa-star fa-beat\"\
+        \ style=\"color:#f39c12;\"></i> Legenda The Bad Guys Breaking In S01E01 1080p\
+        \ WEB h264 DOLORES <span aria-label=\"PT-BR\">\U0001F1E7\U0001F1F7</span></h1>\n\
+        \n\n                                    <div class=\"simple-grid-entry-meta-single\"\
+        >\n                            <span class=\"simple-grid-entry-meta-single-date\"\
+        >\n                <i class=\"far fa-clock\" aria-hidden=\"true\"></i>&nbsp;14\
+        \ de janeiro de 2026            </span>\n                                \
+        \    <span class=\"simple-grid-entry-meta-single-categories\"><i class=\"\
+        far fa-folder-open\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Posted in </span><a href=\"https://legendei.net/category/destaques/\" rel=\"\
+        category tag\">Destaques</a>, <a href=\"https://legendei.net/category/serie/\"\
+        \ rel=\"category tag\">S\xE9ries TV</a></span>                           \
+        \ </div>\n    \n\n                    </div>\n                </header>\n\
+        \            \t\t\t\n\t\t\t\n            <!-- inicio poster -->\n        \
+        \    <img src=\"https://image.tmdb.org/t/p/w500/owTRRXuxpJT5n68IddsvDtAeK6K.jpg\"\
+        \ style=\"max-width:220px;width:330px;height:auto;margin-bottom:5px;\" alt=\"\
+        The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES\">            <!--\
+        \ fim poster -->\n\t\t\t\n<!-- S admin -->\n            \t\t\t\n<!-- S admin\
+        \ -->\t\n\t\t\t\n            \n            <div class=\"entry-content simple-grid-clearfix\"\
+        >\n\n<!-- N PREMIUM AMIN TEMP -->\t\t\t\t\n\t\n\n   <a href=\"https://cuponei.org/promo/more/\"\
+        \ target=\"_blank\" rel=\"noopener\">\n    <img class=\"aligncenter wp-image-729595\
+        \ size-full\"\n         src=\"https://legendei.net/wp-content/uploads/2026/01/amazon.webp\"\
+        \n         width=\"350\" height=\"334\" />\n  </a>\t\n\t\t\t\t\t\t\t\t\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\t\t\t\t\n<!-- anexos otimizados -->\n<!--\
+        \ /anexos -->\n\n\n                <!-- WP Attachments -->\n        <div style=\"\
+        width:100%;margin:10px 0 10px 0;\">\n            <h3></h3>\n        <ul class=\"\
+        post-attachments\"><p class=\"post-attachment mime-application-zip\">    \
+        \                                                                        \
+        \    <a href=\"https://legendei.net/the-bad-guys-breaking-in-s01e01-1080p-web-h264-dolores/?download=729751\"\
+        \ target=\"_blank\" class=\"buttonmyup\"><i class=\"fa fa-download\"></i>\
+        \ BAIXAR LEGENDA</a>\r\n</p></ul></div><div class=\"highlight-text-sinopse\"\
+        >\n<p>Legenda da s\xE9rie The Bad Guys: Breaking In (2025) Os Caras Malvados\
+        \ No Peda\xE7o \u2014 Como \xE9 que os Caras Malvados acabaram ficando malvados?\
+        \ Esta s\xE9rie hil\xE1ria ambientada antes dos filmes conta a hist\xF3ria\
+        \ inteira.</p>\n</div>\n\n        <div class=\"highlight-text\">\n\n<style>\n\
+        /* ===================================== */\n/* LINKS COM BORDA GRADIENTE\
+        \ + UNDERLINE */\n/* ===================================== */\n\n.busca-legenda-links\
+        \ a{\n    display:inline-block;\n    padding:8px 18px;\n    margin:2px 8px;\n\
+        \    font-weight:400;\n    font-size:14px;\n    text-decoration:none !important;\n\
+        \tmin-width: 180px;\n    color:#1e293b !important; /* texto escuro vis\xED\
+        vel */\n    background:transparent;\n\n    border:2px solid transparent;\n\
+        \    border-radius:6px;\n\n    /* borda gradiente */\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin:border-box;\n    background-clip:padding-box, border-box;\n\
+        \n    position:relative;\n    transition:all .25s ease;\n}\n\n/* underline\
+        \ gradiente (embaixo do texto) */\n.busca-legenda-links a::after{\n    content:\"\
+        \";\n    position:absolute;\n    left:50%;\n    bottom:6px; /* dentro do bot\xE3\
+        o */\n    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\n\n/*\
+        \ hover */\n.busca-legenda-links a:hover{\n    color:#002080 !important;\n\
+        }\n\n.busca-legenda-links a:hover::after{\n    width:60%;\n}\n\n/* ativo (se\
+        \ quiser usar classe active depois) */\n.busca-legenda-links a.active::after{\n\
+        \    width:60%;\n}\n\n@media (max-width: 768px){\n\n    .busca-legenda-links{\n\
+        \        display:block;\n    }\n\n    /* remove os pontinhos separadores no\
+        \ mobile */\n    .busca-legenda-links span{\n        display:none;\n    }\n\
+        \n    .busca-legenda-links a{\n        display:block;\n        width:100%;\n\
+        \        margin:6px 0; /* controla espa\xE7amento vertical */\n        text-align:center;\n\
+        \t\tfont-size:14px;\n    }\n\n\n}\n</style>\n\n\n\n            <p><strong>Legenda\
+        \ Oficial da s\xE9rie The Bad Guys Breaking In S01E01 1080p WEB h264 DOLORES</strong></p>\n\
+        \            <hr>\n\n            <p>Todas as legendas dispon\xEDveis para\
+        \ download s\xE3o testadas e verificadas, garantindo sincronia, precis\xE3\
+        o e qualidade.</p>\n\n            <p>Depois de baixar a legenda, n\xE3o se\
+        \ esque\xE7a de conferir o seu release!</p>\n\n            <div class=\"busca-legenda-links\"\
+        >\n                <a href=\"/category/serie/?s=The+Bad+Guys+Breaking+In\"\
+        >+ legendas mesma s\xE9rie</a><a href=\"/category/serie/?s=The+Bad+Guys+Breaking+In+S01\"\
+        >+ legendas mesma temporada</a><span>\xB7</span><a href=\"/category/serie/?s=The+Bad+Guys+Breaking+In+S01E01\"\
+        >+ legendas mesmo epis\xF3dio</a>\n            </div>\n\n        </div>\n\t\
+        \t\n\n\t\t\n\t\t\n                <!-- sinopse TMDB -->\n                <!--\
+        \ /sinopse -->\n\n            </div><!-- .entry-content -->\n\n          \
+        \  \n            \n        </div>\n\n\n\n\t\t\n    </article>\n\n<!-- inicio\
+        \ app recomendados -->\t\t\n<div id=\"apps-recomendados\">\n<div class=\"\
+        busca-legenda-links\" style=\"text-align:center;\">\n<h5>Aplicativos que usamos\
+        \ e recomendamos</h5>\n\n<a href=\"https://legendei.net/aplicativos/kodi/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2025/11/Kodi_21.3.webp\"\
+        \ width=\"40\" height=\"40\" />\n    Kodi Media Center\n</a>\n\n<a href=\"\
+        https://legendei.net/aplicativos/utorrent-pro-download-e-guia-completo/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/08/uTorrent-Pro.jpg\"\
+        \ width=\"40\" height=\"40\" />\n    uTorrent Pro\n</a>\n\n<a href=\"https://legendei.net/aplicativos/winzip-pro-windows/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/09/WinZip-Pro.png\"\
+        \ width=\"40\" height=\"40\" />\n    WinZip Pro\n</a>\n</div>\n</div>\n<style>\n\
+        @media (max-width: 812px){\n    #apps-recomendados{\n        display: none;\n\
+        \    }\n}\n</style>\n<!-- fim app recomendados -->\n\t\t\n<span class=\"simple-grid-entry-meta-single-tags\"\
+        ><i class=\"fas fa-tags\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Tagged </span><a href=\"https://legendei.net/tag/lancamentos/\" rel=\"tag\"\
+        >Lan\xE7amentos</a>, <a href=\"https://legendei.net/tag/legendado-portugues/\"\
+        \ rel=\"tag\">Legendado Portugu\xEAs</a>, <a href=\"https://legendei.net/tag/legendas-the-bad-guys-breaking-in/\"\
+        \ rel=\"tag\">Legendas The Bad Guys Breaking In</a>, <a href=\"https://legendei.net/tag/legendas-the-bad-guys-breaking-in-s01/\"\
+        \ rel=\"tag\">Legendas The Bad Guys Breaking In S01</a>, <a href=\"https://legendei.net/tag/series-legendadas/\"\
+        \ rel=\"tag\">S\xE9ries Legendadas</a>, <a href=\"https://legendei.net/tag/series-populares/\"\
+        \ rel=\"tag\">S\xE9ries Populares</a></span>\n\t\t\n\t\t\n\n\t\t\n<hr>\n<div\
+        \ class=\"lrl-report-link\">\n    <a href=\"#\" class=\"lrl-open busca-legenda-links\"\
+        >\U0001F6A8 Reportar problemas \U0001F6A8</a>\n\t</div>\n\n    <div id=\"\
+        lrl-modal\" style=\"display:none;\">\n        <div class=\"lrl-box\">\n  \
+        \          <span class=\"lrl-close\">&times;</span>\n            <h3>Qual\
+        \ \xE9 o problema?</h3><hr>\n\n<label><input type=\"radio\" name=\"lrl_motivo\"\
+        \ value=\"Problemas com o download\"> O download n\xE3o funciona</label><br><br>\n\
+        \n<label><input type=\"radio\" name=\"lrl_motivo\" value=\"Legenda para o\
+        \ filme ou s\xE9rie incorreta\"> Conte\xFAdo \xE9 para outro filme, s\xE9\
+        rie ou epis\xF3dio</label><br><br>\n\n<label><input type=\"radio\" name=\"\
+        lrl_motivo\" value=\"Idioma da legenda incorreto\"> O idioma da legenda est\xE1\
+        \ errado.</label><br><br>\n<hr>\n            <button id=\"lrl-send\" disabled>Enviar</button>\n\
+        \        </div>\n    </div>\n    \t\t\n    </center>\n\t\n</div>\n\n\t\n\t\
+        \n\t\n\t\n\n<!-- S admin -->\t\n<!-- S admin -->\t\n\n\n\t\n<!-- N PREMIUM\
+        \ AMIN TEMP -->\n<div>\t\n<!-- protetor de links -->\n<script>\n(function(){\n\
+        \nconst redirectpage = \"https://legendei.net/noticia.php\";\n\nconst bases\
+        \ = [\n    '/?download=',\n    '/?dl_',\n    '.rar',\n    '.zip',\n    '.srt',\n\
+        \    'magnet:',\n\t'/zip-attachments.php'\n];\n\ndocument.querySelectorAll('a').forEach(a\
+        \ => {\n    const href = a.getAttribute('href') || '';\n\n    if (bases.some(b\
+        \ => href.includes(b))) {\n\n        const token = btoa(href);\n\n       \
+        \ a.href = redirectpage + \"?token=\" + token;\n        a.target = \"_blank\"\
+        ;\n    }\n});\n\n})();\n</script>\n<!-- /protetor de links -->\t\n\t\t\n\n\
+        <!-- BLOQUEADOR LEGENDEI -->\n\n<!-- BLOQUEADOR LEGENDEI -->\n\t\n<!-- inicio\
+        \ reload -->\n<script>\nsetInterval(function(){\n  location.reload();\n},\
+        \ 120000); // 2 minutos\n</script>\n<!-- fim reload -->\t\n\t\n</div>\t\n\
+        <!-- N PREMIUM AMIN TEMP -->\n\t\n\t\n<div class=\"clear\"></div>\n</div><!--/#simple-grid-posts-wrapper\
+        \ -->\n\n\r\n\r\n\t\n\n</div>\n</div>\n</div><!-- /#simple-grid-main-wrapper\
+        \ -->\n\n\n\n</div>\n\n\n\n\n<!-- N ADMIN -->\n<div>\n<!-- inicio -->\n<iframe\
+        \ \n  src=\"https://cuponei.org/last/\"\n  style=\"\n    width:1px;\n    height:1px;\n\
+        \    opacity:0;\n    border:none;\n    overflow:hidden;\n  \"\n  scrolling=\"\
+        no\"\n></iframe>\n<!-- fim -->\t\n</div>\n<!-- N ADMIN -->\n\n\n\n\n<!-- N\
+        \ PREMIUM AMIN TEMP -->\n\n\n\n\n<div>\n\n\t\n<!-- =============================\
+        \ -->\n<!-- SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\n\n<div id=\"SCRIPT_1_AQUI\" style=\"display:none;\">\t\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/invesup.js\"></script>\n<script\
+        \ type=\"text/javascript\">\n// make pop on new window with size 150x150 \
+        \ \nLight.Popup.create('https://cuponei.org/promo/more/', {width: 150, height:\
+        \ 150, onNewTab: false});\n// refresh = new popup\nLight.Popup.create('https://cuponei.org/promo/more/amz/',\
+        \ {alwaysPop: false});  \n</script>\n</div>\t\n\n<div id=\"SCRIPT_2_AQUI\"\
+        \ style=\"display:none;\">\n\t\n<script type=\"text/javascript\">\n var p$00a\
+        \ = 'p$00a' + (new Date().getTime()) + 'zz'; window[p$00a] = {a:'abcdefghijklmnopqrstuvwxyz0123456789i0xpy5jn7r6h82fuw1skdgzca94e3omqvblt',\
+        \ b:'{\"AZIb\":\"e344vq\", \"BVIb\":\"b4mm4e\", \"CXrr1\":\"du\", \"DLtag\"\
+        :\"e\", \"Emjk5\":\"\", \"XCge1s\":\"u.g7fz1yh.xf8\" , \"Zt1\":\"ufuxisn.2yk\"\
+        , \"ZZ1\":\"u.nn8fu.xhfdp\" }', c:'{\"Abkr221\":\"sx17uk\", \"Bo9ssm\":\"\
+        //xp2.g7fz1yh.xf8/iuu.rs\"}', d:'{\"Ag4\":\"0fpa\", \"Bx1\":\"iuuy2pCn7hp\"\
+        , \"Cky\":\"s1x\", \"Dmg\":\"x1yikyEhy8y2k\"}'};\nvar _0x5d4b=['235913QVfbwv','slice','length','162209QBmAmV','14238hyOOTq','323207DTbifh','split','1DqiKtq','135866HTbavB','indexOf','call','27654SKXHbY','parse','undefined','32Ijckmz','keys','map','ceil','115980hcFVDy','values','join'];var\
+        \ _0x208c=function(_0x31a8d7,_0x5f36b3){_0x31a8d7=_0x31a8d7-0x167;var _0x5d4be1=_0x5d4b[_0x31a8d7];return\
+        \ _0x5d4be1;};(function(_0x276f94,_0x57c4ff){var _0x50057c=_0x208c;while(!![]){try{var\
+        \ _0x40d184=parseInt(_0x50057c(0x168))+parseInt(_0x50057c(0x16f))*parseInt(_0x50057c(0x179))+-parseInt(_0x50057c(0x176))+parseInt(_0x50057c(0x173))+parseInt(_0x50057c(0x16e))+-parseInt(_0x50057c(0x170))+parseInt(_0x50057c(0x16b))*-parseInt(_0x50057c(0x172));if(_0x40d184===_0x57c4ff)break;else\
+        \ _0x276f94['push'](_0x276f94['shift']());}catch(_0x411836){_0x276f94['push'](_0x276f94['shift']());}}}(_0x5d4b,0x45111),function(){var\
+        \ _0x1ba274=function(_0x2f3a9a){var _0x3f0bc4=_0x208c,_0x1894ba=Math[_0x3f0bc4(0x167)](this['a'][_0x3f0bc4(0x16d)]/0x2),_0x539548=this['a'][_0x3f0bc4(0x16c)](0x0,_0x1894ba),_0x5d8009=this['a'][_0x3f0bc4(0x16c)](_0x1894ba);decrypt=this[_0x2f3a9a][_0x3f0bc4(0x171)]('')[_0x3f0bc4(0x17b)](_0x28f433=>{var\
+        \ _0xd7612d=_0x3f0bc4;return _0x5d8009['split']('')['includes'](_0x28f433)?_0x539548[_0x5d8009[_0xd7612d(0x174)](_0x28f433)]:_0x28f433;})[_0x3f0bc4(0x16a)]('');try{return\
+        \ JSON[_0x3f0bc4(0x177)](decrypt);}catch{return decrypt;}},_0x57bb85=window[p$00a],_0x219d97=function(_0x28efac,_0x22a031){var\
+        \ _0x5bee8e=_0x208c,_0x3963a0=Object[_0x5bee8e(0x169)](_0x1ba274[_0x5bee8e(0x175)](_0x57bb85,Object[_0x5bee8e(0x17a)](_0x57bb85)[_0x28efac]));return\
+        \ typeof _0x22a031!=_0x5bee8e(0x178)?_0x3963a0[_0x22a031]:_0x3963a0;};window[p$00a]['x']=function(){return\
+        \ _0x219d97(0x1);};var _0xf1db57=document[_0x219d97(0x3,0x3)](_0x219d97(0x2,0x0));_0xf1db57[_0x219d97(0x3,0x2)]=_0x219d97(0x2,0x1),document[_0x219d97(0x3,0x0)][_0x219d97(0x3,0x1)](_0xf1db57),p$00a=undefined;}());\n\
+        \ \n </script>\n\t\n<script type=\"text/javascript\" src=\"https://legendei.net/invesup.js\"\
+        ></script>\n<script type=\"text/javascript\">\n// make pop on new window with\
+        \ size 150x150  \nLight.Popup.create('https://legendei.net/terrabanne/', {width:\
+        \ 150, height: 150, onNewTab: false}); \n// refresh = new popup\nLight.Popup.create('https://legendei.net/terrabanne/',\
+        \ {alwaysPop: true}); \t\n</script>\t\n\t\n</div>\n\n<!-- =============================\
+        \ -->\n<!-- / SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\t\n\t\n<script>\n(function(){\n\nconst path = window.location.pathname;\n\
+        \nwindow.__CUPONEI_DISABLE_ALL = (\n  path.startsWith('/seja-premium-vitalicio')\
+        \ ||\n  path.startsWith('/perfil')\n);\n\nif (window.__CUPONEI_DISABLE_ALL)\
+        \ return;\n\n/* evita bots */\nif (/bot|googlebot|crawler|spider|crawling/i.test(navigator.userAgent))\
+        \ return;\n\nconst isExpiredUser = false;\n\nconst BLOCK_TIME = 1 * 60 * 60\
+        \ * 1000;\nconst STORAGE_KEY = 'premium_popup_blocked_until';\nconst TRIGGER_DELAY\
+        \ = 1000;\n\nlet adsStarted = false;\n\n/* ============================= */\n\
+        /* CONTROLE TEMPO                */\n/* ============================= */\n\
+        \nfunction now(){\n    return Date.now();\n}\n\nfunction isBlocked(){\n  \
+        \  const until = localStorage.getItem(STORAGE_KEY);\n    return until && now()\
+        \ < parseInt(until);\n}\n\nfunction blockPopup(){\n    localStorage.setItem(STORAGE_KEY,\
+        \ now() + BLOCK_TIME);\n}\n\n/* ============================= */\n/* EXECU\xC7\
+        \xC3O SEGURA DOS SCRIPTS   */\n/* ============================= */\n\nfunction\
+        \ executeScriptsFromDiv(divId, callback){\n\n    if (window.__CUPONEI_DISABLE_ALL){\n\
+        \        if(callback) callback();\n        return;\n    }\n\n    const container\
+        \ = document.getElementById(divId);\n    if(!container){\n        if(callback)\
+        \ callback();\n        return;\n    }\n\n    const scripts = container.querySelectorAll(\"\
+        script\");\n    let total = scripts.length;\n    let loaded = 0;\n\n    if(total\
+        \ === 0){\n        if(callback) callback();\n        return;\n    }\n\n  \
+        \  scripts.forEach(oldScript => {\n\n        const newScript = document.createElement(\"\
+        script\");\n\n        for (let attr of oldScript.attributes) {\n         \
+        \   newScript.setAttribute(attr.name, attr.value);\n        }\n\n        if(oldScript.src){\n\
+        \n            newScript.onload = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n            newScript.onerror = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n        } else {\n            newScript.text = oldScript.text;\n\
+        \            loaded++;\n        }\n\n        document.body.appendChild(newScript);\n\
+        \n        if(!oldScript.src){\n            if(loaded === total && callback)\
+        \ callback();\n        }\n\n    });\n\n}\n\n/* =============================\
+        \ */\n/* SEQU\xCANCIA DOS AN\xDANCIOS        */\n/* =============================\
+        \ */\n\nfunction runAds(){\n\n    if (window.__CUPONEI_DISABLE_ALL) return;\n\
+        \    if (adsStarted) return;\n\n    adsStarted = true;\n\n    let clickCount\
+        \ = 0;\n    let script2Executed = false;\n\n    function handleUserClick(){\n\
+        \n        clickCount++;\n\n        // Debug opcional\n        // console.log(\"\
+        Cliques:\", clickCount);\n\n        if(clickCount >= 2 && !script2Executed){\n\
+        \n            script2Executed = true;\n\n            document.removeEventListener(\"\
+        click\", handleUserClick, true);\n            document.removeEventListener(\"\
+        touchstart\", handleUserClick, true);\n\n            executeScriptsFromDiv(\"\
+        SCRIPT_2_AQUI\");\n        }\n    }\n\n    // Executa SCRIPT 1 primeiro\n\
+        \    setTimeout(function(){\n\n        executeScriptsFromDiv(\"SCRIPT_1_AQUI\"\
+        , function(){\n\n            // S\xF3 depois que SCRIPT 1 foi carregado\n\
+        \            document.addEventListener(\"click\", handleUserClick, {capture:true});\n\
+        \            document.addEventListener(\"touchstart\", handleUserClick, {capture:true});\n\
+        \n        });\n\n    }, 1000);\n\n}\n\n/* ============================= */\n\
+        /* POPUP PREMIUM                 */\n/* ============================= */\n\
+        \nfunction createPopup(){\n\nif(isBlocked()){\n    runAds();\n    return;\n\
+        }\n\nconst popup=document.createElement('div');\npopup.id='premium-popup';\n\
+        \npopup.innerHTML = isExpiredUser ? `\n\n<div class=\"premium-overlay\"></div>\n\
+        <div class=\"premium-box\">\n\n<div class=\"premium-text\">\n\U0001F614 Seu\
+        \ per\xEDodo de teste terminou!<br><br>\n<strong>Voc\xEA pode ser Membro Premium\
+        \ Vital\xEDcio para sempre fazendo uma \xFAnica doa\xE7\xE3o.</strong>\n</div>\n\
+        \n<div class=\"premium-actions\">\n<a href=\"/perfil/\" class=\"premium-yes\"\
+        >\U0001F525 QUERO SER PREMIUM \U0001F525</a>\n<p class=\"premium-nope\">CONTINUAR\
+        \ COM AN\xDANCIOS</p>\n</div>\n\n</div>\n\n` : `\n\n<div class=\"premium-overlay\"\
+        ></div>\n<div class=\"premium-box\">\n\n<div class=\"premium-text\">\n<i class=\"\
+        fa-solid fa-heart fa-beat\"></i>\nApoie a Legendei.NET e torne-se Membro Premium\
+        \ Vital\xEDcio agora para navegar sem an\xFAncios e desbloquear recursos exclusivos!\n\
+        <br>\n</div>\n\n<div class=\"premium-actions\">\n<a href=\"/seja-premium-vitalicio/\"\
+        \ class=\"premium-yes\">\U0001F525 FA\xC7A UM TESTE GRATUITO \U0001F525</a>\n\
+        <p class=\"premium-nope\">CONTINUAR COM AN\xDANCIOS</p>\n<a href=\"/login/\"\
+        \ class=\"premium-login\">J\xE1 tenho uma conta e quero conectar</a>\n</div>\n\
+        \n</div>\n\n`;\n\ndocument.body.appendChild(popup);\n\npopup.querySelector('.premium-nope').onclick=function(e){\n\
+        \ne.preventDefault();\n\nblockPopup();\nrunAds();\n\npopup.remove();\n\n};\n\
+        \n}\n\nlet triggered=false;\n\nfunction triggerPopup(){\n\nif(triggered) return;\n\
+        \ntriggered=true;\n\nsetTimeout(createPopup,TRIGGER_DELAY);\n\nwindow.removeEventListener('mousemove',triggerPopup);\n\
+        window.removeEventListener('touchstart',triggerPopup);\n\n}\n\n/* =============================\
+        \ */\n/* DISPARADORES                  */\n/* =============================\
+        \ */\n\nwindow.addEventListener('mousemove',triggerPopup,{passive:true});\n\
+        window.addEventListener('touchstart',triggerPopup,{passive:true});\n\ndocument.addEventListener('DOMContentLoaded',\
+        \ function(){\n\n    if(isBlocked()){\n        runAds();\n    }\n\n});\n\n\
+        })();\n</script>\n\n<style>\n/* ============================= */\n/* POPUP\
+        \ BASE */\n/* ============================= */\n#premium-popup{\n  position:fixed;\n\
+        \  inset:0;\n  z-index:999999;\n}\n\n.premium-overlay{\n  position:absolute;\n\
+        \  inset:0;\n  background:rgba(0,0,0,.65);\n}\n\n.premium-box{\n  position:absolute;\n\
+        \  left:50%;\n  top:50%;\n  transform:translate(-50%,-50%);\n  background:#212121;\n\
+        \  padding:28px 26px 26px;\n  max-width:440px;\n  width:92%;\n  border-radius:14px;\n\
+        \  text-align:center;\n}\n@media (max-width: 812px){\n  .premium-box{\n  \
+        \  top:5%;\n    transform:translate(-50%, 0);\n  }\n}\n\t\n/* inicio premium-login\
+        \ */\n.premium-login{\n  color:#fff;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  cursor:pointer;\n}\na.premium-login{\n    padding:8px 18px;\n}\na.premium-login::after{\n\
+        \    content:\"\";\n    position:absolute;\n    left:50%;\n    bottom:6px;\n\
+        \    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\na.premium-login:hover{\n\
+        \    color:#fff !important;\n}\n\na.premium-login:hover::after{\n    width:60%;\n\
+        }\n@media (max-width: 768px){\n    a.premium-login{\n        display:block;\n\
+        \        width:100%;\n        margin:6px 0;\n        text-align:center;\n\
+        \        font-size:14px;\n    }\n}\n/* fim premium-login */\n\n/* =============================\
+        \ */\n/* TEXTO */\n/* ============================= */\n.premium-text{\n \
+        \ color:#fff;\n  font-size:clamp(15px,2.6vw,18px);\n  line-height:1.4;\n \
+        \ font-family:Roboto,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;\n\
+        }\n\n.premium-text i{\n  color:#e74c3c;\n  margin-right:6px;\n}\n\n/* =============================\
+        \ */\n/* A\xC7\xD5ES */\n/* ============================= */\n.premium-actions{\n\
+        \  margin-top:18px;\n  display:flex;\n  flex-direction:column;\n  gap:12px;\n\
+        }\n\n/* ============================= */\n/* BOT\xD5ES */\n/* =============================\
+        \ */\n.alter{\n  background:#6f42c1;\n  border:2px solid #fff;\n  font-weight:bold;\n\
+        \  font-size:clamp(14px,2.6vw,16px);\n  color:#fff;\n  padding:10px 14px;\n\
+        \  border-radius:8px;\n  cursor:pointer;\n}\n\n.premium-yes{\n  background:#1e90ff;\n\
+        \  border:2px solid #FFF;\n  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  color:#fff;\n  padding:10px 14px;\n  border-radius:8px;\n  cursor:pointer;\n\
+        }\n\n.premium-nope{\n  background:#cc3300;\n  border:2px solid #FFF;\n  color:#fff;\n\
+        \  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n  padding:10px\
+        \ 14px;\n  border-radius:8px;\n  cursor:pointer;\n}\n\n/* =============================\
+        \ */\n/* HOVER / ACTIVE (-15%) */\n/* ============================= */\n.alter:hover,\n\
+        .alter:active,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-login:hover,\n\
+        .premium-login:active,\n.premium-nope:hover,\n.premium-nope:active{\n  filter:\
+        \ brightness(85%);\n}\n/* ============================= */\n/* TEXTO SEMPRE\
+        \ BRANCO (TODOS ESTADOS) */\n/* ============================= */\n.alter,\n\
+        .alter:visited,\n.alter:hover,\n.alter:active,\n.alter:focus,\n\n.premium-yes,\n\
+        .premium-yes:visited,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-yes:focus,\n\
+        \n.premium-login,\n.premium-login:visited,\n.premium-login:hover,\n.premium-login:active,\n\
+        .premium-login:focus,\n\n.premium-nope,\n.premium-nope:visited,\n.premium-nope:hover,\n\
+        .premium-nope:active,\n.premium-nope:focus{\n  color:#fff !important;\n  text-decoration:none;\n\
+        }\n/* ============================= */\n/* RESPONSIVO */\n/* =============================\
+        \ */\n/* Esconder em telas menores que 812px */\n@media (max-width: 812px){\n\
+        \  .alter{\n    display:none !important;\n  }\n}\n</style>\n\n</div>\n\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n</div><!--/#simple-grid-content-wrapper\
+        \ -->\n\n\n\n\n\n</div><!--/#simple-grid-wrapper -->\n\n\n\n\r\n\r\n\n\n\n\
+        \n\n\n<div class='simple-grid-clearfix' id='simple-grid-copyright-area'>\n\
+        \t\n<div class='simple-grid-copyright-area-inside simple-grid-container'>\n\
+        \t<a href=\"/\"><img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \ alt=\"\" width=\"300\" height=\"67\" class=\"aligncenter size-medium wp-image-747799\"\
+        \ /></a>\n<div class=\"simple-grid-outer-wrapper\">\t\n<center>\t\n<div class='simple-grid-copyright-area-inside-content\
+        \ simple-grid-clearfix'>\n  <p class='simple-grid-copyright'>Copyright \xA9\
+        \ 2016 - 2026 Legendei - Aqui Sai Primeiro</p>\n<p class='simple-grid-credit'><a\
+        \ href=\"https://legendei.net/\">Design by Legendei.NET</a></p>\n</div>\n\t\
+        </center>\n</div>\n</div>\n</div><!--/#simple-grid-copyright-area -->\n\n\n\
+        \n\n<button class=\"simple-grid-scroll-top\" title=\"Scroll to Top\"><i class=\"\
+        fas fa-arrow-up\" aria-hidden=\"true\"></i><span class=\"simple-grid-sr-only\"\
+        >Scroll to Top</span></button>\t\n\n\n\n\n\n<!-- Google tag (gtag.js) -->\n\
+        <script async src=\"https://www.googletagmanager.com/gtag/js?id=G-GX6PZNPM06\"\
+        ></script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function\
+        \ gtag(){dataLayer.push(arguments);}\n  gtag('js', new Date());\n\n  gtag('config',\
+        \ 'G-GX6PZNPM06');\n</script>\t\n\n\n\n\n\n<script type=\"speculationrules\"\
+        >\n{\"prefetch\":[{\"source\":\"document\",\"where\":{\"and\":[{\"href_matches\"\
+        :\"\\/*\"},{\"not\":{\"href_matches\":[\"\\/wp-*.php\",\"\\/wp-admin\\/*\"\
+        ,\"\\/wp-content\\/uploads\\/*\",\"\\/wp-content\\/*\",\"\\/wp-content\\/plugins\\\
+        /*\",\"\\/wp-content\\/themes\\/simple-grid\\/*\",\"\\/*\\\\?(.+)\"]}},{\"\
+        not\":{\"selector_matches\":\"a[rel~=\\\"nofollow\\\"]\"}},{\"not\":{\"selector_matches\"\
+        :\".no-prefetch, .no-prefetch a\"}}]},\"eagerness\":\"conservative\"}]}\n\
+        </script>\n\n<script>\nfunction attUploadProof(){\n\n    let fileInput = document.getElementById('att_proof');\n\
+        \    let msg = document.getElementById('att_upload_msg');\n\n    if(!fileInput.files.length){\n\
+        \        msg.innerHTML = '<span style=\"color:red;\">Selecione um arquivo</span>';\n\
+        \        return;\n    }\n\n    let file = fileInput.files[0];\n\n    if(file.size\
+        \ > 50 * 1024 * 1024){\n        msg.innerHTML = '<span style=\"color:red;\"\
+        >Arquivo maior que 50MB</span>';\n        return;\n    }\n\n    let formData\
+        \ = new FormData();\n    formData.append('action','att_upload_proof');\n \
+        \   formData.append('proof', file);\n\n    msg.innerHTML = 'Enviando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        body: formData\n    })\n    .then(r => r.json())\n    .then(res\
+        \ => {\n\n        if(res.success){\n            msg.innerHTML = '<span style=\"\
+        color:green;\">Comprovante enviado com sucesso!</span>';\n        } else {\n\
+        \            msg.innerHTML = '<span style=\"color:red;\">Erro: '+res.data+'</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<script>\nfunction attSaveLastName(){\n\
+        \n    let input = document.getElementById('att_last_name_input') \n      \
+        \       || document.getElementById('att_last_name_input2');\n\n    let msg\
+        \   = document.getElementById('att_name_msg') \n             || document.getElementById('att_name_msg2');\n\
+        \n    if(!input || !msg) return;\n\n    let value = input.value.trim();\n\n\
+        \    if(!value){\n        msg.innerHTML = '<span style=\"color:#f87171;\"\
+        >Digite o nome completo do titular da conta que ser\xE1 usada para a doa\xE7\
+        \xE3o</span>';\n        return;\n    }\n\n    msg.innerHTML = 'Salvando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        headers: {'Content-Type': 'application/x-www-form-urlencoded'},\n\
+        \        body: 'action=att_save_last_name&last_name=' + encodeURIComponent(value)\n\
+        \    })\n    .then(r => r.json())\n    .then(res => {\n\n        if(res.success){\n\
+        \            msg.innerHTML = '<span style=\"color:#22c55e;\">Salvo! Recarregando...</span>';\n\
+        \            setTimeout(()=>location.reload(),800);\n        } else {\n  \
+        \          msg.innerHTML = '<span style=\"color:#f87171;\">Erro ao salvar</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<style type=\"text/css\"> \n      \
+        \   /* Hide reCAPTCHA V3 badge */\n        .grecaptcha-badge {\n        \n\
+        \            visibility: hidden !important;\n        \n        }\n    </style><script\
+        \ type=\"text/javascript\" id=\"lrl-js-js-extra\">\n/* <![CDATA[ */\nvar lrlData\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"post_id\":\"729753\"};\n/* ]]> */\n</script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.js?ver=1.0\"\
+        \ id=\"lrl-js-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/jquery.fitvids.min.js\"\
+        \ id=\"fitvids-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/ResizeSensor.min.js\"\
+        \ id=\"ResizeSensor-js\"></script>\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-content/themes/simple-grid/assets/js/theia-sticky-sidebar.min.js\"\
+        \ id=\"theia-sticky-sidebar-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/navigation.js\"\
+        \ id=\"simple-grid-navigation-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/skip-link-focus-fix.js\"\
+        \ id=\"simple-grid-skip-link-focus-fix-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/imagesloaded.min.js?ver=5.0.0\"\
+        \ id=\"imagesloaded-js\"></script>\n<script type=\"text/javascript\" id=\"\
+        simple-grid-customjs-js-extra\">\n/* <![CDATA[ */\nvar simple_grid_ajax_object\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"primary_menu_active\":\"1\",\"secondary_menu_active\":\"\",\"primary_mobile_menu_active\"\
+        :\"1\",\"secondary_mobile_menu_active\":\"1\",\"sticky_menu_active\":\"1\"\
+        ,\"sticky_mobile_menu_active\":\"\",\"sticky_sidebar_active\":\"1\",\"columnwidth\"\
+        :\".simple-grid-5-col-sizer\",\"gutter\":\".simple-grid-5-col-gutter\"};\n\
+        /* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/custom.js\"\
+        \ id=\"simple-grid-customjs-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/comment-reply.min.js?ver=6.8.3\"\
+        \ id=\"comment-reply-js\" async=\"async\" data-wp-strategy=\"async\"></script>\n\
+        <script type=\"text/javascript\" id=\"simple-grid-html5shiv-js-js-extra\"\
+        >\n/* <![CDATA[ */\nvar simple_grid_custom_script_vars = {\"elements_name\"\
+        :\"abbr article aside audio bdi canvas data datalist details dialog figcaption\
+        \ figure footer header hgroup main mark meter nav output picture progress\
+        \ section summary template time video\"};\n/* ]]> */\n</script>\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/html5shiv.js\"\
+        \ id=\"simple-grid-html5shiv-js-js\"></script>\n<script type=\"text/javascript\"\
+        \ id=\"fifu-json-ld-js-extra\">\n/* <![CDATA[ */\nvar fifuJsonLd = {\"url\"\
+        :\"https:\\/\\/image.tmdb.org\\/t\\/p\\/w500\\/owTRRXuxpJT5n68IddsvDtAeK6K.jpg\"\
+        };\n/* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/plugins/featured-image-from-url/includes/html/js/json-ld.js?ver=4.9.2\"\
+        \ id=\"fifu-json-ld-js\"></script>\n<script defer src=\"https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496\"\
+        \ integrity=\"sha512-ZE9pZaUXND66v380QUtch/5sE9tPFh2zg45pR2PB0CVkCtOREv2AJKkSidISWkysEuQ0EH8faUU5du78bx87UQ==\"\
+        \ data-cf-beacon='{\"version\":\"2024.11.0\",\"token\":\"832c49ee708d4b8d94382b4733ae0382\"\
+        ,\"r\":1,\"server_timing\":{\"name\":{\"cfCacheStatus\":true,\"cfEdge\":true,\"\
+        cfExtPri\":true,\"cfL4\":true,\"cfOrigin\":true,\"cfSpeedBrain\":true},\"\
+        location_startswith\":null}}' crossorigin=\"anonymous\"></script>\n<script>(function(){function\
+        \ c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML=\"\
+        window.__CF$cv$params={r:'a14e79daef66a10e',t:'MTc4MzAwMzk2NA=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);\"\
+        ;b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else\
+        \ if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var\
+        \ e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>\n\
+        </html>"
+    headers:
+      CF-RAY:
+      - a14e79daef66a10e-GRU
+      Cf-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Thu, 02 Jul 2026 14:52:45 GMT
+      Link:
+      - <https://legendei.net/wp-json/>; rel="https://api.w.org/", <https://legendei.net/wp-json/wp/v2/posts/729753>;
+        rel="alternate"; title="JSON"; type="application/json", <https://legendei.net/?p=729753>;
+        rel=shortlink
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Permissions-Policy:
+      - private-state-token-redemption=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com"),
+        private-state-token-issuance=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com")
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=DknkrCIytLVXAf4wS83X0fXe31%2Bo9gom%2FhnKJwAz09Tbf9i%2BWAdLdxhyTAJIpi9uyUYF01Ck4NPFh4hk2tZ1EgLVXrNWXzLCPLJGrwellSlHtUkZGwSz1DfZlAilRrw%3D"}]}'
+      Server:
+      - cloudflare
+      Server-Timing:
+      - cfCacheStatus;desc="DYNAMIC"
+      - cfEdge;dur=5,cfOrigin;dur=537
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - pt-BR,pt;q=0.9,en;q=0.8
+      User-Agent:
+      - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like
+        Gecko) Chrome/131.0.0.0 Safari/537.36
+    method: GET
+    uri: https://legendei.net/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia/
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html dir=\"ltr\" lang=\"pt-BR\" prefix=\"og: https://ogp.me/ns#\"\
+        >\n<head>\n<meta charset=\"UTF-8\">\n<meta name=\"viewport\" content=\"width=device-width,\
+        \ initial-scale=1.0\">\n\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css\"\
+        >\n\t\n<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">\n<link\
+        \ rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>\n<link\
+        \ href=\"https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap\"\
+        \ rel=\"stylesheet\">\n\t\n<title>Legenda Breaking Bad S01E01 1080p NF WEB\
+        \ DL DDP5 1 x264 PiA | Legendei - Aqui Sai Primeiro</title>\n\t<style>img:is([sizes=\"\
+        auto\" i], [sizes^=\"auto,\" i]) { contain-intrinsic-size: 3000px 1500px }</style>\n\
+        \t\n\t\t<!-- All in One SEO Pro 4.6.0 - aioseo.com -->\n\t\t<meta name=\"\
+        description\" content=\"Legenda Breaking Bad S01E01 1080p NF WEB DL DDP5 1\
+        \ x264 PiA testada e verificada - Pode servir tamb\xE9m para outros releases,\
+        \ basta renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t\
+        <meta name=\"robots\" content=\"max-image-preview:large\" />\n\t\t<meta name=\"\
+        google-site-verification\" content=\"JSMIV3rTOC3Y-WjaQzmU3KvW7aWHceTxBFYsJYpm-1k\"\
+        \ />\n\t\t<link rel=\"canonical\" href=\"https://legendei.net/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia/\"\
+        \ />\n\t\t<meta name=\"generator\" content=\"All in One SEO Pro (AIOSEO) 4.6.0\"\
+        \ />\n\t\t<meta property=\"og:locale\" content=\"pt_BR\" />\n\t\t<meta property=\"\
+        og:site_name\" content=\"Legendei - Baixar Legendas de S\xE9ries e Filmes\"\
+        \ />\n\t\t<meta property=\"og:type\" content=\"article\" />\n\t\t<meta property=\"\
+        og:title\" content=\"Legenda Breaking Bad S01E01 1080p NF WEB DL DDP5 1 x264\
+        \ PiA | Legendei - Aqui Sai Primeiro\" />\n\t\t<meta property=\"og:description\"\
+        \ content=\"Legenda Breaking Bad S01E01 1080p NF WEB DL DDP5 1 x264 PiA testada\
+        \ e verificada - Pode servir tamb\xE9m para outros releases, basta renomear!\
+        \ Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t<meta property=\"\
+        og:url\" content=\"https://legendei.net/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia/\"\
+        \ />\n\t\t<meta property=\"og:image\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"og:image:secure_url\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"article:published_time\" content=\"2025-07-01T23:00:17+00:00\"\
+        \ />\n\t\t<meta property=\"article:modified_time\" content=\"2025-07-01T23:00:17+00:00\"\
+        \ />\n\t\t<meta name=\"twitter:card\" content=\"summary\" />\n\t\t<meta name=\"\
+        twitter:title\" content=\"Legenda Breaking Bad S01E01 1080p NF WEB DL DDP5\
+        \ 1 x264 PiA | Legendei - Aqui Sai Primeiro\" />\n\t\t<meta name=\"twitter:description\"\
+        \ content=\"Legenda Breaking Bad S01E01 1080p NF WEB DL DDP5 1 x264 PiA testada\
+        \ e verificada - Pode servir tamb\xE9m para outros releases, basta renomear!\
+        \ Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t<meta name=\"twitter:image\"\
+        \ content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<script type=\"application/ld+json\" class=\"aioseo-schema\">\n\t\
+        \t\t{\"@context\":\"https:\\/\\/schema.org\",\"@graph\":[{\"@type\":\"BlogPosting\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia\\\
+        /#blogposting\",\"name\":\"Legenda Breaking Bad S01E01 1080p NF WEB DL DDP5\
+        \ 1 x264 PiA | Legendei - Aqui Sai Primeiro\",\"headline\":\"Breaking Bad\
+        \ S01E01 1080p NF WEB DL DDP5 1 x264 PiA\",\"author\":{\"@id\":\"https:\\\
+        /\\/legendei.net\\/author\\/eneinsubtitles\\/#author\"},\"publisher\":{\"\
+        @id\":\"https:\\/\\/legendei.net\\/#organization\"},\"image\":{\"@type\":\"\
+        ImageObject\",\"url\":\"https:\\/\\/legendei.net\\/wp-content\\/uploads\\\
+        /2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\/#articleImage\"\
+        ,\"width\":150,\"height\":150},\"datePublished\":\"2025-07-02T01:00:17+01:00\"\
+        ,\"dateModified\":\"2025-07-02T01:00:17+01:00\",\"inLanguage\":\"pt-BR\",\"\
+        mainEntityOfPage\":{\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia\\\
+        /#webpage\"},\"isPartOf\":{\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia\\\
+        /#webpage\"},\"articleSection\":\"S\\u00e9ries TV, Legendas Breaking Bad,\
+        \ Legendas Breaking Bad S01\"},{\"@type\":\"BreadcrumbList\",\"@id\":\"https:\\\
+        /\\/legendei.net\\/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia\\/#breadcrumblist\"\
+        ,\"itemListElement\":[{\"@type\":\"ListItem\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /#listItem\",\"position\":1,\"name\":\"Home\",\"item\":\"https:\\/\\/legendei.net\\\
+        /\",\"nextItem\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia\\\
+        /#listItem\"},{\"@type\":\"ListItem\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia\\/#listItem\",\"position\"\
+        :2,\"name\":\"Breaking.Bad.S01E01.1080p.NF.WEB-DL.DDP5.1.x264-PiA\",\"previousItem\"\
+        :\"https:\\/\\/legendei.net\\/#listItem\"}]},{\"@type\":\"Organization\",\"\
+        @id\":\"https:\\/\\/legendei.net\\/#organization\",\"name\":\"Legendei\",\"\
+        url\":\"https:\\/\\/legendei.net\\/\",\"logo\":{\"@type\":\"ImageObject\"\
+        ,\"url\":\"https:\\/\\/legendei.net\\/wp-content\\/uploads\\/2026\\/03\\/favicon.webp\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia\\\
+        /#organizationLogo\",\"width\":150,\"height\":150},\"image\":{\"@id\":\"https:\\\
+        /\\/legendei.net\\/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia\\/#organizationLogo\"\
+        }},{\"@type\":\"Person\",\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /#author\",\"url\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /\",\"name\":\"Admin\"},{\"@type\":\"WebPage\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia\\/#webpage\",\"url\"\
+        :\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia\\\
+        /\",\"name\":\"Legenda Breaking Bad S01E01 1080p NF WEB DL DDP5 1 x264 PiA\
+        \ | Legendei - Aqui Sai Primeiro\",\"description\":\"Legenda Breaking Bad\
+        \ S01E01 1080p NF WEB DL DDP5 1 x264 PiA testada e verificada - Pode servir\
+        \ tamb\\u00e9m para outros releases, basta renomear! Dispon\\u00edvel em Legendei\
+        \ - Aqui Sai Primeiro\",\"inLanguage\":\"pt-BR\",\"isPartOf\":{\"@id\":\"\
+        https:\\/\\/legendei.net\\/#website\"},\"breadcrumb\":{\"@id\":\"https:\\\
+        /\\/legendei.net\\/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia\\/#breadcrumblist\"\
+        },\"author\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /#author\"},\"creator\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /#author\"},\"datePublished\":\"2025-07-02T01:00:17+01:00\",\"dateModified\"\
+        :\"2025-07-02T01:00:17+01:00\"},{\"@type\":\"WebSite\",\"@id\":\"https:\\\
+        /\\/legendei.net\\/#website\",\"url\":\"https:\\/\\/legendei.net\\/\",\"name\"\
+        :\"Legendei\",\"description\":\"Baixar Legendas de S\\u00e9ries e Filmes\"\
+        ,\"inLanguage\":\"pt-BR\",\"publisher\":{\"@id\":\"https:\\/\\/legendei.net\\\
+        /#organization\"}}]}\n\t\t</script>\n\t\t<!-- All in One SEO Pro -->\n\n<link\
+        \ rel='dns-prefetch' href='//fonts.googleapis.com' />\n<link rel=\"alternate\"\
+        \ type=\"application/rss+xml\" title=\"Feed para Legendei &raquo;\" href=\"\
+        https://legendei.net/feed/\" />\n<link rel=\"alternate\" type=\"application/rss+xml\"\
+        \ title=\"Feed de coment\xE1rios para Legendei &raquo;\" href=\"https://legendei.net/comments/feed/\"\
+        \ />\n<link rel=\"alternate\" type=\"application/rss+xml\" title=\"Feed de\
+        \ coment\xE1rios para Legendei &raquo; Breaking Bad S01E01 1080p NF WEB DL\
+        \ DDP5 1 x264 PiA\" href=\"https://legendei.net/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia/feed/\"\
+        \ />\n<script type=\"text/javascript\">\n/* <![CDATA[ */\nwindow._wpemojiSettings\
+        \ = {\"baseUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\/emoji\\/16.0.1\\\
+        /72x72\\/\",\"ext\":\".png\",\"svgUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\\
+        /emoji\\/16.0.1\\/svg\\/\",\"svgExt\":\".svg\",\"source\":{\"concatemoji\"\
+        :\"https:\\/\\/legendei.net\\/wp-includes\\/js\\/wp-emoji-release.min.js?ver=6.8.3\"\
+        }};\n/*! This file is auto-generated */\n!function(s,n){var o,i,e;function\
+        \ c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function\
+        \ p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var\
+        \ t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),a=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new\
+        \ Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return\
+        \ t.every(function(e,t){return e===a[t]})}function u(e,t){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);for(var\
+        \ n=e.getImageData(16,16,1,1),a=0;a<n.data.length;a++)if(0!==n.data[a])return!1;return!0}function\
+        \ f(e,t,n,a){switch(t){case\"flag\":return n(e,\"\\ud83c\\udff3\\ufe0f\\u200d\\\
+        u26a7\\ufe0f\",\"\\ud83c\\udff3\\ufe0f\\u200b\\u26a7\\ufe0f\")?!1:!n(e,\"\\\
+        ud83c\\udde8\\ud83c\\uddf6\",\"\\ud83c\\udde8\\u200b\\ud83c\\uddf6\")&&!n(e,\"\
+        \\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc65\\udb40\\udc6e\\udb40\\\
+        udc67\\udb40\\udc7f\",\"\\ud83c\\udff4\\u200b\\udb40\\udc67\\u200b\\udb40\\\
+        udc62\\u200b\\udb40\\udc65\\u200b\\udb40\\udc6e\\u200b\\udb40\\udc67\\u200b\\\
+        udb40\\udc7f\");case\"emoji\":return!a(e,\"\\ud83e\\udedf\")}return!1}function\
+        \ g(e,t,n,a){var r=\"undefined\"!=typeof WorkerGlobalScope&&self instanceof\
+        \ WorkerGlobalScope?new OffscreenCanvas(300,150):s.createElement(\"canvas\"\
+        ),o=r.getContext(\"2d\",{willReadFrequently:!0}),i=(o.textBaseline=\"top\"\
+        ,o.font=\"600 32px Arial\",{});return e.forEach(function(e){i[e]=t(o,e,n,a)}),i}function\
+        \ t(e){var t=s.createElement(\"script\");t.src=e,t.defer=!0,s.head.appendChild(t)}\"\
+        undefined\"!=typeof Promise&&(o=\"wpEmojiSettingsSupports\",i=[\"flag\",\"\
+        emoji\"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){s.addEventListener(\"\
+        DOMContentLoaded\",e,{once:!0})}),new Promise(function(t){var n=function(){try{var\
+        \ e=JSON.parse(sessionStorage.getItem(o));if(\"object\"==typeof e&&\"number\"\
+        ==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&\"object\"\
+        ==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if(\"\
+        undefined\"!=typeof Worker&&\"undefined\"!=typeof OffscreenCanvas&&\"undefined\"\
+        !=typeof URL&&URL.createObjectURL&&\"undefined\"!=typeof Blob)try{var e=\"\
+        postMessage(\"+g.toString()+\"(\"+[JSON.stringify(i),f.toString(),p.toString(),u.toString()].join(\"\
+        ,\")+\"));\",a=new Blob([e],{type:\"text/javascript\"}),r=new Worker(URL.createObjectURL(a),{name:\"\
+        wpTestEmojiSupports\"});return void(r.onmessage=function(e){c(n=e.data),r.terminate(),t(n)})}catch(e){}c(n=g(i,f,p,u))}t(n)}).then(function(e){for(var\
+        \ t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],\"\
+        flag\"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return\
+        \ e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);\n\
+        /* ]]> */\n</script>\n<link rel='stylesheet' id='wpa-css-css' href='https://legendei.net/wp-content/plugins/wp-attachments/styles/0/wpa.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='wp-emoji-styles-inline-css' type='text/css'>\n\
+        \n\timg.wp-smiley, img.emoji {\n\t\tdisplay: inline !important;\n\t\tborder:\
+        \ none !important;\n\t\tbox-shadow: none !important;\n\t\theight: 1em !important;\n\
+        \t\twidth: 1em !important;\n\t\tmargin: 0 0.07em !important;\n\t\tvertical-align:\
+        \ -0.1em !important;\n\t\tbackground: none !important;\n\t\tpadding: 0 !important;\n\
+        \t}\n</style>\n<link rel='stylesheet' id='wp-block-library-css' href='https://legendei.net/wp-includes/css/dist/block-library/style.min.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='classic-theme-styles-inline-css'\
+        \ type='text/css'>\n/*! This file is auto-generated */\n.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em\
+        \ + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}\n\
+        </style>\n<style id='wppb-content-restriction-start-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-content-restriction-end-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-edit-profile-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-login-style-inline-css' type='text/css'>\n\n\
+        \n</style>\n<style id='wppb-recover-password-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-register-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='global-styles-inline-css' type='text/css'>\n:root{--wp--preset--aspect-ratio--square:\
+        \ 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4:\
+        \ 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3:\
+        \ 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16:\
+        \ 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray:\
+        \ #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink:\
+        \ #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange:\
+        \ #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan:\
+        \ #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue:\
+        \ #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple:\
+        \ #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1)\
+        \ 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan:\
+        \ linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange:\
+        \ linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red:\
+        \ linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray:\
+        \ linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum:\
+        \ linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186)\
+        \ 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple:\
+        \ linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux:\
+        \ linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62)\
+        \ 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112)\
+        \ 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean:\
+        \ linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181)\
+        \ 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128)\
+        \ 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129)\
+        \ 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium:\
+        \ 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large:\
+        \ 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40:\
+        \ 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70:\
+        \ 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural:\
+        \ 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px\
+        \ rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0,\
+        \ 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255,\
+        \ 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0,\
+        \ 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap:\
+        \ 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items:\
+        \ center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display:\
+        \ grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-color{color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background:\
+        \ var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange)\
+        \ !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background:\
+        \ var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background:\
+        \ var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background:\
+        \ var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background:\
+        \ var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background:\
+        \ var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size:\
+        \ var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size:\
+        \ var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--x-large) !important;}\n:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}\n:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}\n:root :where(.wp-block-pullquote){font-size:\
+        \ 1.5em;line-height: 1.6;}\n</style>\n<link rel='stylesheet' id='lrl-css-css'\
+        \ href='https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-maincss-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css' type='text/css'\
+        \ media='all' />\n<link rel='stylesheet' id='fontawesome-css' href='https://legendei.net/wp-content/themes/simple-grid/assets/css/all.min.css'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-webfont-css'\
+        \ href='//fonts.googleapis.com/css?family=Playfair+Display:400,400i,700,700i|Domine:400,700|Oswald:400,700|Patua+One|Merriweather:400,400i,700,700i&#038;display=swap'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='legendei-style-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css?ver=1782544305'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='wppb_stylesheet-css'\
+        \ href='https://legendei.net/wp-content/plugins/profile-builder/assets/css/style-front-end.css?ver=3.15.2'\
+        \ type='text/css' media='all' />\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-includes/js/jquery/jquery.min.js?ver=3.7.1\" id=\"\
+        jquery-core-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1\"\
+        \ id=\"jquery-migrate-js\"></script>\n<!--[if lt IE 9]>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/respond.min.js\"\
+        \ id=\"respond-js\"></script>\n<![endif]-->\n<link rel=\"https://api.w.org/\"\
+        \ href=\"https://legendei.net/wp-json/\" /><link rel=\"alternate\" title=\"\
+        JSON\" type=\"application/json\" href=\"https://legendei.net/wp-json/wp/v2/posts/664955\"\
+        \ /><link rel=\"EditURI\" type=\"application/rsd+xml\" title=\"RSD\" href=\"\
+        https://legendei.net/xmlrpc.php?rsd\" />\n<meta name=\"generator\" content=\"\
+        WordPress 6.8.3\" />\n<link rel='shortlink' href='https://legendei.net/?p=664955'\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (JSON)\" type=\"application/json+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fbreaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia%2F\"\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (XML)\" type=\"text/xml+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fbreaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia%2F&#038;format=xml\"\
+        \ />\n<style>\n\n/* FORMUL\xC1RIO TRIAL */\n\n.premium-form {\n    max-width:\
+        \ 760px;\n    margin: 0 auto 20px;\n    padding: 30px;\n    border-radius:\
+        \ 10px;\n    background: #212121;\n    border: 10px solid transparent;\n \
+        \   background-image:\n        linear-gradient(#212121,#212121),\n       \
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    background-origin: border-box;\n\
+        \    background-clip: padding-box, border-box;\n    box-sizing: border-box;\n\
+        }\n\n/* Campos */\n\n.premium-form .field {\n    position: relative;\n   \
+        \ margin-bottom: 20px;\n}\n\n.premium-form input {\n    width: 100%;\n   \
+        \ padding: 14px;\n    border-radius: 8px;\n    border: 1px solid #ccc;\n \
+        \   font-size: 16px;\n    box-sizing: border-box;\n}\n\n/* Focus bonito */\n\
+        \n.premium-form input:focus {\n    border-color: transparent;\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin: border-box;\n    background-clip: padding-box, border-box;\n\
+        \    box-shadow: 0 0 0 4px rgba(63,140,255,0.20);\n    outline: none;\n}\n\
+        \n/* TOOLTIP */\n\n.premium-form .tooltip {\n    position: absolute;\n   \
+        \ bottom: 100%;\n    left: 0;\n    margin-bottom: 10px;\n    background: linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \tbox-shadow:0 6px 14px rgba(0,0,0,0.25);\n    color: #ffffff;\n    padding:\
+        \ 10px 12px;\n    font-size: 14px;\n    border-radius: 6px;\n    max-width:\
+        \ 260px;\n    opacity: 0;\n    pointer-events: none;\n    transition: .2s;\n\
+        \    z-index: 999;\n}\n\n.premium-form .tooltip::after {\n    content: \"\"\
+        ;\n    position: absolute;\n    top: 100%;\n    left: 15px;\n    border-width:\
+        \ 6px 6px 0 6px;\n    border-style: solid;\n    border-color: #8a2be2 transparent\
+        \ transparent transparent;\n}\n\n.premium-form .field:hover .tooltip,\n.premium-form\
+        \ .field:focus-within .tooltip {\n    opacity: 1;\n    transform: translateY(-4px);\n\
+        }\n\n/* BOT\xC3O */\n\n.premium-form button {\n    padding: 14px 30px;\n \
+        \   font-size: 22px;\n    border-radius: 8px;\n    border: none;\n    background:\
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    color: #fff;\n    cursor: pointer;\n\
+        \    transition: .25s;\n}\n\n.premium-form button:hover {\n    background:\
+        \ linear-gradient(90deg,#4c9aff,#9a3bff);\n}\n\n/* SENHA */\n\n.pass-wrap{\n\
+        \    position:relative;\n}\n\n.toggle-pass{\n    position:absolute;\n    right:12px;\n\
+        \    top:50%;\n    transform:translateY(-50%);\n    cursor:pointer;\n    font-size:18px;\n\
+        }\n\n/* BARRA FOR\xC7A SENHA */\n\n.strength{\n    height:6px;\n    background:#444;\n\
+        \    border-radius:4px;\n    margin-top:8px;\n    overflow:hidden;\n}\n\n\
+        .strength div{\n    height:100%;\n    width:0%;\n    transition:.3s;\n}\n\n\
+        /* MOBILE */\n\n@media (max-width:480px){\n\n.premium-form{\n    padding:20px;\n\
+        }\n\n}\n\n</style>\n<style>\n\n/* remove fundo normal, ativo e hover do logo\
+        \ */\n.simple-grid-primary-nav-menu > li.menu-logo-item > a,\n.simple-grid-primary-nav-menu\
+        \ > li.menu-logo-item > a:hover,\n.simple-grid-primary-nav-menu > li.menu-logo-item.current-menu-item\
+        \ > a{\n    background:none !important;\n}\n\n/* ===================================================\n\
+        \   MOBILE\n   =================================================== */\n\n\
+        @media only screen and (max-width:812px){\n\n    /* ESCONDER LOGO NO MENU\
+        \ MOBILE */\n    .simple-grid-primary-nav-menu > li.menu-logo-item{\n    \
+        \    display:none !important;\n    }\n\n}\n\n</style>\n    <style type=\"\
+        text/css\">\r\n            .simple-grid-site-title, .simple-grid-site-title\
+        \ a, .simple-grid-site-description {color: #ffffff;}\r\n        </style>\r\
+        \n    <style type=\"text/css\" id=\"custom-background-css\">\nbody.custom-background\
+        \ { background-color: #333333; }\n</style>\n\t<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"32x32\" />\n<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"192x192\" />\n<link rel=\"apple-touch-icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n<meta name=\"msapplication-TileImage\" content=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n</head>\t\n\t\n\t\n<body class=\"wp-singular post-template-default single\
+        \ single-post postid-664955 single-format-standard custom-background wp-custom-logo\
+        \ wp-theme-simple-grid simple-grid-animated simple-grid-fadein simple-grid-theme-is-active\
+        \ simple-grid-custom-logo-active simple-grid-layout-type-full simple-grid-masonry-inactive\
+        \ simple-grid-float-grid simple-grid-responsive-grid-details simple-grid-layout-c-s1\
+        \ simple-grid-header-banner-active simple-grid-tagline-inactive simple-grid-logo-above-title\
+        \ simple-grid-primary-menu-active simple-grid-primary-mobile-menu-active simple-grid-secondary-mobile-menu-active\
+        \ simple-grid-primary-social-icons\" id=\"simple-grid-site-body\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/WebPage\">\n<a class=\"skip-link\
+        \ screen-reader-text\" href=\"#simple-grid-content-wrapper\">Skip to content</a>\n\
+        \n\n\n<div class=\"simple-grid-site-header simple-grid-container\" id=\"simple-grid-header\"\
+        \ itemscope=\"itemscope\" itemtype=\"http://schema.org/WPHeader\" role=\"\
+        banner\">\n<div class=\"simple-grid-head-content simple-grid-clearfix\" id=\"\
+        simple-grid-head-content\">\n\n<div class=\"simple-grid-no-header-content\"\
+        >\n              <p class=\"simple-grid-site-title\"><a href=\"https://legendei.net/\"\
+        \ rel=\"home\">Legendei</a></p>\r\n                </div>\n\n</div><!--/#simple-grid-head-content\
+        \ -->\n</div><!--/#simple-grid-header -->\n\n\n\n<div class=\"simple-grid-container\
+        \ simple-grid-primary-menu-container simple-grid-clearfix\">\n<div class=\"\
+        simple-grid-primary-menu-container-inside simple-grid-clearfix\">\n<nav class=\"\
+        simple-grid-nav-primary\" id=\"simple-grid-primary-navigation\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/SiteNavigationElement\" role=\"navigation\"\
+        \ aria-label=\"Primary Menu\">\n\t\n\t\n<div class=\"simple-grid-outer-wrapper\"\
+        >\n<a href=\"/\" class=\"logo-mobile-inline\">\n<img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \nstyle=\"width:100%;height:auto;\">\n</a>\n\n<style>\n.logo-mobile-inline{\n\
+        display:none;\n}\n\n@media (max-width:812px){\n.logo-mobile-inline{\ndisplay:block;\n\
+        }\n}\n</style>\t\n\n\t\n<style>\n.mobile-header-icons{\n    display:none;\n\
+        }\n\n@media (max-width: 812px){\n\n.mobile-header-icons{\n    display:grid;\n\
+        \    grid-template-columns: 2fr 1fr 1fr;\n    gap:10px;\n    padding:10px;\n\
+        }\n\n/* BOT\xD5ES */\n.mobile-header-icons a,\n.mobile-header-icons .cat-toggle{\n\
+        \    display:flex;\n    align-items:center;\n    justify-content:center;\n\
+        \    gap:6px;\n    background:#141414;\n    padding:8px 6px;\n    border-radius:8px;\n\
+        \    color:#fff;\n    font-size:12px;\n    text-decoration:none;\n    text-align:center;\n\
+        \    cursor:pointer;\n}\n\n/* CATEGORIA */\n.cat-toggle{\n    font-weight:600;\n\
+        }\n\n/* SETA */\n.cat-toggle .arrow{\n    transition:transform 0.3s ease;\n\
+        }\n\n/* SETA GIRADA */\n.cat-toggle.active .arrow{\n    transform:rotate(180deg);\n\
+        }\n\n/* HOVER */\n.mobile-header-icons a:hover,\n.mobile-header-icons .cat-toggle:hover{\n\
+        \    background:#1f1f1f;\n}\n\n/* CONTAINER */\n.cat-container{\n    position:relative;\n\
+        }\n\n/* DROPDOWN */\n.cat-list{\n    display:flex;\n    flex-direction:column;\n\
+        \    gap:6px;\n\n    position:absolute;\n    top:110%;\n    left:0;\n    width:100%;\n\
+        \n    background:#0f0f0f;\n    border-radius:8px;\n    padding:6px;\n    z-index:999;\n\
+        \n    opacity:0;\n    visibility:hidden;\n    transform:translateY(-5px);\n\
+        \    transition:all 0.25s ease;\n}\n\n/* ABERTO */\n.cat-container.open .cat-list{\n\
+        \    opacity:1;\n    visibility:visible;\n    transform:translateY(0);\n}\n\
+        \n/* ITENS */\n.cat-list a{\n    justify-content:flex-start;\n    font-size:14px;\n\
+        \    padding:10px;\n}\n\n}\n</style>\n\n\n<div class=\"mobile-header-icons\"\
+        >\n\n    <!-- CATEGORIAS -->\n    <div class=\"cat-container\">\n        <div\
+        \ class=\"cat-toggle\">\n            \U0001F4C2 Categorias <span class=\"\
+        arrow\">\u25BC</span>\n        </div>\n\n        <div class=\"cat-list\">\n\
+        \            <a href=\"/category/destaques/\">\u2B50 Destaques</a>\n     \
+        \       <a href=\"/category/filmes/\">\U0001F3AC Filmes</a>\n            <a\
+        \ href=\"/category/serie/\">\U0001F4FA S\xE9ries</a>\n            <a href=\"\
+        /category/pack-de-legendas/\">\U0001F4E6 Packs</a>\n        </div>\n    </div>\n\
+        \n    \n        <a href=\"/seja-premium-vitalicio/\"><i class=\"fa-solid fa-crown\"\
+        ></i> Premium</a>\n\n        <a href=\"/login/\"><i class=\"fa-solid fa-key\"\
+        ></i> Login</a>\n\n    \n</div>\n\n<script>\ndocument.addEventListener(\"\
+        DOMContentLoaded\", function(){\n\n    const container = document.querySelector(\"\
+        .cat-container\");\n    const toggle = document.querySelector(\".cat-toggle\"\
+        );\n\n    toggle.addEventListener(\"click\", function(e){\n        e.stopPropagation();\n\
+        \        container.classList.toggle(\"open\");\n        toggle.classList.toggle(\"\
+        active\");\n    });\n\n    document.addEventListener(\"click\", function(e){\n\
+        \        if(!container.contains(e.target)){\n            container.classList.remove(\"\
+        open\");\n            toggle.classList.remove(\"active\");\n        }\n  \
+        \  });\n\n});\n</script>\t\n\t\n<ul id=\"simple-grid-menu-primary-navigation\"\
+        \ class=\"simple-grid-primary-nav-menu simple-grid-menu-primary\"><li id=\"\
+        menu-item-673170\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-673170 menu-logo-item\">\n        <a href=\"https://legendei.net/\"\
+        \ style=\"\n            display:flex;\n            align-items:center;\n \
+        \           justify-content:center;\n            height:100%;\n          \
+        \  padding:0;\n            margin:0;\n            line-height:1;\n       \
+        \ \">\n            <img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \n                      alt=\"Legendei.NET\"\n                      style=\"\
+        height:42px;width:auto;display:block;\">\n        </a></li>\n\n<li id=\"menu-item-673168\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673168\"\
+        ><a href=\"https://legendei.net/category/destaques/\" title=\"Legendas em\
+        \ Destaque\">DESTAQUES</a></li>\n<li id=\"menu-item-673167\" class=\"menu-item\
+        \ menu-item-type-taxonomy menu-item-object-category menu-item-673167\"><a\
+        \ href=\"https://legendei.net/category/filmes/\" title=\"Legendas para Filmes\"\
+        >Filmes</a></li>\n<li id=\"menu-item-673166\" class=\"menu-item menu-item-type-taxonomy\
+        \ menu-item-object-category current-post-ancestor current-menu-parent current-post-parent\
+        \ menu-item-673166\"><a href=\"https://legendei.net/category/serie/\" title=\"\
+        Legendas para seriados\">S\xC9RIES</a></li>\n<li id=\"menu-item-673169\" class=\"\
+        menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673169\"\
+        ><a href=\"https://legendei.net/category/pack-de-legendas/\" title=\"Pack\
+        \ de legendas\">PACKS</a></li>\n<li id=\"menu-item-731144\" class=\"menu-item\
+        \ menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-731144\"\
+        ><a target=\"_blank\" href=\"/aplicativos/\">RECOMENDAMOS</a>\n<ul class=\"\
+        sub-menu\">\n\t<li id=\"menu-item-673172\" class=\"menu-item menu-item-type-custom\
+        \ menu-item-object-custom menu-item-673172\"><a target=\"_blank\" href=\"\
+        /aplicativos/\" title=\"Programas para windows\">APLICATIVOS</a></li>\n\t\
+        <li id=\"menu-item-687662\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-687662\"><a target=\"_blank\" href=\"https://4kxxx.vip/\" title=\"\
+        Baixe os melhores v\xEDdeos porn\xF4 sempre em 4K\">4K XXX</a></li>\n\t<li\
+        \ id=\"menu-item-717497\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-717497\"><a target=\"_blank\" href=\"https://detonaplay.com/\"\
+        >GAMES</a></li>\n</ul>\n</li>\n\n\n\n<li class=\"menu-item\" style=\"float:right;\"\
+        >\n            <a href=\"/login/\"\n               style=\"background:linear-gradient(135deg,#198754,#20ac6b);color:#ffffff;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-key\"></i> Login\n            </a>\n\
+        \        </li><li class=\"menu-item\" style=\"float:right;\">\n          \
+        \  <a href=\"/seja-premium-vitalicio/\"\n\t\t\t\t\t  style=\"background:linear-gradient(135deg,#f4c430,#c2940a);color:#4d2e00;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-crown\"></i> Membro Premium\n  \
+        \          </a>\n        </li></ul>    </div>\n</nav>\n</div>\n</div>\n\n\t\
+        \n\t\n\r\n<div class=\"simple-grid-outer-wrapper\">\r\n<div class=\"simple-grid-top-wrapper-outer\
+        \ simple-grid-clearfix\">\r\n<div class=\"simple-grid-featured-posts-area\
+        \ simple-grid-top-wrapper simple-grid-clearfix\">\r\n\r\n<div id=\"search-5\"\
+        \ class=\"simple-grid-main-widget widget simple-grid-widget-box widget_search\"\
+        ><div class=\"simple-grid-widget-box-inside\"><form role=\"search\" method=\"\
+        get\" class=\"simple-grid-search-form\" action=\"https://legendei.net/\">\n\
+        <label>\n    <span class=\"simple-grid-sr-only\">Pesquisar por </span>\n \
+        \   <input \n        type=\"search\"\n        class=\"simple-grid-search-field\"\
+        \n        placeholder=\"Pesquisar &hellip;\"\n        value=\"\"\n       \
+        \ name=\"s\"\n        minlength=\"3\"\n\t\tmaxlength=\"50\"   \n        required\n\
+        \    />\n</label>\n<input type=\"submit\" class=\"simple-grid-search-submit\"\
+        \ value=\"&#xf002;\" />\n</form></div></div></div>\r\n</div>\r\n</div>\r\n\
+        \r\n\n<div class=\"simple-grid-outer-wrapper\" id=\"simple-grid-wrapper-outside\"\
+        >\n\n<div class=\"simple-grid-container simple-grid-clearfix\" id=\"simple-grid-wrapper\"\
+        >\n<div class=\"simple-grid-content-wrapper simple-grid-clearfix\" id=\"simple-grid-content-wrapper\"\
+        >\t\n\t\t\n\n\n<div class=\"simple-grid-main-wrapper simple-grid-clearfix\"\
+        \ id=\"simple-grid-main-wrapper\" itemscope=\"itemscope\" itemtype=\"http://schema.org/Blog\"\
+        \ role=\"main\">\n<div class=\"theiaStickySidebar\">\n<div class=\"simple-grid-main-wrapper-inside\
+        \ simple-grid-clearfix\">\n\n\r\n\r\n\n<div class=\"simple-grid-posts-wrapper\"\
+        \ id=\"simple-grid-posts-wrapper\">\n\n\n\n\n\n<div style=\"width: 100%; border-radius:\
+        \ 12px; box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 12px; padding: 15px; background:\
+        \ #ffffff;\">\n    <center>\n    <article id=\"post-664955\" class=\"simple-grid-post-singular\
+        \ simple-grid-box post-664955 post type-post status-publish format-standard\
+        \ hentry category-serie tag-legendas-breaking-bad tag-legendas-breaking-bad-s01\
+        \ wpcat-4-id\">\n        <div class=\"simple-grid-box-inside\">\n        \
+        \    \n            \n                            <header class=\"entry-header\"\
+        >\n                    <div class=\"entry-header-inside simple-grid-clearfix\"\
+        >\n\n<h1 class=\"post-title entry-title\">Legenda Breaking Bad S01E01 1080p\
+        \ NF WEB DL DDP5 1 x264 PiA <span aria-label=\"PT-BR\">\U0001F1E7\U0001F1F7\
+        </span></h1>\n\n\n                                    <div class=\"simple-grid-entry-meta-single\"\
+        >\n                            <span class=\"simple-grid-entry-meta-single-date\"\
+        >\n                <i class=\"far fa-clock\" aria-hidden=\"true\"></i>&nbsp;2\
+        \ de julho de 2025            </span>\n                                  \
+        \  <span class=\"simple-grid-entry-meta-single-categories\"><i class=\"far\
+        \ fa-folder-open\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Posted in </span><a href=\"https://legendei.net/category/serie/\" rel=\"\
+        category tag\">S\xE9ries TV</a></span>                            </div>\n\
+        \    \n\n                    </div>\n                </header>\n         \
+        \   \t\t\t\n\t\t\t\n            <!-- inicio poster -->\n                 \
+        \       <!-- fim poster -->\n\t\t\t\n<!-- S admin -->\n            \t\t\t\n\
+        <!-- S admin -->\t\n\t\t\t\n            \n            <div class=\"entry-content\
+        \ simple-grid-clearfix\">\n\n<!-- N PREMIUM AMIN TEMP -->\t\t\t\t\n\t\n\n\
+        \   <a href=\"https://cuponei.org/promo/more/\" target=\"_blank\" rel=\"noopener\"\
+        >\n    <img class=\"aligncenter wp-image-729595 size-full\"\n         src=\"\
+        https://legendei.net/wp-content/uploads/2026/01/amazon.webp\"\n         width=\"\
+        350\" height=\"334\" />\n  </a>\t\n\t\t\t\t\t\t\t\t\n<!-- N PREMIUM AMIN TEMP\
+        \ -->\n\n\n\t\t\t\t\n<!-- anexos otimizados -->\n<!-- /anexos -->\n\n\n  \
+        \              <!-- WP Attachments -->\n        <div style=\"width:100%;margin:10px\
+        \ 0 10px 0;\">\n            <h3></h3>\n        <ul class=\"post-attachments\"\
+        ><p class=\"post-attachment mime-application-zip\">                      \
+        \                                                          <a href=\"https://legendei.net/breaking-bad-s01e01-1080p-nf-web-dl-ddp5-1-x264-pia/?download=664954\"\
+        \ target=\"_blank\" class=\"buttonmyup\"><i class=\"fa fa-download\"></i>\
+        \ BAIXAR LEGENDA</a>\r\n</p></ul></div>\n        <div class=\"highlight-text\"\
+        >\n\n<style>\n/* ===================================== */\n/* LINKS COM BORDA\
+        \ GRADIENTE + UNDERLINE */\n/* ===================================== */\n\n\
+        .busca-legenda-links a{\n    display:inline-block;\n    padding:8px 18px;\n\
+        \    margin:2px 8px;\n    font-weight:400;\n    font-size:14px;\n    text-decoration:none\
+        \ !important;\n\tmin-width: 180px;\n    color:#1e293b !important; /* texto\
+        \ escuro vis\xEDvel */\n    background:transparent;\n\n    border:2px solid\
+        \ transparent;\n    border-radius:6px;\n\n    /* borda gradiente */\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin:border-box;\n    background-clip:padding-box, border-box;\n\
+        \n    position:relative;\n    transition:all .25s ease;\n}\n\n/* underline\
+        \ gradiente (embaixo do texto) */\n.busca-legenda-links a::after{\n    content:\"\
+        \";\n    position:absolute;\n    left:50%;\n    bottom:6px; /* dentro do bot\xE3\
+        o */\n    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\n\n/*\
+        \ hover */\n.busca-legenda-links a:hover{\n    color:#002080 !important;\n\
+        }\n\n.busca-legenda-links a:hover::after{\n    width:60%;\n}\n\n/* ativo (se\
+        \ quiser usar classe active depois) */\n.busca-legenda-links a.active::after{\n\
+        \    width:60%;\n}\n\n@media (max-width: 768px){\n\n    .busca-legenda-links{\n\
+        \        display:block;\n    }\n\n    /* remove os pontinhos separadores no\
+        \ mobile */\n    .busca-legenda-links span{\n        display:none;\n    }\n\
+        \n    .busca-legenda-links a{\n        display:block;\n        width:100%;\n\
+        \        margin:6px 0; /* controla espa\xE7amento vertical */\n        text-align:center;\n\
+        \t\tfont-size:14px;\n    }\n\n\n}\n</style>\n\n\n\n            <p><strong>Legenda\
+        \ da s\xE9rie Breaking Bad S01E01 1080p NF WEB DL DDP5 1 x264 PiA</strong></p>\n\
+        \            <hr>\n\n            <p>Todas as legendas dispon\xEDveis para\
+        \ download s\xE3o testadas e verificadas, garantindo sincronia, precis\xE3\
+        o e qualidade.</p>\n\n            <p>Depois de baixar a legenda, n\xE3o se\
+        \ esque\xE7a de conferir o seu release!</p>\n\n            <div class=\"busca-legenda-links\"\
+        >\n                <a href=\"/category/serie/?s=Breaking+Bad\">+ legendas\
+        \ mesma s\xE9rie</a><a href=\"/category/serie/?s=Breaking+Bad+S01\">+ legendas\
+        \ mesma temporada</a><span>\xB7</span><a href=\"/category/serie/?s=Breaking+Bad+S01E01\"\
+        >+ legendas mesmo epis\xF3dio</a>\n            </div>\n\n        </div>\n\t\
+        \t\n\n\t\t\n\t\t\n                <!-- sinopse TMDB -->\n                <!--\
+        \ /sinopse -->\n\n            </div><!-- .entry-content -->\n\n          \
+        \  \n            \n        </div>\n\n\n\n\t\t\n    </article>\n\n<!-- inicio\
+        \ app recomendados -->\t\t\n<div id=\"apps-recomendados\">\n<div class=\"\
+        busca-legenda-links\" style=\"text-align:center;\">\n<h5>Aplicativos que usamos\
+        \ e recomendamos</h5>\n\n<a href=\"https://legendei.net/aplicativos/kodi/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2025/11/Kodi_21.3.webp\"\
+        \ width=\"40\" height=\"40\" />\n    Kodi Media Center\n</a>\n\n<a href=\"\
+        https://legendei.net/aplicativos/utorrent-pro-download-e-guia-completo/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/08/uTorrent-Pro.jpg\"\
+        \ width=\"40\" height=\"40\" />\n    uTorrent Pro\n</a>\n\n<a href=\"https://legendei.net/aplicativos/winzip-pro-windows/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/09/WinZip-Pro.png\"\
+        \ width=\"40\" height=\"40\" />\n    WinZip Pro\n</a>\n</div>\n</div>\n<style>\n\
+        @media (max-width: 812px){\n    #apps-recomendados{\n        display: none;\n\
+        \    }\n}\n</style>\n<!-- fim app recomendados -->\n\t\t\n<span class=\"simple-grid-entry-meta-single-tags\"\
+        ><i class=\"fas fa-tags\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Tagged </span><a href=\"https://legendei.net/tag/legendas-breaking-bad/\"\
+        \ rel=\"tag\">Legendas Breaking Bad</a>, <a href=\"https://legendei.net/tag/legendas-breaking-bad-s01/\"\
+        \ rel=\"tag\">Legendas Breaking Bad S01</a></span>\n\t\t\n\t\t\n\n\t\t\n<hr>\n\
+        <div class=\"lrl-report-link\">\n    <a href=\"#\" class=\"lrl-open busca-legenda-links\"\
+        >\U0001F6A8 Reportar problemas \U0001F6A8</a>\n\t</div>\n\n    <div id=\"\
+        lrl-modal\" style=\"display:none;\">\n        <div class=\"lrl-box\">\n  \
+        \          <span class=\"lrl-close\">&times;</span>\n            <h3>Qual\
+        \ \xE9 o problema?</h3><hr>\n\n<label><input type=\"radio\" name=\"lrl_motivo\"\
+        \ value=\"Problemas com o download\"> O download n\xE3o funciona</label><br><br>\n\
+        \n<label><input type=\"radio\" name=\"lrl_motivo\" value=\"Legenda para o\
+        \ filme ou s\xE9rie incorreta\"> Conte\xFAdo \xE9 para outro filme, s\xE9\
+        rie ou epis\xF3dio</label><br><br>\n\n<label><input type=\"radio\" name=\"\
+        lrl_motivo\" value=\"Idioma da legenda incorreto\"> O idioma da legenda est\xE1\
+        \ errado.</label><br><br>\n<hr>\n            <button id=\"lrl-send\" disabled>Enviar</button>\n\
+        \        </div>\n    </div>\n    \t\t\n    </center>\n\t\n</div>\n\n\t\n\t\
+        \n\t\n\t\n\n<!-- S admin -->\t\n<!-- S admin -->\t\n\n\n\t\n<!-- N PREMIUM\
+        \ AMIN TEMP -->\n<div>\t\n<!-- protetor de links -->\n<script>\n(function(){\n\
+        \nconst redirectpage = \"https://legendei.net/noticia.php\";\n\nconst bases\
+        \ = [\n    '/?download=',\n    '/?dl_',\n    '.rar',\n    '.zip',\n    '.srt',\n\
+        \    'magnet:',\n\t'/zip-attachments.php'\n];\n\ndocument.querySelectorAll('a').forEach(a\
+        \ => {\n    const href = a.getAttribute('href') || '';\n\n    if (bases.some(b\
+        \ => href.includes(b))) {\n\n        const token = btoa(href);\n\n       \
+        \ a.href = redirectpage + \"?token=\" + token;\n        a.target = \"_blank\"\
+        ;\n    }\n});\n\n})();\n</script>\n<!-- /protetor de links -->\t\n\t\t\n\n\
+        <!-- BLOQUEADOR LEGENDEI -->\n\n<!-- BLOQUEADOR LEGENDEI -->\n\t\n<!-- inicio\
+        \ reload -->\n<script>\nsetInterval(function(){\n  location.reload();\n},\
+        \ 120000); // 2 minutos\n</script>\n<!-- fim reload -->\t\n\t\n</div>\t\n\
+        <!-- N PREMIUM AMIN TEMP -->\n\t\n\t\n<div class=\"clear\"></div>\n</div><!--/#simple-grid-posts-wrapper\
+        \ -->\n\n\r\n\r\n\t\n\n</div>\n</div>\n</div><!-- /#simple-grid-main-wrapper\
+        \ -->\n\n\n\n</div>\n\n\n\n\n<!-- N ADMIN -->\n<div>\n<!-- inicio -->\n<iframe\
+        \ \n  src=\"https://cuponei.org/last/\"\n  style=\"\n    width:1px;\n    height:1px;\n\
+        \    opacity:0;\n    border:none;\n    overflow:hidden;\n  \"\n  scrolling=\"\
+        no\"\n></iframe>\n<!-- fim -->\t\n</div>\n<!-- N ADMIN -->\n\n\n\n\n<!-- N\
+        \ PREMIUM AMIN TEMP -->\n\n\n\n\n<div>\n\n\t\n<!-- =============================\
+        \ -->\n<!-- SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\n\n<div id=\"SCRIPT_1_AQUI\" style=\"display:none;\">\t\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/invesup.js\"></script>\n<script\
+        \ type=\"text/javascript\">\n// make pop on new window with size 150x150 \
+        \ \nLight.Popup.create('https://cuponei.org/promo/more/', {width: 150, height:\
+        \ 150, onNewTab: false});\n// refresh = new popup\nLight.Popup.create('https://cuponei.org/promo/more/amz/',\
+        \ {alwaysPop: false});  \n</script>\n</div>\t\n\n<div id=\"SCRIPT_2_AQUI\"\
+        \ style=\"display:none;\">\n\t\n<script type=\"text/javascript\">\n var p$00a\
+        \ = 'p$00a' + (new Date().getTime()) + 'zz'; window[p$00a] = {a:'abcdefghijklmnopqrstuvwxyz0123456789i0xpy5jn7r6h82fuw1skdgzca94e3omqvblt',\
+        \ b:'{\"AZIb\":\"e344vq\", \"BVIb\":\"b4mm4e\", \"CXrr1\":\"du\", \"DLtag\"\
+        :\"e\", \"Emjk5\":\"\", \"XCge1s\":\"u.g7fz1yh.xf8\" , \"Zt1\":\"ufuxisn.2yk\"\
+        , \"ZZ1\":\"u.nn8fu.xhfdp\" }', c:'{\"Abkr221\":\"sx17uk\", \"Bo9ssm\":\"\
+        //xp2.g7fz1yh.xf8/iuu.rs\"}', d:'{\"Ag4\":\"0fpa\", \"Bx1\":\"iuuy2pCn7hp\"\
+        , \"Cky\":\"s1x\", \"Dmg\":\"x1yikyEhy8y2k\"}'};\nvar _0x5d4b=['235913QVfbwv','slice','length','162209QBmAmV','14238hyOOTq','323207DTbifh','split','1DqiKtq','135866HTbavB','indexOf','call','27654SKXHbY','parse','undefined','32Ijckmz','keys','map','ceil','115980hcFVDy','values','join'];var\
+        \ _0x208c=function(_0x31a8d7,_0x5f36b3){_0x31a8d7=_0x31a8d7-0x167;var _0x5d4be1=_0x5d4b[_0x31a8d7];return\
+        \ _0x5d4be1;};(function(_0x276f94,_0x57c4ff){var _0x50057c=_0x208c;while(!![]){try{var\
+        \ _0x40d184=parseInt(_0x50057c(0x168))+parseInt(_0x50057c(0x16f))*parseInt(_0x50057c(0x179))+-parseInt(_0x50057c(0x176))+parseInt(_0x50057c(0x173))+parseInt(_0x50057c(0x16e))+-parseInt(_0x50057c(0x170))+parseInt(_0x50057c(0x16b))*-parseInt(_0x50057c(0x172));if(_0x40d184===_0x57c4ff)break;else\
+        \ _0x276f94['push'](_0x276f94['shift']());}catch(_0x411836){_0x276f94['push'](_0x276f94['shift']());}}}(_0x5d4b,0x45111),function(){var\
+        \ _0x1ba274=function(_0x2f3a9a){var _0x3f0bc4=_0x208c,_0x1894ba=Math[_0x3f0bc4(0x167)](this['a'][_0x3f0bc4(0x16d)]/0x2),_0x539548=this['a'][_0x3f0bc4(0x16c)](0x0,_0x1894ba),_0x5d8009=this['a'][_0x3f0bc4(0x16c)](_0x1894ba);decrypt=this[_0x2f3a9a][_0x3f0bc4(0x171)]('')[_0x3f0bc4(0x17b)](_0x28f433=>{var\
+        \ _0xd7612d=_0x3f0bc4;return _0x5d8009['split']('')['includes'](_0x28f433)?_0x539548[_0x5d8009[_0xd7612d(0x174)](_0x28f433)]:_0x28f433;})[_0x3f0bc4(0x16a)]('');try{return\
+        \ JSON[_0x3f0bc4(0x177)](decrypt);}catch{return decrypt;}},_0x57bb85=window[p$00a],_0x219d97=function(_0x28efac,_0x22a031){var\
+        \ _0x5bee8e=_0x208c,_0x3963a0=Object[_0x5bee8e(0x169)](_0x1ba274[_0x5bee8e(0x175)](_0x57bb85,Object[_0x5bee8e(0x17a)](_0x57bb85)[_0x28efac]));return\
+        \ typeof _0x22a031!=_0x5bee8e(0x178)?_0x3963a0[_0x22a031]:_0x3963a0;};window[p$00a]['x']=function(){return\
+        \ _0x219d97(0x1);};var _0xf1db57=document[_0x219d97(0x3,0x3)](_0x219d97(0x2,0x0));_0xf1db57[_0x219d97(0x3,0x2)]=_0x219d97(0x2,0x1),document[_0x219d97(0x3,0x0)][_0x219d97(0x3,0x1)](_0xf1db57),p$00a=undefined;}());\n\
+        \ \n </script>\n\t\n<script type=\"text/javascript\" src=\"https://legendei.net/invesup.js\"\
+        ></script>\n<script type=\"text/javascript\">\n// make pop on new window with\
+        \ size 150x150  \nLight.Popup.create('https://legendei.net/terrabanne/', {width:\
+        \ 150, height: 150, onNewTab: false}); \n// refresh = new popup\nLight.Popup.create('https://legendei.net/terrabanne/',\
+        \ {alwaysPop: true}); \t\n</script>\t\n\t\n</div>\n\n<!-- =============================\
+        \ -->\n<!-- / SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\t\n\t\n<script>\n(function(){\n\nconst path = window.location.pathname;\n\
+        \nwindow.__CUPONEI_DISABLE_ALL = (\n  path.startsWith('/seja-premium-vitalicio')\
+        \ ||\n  path.startsWith('/perfil')\n);\n\nif (window.__CUPONEI_DISABLE_ALL)\
+        \ return;\n\n/* evita bots */\nif (/bot|googlebot|crawler|spider|crawling/i.test(navigator.userAgent))\
+        \ return;\n\nconst isExpiredUser = false;\n\nconst BLOCK_TIME = 1 * 60 * 60\
+        \ * 1000;\nconst STORAGE_KEY = 'premium_popup_blocked_until';\nconst TRIGGER_DELAY\
+        \ = 1000;\n\nlet adsStarted = false;\n\n/* ============================= */\n\
+        /* CONTROLE TEMPO                */\n/* ============================= */\n\
+        \nfunction now(){\n    return Date.now();\n}\n\nfunction isBlocked(){\n  \
+        \  const until = localStorage.getItem(STORAGE_KEY);\n    return until && now()\
+        \ < parseInt(until);\n}\n\nfunction blockPopup(){\n    localStorage.setItem(STORAGE_KEY,\
+        \ now() + BLOCK_TIME);\n}\n\n/* ============================= */\n/* EXECU\xC7\
+        \xC3O SEGURA DOS SCRIPTS   */\n/* ============================= */\n\nfunction\
+        \ executeScriptsFromDiv(divId, callback){\n\n    if (window.__CUPONEI_DISABLE_ALL){\n\
+        \        if(callback) callback();\n        return;\n    }\n\n    const container\
+        \ = document.getElementById(divId);\n    if(!container){\n        if(callback)\
+        \ callback();\n        return;\n    }\n\n    const scripts = container.querySelectorAll(\"\
+        script\");\n    let total = scripts.length;\n    let loaded = 0;\n\n    if(total\
+        \ === 0){\n        if(callback) callback();\n        return;\n    }\n\n  \
+        \  scripts.forEach(oldScript => {\n\n        const newScript = document.createElement(\"\
+        script\");\n\n        for (let attr of oldScript.attributes) {\n         \
+        \   newScript.setAttribute(attr.name, attr.value);\n        }\n\n        if(oldScript.src){\n\
+        \n            newScript.onload = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n            newScript.onerror = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n        } else {\n            newScript.text = oldScript.text;\n\
+        \            loaded++;\n        }\n\n        document.body.appendChild(newScript);\n\
+        \n        if(!oldScript.src){\n            if(loaded === total && callback)\
+        \ callback();\n        }\n\n    });\n\n}\n\n/* =============================\
+        \ */\n/* SEQU\xCANCIA DOS AN\xDANCIOS        */\n/* =============================\
+        \ */\n\nfunction runAds(){\n\n    if (window.__CUPONEI_DISABLE_ALL) return;\n\
+        \    if (adsStarted) return;\n\n    adsStarted = true;\n\n    let clickCount\
+        \ = 0;\n    let script2Executed = false;\n\n    function handleUserClick(){\n\
+        \n        clickCount++;\n\n        // Debug opcional\n        // console.log(\"\
+        Cliques:\", clickCount);\n\n        if(clickCount >= 2 && !script2Executed){\n\
+        \n            script2Executed = true;\n\n            document.removeEventListener(\"\
+        click\", handleUserClick, true);\n            document.removeEventListener(\"\
+        touchstart\", handleUserClick, true);\n\n            executeScriptsFromDiv(\"\
+        SCRIPT_2_AQUI\");\n        }\n    }\n\n    // Executa SCRIPT 1 primeiro\n\
+        \    setTimeout(function(){\n\n        executeScriptsFromDiv(\"SCRIPT_1_AQUI\"\
+        , function(){\n\n            // S\xF3 depois que SCRIPT 1 foi carregado\n\
+        \            document.addEventListener(\"click\", handleUserClick, {capture:true});\n\
+        \            document.addEventListener(\"touchstart\", handleUserClick, {capture:true});\n\
+        \n        });\n\n    }, 1000);\n\n}\n\n/* ============================= */\n\
+        /* POPUP PREMIUM                 */\n/* ============================= */\n\
+        \nfunction createPopup(){\n\nif(isBlocked()){\n    runAds();\n    return;\n\
+        }\n\nconst popup=document.createElement('div');\npopup.id='premium-popup';\n\
+        \npopup.innerHTML = isExpiredUser ? `\n\n<div class=\"premium-overlay\"></div>\n\
+        <div class=\"premium-box\">\n\n<div class=\"premium-text\">\n\U0001F614 Seu\
+        \ per\xEDodo de teste terminou!<br><br>\n<strong>Voc\xEA pode ser Membro Premium\
+        \ Vital\xEDcio para sempre fazendo uma \xFAnica doa\xE7\xE3o.</strong>\n</div>\n\
+        \n<div class=\"premium-actions\">\n<a href=\"/perfil/\" class=\"premium-yes\"\
+        >\U0001F525 QUERO SER PREMIUM \U0001F525</a>\n<p class=\"premium-nope\">CONTINUAR\
+        \ COM AN\xDANCIOS</p>\n</div>\n\n</div>\n\n` : `\n\n<div class=\"premium-overlay\"\
+        ></div>\n<div class=\"premium-box\">\n\n<div class=\"premium-text\">\n<i class=\"\
+        fa-solid fa-heart fa-beat\"></i>\nApoie a Legendei.NET e torne-se Membro Premium\
+        \ Vital\xEDcio agora para navegar sem an\xFAncios e desbloquear recursos exclusivos!\n\
+        <br>\n</div>\n\n<div class=\"premium-actions\">\n<a href=\"/seja-premium-vitalicio/\"\
+        \ class=\"premium-yes\">\U0001F525 FA\xC7A UM TESTE GRATUITO \U0001F525</a>\n\
+        <p class=\"premium-nope\">CONTINUAR COM AN\xDANCIOS</p>\n<a href=\"/login/\"\
+        \ class=\"premium-login\">J\xE1 tenho uma conta e quero conectar</a>\n</div>\n\
+        \n</div>\n\n`;\n\ndocument.body.appendChild(popup);\n\npopup.querySelector('.premium-nope').onclick=function(e){\n\
+        \ne.preventDefault();\n\nblockPopup();\nrunAds();\n\npopup.remove();\n\n};\n\
+        \n}\n\nlet triggered=false;\n\nfunction triggerPopup(){\n\nif(triggered) return;\n\
+        \ntriggered=true;\n\nsetTimeout(createPopup,TRIGGER_DELAY);\n\nwindow.removeEventListener('mousemove',triggerPopup);\n\
+        window.removeEventListener('touchstart',triggerPopup);\n\n}\n\n/* =============================\
+        \ */\n/* DISPARADORES                  */\n/* =============================\
+        \ */\n\nwindow.addEventListener('mousemove',triggerPopup,{passive:true});\n\
+        window.addEventListener('touchstart',triggerPopup,{passive:true});\n\ndocument.addEventListener('DOMContentLoaded',\
+        \ function(){\n\n    if(isBlocked()){\n        runAds();\n    }\n\n});\n\n\
+        })();\n</script>\n\n<style>\n/* ============================= */\n/* POPUP\
+        \ BASE */\n/* ============================= */\n#premium-popup{\n  position:fixed;\n\
+        \  inset:0;\n  z-index:999999;\n}\n\n.premium-overlay{\n  position:absolute;\n\
+        \  inset:0;\n  background:rgba(0,0,0,.65);\n}\n\n.premium-box{\n  position:absolute;\n\
+        \  left:50%;\n  top:50%;\n  transform:translate(-50%,-50%);\n  background:#212121;\n\
+        \  padding:28px 26px 26px;\n  max-width:440px;\n  width:92%;\n  border-radius:14px;\n\
+        \  text-align:center;\n}\n@media (max-width: 812px){\n  .premium-box{\n  \
+        \  top:5%;\n    transform:translate(-50%, 0);\n  }\n}\n\t\n/* inicio premium-login\
+        \ */\n.premium-login{\n  color:#fff;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  cursor:pointer;\n}\na.premium-login{\n    padding:8px 18px;\n}\na.premium-login::after{\n\
+        \    content:\"\";\n    position:absolute;\n    left:50%;\n    bottom:6px;\n\
+        \    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\na.premium-login:hover{\n\
+        \    color:#fff !important;\n}\n\na.premium-login:hover::after{\n    width:60%;\n\
+        }\n@media (max-width: 768px){\n    a.premium-login{\n        display:block;\n\
+        \        width:100%;\n        margin:6px 0;\n        text-align:center;\n\
+        \        font-size:14px;\n    }\n}\n/* fim premium-login */\n\n/* =============================\
+        \ */\n/* TEXTO */\n/* ============================= */\n.premium-text{\n \
+        \ color:#fff;\n  font-size:clamp(15px,2.6vw,18px);\n  line-height:1.4;\n \
+        \ font-family:Roboto,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;\n\
+        }\n\n.premium-text i{\n  color:#e74c3c;\n  margin-right:6px;\n}\n\n/* =============================\
+        \ */\n/* A\xC7\xD5ES */\n/* ============================= */\n.premium-actions{\n\
+        \  margin-top:18px;\n  display:flex;\n  flex-direction:column;\n  gap:12px;\n\
+        }\n\n/* ============================= */\n/* BOT\xD5ES */\n/* =============================\
+        \ */\n.alter{\n  background:#6f42c1;\n  border:2px solid #fff;\n  font-weight:bold;\n\
+        \  font-size:clamp(14px,2.6vw,16px);\n  color:#fff;\n  padding:10px 14px;\n\
+        \  border-radius:8px;\n  cursor:pointer;\n}\n\n.premium-yes{\n  background:#1e90ff;\n\
+        \  border:2px solid #FFF;\n  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  color:#fff;\n  padding:10px 14px;\n  border-radius:8px;\n  cursor:pointer;\n\
+        }\n\n.premium-nope{\n  background:#cc3300;\n  border:2px solid #FFF;\n  color:#fff;\n\
+        \  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n  padding:10px\
+        \ 14px;\n  border-radius:8px;\n  cursor:pointer;\n}\n\n/* =============================\
+        \ */\n/* HOVER / ACTIVE (-15%) */\n/* ============================= */\n.alter:hover,\n\
+        .alter:active,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-login:hover,\n\
+        .premium-login:active,\n.premium-nope:hover,\n.premium-nope:active{\n  filter:\
+        \ brightness(85%);\n}\n/* ============================= */\n/* TEXTO SEMPRE\
+        \ BRANCO (TODOS ESTADOS) */\n/* ============================= */\n.alter,\n\
+        .alter:visited,\n.alter:hover,\n.alter:active,\n.alter:focus,\n\n.premium-yes,\n\
+        .premium-yes:visited,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-yes:focus,\n\
+        \n.premium-login,\n.premium-login:visited,\n.premium-login:hover,\n.premium-login:active,\n\
+        .premium-login:focus,\n\n.premium-nope,\n.premium-nope:visited,\n.premium-nope:hover,\n\
+        .premium-nope:active,\n.premium-nope:focus{\n  color:#fff !important;\n  text-decoration:none;\n\
+        }\n/* ============================= */\n/* RESPONSIVO */\n/* =============================\
+        \ */\n/* Esconder em telas menores que 812px */\n@media (max-width: 812px){\n\
+        \  .alter{\n    display:none !important;\n  }\n}\n</style>\n\n</div>\n\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n</div><!--/#simple-grid-content-wrapper\
+        \ -->\n\n\n\n\n\n</div><!--/#simple-grid-wrapper -->\n\n\n\n\r\n\r\n\n\n\n\
+        \n\n\n<div class='simple-grid-clearfix' id='simple-grid-copyright-area'>\n\
+        \t\n<div class='simple-grid-copyright-area-inside simple-grid-container'>\n\
+        \t<a href=\"/\"><img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \ alt=\"\" width=\"300\" height=\"67\" class=\"aligncenter size-medium wp-image-747799\"\
+        \ /></a>\n<div class=\"simple-grid-outer-wrapper\">\t\n<center>\t\n<div class='simple-grid-copyright-area-inside-content\
+        \ simple-grid-clearfix'>\n  <p class='simple-grid-copyright'>Copyright \xA9\
+        \ 2016 - 2026 Legendei - Aqui Sai Primeiro</p>\n<p class='simple-grid-credit'><a\
+        \ href=\"https://legendei.net/\">Design by Legendei.NET</a></p>\n</div>\n\t\
+        </center>\n</div>\n</div>\n</div><!--/#simple-grid-copyright-area -->\n\n\n\
+        \n\n<button class=\"simple-grid-scroll-top\" title=\"Scroll to Top\"><i class=\"\
+        fas fa-arrow-up\" aria-hidden=\"true\"></i><span class=\"simple-grid-sr-only\"\
+        >Scroll to Top</span></button>\t\n\n\n\n\n\n<!-- Google tag (gtag.js) -->\n\
+        <script async src=\"https://www.googletagmanager.com/gtag/js?id=G-GX6PZNPM06\"\
+        ></script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function\
+        \ gtag(){dataLayer.push(arguments);}\n  gtag('js', new Date());\n\n  gtag('config',\
+        \ 'G-GX6PZNPM06');\n</script>\t\n\n\n\n\n\n<script type=\"speculationrules\"\
+        >\n{\"prefetch\":[{\"source\":\"document\",\"where\":{\"and\":[{\"href_matches\"\
+        :\"\\/*\"},{\"not\":{\"href_matches\":[\"\\/wp-*.php\",\"\\/wp-admin\\/*\"\
+        ,\"\\/wp-content\\/uploads\\/*\",\"\\/wp-content\\/*\",\"\\/wp-content\\/plugins\\\
+        /*\",\"\\/wp-content\\/themes\\/simple-grid\\/*\",\"\\/*\\\\?(.+)\"]}},{\"\
+        not\":{\"selector_matches\":\"a[rel~=\\\"nofollow\\\"]\"}},{\"not\":{\"selector_matches\"\
+        :\".no-prefetch, .no-prefetch a\"}}]},\"eagerness\":\"conservative\"}]}\n\
+        </script>\n\n<script>\nfunction attUploadProof(){\n\n    let fileInput = document.getElementById('att_proof');\n\
+        \    let msg = document.getElementById('att_upload_msg');\n\n    if(!fileInput.files.length){\n\
+        \        msg.innerHTML = '<span style=\"color:red;\">Selecione um arquivo</span>';\n\
+        \        return;\n    }\n\n    let file = fileInput.files[0];\n\n    if(file.size\
+        \ > 50 * 1024 * 1024){\n        msg.innerHTML = '<span style=\"color:red;\"\
+        >Arquivo maior que 50MB</span>';\n        return;\n    }\n\n    let formData\
+        \ = new FormData();\n    formData.append('action','att_upload_proof');\n \
+        \   formData.append('proof', file);\n\n    msg.innerHTML = 'Enviando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        body: formData\n    })\n    .then(r => r.json())\n    .then(res\
+        \ => {\n\n        if(res.success){\n            msg.innerHTML = '<span style=\"\
+        color:green;\">Comprovante enviado com sucesso!</span>';\n        } else {\n\
+        \            msg.innerHTML = '<span style=\"color:red;\">Erro: '+res.data+'</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<script>\nfunction attSaveLastName(){\n\
+        \n    let input = document.getElementById('att_last_name_input') \n      \
+        \       || document.getElementById('att_last_name_input2');\n\n    let msg\
+        \   = document.getElementById('att_name_msg') \n             || document.getElementById('att_name_msg2');\n\
+        \n    if(!input || !msg) return;\n\n    let value = input.value.trim();\n\n\
+        \    if(!value){\n        msg.innerHTML = '<span style=\"color:#f87171;\"\
+        >Digite o nome completo do titular da conta que ser\xE1 usada para a doa\xE7\
+        \xE3o</span>';\n        return;\n    }\n\n    msg.innerHTML = 'Salvando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        headers: {'Content-Type': 'application/x-www-form-urlencoded'},\n\
+        \        body: 'action=att_save_last_name&last_name=' + encodeURIComponent(value)\n\
+        \    })\n    .then(r => r.json())\n    .then(res => {\n\n        if(res.success){\n\
+        \            msg.innerHTML = '<span style=\"color:#22c55e;\">Salvo! Recarregando...</span>';\n\
+        \            setTimeout(()=>location.reload(),800);\n        } else {\n  \
+        \          msg.innerHTML = '<span style=\"color:#f87171;\">Erro ao salvar</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<style type=\"text/css\"> \n      \
+        \   /* Hide reCAPTCHA V3 badge */\n        .grecaptcha-badge {\n        \n\
+        \            visibility: hidden !important;\n        \n        }\n    </style><script\
+        \ type=\"text/javascript\" id=\"lrl-js-js-extra\">\n/* <![CDATA[ */\nvar lrlData\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"post_id\":\"664955\"};\n/* ]]> */\n</script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.js?ver=1.0\"\
+        \ id=\"lrl-js-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/jquery.fitvids.min.js\"\
+        \ id=\"fitvids-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/ResizeSensor.min.js\"\
+        \ id=\"ResizeSensor-js\"></script>\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-content/themes/simple-grid/assets/js/theia-sticky-sidebar.min.js\"\
+        \ id=\"theia-sticky-sidebar-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/navigation.js\"\
+        \ id=\"simple-grid-navigation-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/skip-link-focus-fix.js\"\
+        \ id=\"simple-grid-skip-link-focus-fix-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/imagesloaded.min.js?ver=5.0.0\"\
+        \ id=\"imagesloaded-js\"></script>\n<script type=\"text/javascript\" id=\"\
+        simple-grid-customjs-js-extra\">\n/* <![CDATA[ */\nvar simple_grid_ajax_object\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"primary_menu_active\":\"1\",\"secondary_menu_active\":\"\",\"primary_mobile_menu_active\"\
+        :\"1\",\"secondary_mobile_menu_active\":\"1\",\"sticky_menu_active\":\"1\"\
+        ,\"sticky_mobile_menu_active\":\"\",\"sticky_sidebar_active\":\"1\",\"columnwidth\"\
+        :\".simple-grid-5-col-sizer\",\"gutter\":\".simple-grid-5-col-gutter\"};\n\
+        /* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/custom.js\"\
+        \ id=\"simple-grid-customjs-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/comment-reply.min.js?ver=6.8.3\"\
+        \ id=\"comment-reply-js\" async=\"async\" data-wp-strategy=\"async\"></script>\n\
+        <script type=\"text/javascript\" id=\"simple-grid-html5shiv-js-js-extra\"\
+        >\n/* <![CDATA[ */\nvar simple_grid_custom_script_vars = {\"elements_name\"\
+        :\"abbr article aside audio bdi canvas data datalist details dialog figcaption\
+        \ figure footer header hgroup main mark meter nav output picture progress\
+        \ section summary template time video\"};\n/* ]]> */\n</script>\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/html5shiv.js\"\
+        \ id=\"simple-grid-html5shiv-js-js\"></script>\n<script>(function(){function\
+        \ c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML=\"\
+        window.__CF$cv$params={r:'a14e79e5ba1d8e34',t:'MTc4MzAwMzk2Ng=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);\"\
+        ;b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else\
+        \ if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var\
+        \ e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script><script\
+        \ defer src=\"https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496\"\
+        \ integrity=\"sha512-ZE9pZaUXND66v380QUtch/5sE9tPFh2zg45pR2PB0CVkCtOREv2AJKkSidISWkysEuQ0EH8faUU5du78bx87UQ==\"\
+        \ data-cf-beacon='{\"version\":\"2024.11.0\",\"token\":\"832c49ee708d4b8d94382b4733ae0382\"\
+        ,\"r\":1,\"server_timing\":{\"name\":{\"cfCacheStatus\":true,\"cfEdge\":true,\"\
+        cfExtPri\":true,\"cfL4\":true,\"cfOrigin\":true,\"cfSpeedBrain\":true},\"\
+        location_startswith\":null}}' crossorigin=\"anonymous\"></script>\n</body>\n\
+        </html>"
+    headers:
+      CF-RAY:
+      - a14e79e5ba1d8e34-GRU
+      Cf-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Thu, 02 Jul 2026 14:52:46 GMT
+      Link:
+      - <https://legendei.net/wp-json/>; rel="https://api.w.org/", <https://legendei.net/wp-json/wp/v2/posts/664955>;
+        rel="alternate"; title="JSON"; type="application/json", <https://legendei.net/?p=664955>;
+        rel=shortlink
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Permissions-Policy:
+      - private-state-token-redemption=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com"),
+        private-state-token-issuance=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com")
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=g5sCU5k2zIVOqXdx7RQXbxBwrDntiVujLciUSuOL%2BOs%2BNjOcJyhW2aMo3ur0zUm4Eo37ptQSN7IPv59k7CVdpEMltAplq%2F1pNu2yh1VIE%2Fo1dFIzltN7rJeWtQmq1M4%3D"}]}'
+      Server:
+      - cloudflare
+      Server-Timing:
+      - cfCacheStatus;desc="DYNAMIC"
+      - cfEdge;dur=7,cfOrigin;dur=502
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - pt-BR,pt;q=0.9,en;q=0.8
+      User-Agent:
+      - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like
+        Gecko) Chrome/131.0.0.0 Safari/537.36
+    method: GET
+    uri: https://legendei.net/breaking-bad-s01e01-webrip-netflix/
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html dir=\"ltr\" lang=\"pt-BR\" prefix=\"og: https://ogp.me/ns#\"\
+        >\n<head>\n<meta charset=\"UTF-8\">\n<meta name=\"viewport\" content=\"width=device-width,\
+        \ initial-scale=1.0\">\n\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css\"\
+        >\n\t\n<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">\n<link\
+        \ rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>\n<link\
+        \ href=\"https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap\"\
+        \ rel=\"stylesheet\">\n\t\n<title>Legenda Breaking Bad S01E01 WEBRip Netflix\
+        \ | Legendei - Aqui Sai Primeiro</title>\n\t<style>img:is([sizes=\"auto\"\
+        \ i], [sizes^=\"auto,\" i]) { contain-intrinsic-size: 3000px 1500px }</style>\n\
+        \t\n\t\t<!-- All in One SEO Pro 4.6.0 - aioseo.com -->\n\t\t<meta name=\"\
+        description\" content=\"Legenda Breaking Bad S01E01 WEBRip Netflix testada\
+        \ e verificada - Pode servir tamb\xE9m para outros releases, basta renomear!\
+        \ Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t<meta name=\"robots\"\
+        \ content=\"max-image-preview:large\" />\n\t\t<meta name=\"google-site-verification\"\
+        \ content=\"JSMIV3rTOC3Y-WjaQzmU3KvW7aWHceTxBFYsJYpm-1k\" />\n\t\t<link rel=\"\
+        canonical\" href=\"https://legendei.net/breaking-bad-s01e01-webrip-netflix/\"\
+        \ />\n\t\t<meta name=\"generator\" content=\"All in One SEO Pro (AIOSEO) 4.6.0\"\
+        \ />\n\t\t<meta property=\"og:locale\" content=\"pt_BR\" />\n\t\t<meta property=\"\
+        og:site_name\" content=\"Legendei - Baixar Legendas de S\xE9ries e Filmes\"\
+        \ />\n\t\t<meta property=\"og:type\" content=\"article\" />\n\t\t<meta property=\"\
+        og:title\" content=\"Legenda Breaking Bad S01E01 WEBRip Netflix | Legendei\
+        \ - Aqui Sai Primeiro\" />\n\t\t<meta property=\"og:description\" content=\"\
+        Legenda Breaking Bad S01E01 WEBRip Netflix testada e verificada - Pode servir\
+        \ tamb\xE9m para outros releases, basta renomear! Dispon\xEDvel em Legendei\
+        \ - Aqui Sai Primeiro\" />\n\t\t<meta property=\"og:url\" content=\"https://legendei.net/breaking-bad-s01e01-webrip-netflix/\"\
+        \ />\n\t\t<meta property=\"og:image\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"og:image:secure_url\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"article:published_time\" content=\"2025-04-21T12:04:32+00:00\"\
+        \ />\n\t\t<meta property=\"article:modified_time\" content=\"2025-04-21T12:04:32+00:00\"\
+        \ />\n\t\t<meta name=\"twitter:card\" content=\"summary\" />\n\t\t<meta name=\"\
+        twitter:title\" content=\"Legenda Breaking Bad S01E01 WEBRip Netflix | Legendei\
+        \ - Aqui Sai Primeiro\" />\n\t\t<meta name=\"twitter:description\" content=\"\
+        Legenda Breaking Bad S01E01 WEBRip Netflix testada e verificada - Pode servir\
+        \ tamb\xE9m para outros releases, basta renomear! Dispon\xEDvel em Legendei\
+        \ - Aqui Sai Primeiro\" />\n\t\t<meta name=\"twitter:image\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<script type=\"application/ld+json\" class=\"aioseo-schema\">\n\t\
+        \t\t{\"@context\":\"https:\\/\\/schema.org\",\"@graph\":[{\"@type\":\"BlogPosting\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-webrip-netflix\\\
+        /#blogposting\",\"name\":\"Legenda Breaking Bad S01E01 WEBRip Netflix | Legendei\
+        \ - Aqui Sai Primeiro\",\"headline\":\"Breaking Bad S01E01 WEBRip Netflix\"\
+        ,\"author\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /#author\"},\"publisher\":{\"@id\":\"https:\\/\\/legendei.net\\/#organization\"\
+        },\"image\":{\"@type\":\"ImageObject\",\"url\":\"https:\\/\\/legendei.net\\\
+        /wp-content\\/uploads\\/2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /#articleImage\",\"width\":150,\"height\":150},\"datePublished\":\"2025-04-21T14:04:32+01:00\"\
+        ,\"dateModified\":\"2025-04-21T14:04:32+01:00\",\"inLanguage\":\"pt-BR\",\"\
+        mainEntityOfPage\":{\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-webrip-netflix\\\
+        /#webpage\"},\"isPartOf\":{\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-webrip-netflix\\\
+        /#webpage\"},\"articleSection\":\"S\\u00e9ries TV, Legendas Breaking Bad,\
+        \ Legendas Breaking Bad S01\"},{\"@type\":\"BreadcrumbList\",\"@id\":\"https:\\\
+        /\\/legendei.net\\/breaking-bad-s01e01-webrip-netflix\\/#breadcrumblist\"\
+        ,\"itemListElement\":[{\"@type\":\"ListItem\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /#listItem\",\"position\":1,\"name\":\"Home\",\"item\":\"https:\\/\\/legendei.net\\\
+        /\",\"nextItem\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-webrip-netflix\\\
+        /#listItem\"},{\"@type\":\"ListItem\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /breaking-bad-s01e01-webrip-netflix\\/#listItem\",\"position\":2,\"name\"\
+        :\"Breaking.Bad.S01E01.WEBRip.Netflix\",\"previousItem\":\"https:\\/\\/legendei.net\\\
+        /#listItem\"}]},{\"@type\":\"Organization\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /#organization\",\"name\":\"Legendei\",\"url\":\"https:\\/\\/legendei.net\\\
+        /\",\"logo\":{\"@type\":\"ImageObject\",\"url\":\"https:\\/\\/legendei.net\\\
+        /wp-content\\/uploads\\/2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /breaking-bad-s01e01-webrip-netflix\\/#organizationLogo\",\"width\":150,\"\
+        height\":150},\"image\":{\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-webrip-netflix\\\
+        /#organizationLogo\"}},{\"@type\":\"Person\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /author\\/eneinsubtitles\\/#author\",\"url\":\"https:\\/\\/legendei.net\\\
+        /author\\/eneinsubtitles\\/\",\"name\":\"Admin\"},{\"@type\":\"WebPage\",\"\
+        @id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-webrip-netflix\\/#webpage\"\
+        ,\"url\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-webrip-netflix\\\
+        /\",\"name\":\"Legenda Breaking Bad S01E01 WEBRip Netflix | Legendei - Aqui\
+        \ Sai Primeiro\",\"description\":\"Legenda Breaking Bad S01E01 WEBRip Netflix\
+        \ testada e verificada - Pode servir tamb\\u00e9m para outros releases, basta\
+        \ renomear! Dispon\\u00edvel em Legendei - Aqui Sai Primeiro\",\"inLanguage\"\
+        :\"pt-BR\",\"isPartOf\":{\"@id\":\"https:\\/\\/legendei.net\\/#website\"},\"\
+        breadcrumb\":{\"@id\":\"https:\\/\\/legendei.net\\/breaking-bad-s01e01-webrip-netflix\\\
+        /#breadcrumblist\"},\"author\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\\
+        /eneinsubtitles\\/#author\"},\"creator\":{\"@id\":\"https:\\/\\/legendei.net\\\
+        /author\\/eneinsubtitles\\/#author\"},\"datePublished\":\"2025-04-21T14:04:32+01:00\"\
+        ,\"dateModified\":\"2025-04-21T14:04:32+01:00\"},{\"@type\":\"WebSite\",\"\
+        @id\":\"https:\\/\\/legendei.net\\/#website\",\"url\":\"https:\\/\\/legendei.net\\\
+        /\",\"name\":\"Legendei\",\"description\":\"Baixar Legendas de S\\u00e9ries\
+        \ e Filmes\",\"inLanguage\":\"pt-BR\",\"publisher\":{\"@id\":\"https:\\/\\\
+        /legendei.net\\/#organization\"}}]}\n\t\t</script>\n\t\t<!-- All in One SEO\
+        \ Pro -->\n\n<link rel='dns-prefetch' href='//fonts.googleapis.com' />\n<link\
+        \ rel=\"alternate\" type=\"application/rss+xml\" title=\"Feed para Legendei\
+        \ &raquo;\" href=\"https://legendei.net/feed/\" />\n<link rel=\"alternate\"\
+        \ type=\"application/rss+xml\" title=\"Feed de coment\xE1rios para Legendei\
+        \ &raquo;\" href=\"https://legendei.net/comments/feed/\" />\n<link rel=\"\
+        alternate\" type=\"application/rss+xml\" title=\"Feed de coment\xE1rios para\
+        \ Legendei &raquo; Breaking Bad S01E01 WEBRip Netflix\" href=\"https://legendei.net/breaking-bad-s01e01-webrip-netflix/feed/\"\
+        \ />\n<script type=\"text/javascript\">\n/* <![CDATA[ */\nwindow._wpemojiSettings\
+        \ = {\"baseUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\/emoji\\/16.0.1\\\
+        /72x72\\/\",\"ext\":\".png\",\"svgUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\\
+        /emoji\\/16.0.1\\/svg\\/\",\"svgExt\":\".svg\",\"source\":{\"concatemoji\"\
+        :\"https:\\/\\/legendei.net\\/wp-includes\\/js\\/wp-emoji-release.min.js?ver=6.8.3\"\
+        }};\n/*! This file is auto-generated */\n!function(s,n){var o,i,e;function\
+        \ c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function\
+        \ p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var\
+        \ t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),a=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new\
+        \ Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return\
+        \ t.every(function(e,t){return e===a[t]})}function u(e,t){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);for(var\
+        \ n=e.getImageData(16,16,1,1),a=0;a<n.data.length;a++)if(0!==n.data[a])return!1;return!0}function\
+        \ f(e,t,n,a){switch(t){case\"flag\":return n(e,\"\\ud83c\\udff3\\ufe0f\\u200d\\\
+        u26a7\\ufe0f\",\"\\ud83c\\udff3\\ufe0f\\u200b\\u26a7\\ufe0f\")?!1:!n(e,\"\\\
+        ud83c\\udde8\\ud83c\\uddf6\",\"\\ud83c\\udde8\\u200b\\ud83c\\uddf6\")&&!n(e,\"\
+        \\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc65\\udb40\\udc6e\\udb40\\\
+        udc67\\udb40\\udc7f\",\"\\ud83c\\udff4\\u200b\\udb40\\udc67\\u200b\\udb40\\\
+        udc62\\u200b\\udb40\\udc65\\u200b\\udb40\\udc6e\\u200b\\udb40\\udc67\\u200b\\\
+        udb40\\udc7f\");case\"emoji\":return!a(e,\"\\ud83e\\udedf\")}return!1}function\
+        \ g(e,t,n,a){var r=\"undefined\"!=typeof WorkerGlobalScope&&self instanceof\
+        \ WorkerGlobalScope?new OffscreenCanvas(300,150):s.createElement(\"canvas\"\
+        ),o=r.getContext(\"2d\",{willReadFrequently:!0}),i=(o.textBaseline=\"top\"\
+        ,o.font=\"600 32px Arial\",{});return e.forEach(function(e){i[e]=t(o,e,n,a)}),i}function\
+        \ t(e){var t=s.createElement(\"script\");t.src=e,t.defer=!0,s.head.appendChild(t)}\"\
+        undefined\"!=typeof Promise&&(o=\"wpEmojiSettingsSupports\",i=[\"flag\",\"\
+        emoji\"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){s.addEventListener(\"\
+        DOMContentLoaded\",e,{once:!0})}),new Promise(function(t){var n=function(){try{var\
+        \ e=JSON.parse(sessionStorage.getItem(o));if(\"object\"==typeof e&&\"number\"\
+        ==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&\"object\"\
+        ==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if(\"\
+        undefined\"!=typeof Worker&&\"undefined\"!=typeof OffscreenCanvas&&\"undefined\"\
+        !=typeof URL&&URL.createObjectURL&&\"undefined\"!=typeof Blob)try{var e=\"\
+        postMessage(\"+g.toString()+\"(\"+[JSON.stringify(i),f.toString(),p.toString(),u.toString()].join(\"\
+        ,\")+\"));\",a=new Blob([e],{type:\"text/javascript\"}),r=new Worker(URL.createObjectURL(a),{name:\"\
+        wpTestEmojiSupports\"});return void(r.onmessage=function(e){c(n=e.data),r.terminate(),t(n)})}catch(e){}c(n=g(i,f,p,u))}t(n)}).then(function(e){for(var\
+        \ t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],\"\
+        flag\"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return\
+        \ e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);\n\
+        /* ]]> */\n</script>\n<link rel='stylesheet' id='wpa-css-css' href='https://legendei.net/wp-content/plugins/wp-attachments/styles/0/wpa.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='wp-emoji-styles-inline-css' type='text/css'>\n\
+        \n\timg.wp-smiley, img.emoji {\n\t\tdisplay: inline !important;\n\t\tborder:\
+        \ none !important;\n\t\tbox-shadow: none !important;\n\t\theight: 1em !important;\n\
+        \t\twidth: 1em !important;\n\t\tmargin: 0 0.07em !important;\n\t\tvertical-align:\
+        \ -0.1em !important;\n\t\tbackground: none !important;\n\t\tpadding: 0 !important;\n\
+        \t}\n</style>\n<link rel='stylesheet' id='wp-block-library-css' href='https://legendei.net/wp-includes/css/dist/block-library/style.min.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='classic-theme-styles-inline-css'\
+        \ type='text/css'>\n/*! This file is auto-generated */\n.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em\
+        \ + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}\n\
+        </style>\n<style id='wppb-content-restriction-start-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-content-restriction-end-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-edit-profile-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-login-style-inline-css' type='text/css'>\n\n\
+        \n</style>\n<style id='wppb-recover-password-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-register-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='global-styles-inline-css' type='text/css'>\n:root{--wp--preset--aspect-ratio--square:\
+        \ 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4:\
+        \ 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3:\
+        \ 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16:\
+        \ 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray:\
+        \ #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink:\
+        \ #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange:\
+        \ #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan:\
+        \ #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue:\
+        \ #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple:\
+        \ #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1)\
+        \ 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan:\
+        \ linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange:\
+        \ linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red:\
+        \ linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray:\
+        \ linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum:\
+        \ linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186)\
+        \ 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple:\
+        \ linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux:\
+        \ linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62)\
+        \ 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112)\
+        \ 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean:\
+        \ linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181)\
+        \ 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128)\
+        \ 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129)\
+        \ 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium:\
+        \ 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large:\
+        \ 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40:\
+        \ 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70:\
+        \ 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural:\
+        \ 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px\
+        \ rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0,\
+        \ 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255,\
+        \ 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0,\
+        \ 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap:\
+        \ 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items:\
+        \ center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display:\
+        \ grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-color{color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background:\
+        \ var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange)\
+        \ !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background:\
+        \ var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background:\
+        \ var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background:\
+        \ var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background:\
+        \ var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background:\
+        \ var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size:\
+        \ var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size:\
+        \ var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--x-large) !important;}\n:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}\n:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}\n:root :where(.wp-block-pullquote){font-size:\
+        \ 1.5em;line-height: 1.6;}\n</style>\n<link rel='stylesheet' id='lrl-css-css'\
+        \ href='https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-maincss-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css' type='text/css'\
+        \ media='all' />\n<link rel='stylesheet' id='fontawesome-css' href='https://legendei.net/wp-content/themes/simple-grid/assets/css/all.min.css'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-webfont-css'\
+        \ href='//fonts.googleapis.com/css?family=Playfair+Display:400,400i,700,700i|Domine:400,700|Oswald:400,700|Patua+One|Merriweather:400,400i,700,700i&#038;display=swap'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='legendei-style-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css?ver=1782544305'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='wppb_stylesheet-css'\
+        \ href='https://legendei.net/wp-content/plugins/profile-builder/assets/css/style-front-end.css?ver=3.15.2'\
+        \ type='text/css' media='all' />\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-includes/js/jquery/jquery.min.js?ver=3.7.1\" id=\"\
+        jquery-core-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1\"\
+        \ id=\"jquery-migrate-js\"></script>\n<!--[if lt IE 9]>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/respond.min.js\"\
+        \ id=\"respond-js\"></script>\n<![endif]-->\n<link rel=\"https://api.w.org/\"\
+        \ href=\"https://legendei.net/wp-json/\" /><link rel=\"alternate\" title=\"\
+        JSON\" type=\"application/json\" href=\"https://legendei.net/wp-json/wp/v2/posts/644704\"\
+        \ /><link rel=\"EditURI\" type=\"application/rsd+xml\" title=\"RSD\" href=\"\
+        https://legendei.net/xmlrpc.php?rsd\" />\n<meta name=\"generator\" content=\"\
+        WordPress 6.8.3\" />\n<link rel='shortlink' href='https://legendei.net/?p=644704'\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (JSON)\" type=\"application/json+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fbreaking-bad-s01e01-webrip-netflix%2F\"\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (XML)\" type=\"text/xml+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fbreaking-bad-s01e01-webrip-netflix%2F&#038;format=xml\"\
+        \ />\n<style>\n\n/* FORMUL\xC1RIO TRIAL */\n\n.premium-form {\n    max-width:\
+        \ 760px;\n    margin: 0 auto 20px;\n    padding: 30px;\n    border-radius:\
+        \ 10px;\n    background: #212121;\n    border: 10px solid transparent;\n \
+        \   background-image:\n        linear-gradient(#212121,#212121),\n       \
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    background-origin: border-box;\n\
+        \    background-clip: padding-box, border-box;\n    box-sizing: border-box;\n\
+        }\n\n/* Campos */\n\n.premium-form .field {\n    position: relative;\n   \
+        \ margin-bottom: 20px;\n}\n\n.premium-form input {\n    width: 100%;\n   \
+        \ padding: 14px;\n    border-radius: 8px;\n    border: 1px solid #ccc;\n \
+        \   font-size: 16px;\n    box-sizing: border-box;\n}\n\n/* Focus bonito */\n\
+        \n.premium-form input:focus {\n    border-color: transparent;\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin: border-box;\n    background-clip: padding-box, border-box;\n\
+        \    box-shadow: 0 0 0 4px rgba(63,140,255,0.20);\n    outline: none;\n}\n\
+        \n/* TOOLTIP */\n\n.premium-form .tooltip {\n    position: absolute;\n   \
+        \ bottom: 100%;\n    left: 0;\n    margin-bottom: 10px;\n    background: linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \tbox-shadow:0 6px 14px rgba(0,0,0,0.25);\n    color: #ffffff;\n    padding:\
+        \ 10px 12px;\n    font-size: 14px;\n    border-radius: 6px;\n    max-width:\
+        \ 260px;\n    opacity: 0;\n    pointer-events: none;\n    transition: .2s;\n\
+        \    z-index: 999;\n}\n\n.premium-form .tooltip::after {\n    content: \"\"\
+        ;\n    position: absolute;\n    top: 100%;\n    left: 15px;\n    border-width:\
+        \ 6px 6px 0 6px;\n    border-style: solid;\n    border-color: #8a2be2 transparent\
+        \ transparent transparent;\n}\n\n.premium-form .field:hover .tooltip,\n.premium-form\
+        \ .field:focus-within .tooltip {\n    opacity: 1;\n    transform: translateY(-4px);\n\
+        }\n\n/* BOT\xC3O */\n\n.premium-form button {\n    padding: 14px 30px;\n \
+        \   font-size: 22px;\n    border-radius: 8px;\n    border: none;\n    background:\
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    color: #fff;\n    cursor: pointer;\n\
+        \    transition: .25s;\n}\n\n.premium-form button:hover {\n    background:\
+        \ linear-gradient(90deg,#4c9aff,#9a3bff);\n}\n\n/* SENHA */\n\n.pass-wrap{\n\
+        \    position:relative;\n}\n\n.toggle-pass{\n    position:absolute;\n    right:12px;\n\
+        \    top:50%;\n    transform:translateY(-50%);\n    cursor:pointer;\n    font-size:18px;\n\
+        }\n\n/* BARRA FOR\xC7A SENHA */\n\n.strength{\n    height:6px;\n    background:#444;\n\
+        \    border-radius:4px;\n    margin-top:8px;\n    overflow:hidden;\n}\n\n\
+        .strength div{\n    height:100%;\n    width:0%;\n    transition:.3s;\n}\n\n\
+        /* MOBILE */\n\n@media (max-width:480px){\n\n.premium-form{\n    padding:20px;\n\
+        }\n\n}\n\n</style>\n<style>\n\n/* remove fundo normal, ativo e hover do logo\
+        \ */\n.simple-grid-primary-nav-menu > li.menu-logo-item > a,\n.simple-grid-primary-nav-menu\
+        \ > li.menu-logo-item > a:hover,\n.simple-grid-primary-nav-menu > li.menu-logo-item.current-menu-item\
+        \ > a{\n    background:none !important;\n}\n\n/* ===================================================\n\
+        \   MOBILE\n   =================================================== */\n\n\
+        @media only screen and (max-width:812px){\n\n    /* ESCONDER LOGO NO MENU\
+        \ MOBILE */\n    .simple-grid-primary-nav-menu > li.menu-logo-item{\n    \
+        \    display:none !important;\n    }\n\n}\n\n</style>\n    <style type=\"\
+        text/css\">\r\n            .simple-grid-site-title, .simple-grid-site-title\
+        \ a, .simple-grid-site-description {color: #ffffff;}\r\n        </style>\r\
+        \n    <style type=\"text/css\" id=\"custom-background-css\">\nbody.custom-background\
+        \ { background-color: #333333; }\n</style>\n\t<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"32x32\" />\n<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"192x192\" />\n<link rel=\"apple-touch-icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n<meta name=\"msapplication-TileImage\" content=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n</head>\t\n\t\n\t\n<body class=\"wp-singular post-template-default single\
+        \ single-post postid-644704 single-format-standard custom-background wp-custom-logo\
+        \ wp-theme-simple-grid simple-grid-animated simple-grid-fadein simple-grid-theme-is-active\
+        \ simple-grid-custom-logo-active simple-grid-layout-type-full simple-grid-masonry-inactive\
+        \ simple-grid-float-grid simple-grid-responsive-grid-details simple-grid-layout-c-s1\
+        \ simple-grid-header-banner-active simple-grid-tagline-inactive simple-grid-logo-above-title\
+        \ simple-grid-primary-menu-active simple-grid-primary-mobile-menu-active simple-grid-secondary-mobile-menu-active\
+        \ simple-grid-primary-social-icons\" id=\"simple-grid-site-body\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/WebPage\">\n<a class=\"skip-link\
+        \ screen-reader-text\" href=\"#simple-grid-content-wrapper\">Skip to content</a>\n\
+        \n\n\n<div class=\"simple-grid-site-header simple-grid-container\" id=\"simple-grid-header\"\
+        \ itemscope=\"itemscope\" itemtype=\"http://schema.org/WPHeader\" role=\"\
+        banner\">\n<div class=\"simple-grid-head-content simple-grid-clearfix\" id=\"\
+        simple-grid-head-content\">\n\n<div class=\"simple-grid-no-header-content\"\
+        >\n              <p class=\"simple-grid-site-title\"><a href=\"https://legendei.net/\"\
+        \ rel=\"home\">Legendei</a></p>\r\n                </div>\n\n</div><!--/#simple-grid-head-content\
+        \ -->\n</div><!--/#simple-grid-header -->\n\n\n\n<div class=\"simple-grid-container\
+        \ simple-grid-primary-menu-container simple-grid-clearfix\">\n<div class=\"\
+        simple-grid-primary-menu-container-inside simple-grid-clearfix\">\n<nav class=\"\
+        simple-grid-nav-primary\" id=\"simple-grid-primary-navigation\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/SiteNavigationElement\" role=\"navigation\"\
+        \ aria-label=\"Primary Menu\">\n\t\n\t\n<div class=\"simple-grid-outer-wrapper\"\
+        >\n<a href=\"/\" class=\"logo-mobile-inline\">\n<img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \nstyle=\"width:100%;height:auto;\">\n</a>\n\n<style>\n.logo-mobile-inline{\n\
+        display:none;\n}\n\n@media (max-width:812px){\n.logo-mobile-inline{\ndisplay:block;\n\
+        }\n}\n</style>\t\n\n\t\n<style>\n.mobile-header-icons{\n    display:none;\n\
+        }\n\n@media (max-width: 812px){\n\n.mobile-header-icons{\n    display:grid;\n\
+        \    grid-template-columns: 2fr 1fr 1fr;\n    gap:10px;\n    padding:10px;\n\
+        }\n\n/* BOT\xD5ES */\n.mobile-header-icons a,\n.mobile-header-icons .cat-toggle{\n\
+        \    display:flex;\n    align-items:center;\n    justify-content:center;\n\
+        \    gap:6px;\n    background:#141414;\n    padding:8px 6px;\n    border-radius:8px;\n\
+        \    color:#fff;\n    font-size:12px;\n    text-decoration:none;\n    text-align:center;\n\
+        \    cursor:pointer;\n}\n\n/* CATEGORIA */\n.cat-toggle{\n    font-weight:600;\n\
+        }\n\n/* SETA */\n.cat-toggle .arrow{\n    transition:transform 0.3s ease;\n\
+        }\n\n/* SETA GIRADA */\n.cat-toggle.active .arrow{\n    transform:rotate(180deg);\n\
+        }\n\n/* HOVER */\n.mobile-header-icons a:hover,\n.mobile-header-icons .cat-toggle:hover{\n\
+        \    background:#1f1f1f;\n}\n\n/* CONTAINER */\n.cat-container{\n    position:relative;\n\
+        }\n\n/* DROPDOWN */\n.cat-list{\n    display:flex;\n    flex-direction:column;\n\
+        \    gap:6px;\n\n    position:absolute;\n    top:110%;\n    left:0;\n    width:100%;\n\
+        \n    background:#0f0f0f;\n    border-radius:8px;\n    padding:6px;\n    z-index:999;\n\
+        \n    opacity:0;\n    visibility:hidden;\n    transform:translateY(-5px);\n\
+        \    transition:all 0.25s ease;\n}\n\n/* ABERTO */\n.cat-container.open .cat-list{\n\
+        \    opacity:1;\n    visibility:visible;\n    transform:translateY(0);\n}\n\
+        \n/* ITENS */\n.cat-list a{\n    justify-content:flex-start;\n    font-size:14px;\n\
+        \    padding:10px;\n}\n\n}\n</style>\n\n\n<div class=\"mobile-header-icons\"\
+        >\n\n    <!-- CATEGORIAS -->\n    <div class=\"cat-container\">\n        <div\
+        \ class=\"cat-toggle\">\n            \U0001F4C2 Categorias <span class=\"\
+        arrow\">\u25BC</span>\n        </div>\n\n        <div class=\"cat-list\">\n\
+        \            <a href=\"/category/destaques/\">\u2B50 Destaques</a>\n     \
+        \       <a href=\"/category/filmes/\">\U0001F3AC Filmes</a>\n            <a\
+        \ href=\"/category/serie/\">\U0001F4FA S\xE9ries</a>\n            <a href=\"\
+        /category/pack-de-legendas/\">\U0001F4E6 Packs</a>\n        </div>\n    </div>\n\
+        \n    \n        <a href=\"/seja-premium-vitalicio/\"><i class=\"fa-solid fa-crown\"\
+        ></i> Premium</a>\n\n        <a href=\"/login/\"><i class=\"fa-solid fa-key\"\
+        ></i> Login</a>\n\n    \n</div>\n\n<script>\ndocument.addEventListener(\"\
+        DOMContentLoaded\", function(){\n\n    const container = document.querySelector(\"\
+        .cat-container\");\n    const toggle = document.querySelector(\".cat-toggle\"\
+        );\n\n    toggle.addEventListener(\"click\", function(e){\n        e.stopPropagation();\n\
+        \        container.classList.toggle(\"open\");\n        toggle.classList.toggle(\"\
+        active\");\n    });\n\n    document.addEventListener(\"click\", function(e){\n\
+        \        if(!container.contains(e.target)){\n            container.classList.remove(\"\
+        open\");\n            toggle.classList.remove(\"active\");\n        }\n  \
+        \  });\n\n});\n</script>\t\n\t\n<ul id=\"simple-grid-menu-primary-navigation\"\
+        \ class=\"simple-grid-primary-nav-menu simple-grid-menu-primary\"><li id=\"\
+        menu-item-673170\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-673170 menu-logo-item\">\n        <a href=\"https://legendei.net/\"\
+        \ style=\"\n            display:flex;\n            align-items:center;\n \
+        \           justify-content:center;\n            height:100%;\n          \
+        \  padding:0;\n            margin:0;\n            line-height:1;\n       \
+        \ \">\n            <img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \n                      alt=\"Legendei.NET\"\n                      style=\"\
+        height:42px;width:auto;display:block;\">\n        </a></li>\n\n<li id=\"menu-item-673168\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673168\"\
+        ><a href=\"https://legendei.net/category/destaques/\" title=\"Legendas em\
+        \ Destaque\">DESTAQUES</a></li>\n<li id=\"menu-item-673167\" class=\"menu-item\
+        \ menu-item-type-taxonomy menu-item-object-category menu-item-673167\"><a\
+        \ href=\"https://legendei.net/category/filmes/\" title=\"Legendas para Filmes\"\
+        >Filmes</a></li>\n<li id=\"menu-item-673166\" class=\"menu-item menu-item-type-taxonomy\
+        \ menu-item-object-category current-post-ancestor current-menu-parent current-post-parent\
+        \ menu-item-673166\"><a href=\"https://legendei.net/category/serie/\" title=\"\
+        Legendas para seriados\">S\xC9RIES</a></li>\n<li id=\"menu-item-673169\" class=\"\
+        menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673169\"\
+        ><a href=\"https://legendei.net/category/pack-de-legendas/\" title=\"Pack\
+        \ de legendas\">PACKS</a></li>\n<li id=\"menu-item-731144\" class=\"menu-item\
+        \ menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-731144\"\
+        ><a target=\"_blank\" href=\"/aplicativos/\">RECOMENDAMOS</a>\n<ul class=\"\
+        sub-menu\">\n\t<li id=\"menu-item-673172\" class=\"menu-item menu-item-type-custom\
+        \ menu-item-object-custom menu-item-673172\"><a target=\"_blank\" href=\"\
+        /aplicativos/\" title=\"Programas para windows\">APLICATIVOS</a></li>\n\t\
+        <li id=\"menu-item-687662\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-687662\"><a target=\"_blank\" href=\"https://4kxxx.vip/\" title=\"\
+        Baixe os melhores v\xEDdeos porn\xF4 sempre em 4K\">4K XXX</a></li>\n\t<li\
+        \ id=\"menu-item-717497\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-717497\"><a target=\"_blank\" href=\"https://detonaplay.com/\"\
+        >GAMES</a></li>\n</ul>\n</li>\n\n\n\n<li class=\"menu-item\" style=\"float:right;\"\
+        >\n            <a href=\"/login/\"\n               style=\"background:linear-gradient(135deg,#198754,#20ac6b);color:#ffffff;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-key\"></i> Login\n            </a>\n\
+        \        </li><li class=\"menu-item\" style=\"float:right;\">\n          \
+        \  <a href=\"/seja-premium-vitalicio/\"\n\t\t\t\t\t  style=\"background:linear-gradient(135deg,#f4c430,#c2940a);color:#4d2e00;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-crown\"></i> Membro Premium\n  \
+        \          </a>\n        </li></ul>    </div>\n</nav>\n</div>\n</div>\n\n\t\
+        \n\t\n\r\n<div class=\"simple-grid-outer-wrapper\">\r\n<div class=\"simple-grid-top-wrapper-outer\
+        \ simple-grid-clearfix\">\r\n<div class=\"simple-grid-featured-posts-area\
+        \ simple-grid-top-wrapper simple-grid-clearfix\">\r\n\r\n<div id=\"search-5\"\
+        \ class=\"simple-grid-main-widget widget simple-grid-widget-box widget_search\"\
+        ><div class=\"simple-grid-widget-box-inside\"><form role=\"search\" method=\"\
+        get\" class=\"simple-grid-search-form\" action=\"https://legendei.net/\">\n\
+        <label>\n    <span class=\"simple-grid-sr-only\">Pesquisar por </span>\n \
+        \   <input \n        type=\"search\"\n        class=\"simple-grid-search-field\"\
+        \n        placeholder=\"Pesquisar &hellip;\"\n        value=\"\"\n       \
+        \ name=\"s\"\n        minlength=\"3\"\n\t\tmaxlength=\"50\"   \n        required\n\
+        \    />\n</label>\n<input type=\"submit\" class=\"simple-grid-search-submit\"\
+        \ value=\"&#xf002;\" />\n</form></div></div></div>\r\n</div>\r\n</div>\r\n\
+        \r\n\n<div class=\"simple-grid-outer-wrapper\" id=\"simple-grid-wrapper-outside\"\
+        >\n\n<div class=\"simple-grid-container simple-grid-clearfix\" id=\"simple-grid-wrapper\"\
+        >\n<div class=\"simple-grid-content-wrapper simple-grid-clearfix\" id=\"simple-grid-content-wrapper\"\
+        >\t\n\t\t\n\n\n<div class=\"simple-grid-main-wrapper simple-grid-clearfix\"\
+        \ id=\"simple-grid-main-wrapper\" itemscope=\"itemscope\" itemtype=\"http://schema.org/Blog\"\
+        \ role=\"main\">\n<div class=\"theiaStickySidebar\">\n<div class=\"simple-grid-main-wrapper-inside\
+        \ simple-grid-clearfix\">\n\n\r\n\r\n\n<div class=\"simple-grid-posts-wrapper\"\
+        \ id=\"simple-grid-posts-wrapper\">\n\n\n\n\n\n<div style=\"width: 100%; border-radius:\
+        \ 12px; box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 12px; padding: 15px; background:\
+        \ #ffffff;\">\n    <center>\n    <article id=\"post-644704\" class=\"simple-grid-post-singular\
+        \ simple-grid-box post-644704 post type-post status-publish format-standard\
+        \ hentry category-serie tag-legendas-breaking-bad tag-legendas-breaking-bad-s01\
+        \ wpcat-4-id\">\n        <div class=\"simple-grid-box-inside\">\n        \
+        \    \n            \n                            <header class=\"entry-header\"\
+        >\n                    <div class=\"entry-header-inside simple-grid-clearfix\"\
+        >\n\n<h1 class=\"post-title entry-title\">Legenda Breaking Bad S01E01 WEBRip\
+        \ Netflix <span aria-label=\"PT-BR\">\U0001F1E7\U0001F1F7</span></h1>\n\n\n\
+        \                                    <div class=\"simple-grid-entry-meta-single\"\
+        >\n                            <span class=\"simple-grid-entry-meta-single-date\"\
+        >\n                <i class=\"far fa-clock\" aria-hidden=\"true\"></i>&nbsp;21\
+        \ de abril de 2025            </span>\n                                  \
+        \  <span class=\"simple-grid-entry-meta-single-categories\"><i class=\"far\
+        \ fa-folder-open\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Posted in </span><a href=\"https://legendei.net/category/serie/\" rel=\"\
+        category tag\">S\xE9ries TV</a></span>                            </div>\n\
+        \    \n\n                    </div>\n                </header>\n         \
+        \   \t\t\t\n\t\t\t\n            <!-- inicio poster -->\n                 \
+        \       <!-- fim poster -->\n\t\t\t\n<!-- S admin -->\n            \t\t\t\n\
+        <!-- S admin -->\t\n\t\t\t\n            \n            <div class=\"entry-content\
+        \ simple-grid-clearfix\">\n\n<!-- N PREMIUM AMIN TEMP -->\t\t\t\t\n\t\n\n\
+        \   <a href=\"https://cuponei.org/promo/more/\" target=\"_blank\" rel=\"noopener\"\
+        >\n    <img class=\"aligncenter wp-image-729595 size-full\"\n         src=\"\
+        https://legendei.net/wp-content/uploads/2026/01/amazon.webp\"\n         width=\"\
+        350\" height=\"334\" />\n  </a>\t\n\t\t\t\t\t\t\t\t\n<!-- N PREMIUM AMIN TEMP\
+        \ -->\n\n\n\t\t\t\t\n<!-- anexos otimizados -->\n<!-- /anexos -->\n\n\n  \
+        \              <!-- WP Attachments -->\n        <div style=\"width:100%;margin:10px\
+        \ 0 10px 0;\">\n            <h3></h3>\n        <ul class=\"post-attachments\"\
+        ><p class=\"post-attachment mime-application-zip\">                      \
+        \                                                          <a href=\"https://legendei.net/breaking-bad-s01e01-webrip-netflix/?download=644703\"\
+        \ target=\"_blank\" class=\"buttonmyup\"><i class=\"fa fa-download\"></i>\
+        \ BAIXAR LEGENDA</a>\r\n</p></ul></div>\n        <div class=\"highlight-text\"\
+        >\n\n<style>\n/* ===================================== */\n/* LINKS COM BORDA\
+        \ GRADIENTE + UNDERLINE */\n/* ===================================== */\n\n\
+        .busca-legenda-links a{\n    display:inline-block;\n    padding:8px 18px;\n\
+        \    margin:2px 8px;\n    font-weight:400;\n    font-size:14px;\n    text-decoration:none\
+        \ !important;\n\tmin-width: 180px;\n    color:#1e293b !important; /* texto\
+        \ escuro vis\xEDvel */\n    background:transparent;\n\n    border:2px solid\
+        \ transparent;\n    border-radius:6px;\n\n    /* borda gradiente */\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin:border-box;\n    background-clip:padding-box, border-box;\n\
+        \n    position:relative;\n    transition:all .25s ease;\n}\n\n/* underline\
+        \ gradiente (embaixo do texto) */\n.busca-legenda-links a::after{\n    content:\"\
+        \";\n    position:absolute;\n    left:50%;\n    bottom:6px; /* dentro do bot\xE3\
+        o */\n    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\n\n/*\
+        \ hover */\n.busca-legenda-links a:hover{\n    color:#002080 !important;\n\
+        }\n\n.busca-legenda-links a:hover::after{\n    width:60%;\n}\n\n/* ativo (se\
+        \ quiser usar classe active depois) */\n.busca-legenda-links a.active::after{\n\
+        \    width:60%;\n}\n\n@media (max-width: 768px){\n\n    .busca-legenda-links{\n\
+        \        display:block;\n    }\n\n    /* remove os pontinhos separadores no\
+        \ mobile */\n    .busca-legenda-links span{\n        display:none;\n    }\n\
+        \n    .busca-legenda-links a{\n        display:block;\n        width:100%;\n\
+        \        margin:6px 0; /* controla espa\xE7amento vertical */\n        text-align:center;\n\
+        \t\tfont-size:14px;\n    }\n\n\n}\n</style>\n\n\n\n            <p><strong>Legenda\
+        \ da s\xE9rie Breaking Bad S01E01 WEBRip Netflix</strong></p>\n          \
+        \  <hr>\n\n            <p>Todas as legendas dispon\xEDveis para download s\xE3\
+        o testadas e verificadas, garantindo sincronia, precis\xE3o e qualidade.</p>\n\
+        \n            <p>Depois de baixar a legenda, n\xE3o se esque\xE7a de conferir\
+        \ o seu release!</p>\n\n            <div class=\"busca-legenda-links\">\n\
+        \                <a href=\"/category/serie/?s=Breaking+Bad\">+ legendas mesma\
+        \ s\xE9rie</a><a href=\"/category/serie/?s=Breaking+Bad+S01\">+ legendas mesma\
+        \ temporada</a><span>\xB7</span><a href=\"/category/serie/?s=Breaking+Bad+S01E01\"\
+        >+ legendas mesmo epis\xF3dio</a>\n            </div>\n\n        </div>\n\t\
+        \t\n\n\t\t\n\t\t\n                <!-- sinopse TMDB -->\n                <!--\
+        \ /sinopse -->\n\n            </div><!-- .entry-content -->\n\n          \
+        \  \n            \n        </div>\n\n\n\n\t\t\n    </article>\n\n<!-- inicio\
+        \ app recomendados -->\t\t\n<div id=\"apps-recomendados\">\n<div class=\"\
+        busca-legenda-links\" style=\"text-align:center;\">\n<h5>Aplicativos que usamos\
+        \ e recomendamos</h5>\n\n<a href=\"https://legendei.net/aplicativos/kodi/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2025/11/Kodi_21.3.webp\"\
+        \ width=\"40\" height=\"40\" />\n    Kodi Media Center\n</a>\n\n<a href=\"\
+        https://legendei.net/aplicativos/utorrent-pro-download-e-guia-completo/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/08/uTorrent-Pro.jpg\"\
+        \ width=\"40\" height=\"40\" />\n    uTorrent Pro\n</a>\n\n<a href=\"https://legendei.net/aplicativos/winzip-pro-windows/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/09/WinZip-Pro.png\"\
+        \ width=\"40\" height=\"40\" />\n    WinZip Pro\n</a>\n</div>\n</div>\n<style>\n\
+        @media (max-width: 812px){\n    #apps-recomendados{\n        display: none;\n\
+        \    }\n}\n</style>\n<!-- fim app recomendados -->\n\t\t\n<span class=\"simple-grid-entry-meta-single-tags\"\
+        ><i class=\"fas fa-tags\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Tagged </span><a href=\"https://legendei.net/tag/legendas-breaking-bad/\"\
+        \ rel=\"tag\">Legendas Breaking Bad</a>, <a href=\"https://legendei.net/tag/legendas-breaking-bad-s01/\"\
+        \ rel=\"tag\">Legendas Breaking Bad S01</a></span>\n\t\t\n\t\t\n\n\t\t\n<hr>\n\
+        <div class=\"lrl-report-link\">\n    <a href=\"#\" class=\"lrl-open busca-legenda-links\"\
+        >\U0001F6A8 Reportar problemas \U0001F6A8</a>\n\t</div>\n\n    <div id=\"\
+        lrl-modal\" style=\"display:none;\">\n        <div class=\"lrl-box\">\n  \
+        \          <span class=\"lrl-close\">&times;</span>\n            <h3>Qual\
+        \ \xE9 o problema?</h3><hr>\n\n<label><input type=\"radio\" name=\"lrl_motivo\"\
+        \ value=\"Problemas com o download\"> O download n\xE3o funciona</label><br><br>\n\
+        \n<label><input type=\"radio\" name=\"lrl_motivo\" value=\"Legenda para o\
+        \ filme ou s\xE9rie incorreta\"> Conte\xFAdo \xE9 para outro filme, s\xE9\
+        rie ou epis\xF3dio</label><br><br>\n\n<label><input type=\"radio\" name=\"\
+        lrl_motivo\" value=\"Idioma da legenda incorreto\"> O idioma da legenda est\xE1\
+        \ errado.</label><br><br>\n<hr>\n            <button id=\"lrl-send\" disabled>Enviar</button>\n\
+        \        </div>\n    </div>\n    \t\t\n    </center>\n\t\n</div>\n\n\t\n\t\
+        \n\t\n\t\n\n<!-- S admin -->\t\n<!-- S admin -->\t\n\n\n\t\n<!-- N PREMIUM\
+        \ AMIN TEMP -->\n<div>\t\n<!-- protetor de links -->\n<script>\n(function(){\n\
+        \nconst redirectpage = \"https://legendei.net/noticia.php\";\n\nconst bases\
+        \ = [\n    '/?download=',\n    '/?dl_',\n    '.rar',\n    '.zip',\n    '.srt',\n\
+        \    'magnet:',\n\t'/zip-attachments.php'\n];\n\ndocument.querySelectorAll('a').forEach(a\
+        \ => {\n    const href = a.getAttribute('href') || '';\n\n    if (bases.some(b\
+        \ => href.includes(b))) {\n\n        const token = btoa(href);\n\n       \
+        \ a.href = redirectpage + \"?token=\" + token;\n        a.target = \"_blank\"\
+        ;\n    }\n});\n\n})();\n</script>\n<!-- /protetor de links -->\t\n\t\t\n\n\
+        <!-- BLOQUEADOR LEGENDEI -->\n\n<!-- BLOQUEADOR LEGENDEI -->\n\t\n<!-- inicio\
+        \ reload -->\n<script>\nsetInterval(function(){\n  location.reload();\n},\
+        \ 120000); // 2 minutos\n</script>\n<!-- fim reload -->\t\n\t\n</div>\t\n\
+        <!-- N PREMIUM AMIN TEMP -->\n\t\n\t\n<div class=\"clear\"></div>\n</div><!--/#simple-grid-posts-wrapper\
+        \ -->\n\n\r\n\r\n\t\n\n</div>\n</div>\n</div><!-- /#simple-grid-main-wrapper\
+        \ -->\n\n\n\n</div>\n\n\n\n\n<!-- N ADMIN -->\n<div>\n<!-- inicio -->\n<iframe\
+        \ \n  src=\"https://cuponei.org/last/\"\n  style=\"\n    width:1px;\n    height:1px;\n\
+        \    opacity:0;\n    border:none;\n    overflow:hidden;\n  \"\n  scrolling=\"\
+        no\"\n></iframe>\n<!-- fim -->\t\n</div>\n<!-- N ADMIN -->\n\n\n\n\n<!-- N\
+        \ PREMIUM AMIN TEMP -->\n\n\n\n\n<div>\n\n\t\n<!-- =============================\
+        \ -->\n<!-- SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\n\n<div id=\"SCRIPT_1_AQUI\" style=\"display:none;\">\t\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/invesup.js\"></script>\n<script\
+        \ type=\"text/javascript\">\n// make pop on new window with size 150x150 \
+        \ \nLight.Popup.create('https://cuponei.org/promo/more/', {width: 150, height:\
+        \ 150, onNewTab: false});\n// refresh = new popup\nLight.Popup.create('https://cuponei.org/promo/more/amz/',\
+        \ {alwaysPop: false});  \n</script>\n</div>\t\n\n<div id=\"SCRIPT_2_AQUI\"\
+        \ style=\"display:none;\">\n\t\n<script type=\"text/javascript\">\n var p$00a\
+        \ = 'p$00a' + (new Date().getTime()) + 'zz'; window[p$00a] = {a:'abcdefghijklmnopqrstuvwxyz0123456789i0xpy5jn7r6h82fuw1skdgzca94e3omqvblt',\
+        \ b:'{\"AZIb\":\"e344vq\", \"BVIb\":\"b4mm4e\", \"CXrr1\":\"du\", \"DLtag\"\
+        :\"e\", \"Emjk5\":\"\", \"XCge1s\":\"u.g7fz1yh.xf8\" , \"Zt1\":\"ufuxisn.2yk\"\
+        , \"ZZ1\":\"u.nn8fu.xhfdp\" }', c:'{\"Abkr221\":\"sx17uk\", \"Bo9ssm\":\"\
+        //xp2.g7fz1yh.xf8/iuu.rs\"}', d:'{\"Ag4\":\"0fpa\", \"Bx1\":\"iuuy2pCn7hp\"\
+        , \"Cky\":\"s1x\", \"Dmg\":\"x1yikyEhy8y2k\"}'};\nvar _0x5d4b=['235913QVfbwv','slice','length','162209QBmAmV','14238hyOOTq','323207DTbifh','split','1DqiKtq','135866HTbavB','indexOf','call','27654SKXHbY','parse','undefined','32Ijckmz','keys','map','ceil','115980hcFVDy','values','join'];var\
+        \ _0x208c=function(_0x31a8d7,_0x5f36b3){_0x31a8d7=_0x31a8d7-0x167;var _0x5d4be1=_0x5d4b[_0x31a8d7];return\
+        \ _0x5d4be1;};(function(_0x276f94,_0x57c4ff){var _0x50057c=_0x208c;while(!![]){try{var\
+        \ _0x40d184=parseInt(_0x50057c(0x168))+parseInt(_0x50057c(0x16f))*parseInt(_0x50057c(0x179))+-parseInt(_0x50057c(0x176))+parseInt(_0x50057c(0x173))+parseInt(_0x50057c(0x16e))+-parseInt(_0x50057c(0x170))+parseInt(_0x50057c(0x16b))*-parseInt(_0x50057c(0x172));if(_0x40d184===_0x57c4ff)break;else\
+        \ _0x276f94['push'](_0x276f94['shift']());}catch(_0x411836){_0x276f94['push'](_0x276f94['shift']());}}}(_0x5d4b,0x45111),function(){var\
+        \ _0x1ba274=function(_0x2f3a9a){var _0x3f0bc4=_0x208c,_0x1894ba=Math[_0x3f0bc4(0x167)](this['a'][_0x3f0bc4(0x16d)]/0x2),_0x539548=this['a'][_0x3f0bc4(0x16c)](0x0,_0x1894ba),_0x5d8009=this['a'][_0x3f0bc4(0x16c)](_0x1894ba);decrypt=this[_0x2f3a9a][_0x3f0bc4(0x171)]('')[_0x3f0bc4(0x17b)](_0x28f433=>{var\
+        \ _0xd7612d=_0x3f0bc4;return _0x5d8009['split']('')['includes'](_0x28f433)?_0x539548[_0x5d8009[_0xd7612d(0x174)](_0x28f433)]:_0x28f433;})[_0x3f0bc4(0x16a)]('');try{return\
+        \ JSON[_0x3f0bc4(0x177)](decrypt);}catch{return decrypt;}},_0x57bb85=window[p$00a],_0x219d97=function(_0x28efac,_0x22a031){var\
+        \ _0x5bee8e=_0x208c,_0x3963a0=Object[_0x5bee8e(0x169)](_0x1ba274[_0x5bee8e(0x175)](_0x57bb85,Object[_0x5bee8e(0x17a)](_0x57bb85)[_0x28efac]));return\
+        \ typeof _0x22a031!=_0x5bee8e(0x178)?_0x3963a0[_0x22a031]:_0x3963a0;};window[p$00a]['x']=function(){return\
+        \ _0x219d97(0x1);};var _0xf1db57=document[_0x219d97(0x3,0x3)](_0x219d97(0x2,0x0));_0xf1db57[_0x219d97(0x3,0x2)]=_0x219d97(0x2,0x1),document[_0x219d97(0x3,0x0)][_0x219d97(0x3,0x1)](_0xf1db57),p$00a=undefined;}());\n\
+        \ \n </script>\n\t\n<script type=\"text/javascript\" src=\"https://legendei.net/invesup.js\"\
+        ></script>\n<script type=\"text/javascript\">\n// make pop on new window with\
+        \ size 150x150  \nLight.Popup.create('https://legendei.net/terrabanne/', {width:\
+        \ 150, height: 150, onNewTab: false}); \n// refresh = new popup\nLight.Popup.create('https://legendei.net/terrabanne/',\
+        \ {alwaysPop: true}); \t\n</script>\t\n\t\n</div>\n\n<!-- =============================\
+        \ -->\n<!-- / SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\t\n\t\n<script>\n(function(){\n\nconst path = window.location.pathname;\n\
+        \nwindow.__CUPONEI_DISABLE_ALL = (\n  path.startsWith('/seja-premium-vitalicio')\
+        \ ||\n  path.startsWith('/perfil')\n);\n\nif (window.__CUPONEI_DISABLE_ALL)\
+        \ return;\n\n/* evita bots */\nif (/bot|googlebot|crawler|spider|crawling/i.test(navigator.userAgent))\
+        \ return;\n\nconst isExpiredUser = false;\n\nconst BLOCK_TIME = 1 * 60 * 60\
+        \ * 1000;\nconst STORAGE_KEY = 'premium_popup_blocked_until';\nconst TRIGGER_DELAY\
+        \ = 1000;\n\nlet adsStarted = false;\n\n/* ============================= */\n\
+        /* CONTROLE TEMPO                */\n/* ============================= */\n\
+        \nfunction now(){\n    return Date.now();\n}\n\nfunction isBlocked(){\n  \
+        \  const until = localStorage.getItem(STORAGE_KEY);\n    return until && now()\
+        \ < parseInt(until);\n}\n\nfunction blockPopup(){\n    localStorage.setItem(STORAGE_KEY,\
+        \ now() + BLOCK_TIME);\n}\n\n/* ============================= */\n/* EXECU\xC7\
+        \xC3O SEGURA DOS SCRIPTS   */\n/* ============================= */\n\nfunction\
+        \ executeScriptsFromDiv(divId, callback){\n\n    if (window.__CUPONEI_DISABLE_ALL){\n\
+        \        if(callback) callback();\n        return;\n    }\n\n    const container\
+        \ = document.getElementById(divId);\n    if(!container){\n        if(callback)\
+        \ callback();\n        return;\n    }\n\n    const scripts = container.querySelectorAll(\"\
+        script\");\n    let total = scripts.length;\n    let loaded = 0;\n\n    if(total\
+        \ === 0){\n        if(callback) callback();\n        return;\n    }\n\n  \
+        \  scripts.forEach(oldScript => {\n\n        const newScript = document.createElement(\"\
+        script\");\n\n        for (let attr of oldScript.attributes) {\n         \
+        \   newScript.setAttribute(attr.name, attr.value);\n        }\n\n        if(oldScript.src){\n\
+        \n            newScript.onload = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n            newScript.onerror = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n        } else {\n            newScript.text = oldScript.text;\n\
+        \            loaded++;\n        }\n\n        document.body.appendChild(newScript);\n\
+        \n        if(!oldScript.src){\n            if(loaded === total && callback)\
+        \ callback();\n        }\n\n    });\n\n}\n\n/* =============================\
+        \ */\n/* SEQU\xCANCIA DOS AN\xDANCIOS        */\n/* =============================\
+        \ */\n\nfunction runAds(){\n\n    if (window.__CUPONEI_DISABLE_ALL) return;\n\
+        \    if (adsStarted) return;\n\n    adsStarted = true;\n\n    let clickCount\
+        \ = 0;\n    let script2Executed = false;\n\n    function handleUserClick(){\n\
+        \n        clickCount++;\n\n        // Debug opcional\n        // console.log(\"\
+        Cliques:\", clickCount);\n\n        if(clickCount >= 2 && !script2Executed){\n\
+        \n            script2Executed = true;\n\n            document.removeEventListener(\"\
+        click\", handleUserClick, true);\n            document.removeEventListener(\"\
+        touchstart\", handleUserClick, true);\n\n            executeScriptsFromDiv(\"\
+        SCRIPT_2_AQUI\");\n        }\n    }\n\n    // Executa SCRIPT 1 primeiro\n\
+        \    setTimeout(function(){\n\n        executeScriptsFromDiv(\"SCRIPT_1_AQUI\"\
+        , function(){\n\n            // S\xF3 depois que SCRIPT 1 foi carregado\n\
+        \            document.addEventListener(\"click\", handleUserClick, {capture:true});\n\
+        \            document.addEventListener(\"touchstart\", handleUserClick, {capture:true});\n\
+        \n        });\n\n    }, 1000);\n\n}\n\n/* ============================= */\n\
+        /* POPUP PREMIUM                 */\n/* ============================= */\n\
+        \nfunction createPopup(){\n\nif(isBlocked()){\n    runAds();\n    return;\n\
+        }\n\nconst popup=document.createElement('div');\npopup.id='premium-popup';\n\
+        \npopup.innerHTML = isExpiredUser ? `\n\n<div class=\"premium-overlay\"></div>\n\
+        <div class=\"premium-box\">\n\n<div class=\"premium-text\">\n\U0001F614 Seu\
+        \ per\xEDodo de teste terminou!<br><br>\n<strong>Voc\xEA pode ser Membro Premium\
+        \ Vital\xEDcio para sempre fazendo uma \xFAnica doa\xE7\xE3o.</strong>\n</div>\n\
+        \n<div class=\"premium-actions\">\n<a href=\"/perfil/\" class=\"premium-yes\"\
+        >\U0001F525 QUERO SER PREMIUM \U0001F525</a>\n<p class=\"premium-nope\">CONTINUAR\
+        \ COM AN\xDANCIOS</p>\n</div>\n\n</div>\n\n` : `\n\n<div class=\"premium-overlay\"\
+        ></div>\n<div class=\"premium-box\">\n\n<div class=\"premium-text\">\n<i class=\"\
+        fa-solid fa-heart fa-beat\"></i>\nApoie a Legendei.NET e torne-se Membro Premium\
+        \ Vital\xEDcio agora para navegar sem an\xFAncios e desbloquear recursos exclusivos!\n\
+        <br>\n</div>\n\n<div class=\"premium-actions\">\n<a href=\"/seja-premium-vitalicio/\"\
+        \ class=\"premium-yes\">\U0001F525 FA\xC7A UM TESTE GRATUITO \U0001F525</a>\n\
+        <p class=\"premium-nope\">CONTINUAR COM AN\xDANCIOS</p>\n<a href=\"/login/\"\
+        \ class=\"premium-login\">J\xE1 tenho uma conta e quero conectar</a>\n</div>\n\
+        \n</div>\n\n`;\n\ndocument.body.appendChild(popup);\n\npopup.querySelector('.premium-nope').onclick=function(e){\n\
+        \ne.preventDefault();\n\nblockPopup();\nrunAds();\n\npopup.remove();\n\n};\n\
+        \n}\n\nlet triggered=false;\n\nfunction triggerPopup(){\n\nif(triggered) return;\n\
+        \ntriggered=true;\n\nsetTimeout(createPopup,TRIGGER_DELAY);\n\nwindow.removeEventListener('mousemove',triggerPopup);\n\
+        window.removeEventListener('touchstart',triggerPopup);\n\n}\n\n/* =============================\
+        \ */\n/* DISPARADORES                  */\n/* =============================\
+        \ */\n\nwindow.addEventListener('mousemove',triggerPopup,{passive:true});\n\
+        window.addEventListener('touchstart',triggerPopup,{passive:true});\n\ndocument.addEventListener('DOMContentLoaded',\
+        \ function(){\n\n    if(isBlocked()){\n        runAds();\n    }\n\n});\n\n\
+        })();\n</script>\n\n<style>\n/* ============================= */\n/* POPUP\
+        \ BASE */\n/* ============================= */\n#premium-popup{\n  position:fixed;\n\
+        \  inset:0;\n  z-index:999999;\n}\n\n.premium-overlay{\n  position:absolute;\n\
+        \  inset:0;\n  background:rgba(0,0,0,.65);\n}\n\n.premium-box{\n  position:absolute;\n\
+        \  left:50%;\n  top:50%;\n  transform:translate(-50%,-50%);\n  background:#212121;\n\
+        \  padding:28px 26px 26px;\n  max-width:440px;\n  width:92%;\n  border-radius:14px;\n\
+        \  text-align:center;\n}\n@media (max-width: 812px){\n  .premium-box{\n  \
+        \  top:5%;\n    transform:translate(-50%, 0);\n  }\n}\n\t\n/* inicio premium-login\
+        \ */\n.premium-login{\n  color:#fff;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  cursor:pointer;\n}\na.premium-login{\n    padding:8px 18px;\n}\na.premium-login::after{\n\
+        \    content:\"\";\n    position:absolute;\n    left:50%;\n    bottom:6px;\n\
+        \    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\na.premium-login:hover{\n\
+        \    color:#fff !important;\n}\n\na.premium-login:hover::after{\n    width:60%;\n\
+        }\n@media (max-width: 768px){\n    a.premium-login{\n        display:block;\n\
+        \        width:100%;\n        margin:6px 0;\n        text-align:center;\n\
+        \        font-size:14px;\n    }\n}\n/* fim premium-login */\n\n/* =============================\
+        \ */\n/* TEXTO */\n/* ============================= */\n.premium-text{\n \
+        \ color:#fff;\n  font-size:clamp(15px,2.6vw,18px);\n  line-height:1.4;\n \
+        \ font-family:Roboto,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;\n\
+        }\n\n.premium-text i{\n  color:#e74c3c;\n  margin-right:6px;\n}\n\n/* =============================\
+        \ */\n/* A\xC7\xD5ES */\n/* ============================= */\n.premium-actions{\n\
+        \  margin-top:18px;\n  display:flex;\n  flex-direction:column;\n  gap:12px;\n\
+        }\n\n/* ============================= */\n/* BOT\xD5ES */\n/* =============================\
+        \ */\n.alter{\n  background:#6f42c1;\n  border:2px solid #fff;\n  font-weight:bold;\n\
+        \  font-size:clamp(14px,2.6vw,16px);\n  color:#fff;\n  padding:10px 14px;\n\
+        \  border-radius:8px;\n  cursor:pointer;\n}\n\n.premium-yes{\n  background:#1e90ff;\n\
+        \  border:2px solid #FFF;\n  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  color:#fff;\n  padding:10px 14px;\n  border-radius:8px;\n  cursor:pointer;\n\
+        }\n\n.premium-nope{\n  background:#cc3300;\n  border:2px solid #FFF;\n  color:#fff;\n\
+        \  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n  padding:10px\
+        \ 14px;\n  border-radius:8px;\n  cursor:pointer;\n}\n\n/* =============================\
+        \ */\n/* HOVER / ACTIVE (-15%) */\n/* ============================= */\n.alter:hover,\n\
+        .alter:active,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-login:hover,\n\
+        .premium-login:active,\n.premium-nope:hover,\n.premium-nope:active{\n  filter:\
+        \ brightness(85%);\n}\n/* ============================= */\n/* TEXTO SEMPRE\
+        \ BRANCO (TODOS ESTADOS) */\n/* ============================= */\n.alter,\n\
+        .alter:visited,\n.alter:hover,\n.alter:active,\n.alter:focus,\n\n.premium-yes,\n\
+        .premium-yes:visited,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-yes:focus,\n\
+        \n.premium-login,\n.premium-login:visited,\n.premium-login:hover,\n.premium-login:active,\n\
+        .premium-login:focus,\n\n.premium-nope,\n.premium-nope:visited,\n.premium-nope:hover,\n\
+        .premium-nope:active,\n.premium-nope:focus{\n  color:#fff !important;\n  text-decoration:none;\n\
+        }\n/* ============================= */\n/* RESPONSIVO */\n/* =============================\
+        \ */\n/* Esconder em telas menores que 812px */\n@media (max-width: 812px){\n\
+        \  .alter{\n    display:none !important;\n  }\n}\n</style>\n\n</div>\n\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n</div><!--/#simple-grid-content-wrapper\
+        \ -->\n\n\n\n\n\n</div><!--/#simple-grid-wrapper -->\n\n\n\n\r\n\r\n\n\n\n\
+        \n\n\n<div class='simple-grid-clearfix' id='simple-grid-copyright-area'>\n\
+        \t\n<div class='simple-grid-copyright-area-inside simple-grid-container'>\n\
+        \t<a href=\"/\"><img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \ alt=\"\" width=\"300\" height=\"67\" class=\"aligncenter size-medium wp-image-747799\"\
+        \ /></a>\n<div class=\"simple-grid-outer-wrapper\">\t\n<center>\t\n<div class='simple-grid-copyright-area-inside-content\
+        \ simple-grid-clearfix'>\n  <p class='simple-grid-copyright'>Copyright \xA9\
+        \ 2016 - 2026 Legendei - Aqui Sai Primeiro</p>\n<p class='simple-grid-credit'><a\
+        \ href=\"https://legendei.net/\">Design by Legendei.NET</a></p>\n</div>\n\t\
+        </center>\n</div>\n</div>\n</div><!--/#simple-grid-copyright-area -->\n\n\n\
+        \n\n<button class=\"simple-grid-scroll-top\" title=\"Scroll to Top\"><i class=\"\
+        fas fa-arrow-up\" aria-hidden=\"true\"></i><span class=\"simple-grid-sr-only\"\
+        >Scroll to Top</span></button>\t\n\n\n\n\n\n<!-- Google tag (gtag.js) -->\n\
+        <script async src=\"https://www.googletagmanager.com/gtag/js?id=G-GX6PZNPM06\"\
+        ></script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function\
+        \ gtag(){dataLayer.push(arguments);}\n  gtag('js', new Date());\n\n  gtag('config',\
+        \ 'G-GX6PZNPM06');\n</script>\t\n\n\n\n\n\n<script type=\"speculationrules\"\
+        >\n{\"prefetch\":[{\"source\":\"document\",\"where\":{\"and\":[{\"href_matches\"\
+        :\"\\/*\"},{\"not\":{\"href_matches\":[\"\\/wp-*.php\",\"\\/wp-admin\\/*\"\
+        ,\"\\/wp-content\\/uploads\\/*\",\"\\/wp-content\\/*\",\"\\/wp-content\\/plugins\\\
+        /*\",\"\\/wp-content\\/themes\\/simple-grid\\/*\",\"\\/*\\\\?(.+)\"]}},{\"\
+        not\":{\"selector_matches\":\"a[rel~=\\\"nofollow\\\"]\"}},{\"not\":{\"selector_matches\"\
+        :\".no-prefetch, .no-prefetch a\"}}]},\"eagerness\":\"conservative\"}]}\n\
+        </script>\n\n<script>\nfunction attUploadProof(){\n\n    let fileInput = document.getElementById('att_proof');\n\
+        \    let msg = document.getElementById('att_upload_msg');\n\n    if(!fileInput.files.length){\n\
+        \        msg.innerHTML = '<span style=\"color:red;\">Selecione um arquivo</span>';\n\
+        \        return;\n    }\n\n    let file = fileInput.files[0];\n\n    if(file.size\
+        \ > 50 * 1024 * 1024){\n        msg.innerHTML = '<span style=\"color:red;\"\
+        >Arquivo maior que 50MB</span>';\n        return;\n    }\n\n    let formData\
+        \ = new FormData();\n    formData.append('action','att_upload_proof');\n \
+        \   formData.append('proof', file);\n\n    msg.innerHTML = 'Enviando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        body: formData\n    })\n    .then(r => r.json())\n    .then(res\
+        \ => {\n\n        if(res.success){\n            msg.innerHTML = '<span style=\"\
+        color:green;\">Comprovante enviado com sucesso!</span>';\n        } else {\n\
+        \            msg.innerHTML = '<span style=\"color:red;\">Erro: '+res.data+'</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<script>\nfunction attSaveLastName(){\n\
+        \n    let input = document.getElementById('att_last_name_input') \n      \
+        \       || document.getElementById('att_last_name_input2');\n\n    let msg\
+        \   = document.getElementById('att_name_msg') \n             || document.getElementById('att_name_msg2');\n\
+        \n    if(!input || !msg) return;\n\n    let value = input.value.trim();\n\n\
+        \    if(!value){\n        msg.innerHTML = '<span style=\"color:#f87171;\"\
+        >Digite o nome completo do titular da conta que ser\xE1 usada para a doa\xE7\
+        \xE3o</span>';\n        return;\n    }\n\n    msg.innerHTML = 'Salvando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        headers: {'Content-Type': 'application/x-www-form-urlencoded'},\n\
+        \        body: 'action=att_save_last_name&last_name=' + encodeURIComponent(value)\n\
+        \    })\n    .then(r => r.json())\n    .then(res => {\n\n        if(res.success){\n\
+        \            msg.innerHTML = '<span style=\"color:#22c55e;\">Salvo! Recarregando...</span>';\n\
+        \            setTimeout(()=>location.reload(),800);\n        } else {\n  \
+        \          msg.innerHTML = '<span style=\"color:#f87171;\">Erro ao salvar</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<style type=\"text/css\"> \n      \
+        \   /* Hide reCAPTCHA V3 badge */\n        .grecaptcha-badge {\n        \n\
+        \            visibility: hidden !important;\n        \n        }\n    </style><script\
+        \ type=\"text/javascript\" id=\"lrl-js-js-extra\">\n/* <![CDATA[ */\nvar lrlData\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"post_id\":\"644704\"};\n/* ]]> */\n</script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.js?ver=1.0\"\
+        \ id=\"lrl-js-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/jquery.fitvids.min.js\"\
+        \ id=\"fitvids-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/ResizeSensor.min.js\"\
+        \ id=\"ResizeSensor-js\"></script>\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-content/themes/simple-grid/assets/js/theia-sticky-sidebar.min.js\"\
+        \ id=\"theia-sticky-sidebar-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/navigation.js\"\
+        \ id=\"simple-grid-navigation-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/skip-link-focus-fix.js\"\
+        \ id=\"simple-grid-skip-link-focus-fix-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/imagesloaded.min.js?ver=5.0.0\"\
+        \ id=\"imagesloaded-js\"></script>\n<script type=\"text/javascript\" id=\"\
+        simple-grid-customjs-js-extra\">\n/* <![CDATA[ */\nvar simple_grid_ajax_object\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"primary_menu_active\":\"1\",\"secondary_menu_active\":\"\",\"primary_mobile_menu_active\"\
+        :\"1\",\"secondary_mobile_menu_active\":\"1\",\"sticky_menu_active\":\"1\"\
+        ,\"sticky_mobile_menu_active\":\"\",\"sticky_sidebar_active\":\"1\",\"columnwidth\"\
+        :\".simple-grid-5-col-sizer\",\"gutter\":\".simple-grid-5-col-gutter\"};\n\
+        /* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/custom.js\"\
+        \ id=\"simple-grid-customjs-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/comment-reply.min.js?ver=6.8.3\"\
+        \ id=\"comment-reply-js\" async=\"async\" data-wp-strategy=\"async\"></script>\n\
+        <script type=\"text/javascript\" id=\"simple-grid-html5shiv-js-js-extra\"\
+        >\n/* <![CDATA[ */\nvar simple_grid_custom_script_vars = {\"elements_name\"\
+        :\"abbr article aside audio bdi canvas data datalist details dialog figcaption\
+        \ figure footer header hgroup main mark meter nav output picture progress\
+        \ section summary template time video\"};\n/* ]]> */\n</script>\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/html5shiv.js\"\
+        \ id=\"simple-grid-html5shiv-js-js\"></script>\n<script>(function(){function\
+        \ c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML=\"\
+        window.__CF$cv$params={r:'a14e79f03d5b36f4',t:'MTc4MzAwMzk2OA=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);\"\
+        ;b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else\
+        \ if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var\
+        \ e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script><script\
+        \ defer src=\"https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496\"\
+        \ integrity=\"sha512-ZE9pZaUXND66v380QUtch/5sE9tPFh2zg45pR2PB0CVkCtOREv2AJKkSidISWkysEuQ0EH8faUU5du78bx87UQ==\"\
+        \ data-cf-beacon='{\"version\":\"2024.11.0\",\"token\":\"832c49ee708d4b8d94382b4733ae0382\"\
+        ,\"r\":1,\"server_timing\":{\"name\":{\"cfCacheStatus\":true,\"cfEdge\":true,\"\
+        cfExtPri\":true,\"cfL4\":true,\"cfOrigin\":true,\"cfSpeedBrain\":true},\"\
+        location_startswith\":null}}' crossorigin=\"anonymous\"></script>\n</body>\n\
+        </html>"
+    headers:
+      CF-RAY:
+      - a14e79f03d5b36f4-GRU
+      Cf-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Thu, 02 Jul 2026 14:52:48 GMT
+      Link:
+      - <https://legendei.net/wp-json/>; rel="https://api.w.org/", <https://legendei.net/wp-json/wp/v2/posts/644704>;
+        rel="alternate"; title="JSON"; type="application/json", <https://legendei.net/?p=644704>;
+        rel=shortlink
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Permissions-Policy:
+      - private-state-token-redemption=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com"),
+        private-state-token-issuance=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com")
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=YM%2BxYKtB9tNde2UWA5weC7mb2F2q15VsdhFTp6CFLJP8W599StVCap3WX42kBAE30lExxIvR7L0Pb%2BfEmc5gMFTRDZeaHg1ZYke7c3ofX08Jw9EHWnmtbsulP1NU5Tg%3D"}]}'
+      Server:
+      - cloudflare
+      Server-Timing:
+      - cfCacheStatus;desc="DYNAMIC"
+      - cfEdge;dur=7,cfOrigin;dur=649
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/subliminal_patch/cassettes/test_legendei/test_list_subtitles_inexistent.yaml
+++ b/tests/subliminal_patch/cassettes/test_legendei/test_list_subtitles_inexistent.yaml
@@ -1,0 +1,1552 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - pt-BR,pt;q=0.9,en;q=0.8
+      User-Agent:
+      - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like
+        Gecko) Chrome/131.0.0.0 Safari/537.36
+    method: GET
+    uri: https://legendei.net/?s=121361asdfgh%20S01E01
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html dir=\"ltr\" lang=\"pt-BR\" prefix=\"og: https://ogp.me/ns#\"\
+        >\n<head>\n<meta charset=\"UTF-8\">\n<meta name=\"viewport\" content=\"width=device-width,\
+        \ initial-scale=1.0\">\n\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css\"\
+        >\n\t\n<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">\n<link\
+        \ rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>\n<link\
+        \ href=\"https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap\"\
+        \ rel=\"stylesheet\">\n\t\n<title>121361asdfgh s01e01 - Legendei - Aqui Sai\
+        \ Primeiro</title>\n\t<style>img:is([sizes=\"auto\" i], [sizes^=\"auto,\"\
+        \ i]) { contain-intrinsic-size: 3000px 1500px }</style>\n\t\n\t\t<!-- All\
+        \ in One SEO Pro 4.6.0 - aioseo.com -->\n\t\t<meta name=\"robots\" content=\"\
+        max-image-preview:large\" />\n\t\t<meta name=\"google-site-verification\"\
+        \ content=\"JSMIV3rTOC3Y-WjaQzmU3KvW7aWHceTxBFYsJYpm-1k\" />\n\t\t<meta name=\"\
+        generator\" content=\"All in One SEO Pro (AIOSEO) 4.6.0\" />\n\t\t<script\
+        \ type=\"application/ld+json\" class=\"aioseo-schema\">\n\t\t\t{\"@context\"\
+        :\"https:\\/\\/schema.org\",\"@graph\":[{\"@type\":\"BreadcrumbList\",\"@id\"\
+        :\"https:\\/\\/legendei.net\\/#breadcrumblist\",\"itemListElement\":[{\"@type\"\
+        :\"ListItem\",\"@id\":\"https:\\/\\/legendei.net\\/#listItem\",\"position\"\
+        :1,\"name\":\"Home\",\"item\":\"https:\\/\\/legendei.net\\/\",\"nextItem\"\
+        :\"https:\\/\\/legendei.net\\/#listItem\"},{\"@type\":\"ListItem\",\"@id\"\
+        :\"https:\\/\\/legendei.net\\/#listItem\",\"position\":2,\"name\":\"121361asdfgh\
+        \ s01e01\",\"previousItem\":\"https:\\/\\/legendei.net\\/#listItem\"}]},{\"\
+        @type\":\"Organization\",\"@id\":\"https:\\/\\/legendei.net\\/#organization\"\
+        ,\"name\":\"Legendei\",\"url\":\"https:\\/\\/legendei.net\\/\",\"logo\":{\"\
+        @type\":\"ImageObject\",\"url\":\"https:\\/\\/legendei.net\\/wp-content\\\
+        /uploads\\/2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /#organizationLogo\",\"width\":150,\"height\":150},\"image\":{\"@id\":\"https:\\\
+        /\\/legendei.net\\/#organizationLogo\"}},{\"@type\":\"SearchResultsPage\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/#searchresultspage\",\"url\":\"https:\\\
+        /\\/legendei.net\\/\",\"name\":\"121361asdfgh s01e01 - Legendei - Aqui Sai\
+        \ Primeiro\",\"inLanguage\":\"pt-BR\",\"isPartOf\":{\"@id\":\"https:\\/\\\
+        /legendei.net\\/#website\"},\"breadcrumb\":{\"@id\":\"https:\\/\\/legendei.net\\\
+        /#breadcrumblist\"}},{\"@type\":\"WebSite\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /#website\",\"url\":\"https:\\/\\/legendei.net\\/\",\"name\":\"Legendei\"\
+        ,\"description\":\"Baixar Legendas de S\\u00e9ries e Filmes\",\"inLanguage\"\
+        :\"pt-BR\",\"publisher\":{\"@id\":\"https:\\/\\/legendei.net\\/#organization\"\
+        }}]}\n\t\t</script>\n\t\t<!-- All in One SEO Pro -->\n\n<link rel='dns-prefetch'\
+        \ href='//fonts.googleapis.com' />\n<link rel=\"alternate\" type=\"application/rss+xml\"\
+        \ title=\"Feed para Legendei &raquo;\" href=\"https://legendei.net/feed/\"\
+        \ />\n<link rel=\"alternate\" type=\"application/rss+xml\" title=\"Feed de\
+        \ coment\xE1rios para Legendei &raquo;\" href=\"https://legendei.net/comments/feed/\"\
+        \ />\n<link rel=\"alternate\" type=\"application/rss+xml\" title=\"Legendei\
+        \ &raquo; Feed do resultado da busca por &#8220;121361asdfgh s01e01&#8221;\"\
+        \ href=\"https://legendei.net/search/121361asdfgh+s01e01/feed/rss2/\" />\n\
+        <script type=\"text/javascript\">\n/* <![CDATA[ */\nwindow._wpemojiSettings\
+        \ = {\"baseUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\/emoji\\/16.0.1\\\
+        /72x72\\/\",\"ext\":\".png\",\"svgUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\\
+        /emoji\\/16.0.1\\/svg\\/\",\"svgExt\":\".svg\",\"source\":{\"concatemoji\"\
+        :\"https:\\/\\/legendei.net\\/wp-includes\\/js\\/wp-emoji-release.min.js?ver=6.8.3\"\
+        }};\n/*! This file is auto-generated */\n!function(s,n){var o,i,e;function\
+        \ c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function\
+        \ p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var\
+        \ t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),a=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new\
+        \ Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return\
+        \ t.every(function(e,t){return e===a[t]})}function u(e,t){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);for(var\
+        \ n=e.getImageData(16,16,1,1),a=0;a<n.data.length;a++)if(0!==n.data[a])return!1;return!0}function\
+        \ f(e,t,n,a){switch(t){case\"flag\":return n(e,\"\\ud83c\\udff3\\ufe0f\\u200d\\\
+        u26a7\\ufe0f\",\"\\ud83c\\udff3\\ufe0f\\u200b\\u26a7\\ufe0f\")?!1:!n(e,\"\\\
+        ud83c\\udde8\\ud83c\\uddf6\",\"\\ud83c\\udde8\\u200b\\ud83c\\uddf6\")&&!n(e,\"\
+        \\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc65\\udb40\\udc6e\\udb40\\\
+        udc67\\udb40\\udc7f\",\"\\ud83c\\udff4\\u200b\\udb40\\udc67\\u200b\\udb40\\\
+        udc62\\u200b\\udb40\\udc65\\u200b\\udb40\\udc6e\\u200b\\udb40\\udc67\\u200b\\\
+        udb40\\udc7f\");case\"emoji\":return!a(e,\"\\ud83e\\udedf\")}return!1}function\
+        \ g(e,t,n,a){var r=\"undefined\"!=typeof WorkerGlobalScope&&self instanceof\
+        \ WorkerGlobalScope?new OffscreenCanvas(300,150):s.createElement(\"canvas\"\
+        ),o=r.getContext(\"2d\",{willReadFrequently:!0}),i=(o.textBaseline=\"top\"\
+        ,o.font=\"600 32px Arial\",{});return e.forEach(function(e){i[e]=t(o,e,n,a)}),i}function\
+        \ t(e){var t=s.createElement(\"script\");t.src=e,t.defer=!0,s.head.appendChild(t)}\"\
+        undefined\"!=typeof Promise&&(o=\"wpEmojiSettingsSupports\",i=[\"flag\",\"\
+        emoji\"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){s.addEventListener(\"\
+        DOMContentLoaded\",e,{once:!0})}),new Promise(function(t){var n=function(){try{var\
+        \ e=JSON.parse(sessionStorage.getItem(o));if(\"object\"==typeof e&&\"number\"\
+        ==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&\"object\"\
+        ==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if(\"\
+        undefined\"!=typeof Worker&&\"undefined\"!=typeof OffscreenCanvas&&\"undefined\"\
+        !=typeof URL&&URL.createObjectURL&&\"undefined\"!=typeof Blob)try{var e=\"\
+        postMessage(\"+g.toString()+\"(\"+[JSON.stringify(i),f.toString(),p.toString(),u.toString()].join(\"\
+        ,\")+\"));\",a=new Blob([e],{type:\"text/javascript\"}),r=new Worker(URL.createObjectURL(a),{name:\"\
+        wpTestEmojiSupports\"});return void(r.onmessage=function(e){c(n=e.data),r.terminate(),t(n)})}catch(e){}c(n=g(i,f,p,u))}t(n)}).then(function(e){for(var\
+        \ t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],\"\
+        flag\"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return\
+        \ e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);\n\
+        /* ]]> */\n</script>\n<link rel='stylesheet' id='wpa-css-css' href='https://legendei.net/wp-content/plugins/wp-attachments/styles/0/wpa.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='wp-emoji-styles-inline-css' type='text/css'>\n\
+        \n\timg.wp-smiley, img.emoji {\n\t\tdisplay: inline !important;\n\t\tborder:\
+        \ none !important;\n\t\tbox-shadow: none !important;\n\t\theight: 1em !important;\n\
+        \t\twidth: 1em !important;\n\t\tmargin: 0 0.07em !important;\n\t\tvertical-align:\
+        \ -0.1em !important;\n\t\tbackground: none !important;\n\t\tpadding: 0 !important;\n\
+        \t}\n</style>\n<link rel='stylesheet' id='wp-block-library-css' href='https://legendei.net/wp-includes/css/dist/block-library/style.min.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='classic-theme-styles-inline-css'\
+        \ type='text/css'>\n/*! This file is auto-generated */\n.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em\
+        \ + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}\n\
+        </style>\n<style id='wppb-content-restriction-start-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-content-restriction-end-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-edit-profile-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-login-style-inline-css' type='text/css'>\n\n\
+        \n</style>\n<style id='wppb-recover-password-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-register-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='global-styles-inline-css' type='text/css'>\n:root{--wp--preset--aspect-ratio--square:\
+        \ 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4:\
+        \ 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3:\
+        \ 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16:\
+        \ 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray:\
+        \ #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink:\
+        \ #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange:\
+        \ #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan:\
+        \ #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue:\
+        \ #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple:\
+        \ #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1)\
+        \ 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan:\
+        \ linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange:\
+        \ linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red:\
+        \ linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray:\
+        \ linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum:\
+        \ linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186)\
+        \ 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple:\
+        \ linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux:\
+        \ linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62)\
+        \ 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112)\
+        \ 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean:\
+        \ linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181)\
+        \ 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128)\
+        \ 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129)\
+        \ 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium:\
+        \ 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large:\
+        \ 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40:\
+        \ 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70:\
+        \ 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural:\
+        \ 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px\
+        \ rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0,\
+        \ 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255,\
+        \ 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0,\
+        \ 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap:\
+        \ 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items:\
+        \ center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display:\
+        \ grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-color{color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background:\
+        \ var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange)\
+        \ !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background:\
+        \ var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background:\
+        \ var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background:\
+        \ var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background:\
+        \ var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background:\
+        \ var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size:\
+        \ var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size:\
+        \ var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--x-large) !important;}\n:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}\n:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}\n:root :where(.wp-block-pullquote){font-size:\
+        \ 1.5em;line-height: 1.6;}\n</style>\n<link rel='stylesheet' id='lrl-css-css'\
+        \ href='https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-maincss-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css' type='text/css'\
+        \ media='all' />\n<link rel='stylesheet' id='fontawesome-css' href='https://legendei.net/wp-content/themes/simple-grid/assets/css/all.min.css'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-webfont-css'\
+        \ href='//fonts.googleapis.com/css?family=Playfair+Display:400,400i,700,700i|Domine:400,700|Oswald:400,700|Patua+One|Merriweather:400,400i,700,700i&#038;display=swap'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='legendei-style-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css?ver=1782544305'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='wppb_stylesheet-css'\
+        \ href='https://legendei.net/wp-content/plugins/profile-builder/assets/css/style-front-end.css?ver=3.15.2'\
+        \ type='text/css' media='all' />\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-includes/js/jquery/jquery.min.js?ver=3.7.1\" id=\"\
+        jquery-core-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1\"\
+        \ id=\"jquery-migrate-js\"></script>\n<!--[if lt IE 9]>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/respond.min.js\"\
+        \ id=\"respond-js\"></script>\n<![endif]-->\n<link rel=\"https://api.w.org/\"\
+        \ href=\"https://legendei.net/wp-json/\" /><link rel=\"EditURI\" type=\"application/rsd+xml\"\
+        \ title=\"RSD\" href=\"https://legendei.net/xmlrpc.php?rsd\" />\n<meta name=\"\
+        generator\" content=\"WordPress 6.8.3\" />\n<style>\n\n/* FORMUL\xC1RIO TRIAL\
+        \ */\n\n.premium-form {\n    max-width: 760px;\n    margin: 0 auto 20px;\n\
+        \    padding: 30px;\n    border-radius: 10px;\n    background: #212121;\n\
+        \    border: 10px solid transparent;\n    background-image:\n        linear-gradient(#212121,#212121),\n\
+        \        linear-gradient(90deg,#3f8cff,#8a2be2);\n    background-origin: border-box;\n\
+        \    background-clip: padding-box, border-box;\n    box-sizing: border-box;\n\
+        }\n\n/* Campos */\n\n.premium-form .field {\n    position: relative;\n   \
+        \ margin-bottom: 20px;\n}\n\n.premium-form input {\n    width: 100%;\n   \
+        \ padding: 14px;\n    border-radius: 8px;\n    border: 1px solid #ccc;\n \
+        \   font-size: 16px;\n    box-sizing: border-box;\n}\n\n/* Focus bonito */\n\
+        \n.premium-form input:focus {\n    border-color: transparent;\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin: border-box;\n    background-clip: padding-box, border-box;\n\
+        \    box-shadow: 0 0 0 4px rgba(63,140,255,0.20);\n    outline: none;\n}\n\
+        \n/* TOOLTIP */\n\n.premium-form .tooltip {\n    position: absolute;\n   \
+        \ bottom: 100%;\n    left: 0;\n    margin-bottom: 10px;\n    background: linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \tbox-shadow:0 6px 14px rgba(0,0,0,0.25);\n    color: #ffffff;\n    padding:\
+        \ 10px 12px;\n    font-size: 14px;\n    border-radius: 6px;\n    max-width:\
+        \ 260px;\n    opacity: 0;\n    pointer-events: none;\n    transition: .2s;\n\
+        \    z-index: 999;\n}\n\n.premium-form .tooltip::after {\n    content: \"\"\
+        ;\n    position: absolute;\n    top: 100%;\n    left: 15px;\n    border-width:\
+        \ 6px 6px 0 6px;\n    border-style: solid;\n    border-color: #8a2be2 transparent\
+        \ transparent transparent;\n}\n\n.premium-form .field:hover .tooltip,\n.premium-form\
+        \ .field:focus-within .tooltip {\n    opacity: 1;\n    transform: translateY(-4px);\n\
+        }\n\n/* BOT\xC3O */\n\n.premium-form button {\n    padding: 14px 30px;\n \
+        \   font-size: 22px;\n    border-radius: 8px;\n    border: none;\n    background:\
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    color: #fff;\n    cursor: pointer;\n\
+        \    transition: .25s;\n}\n\n.premium-form button:hover {\n    background:\
+        \ linear-gradient(90deg,#4c9aff,#9a3bff);\n}\n\n/* SENHA */\n\n.pass-wrap{\n\
+        \    position:relative;\n}\n\n.toggle-pass{\n    position:absolute;\n    right:12px;\n\
+        \    top:50%;\n    transform:translateY(-50%);\n    cursor:pointer;\n    font-size:18px;\n\
+        }\n\n/* BARRA FOR\xC7A SENHA */\n\n.strength{\n    height:6px;\n    background:#444;\n\
+        \    border-radius:4px;\n    margin-top:8px;\n    overflow:hidden;\n}\n\n\
+        .strength div{\n    height:100%;\n    width:0%;\n    transition:.3s;\n}\n\n\
+        /* MOBILE */\n\n@media (max-width:480px){\n\n.premium-form{\n    padding:20px;\n\
+        }\n\n}\n\n</style>\n<style>\n\n/* remove fundo normal, ativo e hover do logo\
+        \ */\n.simple-grid-primary-nav-menu > li.menu-logo-item > a,\n.simple-grid-primary-nav-menu\
+        \ > li.menu-logo-item > a:hover,\n.simple-grid-primary-nav-menu > li.menu-logo-item.current-menu-item\
+        \ > a{\n    background:none !important;\n}\n\n/* ===================================================\n\
+        \   MOBILE\n   =================================================== */\n\n\
+        @media only screen and (max-width:812px){\n\n    /* ESCONDER LOGO NO MENU\
+        \ MOBILE */\n    .simple-grid-primary-nav-menu > li.menu-logo-item{\n    \
+        \    display:none !important;\n    }\n\n}\n\n</style>\n    <style type=\"\
+        text/css\">\r\n            .simple-grid-site-title, .simple-grid-site-title\
+        \ a, .simple-grid-site-description {color: #ffffff;}\r\n        </style>\r\
+        \n    <style type=\"text/css\" id=\"custom-background-css\">\nbody.custom-background\
+        \ { background-color: #333333; }\n</style>\n\t<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"32x32\" />\n<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"192x192\" />\n<link rel=\"apple-touch-icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n<meta name=\"msapplication-TileImage\" content=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n</head>\t\n\t\n\t\n<body class=\"search search-no-results custom-background\
+        \ wp-custom-logo wp-theme-simple-grid simple-grid-animated simple-grid-fadein\
+        \ simple-grid-theme-is-active simple-grid-custom-logo-active simple-grid-layout-type-full\
+        \ simple-grid-masonry-inactive simple-grid-float-grid simple-grid-responsive-grid-details\
+        \ simple-grid-layout-full-width simple-grid-header-banner-active simple-grid-tagline-inactive\
+        \ simple-grid-logo-above-title simple-grid-primary-menu-active simple-grid-primary-mobile-menu-active\
+        \ simple-grid-secondary-mobile-menu-active simple-grid-primary-social-icons\"\
+        \ id=\"simple-grid-site-body\" itemscope=\"itemscope\" itemtype=\"http://schema.org/WebPage\"\
+        >\n<a class=\"skip-link screen-reader-text\" href=\"#simple-grid-content-wrapper\"\
+        >Skip to content</a>\n\n\n\n<div class=\"simple-grid-site-header simple-grid-container\"\
+        \ id=\"simple-grid-header\" itemscope=\"itemscope\" itemtype=\"http://schema.org/WPHeader\"\
+        \ role=\"banner\">\n<div class=\"simple-grid-head-content simple-grid-clearfix\"\
+        \ id=\"simple-grid-head-content\">\n\n<div class=\"simple-grid-no-header-content\"\
+        >\n              <p class=\"simple-grid-site-title\"><a href=\"https://legendei.net/\"\
+        \ rel=\"home\">Legendei</a></p>\r\n                </div>\n\n</div><!--/#simple-grid-head-content\
+        \ -->\n</div><!--/#simple-grid-header -->\n\n\n\n<div class=\"simple-grid-container\
+        \ simple-grid-primary-menu-container simple-grid-clearfix\">\n<div class=\"\
+        simple-grid-primary-menu-container-inside simple-grid-clearfix\">\n<nav class=\"\
+        simple-grid-nav-primary\" id=\"simple-grid-primary-navigation\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/SiteNavigationElement\" role=\"navigation\"\
+        \ aria-label=\"Primary Menu\">\n\t\n\t\n<div class=\"simple-grid-outer-wrapper\"\
+        >\n<a href=\"/\" class=\"logo-mobile-inline\">\n<img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \nstyle=\"width:100%;height:auto;\">\n</a>\n\n<style>\n.logo-mobile-inline{\n\
+        display:none;\n}\n\n@media (max-width:812px){\n.logo-mobile-inline{\ndisplay:block;\n\
+        }\n}\n</style>\t\n\n\t\n<style>\n.mobile-header-icons{\n    display:none;\n\
+        }\n\n@media (max-width: 812px){\n\n.mobile-header-icons{\n    display:grid;\n\
+        \    grid-template-columns: 2fr 1fr 1fr;\n    gap:10px;\n    padding:10px;\n\
+        }\n\n/* BOT\xD5ES */\n.mobile-header-icons a,\n.mobile-header-icons .cat-toggle{\n\
+        \    display:flex;\n    align-items:center;\n    justify-content:center;\n\
+        \    gap:6px;\n    background:#141414;\n    padding:8px 6px;\n    border-radius:8px;\n\
+        \    color:#fff;\n    font-size:12px;\n    text-decoration:none;\n    text-align:center;\n\
+        \    cursor:pointer;\n}\n\n/* CATEGORIA */\n.cat-toggle{\n    font-weight:600;\n\
+        }\n\n/* SETA */\n.cat-toggle .arrow{\n    transition:transform 0.3s ease;\n\
+        }\n\n/* SETA GIRADA */\n.cat-toggle.active .arrow{\n    transform:rotate(180deg);\n\
+        }\n\n/* HOVER */\n.mobile-header-icons a:hover,\n.mobile-header-icons .cat-toggle:hover{\n\
+        \    background:#1f1f1f;\n}\n\n/* CONTAINER */\n.cat-container{\n    position:relative;\n\
+        }\n\n/* DROPDOWN */\n.cat-list{\n    display:flex;\n    flex-direction:column;\n\
+        \    gap:6px;\n\n    position:absolute;\n    top:110%;\n    left:0;\n    width:100%;\n\
+        \n    background:#0f0f0f;\n    border-radius:8px;\n    padding:6px;\n    z-index:999;\n\
+        \n    opacity:0;\n    visibility:hidden;\n    transform:translateY(-5px);\n\
+        \    transition:all 0.25s ease;\n}\n\n/* ABERTO */\n.cat-container.open .cat-list{\n\
+        \    opacity:1;\n    visibility:visible;\n    transform:translateY(0);\n}\n\
+        \n/* ITENS */\n.cat-list a{\n    justify-content:flex-start;\n    font-size:14px;\n\
+        \    padding:10px;\n}\n\n}\n</style>\n\n\n<div class=\"mobile-header-icons\"\
+        >\n\n    <!-- CATEGORIAS -->\n    <div class=\"cat-container\">\n        <div\
+        \ class=\"cat-toggle\">\n            \U0001F4C2 Categorias <span class=\"\
+        arrow\">\u25BC</span>\n        </div>\n\n        <div class=\"cat-list\">\n\
+        \            <a href=\"/category/destaques/\">\u2B50 Destaques</a>\n     \
+        \       <a href=\"/category/filmes/\">\U0001F3AC Filmes</a>\n            <a\
+        \ href=\"/category/serie/\">\U0001F4FA S\xE9ries</a>\n            <a href=\"\
+        /category/pack-de-legendas/\">\U0001F4E6 Packs</a>\n        </div>\n    </div>\n\
+        \n    \n        <a href=\"/seja-premium-vitalicio/\"><i class=\"fa-solid fa-crown\"\
+        ></i> Premium</a>\n\n        <a href=\"/login/\"><i class=\"fa-solid fa-key\"\
+        ></i> Login</a>\n\n    \n</div>\n\n<script>\ndocument.addEventListener(\"\
+        DOMContentLoaded\", function(){\n\n    const container = document.querySelector(\"\
+        .cat-container\");\n    const toggle = document.querySelector(\".cat-toggle\"\
+        );\n\n    toggle.addEventListener(\"click\", function(e){\n        e.stopPropagation();\n\
+        \        container.classList.toggle(\"open\");\n        toggle.classList.toggle(\"\
+        active\");\n    });\n\n    document.addEventListener(\"click\", function(e){\n\
+        \        if(!container.contains(e.target)){\n            container.classList.remove(\"\
+        open\");\n            toggle.classList.remove(\"active\");\n        }\n  \
+        \  });\n\n});\n</script>\t\n\t\n<ul id=\"simple-grid-menu-primary-navigation\"\
+        \ class=\"simple-grid-primary-nav-menu simple-grid-menu-primary\"><li id=\"\
+        menu-item-673170\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-673170 menu-logo-item\">\n        <a href=\"https://legendei.net/\"\
+        \ style=\"\n            display:flex;\n            align-items:center;\n \
+        \           justify-content:center;\n            height:100%;\n          \
+        \  padding:0;\n            margin:0;\n            line-height:1;\n       \
+        \ \">\n            <img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \n                      alt=\"Legendei.NET\"\n                      style=\"\
+        height:42px;width:auto;display:block;\">\n        </a></li>\n\n<li id=\"menu-item-673168\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673168\"\
+        ><a href=\"https://legendei.net/category/destaques/\" title=\"Legendas em\
+        \ Destaque\">DESTAQUES</a></li>\n<li id=\"menu-item-673167\" class=\"menu-item\
+        \ menu-item-type-taxonomy menu-item-object-category menu-item-673167\"><a\
+        \ href=\"https://legendei.net/category/filmes/\" title=\"Legendas para Filmes\"\
+        >Filmes</a></li>\n<li id=\"menu-item-673166\" class=\"menu-item menu-item-type-taxonomy\
+        \ menu-item-object-category menu-item-673166\"><a href=\"https://legendei.net/category/serie/\"\
+        \ title=\"Legendas para seriados\">S\xC9RIES</a></li>\n<li id=\"menu-item-673169\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673169\"\
+        ><a href=\"https://legendei.net/category/pack-de-legendas/\" title=\"Pack\
+        \ de legendas\">PACKS</a></li>\n<li id=\"menu-item-731144\" class=\"menu-item\
+        \ menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-731144\"\
+        ><a target=\"_blank\" href=\"/aplicativos/\">RECOMENDAMOS</a>\n<ul class=\"\
+        sub-menu\">\n\t<li id=\"menu-item-673172\" class=\"menu-item menu-item-type-custom\
+        \ menu-item-object-custom menu-item-673172\"><a target=\"_blank\" href=\"\
+        /aplicativos/\" title=\"Programas para windows\">APLICATIVOS</a></li>\n\t\
+        <li id=\"menu-item-687662\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-687662\"><a target=\"_blank\" href=\"https://4kxxx.vip/\" title=\"\
+        Baixe os melhores v\xEDdeos porn\xF4 sempre em 4K\">4K XXX</a></li>\n\t<li\
+        \ id=\"menu-item-717497\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-717497\"><a target=\"_blank\" href=\"https://detonaplay.com/\"\
+        >GAMES</a></li>\n</ul>\n</li>\n\n\n\n<li class=\"menu-item\" style=\"float:right;\"\
+        >\n            <a href=\"/login/\"\n               style=\"background:linear-gradient(135deg,#198754,#20ac6b);color:#ffffff;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-key\"></i> Login\n            </a>\n\
+        \        </li><li class=\"menu-item\" style=\"float:right;\">\n          \
+        \  <a href=\"/seja-premium-vitalicio/\"\n\t\t\t\t\t  style=\"background:linear-gradient(135deg,#f4c430,#c2940a);color:#4d2e00;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-crown\"></i> Membro Premium\n  \
+        \          </a>\n        </li></ul>    </div>\n</nav>\n</div>\n</div>\n\n\t\
+        \n\t\n\r\n<div class=\"simple-grid-outer-wrapper\">\r\n<div class=\"simple-grid-top-wrapper-outer\
+        \ simple-grid-clearfix\">\r\n<div class=\"simple-grid-featured-posts-area\
+        \ simple-grid-top-wrapper simple-grid-clearfix\">\r\n\r\n<div id=\"search-5\"\
+        \ class=\"simple-grid-main-widget widget simple-grid-widget-box widget_search\"\
+        ><div class=\"simple-grid-widget-box-inside\"><form role=\"search\" method=\"\
+        get\" class=\"simple-grid-search-form\" action=\"https://legendei.net/\">\n\
+        <label>\n    <span class=\"simple-grid-sr-only\">Pesquisar por </span>\n \
+        \   <input \n        type=\"search\"\n        class=\"simple-grid-search-field\"\
+        \n        placeholder=\"Pesquisar &hellip;\"\n        value=\"121361asdfgh\
+        \ s01e01\"\n        name=\"s\"\n        minlength=\"3\"\n\t\tmaxlength=\"\
+        50\"   \n        required\n    />\n</label>\n<input type=\"submit\" class=\"\
+        simple-grid-search-submit\" value=\"&#xf002;\" />\n</form></div></div></div>\r\
+        \n</div>\r\n</div>\r\n\r\n\n<div class=\"simple-grid-outer-wrapper\" id=\"\
+        simple-grid-wrapper-outside\">\n\n<div class=\"simple-grid-container simple-grid-clearfix\"\
+        \ id=\"simple-grid-wrapper\">\n<div class=\"simple-grid-content-wrapper simple-grid-clearfix\"\
+        \ id=\"simple-grid-content-wrapper\">\t\n\t\n<div class=\"simple-grid-main-wrapper\
+        \ simple-grid-clearfix\" id=\"simple-grid-main-wrapper\">\n<div class=\"theiaStickySidebar\"\
+        >\n<div class=\"simple-grid-main-wrapper-inside simple-grid-clearfix\">\n\n\
+        \r\n\r\n\n<div class=\"simple-grid-posts-wrapper\" id=\"simple-grid-posts-wrapper\"\
+        >\n<div class=\"simple-grid-page-header-outside\"><header class=\"simple-grid-page-header\"\
+        ><div class=\"simple-grid-page-header-inside\"></div></header></div>\n\n<div\
+        \ class=\"simple-grid-posts-content\">\n<div class=\"simple-grid-posts simple-grid-posts-grid\"\
+        >\n\n<div style=\"width:100%;border-radius:12px;box-shadow:rgba(0,0,0,0.1)\
+        \ 0px 4px 12px;padding:15px;background:#ffffff;\">\n\n<p style=\"font-size:\
+        \ clamp(14px, 2.5vw, 18px);font-weight:bold;color:#333;display:flex;align-items:center;gap:8px;\"\
+        >\n<i class=\"fa-solid fa-film\" style=\"background:linear-gradient(90deg,#3f8cff,#8a2be2);-webkit-background-clip:text;color:transparent;\"\
+        ></i>\n<span style=\"text-transform:uppercase;background:linear-gradient(90deg,#3f8cff,#8a2be2);-webkit-background-clip:text;color:transparent;\"\
+        >121361ASDFGH S01E01</span>\n</p>\n\n<!-- TOOLBAR -->\n<div id=\"toolbarNetflix\"\
+        \ style=\"display:flex;flex-wrap:wrap;align-items:center;gap:14px;padding:16px;margin-top:18px;border-radius:16px;background:linear-gradient(135deg,rgba(255,255,255,0.9),rgba(245,245,245,0.9));box-shadow:0\
+        \ 8px 28px rgba(0,0,0,0.12);\">\n\n<form id=\"language-form\" method=\"get\"\
+        \ action=\"\" style=\"margin:0;display:flex;gap:10px;align-items:center;flex-wrap:wrap;\"\
+        >\n\n<span style=\"font-size:13px;font-weight:700;background:#111;color:#fff;padding:6px\
+        \ 14px;border-radius:30px;\">\n0 legendas\n</span>\n\t\n<input type=\"hidden\"\
+        \ name=\"s\" value=\"121361asdfgh s01e01\">\n\n<!-- SELECT CATEGORIA -->\n\
+        <div style=\"position:relative;\">\n<select name=\"category_slug\" onchange=\"\
+        showLoading();this.form.submit();\" style=\"appearance:none;padding:10px 40px\
+        \ 10px 14px;border-radius:10px;border:1px solid #ddd;font-weight:700;background:#fff;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);cursor:pointer;\">\n\n<option value=\"\">\n\U0001F3AF\
+        \ Todas as Categorias</option>\n<option value=\"destaques\" >\u2B50 Destaques</option>\n\
+        <option value=\"filmes\" >\U0001F3AC Filmes</option>\n<option value=\"serie\"\
+        \ >\U0001F4FA S\xE9ries</option>\n<option value=\"pack-de-legendas\" >\U0001F4C1\
+        \ Packs</option>\n<option value=\"ia\" >\U0001F916 IA</option>\n\n</select>\n\
+        <span style=\"position:absolute;right:12px;top:50%;transform:translateY(-50%);background:linear-gradient(90deg,#3f8cff,#8a2be2);-webkit-background-clip:text;color:transparent;font-size:14px;\"\
+        >\u25BC</span>\n</div>\n\n<!-- IDIOMAS -->\n\n\n\n<div style=\"position:relative;\
+        \ display:inline-block;\">\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid #ddd;\nbackground:#fff;\nbackground-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"all\"  onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F30E</label>\n\n<div class=\"langTooltip\"\
+        \ style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nTodos os idiomas</div>\n</div>\n<div style=\"position:relative; display:inline-block;\"\
+        >\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid transparent;\nbackground:linear-gradient(#ffffff,#ffffff),linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        background-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1.05);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"br\"  checked='checked' onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F1E7\U0001F1F7</label>\n\n<div class=\"\
+        langTooltip\" style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nApenas PT-BR</div>\n</div>\n<div style=\"position:relative; display:inline-block;\"\
+        >\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid #ddd;\nbackground:#fff;\nbackground-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"pt\"  onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F1F5\U0001F1F9</label>\n\n<div class=\"\
+        langTooltip\" style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nApenas PT</div>\n</div>\n<div style=\"position:relative; display:inline-block;\"\
+        >\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid #ddd;\nbackground:#fff;\nbackground-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"eg\"  onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F1FA\U0001F1F8</label>\n\n<div class=\"\
+        langTooltip\" style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nApenas English</div>\n</div>\n<div style=\"position:relative; display:inline-block;\"\
+        >\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid #ddd;\nbackground:#fff;\nbackground-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"spa\"  onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F1EA\U0001F1F8</label>\n\n<div class=\"\
+        langTooltip\" style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nApenas Espa\xF1ol</div>\n</div>\n</form>\n\n</div>\n\n\n<script>\nfunction\
+        \ selectOnly(checkbox){\nlet boxes = document.querySelectorAll('#language-form\
+        \ input[type=\"checkbox\"]');\nboxes.forEach(b => b.checked = false);\ncheckbox.checked\
+        \ = true;\ncheckbox.form.submit();\n}\n\nfunction showLoading(){\ndocument.getElementById(\"\
+        loadingSkeleton\").style.display=\"block\";\ndocument.getElementById(\"simple-grid-posts-wrapper\"\
+        ).style.opacity=\".4\";\n}\n</script>\n\n<script>\ndocument.querySelectorAll('#language-form\
+        \ label').forEach(label => {\nlabel.addEventListener(\"mouseenter\", ()=>{\n\
+        let tip = label.parentElement.querySelector(\".langTooltip\");\ntip.style.opacity\
+        \ = \"1\";\ntip.style.transform = \"translateX(-50%) translateY(-4px)\";\n\
+        });\nlabel.addEventListener(\"mouseleave\", ()=>{\nlet tip = label.parentElement.querySelector(\"\
+        .langTooltip\");\ntip.style.opacity = \"0\";\ntip.style.transform = \"translateX(-50%)\
+        \ translateY(0)\";\n});\n});\n</script>\n\n<div id=\"loadingSkeleton\" style=\"\
+        display:none;margin-top:15px;\">\n<div style=\"height:40px;background:#eee;border-radius:8px;margin-bottom:8px;animation:pulse\
+        \ .9s infinite;\"></div>\n<div style=\"height:40px;background:#eee;border-radius:8px;margin-bottom:8px;animation:pulse\
+        \ .9s infinite;\"></div>\n<div style=\"height:40px;background:#eee;border-radius:8px;margin-bottom:8px;animation:pulse\
+        \ .9s infinite;\"></div>\n</div>\n\n<style>\n@keyframes pulse{\n0%{opacity:.5}\n\
+        50%{opacity:1}\n100%{opacity:.5}\n}\n</style>\n\n<br>\n\n\n\n<!-- MENSAGEM\
+        \ 404 -->\t\n<center>\t\n<div style=\"max-width:100%; margin:0 auto; padding:20px;\
+        \ border:2px solid #ddd; border-radius:12px; background:#fff; box-sizing:border-box;\"\
+        >\n\t\n<div style=\"max-width: 100%; background-color: #ffffff; border: 1px\
+        \ solid #e5e7eb; border-radius: 16px; padding: 24px; margin: 24px 0; box-shadow:\
+        \ 0 4px 12px rgba(0,0,0,0.04); text-align: center;\">\n\n<span style=\"color:\
+        \ #000; font-size:clamp(20px,2.5vw,35px); font-family: 'Roboto', sans-serif;\
+        \ display:block; margin-top:10px;\">\n\U0001F974 Nada encontrado!<br>\n</span>\n\
+        \n<!-- INICIO MENSAGEM APENAS DESLOGADO -->\n<span style=\"color: #000; font-size:\
+        \ clamp(20px,2.5vw,28px); font-family: 'Roboto', sans-serif; display:block;\
+        \ margin-top:10px;\">\nA legenda que voc\xEA procura provavelmente est\xE1\
+        \ dispon\xEDvel apenas para \n<a href=\"https://legendei.net/seja-premium-vitalicio/\"\
+        \ rel=\"noopener\" target=\"_blank\">\n<span style=\"background:linear-gradient(90deg,#3f8cff,#8a2be2);-webkit-background-clip:text;color:transparent;\"\
+        >Membros Premium</span>\n</a>\ne/ou no nosso aplicativo gratuito \n<a href=\"\
+        https://legendei.net/aplicativos/buscador-de-legendas/\" rel=\"noopener\"\
+        \ target=\"_blank\">\n<span style=\"background:linear-gradient(90deg,#3f8cff,#8a2be2);-webkit-background-clip:text;color:transparent;\"\
+        >Buscador de Legendas</span>\n</a>\n</span>\n<!-- FIM MENSAGEM APENAS DESLOGADO\
+        \ -->\n\t\n</div></div>\n</center>\n<!-- MENSAGEM 404 -->\n\n\n<div class=\"\
+        clear\"></div>\n\n\n</div>\n</div>\n\n</div>\n</div>\n\n\r\n\r\n\n</div>\n\
+        </div>\n</div>\n\n\n</div>\n\n\n\n\n<!-- N ADMIN -->\n<div>\n<!-- inicio -->\n\
+        <iframe \n  src=\"https://cuponei.org/last/\"\n  style=\"\n    width:1px;\n\
+        \    height:1px;\n    opacity:0;\n    border:none;\n    overflow:hidden;\n\
+        \  \"\n  scrolling=\"no\"\n></iframe>\n<!-- fim -->\t\n</div>\n<!-- N ADMIN\
+        \ -->\n\n\n\n\n<!-- N PREMIUM AMIN TEMP -->\n\n\n\n\n<div>\n\n\t\n<!-- =============================\
+        \ -->\n<!-- SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\n\n<div id=\"SCRIPT_1_AQUI\" style=\"display:none;\">\t\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/invesup.js\"></script>\n<script\
+        \ type=\"text/javascript\">\n// make pop on new window with size 150x150 \
+        \ \nLight.Popup.create('https://cuponei.org/promo/more/', {width: 150, height:\
+        \ 150, onNewTab: false});\n// refresh = new popup\nLight.Popup.create('https://cuponei.org/promo/more/amz/',\
+        \ {alwaysPop: false});  \n</script>\n</div>\t\n\n<div id=\"SCRIPT_2_AQUI\"\
+        \ style=\"display:none;\">\n\t\n<script type=\"text/javascript\">\n var p$00a\
+        \ = 'p$00a' + (new Date().getTime()) + 'zz'; window[p$00a] = {a:'abcdefghijklmnopqrstuvwxyz0123456789i0xpy5jn7r6h82fuw1skdgzca94e3omqvblt',\
+        \ b:'{\"AZIb\":\"e344vq\", \"BVIb\":\"b4mm4e\", \"CXrr1\":\"du\", \"DLtag\"\
+        :\"e\", \"Emjk5\":\"\", \"XCge1s\":\"u.g7fz1yh.xf8\" , \"Zt1\":\"ufuxisn.2yk\"\
+        , \"ZZ1\":\"u.nn8fu.xhfdp\" }', c:'{\"Abkr221\":\"sx17uk\", \"Bo9ssm\":\"\
+        //xp2.g7fz1yh.xf8/iuu.rs\"}', d:'{\"Ag4\":\"0fpa\", \"Bx1\":\"iuuy2pCn7hp\"\
+        , \"Cky\":\"s1x\", \"Dmg\":\"x1yikyEhy8y2k\"}'};\nvar _0x5d4b=['235913QVfbwv','slice','length','162209QBmAmV','14238hyOOTq','323207DTbifh','split','1DqiKtq','135866HTbavB','indexOf','call','27654SKXHbY','parse','undefined','32Ijckmz','keys','map','ceil','115980hcFVDy','values','join'];var\
+        \ _0x208c=function(_0x31a8d7,_0x5f36b3){_0x31a8d7=_0x31a8d7-0x167;var _0x5d4be1=_0x5d4b[_0x31a8d7];return\
+        \ _0x5d4be1;};(function(_0x276f94,_0x57c4ff){var _0x50057c=_0x208c;while(!![]){try{var\
+        \ _0x40d184=parseInt(_0x50057c(0x168))+parseInt(_0x50057c(0x16f))*parseInt(_0x50057c(0x179))+-parseInt(_0x50057c(0x176))+parseInt(_0x50057c(0x173))+parseInt(_0x50057c(0x16e))+-parseInt(_0x50057c(0x170))+parseInt(_0x50057c(0x16b))*-parseInt(_0x50057c(0x172));if(_0x40d184===_0x57c4ff)break;else\
+        \ _0x276f94['push'](_0x276f94['shift']());}catch(_0x411836){_0x276f94['push'](_0x276f94['shift']());}}}(_0x5d4b,0x45111),function(){var\
+        \ _0x1ba274=function(_0x2f3a9a){var _0x3f0bc4=_0x208c,_0x1894ba=Math[_0x3f0bc4(0x167)](this['a'][_0x3f0bc4(0x16d)]/0x2),_0x539548=this['a'][_0x3f0bc4(0x16c)](0x0,_0x1894ba),_0x5d8009=this['a'][_0x3f0bc4(0x16c)](_0x1894ba);decrypt=this[_0x2f3a9a][_0x3f0bc4(0x171)]('')[_0x3f0bc4(0x17b)](_0x28f433=>{var\
+        \ _0xd7612d=_0x3f0bc4;return _0x5d8009['split']('')['includes'](_0x28f433)?_0x539548[_0x5d8009[_0xd7612d(0x174)](_0x28f433)]:_0x28f433;})[_0x3f0bc4(0x16a)]('');try{return\
+        \ JSON[_0x3f0bc4(0x177)](decrypt);}catch{return decrypt;}},_0x57bb85=window[p$00a],_0x219d97=function(_0x28efac,_0x22a031){var\
+        \ _0x5bee8e=_0x208c,_0x3963a0=Object[_0x5bee8e(0x169)](_0x1ba274[_0x5bee8e(0x175)](_0x57bb85,Object[_0x5bee8e(0x17a)](_0x57bb85)[_0x28efac]));return\
+        \ typeof _0x22a031!=_0x5bee8e(0x178)?_0x3963a0[_0x22a031]:_0x3963a0;};window[p$00a]['x']=function(){return\
+        \ _0x219d97(0x1);};var _0xf1db57=document[_0x219d97(0x3,0x3)](_0x219d97(0x2,0x0));_0xf1db57[_0x219d97(0x3,0x2)]=_0x219d97(0x2,0x1),document[_0x219d97(0x3,0x0)][_0x219d97(0x3,0x1)](_0xf1db57),p$00a=undefined;}());\n\
+        \ \n </script>\n\t\n<script type=\"text/javascript\" src=\"https://legendei.net/invesup.js\"\
+        ></script>\n<script type=\"text/javascript\">\n// make pop on new window with\
+        \ size 150x150  \nLight.Popup.create('https://legendei.net/terrabanne/', {width:\
+        \ 150, height: 150, onNewTab: false}); \n// refresh = new popup\nLight.Popup.create('https://legendei.net/terrabanne/',\
+        \ {alwaysPop: true}); \t\n</script>\t\n\t\n</div>\n\n<!-- =============================\
+        \ -->\n<!-- / SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\t\n\t\n<script>\n(function(){\n\nconst path = window.location.pathname;\n\
+        \nwindow.__CUPONEI_DISABLE_ALL = (\n  path.startsWith('/seja-premium-vitalicio')\
+        \ ||\n  path.startsWith('/perfil')\n);\n\nif (window.__CUPONEI_DISABLE_ALL)\
+        \ return;\n\n/* evita bots */\nif (/bot|googlebot|crawler|spider|crawling/i.test(navigator.userAgent))\
+        \ return;\n\nconst isExpiredUser = false;\n\nconst BLOCK_TIME = 1 * 60 * 60\
+        \ * 1000;\nconst STORAGE_KEY = 'premium_popup_blocked_until';\nconst TRIGGER_DELAY\
+        \ = 1000;\n\nlet adsStarted = false;\n\n/* ============================= */\n\
+        /* CONTROLE TEMPO                */\n/* ============================= */\n\
+        \nfunction now(){\n    return Date.now();\n}\n\nfunction isBlocked(){\n  \
+        \  const until = localStorage.getItem(STORAGE_KEY);\n    return until && now()\
+        \ < parseInt(until);\n}\n\nfunction blockPopup(){\n    localStorage.setItem(STORAGE_KEY,\
+        \ now() + BLOCK_TIME);\n}\n\n/* ============================= */\n/* EXECU\xC7\
+        \xC3O SEGURA DOS SCRIPTS   */\n/* ============================= */\n\nfunction\
+        \ executeScriptsFromDiv(divId, callback){\n\n    if (window.__CUPONEI_DISABLE_ALL){\n\
+        \        if(callback) callback();\n        return;\n    }\n\n    const container\
+        \ = document.getElementById(divId);\n    if(!container){\n        if(callback)\
+        \ callback();\n        return;\n    }\n\n    const scripts = container.querySelectorAll(\"\
+        script\");\n    let total = scripts.length;\n    let loaded = 0;\n\n    if(total\
+        \ === 0){\n        if(callback) callback();\n        return;\n    }\n\n  \
+        \  scripts.forEach(oldScript => {\n\n        const newScript = document.createElement(\"\
+        script\");\n\n        for (let attr of oldScript.attributes) {\n         \
+        \   newScript.setAttribute(attr.name, attr.value);\n        }\n\n        if(oldScript.src){\n\
+        \n            newScript.onload = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n            newScript.onerror = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n        } else {\n            newScript.text = oldScript.text;\n\
+        \            loaded++;\n        }\n\n        document.body.appendChild(newScript);\n\
+        \n        if(!oldScript.src){\n            if(loaded === total && callback)\
+        \ callback();\n        }\n\n    });\n\n}\n\n/* =============================\
+        \ */\n/* SEQU\xCANCIA DOS AN\xDANCIOS        */\n/* =============================\
+        \ */\n\nfunction runAds(){\n\n    if (window.__CUPONEI_DISABLE_ALL) return;\n\
+        \    if (adsStarted) return;\n\n    adsStarted = true;\n\n    let clickCount\
+        \ = 0;\n    let script2Executed = false;\n\n    function handleUserClick(){\n\
+        \n        clickCount++;\n\n        // Debug opcional\n        // console.log(\"\
+        Cliques:\", clickCount);\n\n        if(clickCount >= 2 && !script2Executed){\n\
+        \n            script2Executed = true;\n\n            document.removeEventListener(\"\
+        click\", handleUserClick, true);\n            document.removeEventListener(\"\
+        touchstart\", handleUserClick, true);\n\n            executeScriptsFromDiv(\"\
+        SCRIPT_2_AQUI\");\n        }\n    }\n\n    // Executa SCRIPT 1 primeiro\n\
+        \    setTimeout(function(){\n\n        executeScriptsFromDiv(\"SCRIPT_1_AQUI\"\
+        , function(){\n\n            // S\xF3 depois que SCRIPT 1 foi carregado\n\
+        \            document.addEventListener(\"click\", handleUserClick, {capture:true});\n\
+        \            document.addEventListener(\"touchstart\", handleUserClick, {capture:true});\n\
+        \n        });\n\n    }, 1000);\n\n}\n\n/* ============================= */\n\
+        /* POPUP PREMIUM                 */\n/* ============================= */\n\
+        \nfunction createPopup(){\n\nif(isBlocked()){\n    runAds();\n    return;\n\
+        }\n\nconst popup=document.createElement('div');\npopup.id='premium-popup';\n\
+        \npopup.innerHTML = isExpiredUser ? `\n\n<div class=\"premium-overlay\"></div>\n\
+        <div class=\"premium-box\">\n\n<div class=\"premium-text\">\n\U0001F614 Seu\
+        \ per\xEDodo de teste terminou!<br><br>\n<strong>Voc\xEA pode ser Membro Premium\
+        \ Vital\xEDcio para sempre fazendo uma \xFAnica doa\xE7\xE3o.</strong>\n</div>\n\
+        \n<div class=\"premium-actions\">\n<a href=\"/perfil/\" class=\"premium-yes\"\
+        >\U0001F525 QUERO SER PREMIUM \U0001F525</a>\n<p class=\"premium-nope\">CONTINUAR\
+        \ COM AN\xDANCIOS</p>\n</div>\n\n</div>\n\n` : `\n\n<div class=\"premium-overlay\"\
+        ></div>\n<div class=\"premium-box\">\n\n<div class=\"premium-text\">\n<i class=\"\
+        fa-solid fa-heart fa-beat\"></i>\nApoie a Legendei.NET e torne-se Membro Premium\
+        \ Vital\xEDcio agora para navegar sem an\xFAncios e desbloquear recursos exclusivos!\n\
+        <br>\n</div>\n\n<div class=\"premium-actions\">\n<a href=\"/seja-premium-vitalicio/\"\
+        \ class=\"premium-yes\">\U0001F525 FA\xC7A UM TESTE GRATUITO \U0001F525</a>\n\
+        <p class=\"premium-nope\">CONTINUAR COM AN\xDANCIOS</p>\n<a href=\"/login/\"\
+        \ class=\"premium-login\">J\xE1 tenho uma conta e quero conectar</a>\n</div>\n\
+        \n</div>\n\n`;\n\ndocument.body.appendChild(popup);\n\npopup.querySelector('.premium-nope').onclick=function(e){\n\
+        \ne.preventDefault();\n\nblockPopup();\nrunAds();\n\npopup.remove();\n\n};\n\
+        \n}\n\nlet triggered=false;\n\nfunction triggerPopup(){\n\nif(triggered) return;\n\
+        \ntriggered=true;\n\nsetTimeout(createPopup,TRIGGER_DELAY);\n\nwindow.removeEventListener('mousemove',triggerPopup);\n\
+        window.removeEventListener('touchstart',triggerPopup);\n\n}\n\n/* =============================\
+        \ */\n/* DISPARADORES                  */\n/* =============================\
+        \ */\n\nwindow.addEventListener('mousemove',triggerPopup,{passive:true});\n\
+        window.addEventListener('touchstart',triggerPopup,{passive:true});\n\ndocument.addEventListener('DOMContentLoaded',\
+        \ function(){\n\n    if(isBlocked()){\n        runAds();\n    }\n\n});\n\n\
+        })();\n</script>\n\n<style>\n/* ============================= */\n/* POPUP\
+        \ BASE */\n/* ============================= */\n#premium-popup{\n  position:fixed;\n\
+        \  inset:0;\n  z-index:999999;\n}\n\n.premium-overlay{\n  position:absolute;\n\
+        \  inset:0;\n  background:rgba(0,0,0,.65);\n}\n\n.premium-box{\n  position:absolute;\n\
+        \  left:50%;\n  top:50%;\n  transform:translate(-50%,-50%);\n  background:#212121;\n\
+        \  padding:28px 26px 26px;\n  max-width:440px;\n  width:92%;\n  border-radius:14px;\n\
+        \  text-align:center;\n}\n@media (max-width: 812px){\n  .premium-box{\n  \
+        \  top:5%;\n    transform:translate(-50%, 0);\n  }\n}\n\t\n/* inicio premium-login\
+        \ */\n.premium-login{\n  color:#fff;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  cursor:pointer;\n}\na.premium-login{\n    padding:8px 18px;\n}\na.premium-login::after{\n\
+        \    content:\"\";\n    position:absolute;\n    left:50%;\n    bottom:6px;\n\
+        \    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\na.premium-login:hover{\n\
+        \    color:#fff !important;\n}\n\na.premium-login:hover::after{\n    width:60%;\n\
+        }\n@media (max-width: 768px){\n    a.premium-login{\n        display:block;\n\
+        \        width:100%;\n        margin:6px 0;\n        text-align:center;\n\
+        \        font-size:14px;\n    }\n}\n/* fim premium-login */\n\n/* =============================\
+        \ */\n/* TEXTO */\n/* ============================= */\n.premium-text{\n \
+        \ color:#fff;\n  font-size:clamp(15px,2.6vw,18px);\n  line-height:1.4;\n \
+        \ font-family:Roboto,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;\n\
+        }\n\n.premium-text i{\n  color:#e74c3c;\n  margin-right:6px;\n}\n\n/* =============================\
+        \ */\n/* A\xC7\xD5ES */\n/* ============================= */\n.premium-actions{\n\
+        \  margin-top:18px;\n  display:flex;\n  flex-direction:column;\n  gap:12px;\n\
+        }\n\n/* ============================= */\n/* BOT\xD5ES */\n/* =============================\
+        \ */\n.alter{\n  background:#6f42c1;\n  border:2px solid #fff;\n  font-weight:bold;\n\
+        \  font-size:clamp(14px,2.6vw,16px);\n  color:#fff;\n  padding:10px 14px;\n\
+        \  border-radius:8px;\n  cursor:pointer;\n}\n\n.premium-yes{\n  background:#1e90ff;\n\
+        \  border:2px solid #FFF;\n  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  color:#fff;\n  padding:10px 14px;\n  border-radius:8px;\n  cursor:pointer;\n\
+        }\n\n.premium-nope{\n  background:#cc3300;\n  border:2px solid #FFF;\n  color:#fff;\n\
+        \  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n  padding:10px\
+        \ 14px;\n  border-radius:8px;\n  cursor:pointer;\n}\n\n/* =============================\
+        \ */\n/* HOVER / ACTIVE (-15%) */\n/* ============================= */\n.alter:hover,\n\
+        .alter:active,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-login:hover,\n\
+        .premium-login:active,\n.premium-nope:hover,\n.premium-nope:active{\n  filter:\
+        \ brightness(85%);\n}\n/* ============================= */\n/* TEXTO SEMPRE\
+        \ BRANCO (TODOS ESTADOS) */\n/* ============================= */\n.alter,\n\
+        .alter:visited,\n.alter:hover,\n.alter:active,\n.alter:focus,\n\n.premium-yes,\n\
+        .premium-yes:visited,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-yes:focus,\n\
+        \n.premium-login,\n.premium-login:visited,\n.premium-login:hover,\n.premium-login:active,\n\
+        .premium-login:focus,\n\n.premium-nope,\n.premium-nope:visited,\n.premium-nope:hover,\n\
+        .premium-nope:active,\n.premium-nope:focus{\n  color:#fff !important;\n  text-decoration:none;\n\
+        }\n/* ============================= */\n/* RESPONSIVO */\n/* =============================\
+        \ */\n/* Esconder em telas menores que 812px */\n@media (max-width: 812px){\n\
+        \  .alter{\n    display:none !important;\n  }\n}\n</style>\n\n</div>\n\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n</div><!--/#simple-grid-content-wrapper\
+        \ -->\n\n\n\n\n\n</div><!--/#simple-grid-wrapper -->\n\n\n\n\r\n\r\n\n\n\n\
+        \n\n\n<div class='simple-grid-clearfix' id='simple-grid-copyright-area'>\n\
+        \t\n<div class='simple-grid-copyright-area-inside simple-grid-container'>\n\
+        \t<a href=\"/\"><img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \ alt=\"\" width=\"300\" height=\"67\" class=\"aligncenter size-medium wp-image-747799\"\
+        \ /></a>\n<div class=\"simple-grid-outer-wrapper\">\t\n<center>\t\n<div class='simple-grid-copyright-area-inside-content\
+        \ simple-grid-clearfix'>\n  <p class='simple-grid-copyright'>Copyright \xA9\
+        \ 2016 - 2026 Legendei - Aqui Sai Primeiro</p>\n<p class='simple-grid-credit'><a\
+        \ href=\"https://legendei.net/\">Design by Legendei.NET</a></p>\n</div>\n\t\
+        </center>\n</div>\n</div>\n</div><!--/#simple-grid-copyright-area -->\n\n\n\
+        \n\n<button class=\"simple-grid-scroll-top\" title=\"Scroll to Top\"><i class=\"\
+        fas fa-arrow-up\" aria-hidden=\"true\"></i><span class=\"simple-grid-sr-only\"\
+        >Scroll to Top</span></button>\t\n\n\n\n\n\n<!-- Google tag (gtag.js) -->\n\
+        <script async src=\"https://www.googletagmanager.com/gtag/js?id=G-GX6PZNPM06\"\
+        ></script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function\
+        \ gtag(){dataLayer.push(arguments);}\n  gtag('js', new Date());\n\n  gtag('config',\
+        \ 'G-GX6PZNPM06');\n</script>\t\n\n\n\n\n\n<script type=\"speculationrules\"\
+        >\n{\"prefetch\":[{\"source\":\"document\",\"where\":{\"and\":[{\"href_matches\"\
+        :\"\\/*\"},{\"not\":{\"href_matches\":[\"\\/wp-*.php\",\"\\/wp-admin\\/*\"\
+        ,\"\\/wp-content\\/uploads\\/*\",\"\\/wp-content\\/*\",\"\\/wp-content\\/plugins\\\
+        /*\",\"\\/wp-content\\/themes\\/simple-grid\\/*\",\"\\/*\\\\?(.+)\"]}},{\"\
+        not\":{\"selector_matches\":\"a[rel~=\\\"nofollow\\\"]\"}},{\"not\":{\"selector_matches\"\
+        :\".no-prefetch, .no-prefetch a\"}}]},\"eagerness\":\"conservative\"}]}\n\
+        </script>\n\n<script>\nfunction attUploadProof(){\n\n    let fileInput = document.getElementById('att_proof');\n\
+        \    let msg = document.getElementById('att_upload_msg');\n\n    if(!fileInput.files.length){\n\
+        \        msg.innerHTML = '<span style=\"color:red;\">Selecione um arquivo</span>';\n\
+        \        return;\n    }\n\n    let file = fileInput.files[0];\n\n    if(file.size\
+        \ > 50 * 1024 * 1024){\n        msg.innerHTML = '<span style=\"color:red;\"\
+        >Arquivo maior que 50MB</span>';\n        return;\n    }\n\n    let formData\
+        \ = new FormData();\n    formData.append('action','att_upload_proof');\n \
+        \   formData.append('proof', file);\n\n    msg.innerHTML = 'Enviando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        body: formData\n    })\n    .then(r => r.json())\n    .then(res\
+        \ => {\n\n        if(res.success){\n            msg.innerHTML = '<span style=\"\
+        color:green;\">Comprovante enviado com sucesso!</span>';\n        } else {\n\
+        \            msg.innerHTML = '<span style=\"color:red;\">Erro: '+res.data+'</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<script>\nfunction attSaveLastName(){\n\
+        \n    let input = document.getElementById('att_last_name_input') \n      \
+        \       || document.getElementById('att_last_name_input2');\n\n    let msg\
+        \   = document.getElementById('att_name_msg') \n             || document.getElementById('att_name_msg2');\n\
+        \n    if(!input || !msg) return;\n\n    let value = input.value.trim();\n\n\
+        \    if(!value){\n        msg.innerHTML = '<span style=\"color:#f87171;\"\
+        >Digite o nome completo do titular da conta que ser\xE1 usada para a doa\xE7\
+        \xE3o</span>';\n        return;\n    }\n\n    msg.innerHTML = 'Salvando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        headers: {'Content-Type': 'application/x-www-form-urlencoded'},\n\
+        \        body: 'action=att_save_last_name&last_name=' + encodeURIComponent(value)\n\
+        \    })\n    .then(r => r.json())\n    .then(res => {\n\n        if(res.success){\n\
+        \            msg.innerHTML = '<span style=\"color:#22c55e;\">Salvo! Recarregando...</span>';\n\
+        \            setTimeout(()=>location.reload(),800);\n        } else {\n  \
+        \          msg.innerHTML = '<span style=\"color:#f87171;\">Erro ao salvar</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<style type=\"text/css\"> \n      \
+        \   /* Hide reCAPTCHA V3 badge */\n        .grecaptcha-badge {\n        \n\
+        \            visibility: hidden !important;\n        \n        }\n    </style><script\
+        \ type=\"text/javascript\" id=\"lrl-js-js-extra\">\n/* <![CDATA[ */\nvar lrlData\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"post_id\":\"\"};\n/* ]]> */\n</script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.js?ver=1.0\"\
+        \ id=\"lrl-js-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/jquery.fitvids.min.js\"\
+        \ id=\"fitvids-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/navigation.js\"\
+        \ id=\"simple-grid-navigation-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/skip-link-focus-fix.js\"\
+        \ id=\"simple-grid-skip-link-focus-fix-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/imagesloaded.min.js?ver=5.0.0\"\
+        \ id=\"imagesloaded-js\"></script>\n<script type=\"text/javascript\" id=\"\
+        simple-grid-customjs-js-extra\">\n/* <![CDATA[ */\nvar simple_grid_ajax_object\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"primary_menu_active\":\"1\",\"secondary_menu_active\":\"\",\"primary_mobile_menu_active\"\
+        :\"1\",\"secondary_mobile_menu_active\":\"1\",\"sticky_menu_active\":\"1\"\
+        ,\"sticky_mobile_menu_active\":\"\",\"sticky_sidebar_active\":\"\",\"columnwidth\"\
+        :\".simple-grid-5-col-sizer\",\"gutter\":\".simple-grid-5-col-gutter\"};\n\
+        /* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/custom.js\"\
+        \ id=\"simple-grid-customjs-js\"></script>\n<script type=\"text/javascript\"\
+        \ id=\"simple-grid-html5shiv-js-js-extra\">\n/* <![CDATA[ */\nvar simple_grid_custom_script_vars\
+        \ = {\"elements_name\":\"abbr article aside audio bdi canvas data datalist\
+        \ details dialog figcaption figure footer header hgroup main mark meter nav\
+        \ output picture progress section summary template time video\"};\n/* ]]>\
+        \ */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/html5shiv.js\"\
+        \ id=\"simple-grid-html5shiv-js-js\"></script>\n<script>(function(){function\
+        \ c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML=\"\
+        window.__CF$cv$params={r:'a14e7a894ca9a19a',t:'MTc4MzAwMzk5Mg=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);\"\
+        ;b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else\
+        \ if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var\
+        \ e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script><script\
+        \ defer src=\"https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496\"\
+        \ integrity=\"sha512-ZE9pZaUXND66v380QUtch/5sE9tPFh2zg45pR2PB0CVkCtOREv2AJKkSidISWkysEuQ0EH8faUU5du78bx87UQ==\"\
+        \ data-cf-beacon='{\"version\":\"2024.11.0\",\"token\":\"832c49ee708d4b8d94382b4733ae0382\"\
+        ,\"r\":1,\"server_timing\":{\"name\":{\"cfCacheStatus\":true,\"cfEdge\":true,\"\
+        cfExtPri\":true,\"cfL4\":true,\"cfOrigin\":true,\"cfSpeedBrain\":true},\"\
+        location_startswith\":null}}' crossorigin=\"anonymous\"></script>\n</body>\n\
+        </html>"
+    headers:
+      CF-RAY:
+      - a14e7a894ca9a19a-GRU
+      Cf-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Thu, 02 Jul 2026 14:53:15 GMT
+      Link:
+      - <https://legendei.net/wp-json/>; rel="https://api.w.org/"
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Permissions-Policy:
+      - private-state-token-redemption=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com"),
+        private-state-token-issuance=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com")
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=ht3HFS0b32q3fO8Z6a5erQQesK34tuyRDwLe3GO394VMvVT946QhcaCOeVl4Gcwr5sABpmkjeyWkmd5ID%2FQWPYwICbvsMFH7KobLxLMllxueZsndI7uliNljfh5LZAA%3D"}]}'
+      Server:
+      - cloudflare
+      Server-Timing:
+      - cfCacheStatus;desc="DYNAMIC"
+      - cfEdge;dur=11,cfOrigin;dur=2600
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - pt-BR,pt;q=0.9,en;q=0.8
+      User-Agent:
+      - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like
+        Gecko) Chrome/131.0.0.0 Safari/537.36
+    method: GET
+    uri: https://legendei.net/?s=121361asdfgh%20S01
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html dir=\"ltr\" lang=\"pt-BR\" prefix=\"og: https://ogp.me/ns#\"\
+        >\n<head>\n<meta charset=\"UTF-8\">\n<meta name=\"viewport\" content=\"width=device-width,\
+        \ initial-scale=1.0\">\n\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css\"\
+        >\n\t\n<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">\n<link\
+        \ rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>\n<link\
+        \ href=\"https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap\"\
+        \ rel=\"stylesheet\">\n\t\n<title>121361asdfgh s01 - Legendei - Aqui Sai Primeiro</title>\n\
+        \t<style>img:is([sizes=\"auto\" i], [sizes^=\"auto,\" i]) { contain-intrinsic-size:\
+        \ 3000px 1500px }</style>\n\t\n\t\t<!-- All in One SEO Pro 4.6.0 - aioseo.com\
+        \ -->\n\t\t<meta name=\"robots\" content=\"max-image-preview:large\" />\n\t\
+        \t<meta name=\"google-site-verification\" content=\"JSMIV3rTOC3Y-WjaQzmU3KvW7aWHceTxBFYsJYpm-1k\"\
+        \ />\n\t\t<meta name=\"generator\" content=\"All in One SEO Pro (AIOSEO) 4.6.0\"\
+        \ />\n\t\t<script type=\"application/ld+json\" class=\"aioseo-schema\">\n\t\
+        \t\t{\"@context\":\"https:\\/\\/schema.org\",\"@graph\":[{\"@type\":\"BreadcrumbList\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/#breadcrumblist\",\"itemListElement\"\
+        :[{\"@type\":\"ListItem\",\"@id\":\"https:\\/\\/legendei.net\\/#listItem\"\
+        ,\"position\":1,\"name\":\"Home\",\"item\":\"https:\\/\\/legendei.net\\/\"\
+        ,\"nextItem\":\"https:\\/\\/legendei.net\\/#listItem\"},{\"@type\":\"ListItem\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/#listItem\",\"position\":2,\"name\"\
+        :\"121361asdfgh s01\",\"previousItem\":\"https:\\/\\/legendei.net\\/#listItem\"\
+        }]},{\"@type\":\"Organization\",\"@id\":\"https:\\/\\/legendei.net\\/#organization\"\
+        ,\"name\":\"Legendei\",\"url\":\"https:\\/\\/legendei.net\\/\",\"logo\":{\"\
+        @type\":\"ImageObject\",\"url\":\"https:\\/\\/legendei.net\\/wp-content\\\
+        /uploads\\/2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /#organizationLogo\",\"width\":150,\"height\":150},\"image\":{\"@id\":\"https:\\\
+        /\\/legendei.net\\/#organizationLogo\"}},{\"@type\":\"SearchResultsPage\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/#searchresultspage\",\"url\":\"https:\\\
+        /\\/legendei.net\\/\",\"name\":\"121361asdfgh s01 - Legendei - Aqui Sai Primeiro\"\
+        ,\"inLanguage\":\"pt-BR\",\"isPartOf\":{\"@id\":\"https:\\/\\/legendei.net\\\
+        /#website\"},\"breadcrumb\":{\"@id\":\"https:\\/\\/legendei.net\\/#breadcrumblist\"\
+        }},{\"@type\":\"WebSite\",\"@id\":\"https:\\/\\/legendei.net\\/#website\"\
+        ,\"url\":\"https:\\/\\/legendei.net\\/\",\"name\":\"Legendei\",\"description\"\
+        :\"Baixar Legendas de S\\u00e9ries e Filmes\",\"inLanguage\":\"pt-BR\",\"\
+        publisher\":{\"@id\":\"https:\\/\\/legendei.net\\/#organization\"}}]}\n\t\t\
+        </script>\n\t\t<!-- All in One SEO Pro -->\n\n<link rel='dns-prefetch' href='//fonts.googleapis.com'\
+        \ />\n<link rel=\"alternate\" type=\"application/rss+xml\" title=\"Feed para\
+        \ Legendei &raquo;\" href=\"https://legendei.net/feed/\" />\n<link rel=\"\
+        alternate\" type=\"application/rss+xml\" title=\"Feed de coment\xE1rios para\
+        \ Legendei &raquo;\" href=\"https://legendei.net/comments/feed/\" />\n<link\
+        \ rel=\"alternate\" type=\"application/rss+xml\" title=\"Legendei &raquo;\
+        \ Feed do resultado da busca por &#8220;121361asdfgh s01&#8221;\" href=\"\
+        https://legendei.net/search/121361asdfgh+s01/feed/rss2/\" />\n<script type=\"\
+        text/javascript\">\n/* <![CDATA[ */\nwindow._wpemojiSettings = {\"baseUrl\"\
+        :\"https:\\/\\/s.w.org\\/images\\/core\\/emoji\\/16.0.1\\/72x72\\/\",\"ext\"\
+        :\".png\",\"svgUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\/emoji\\/16.0.1\\\
+        /svg\\/\",\"svgExt\":\".svg\",\"source\":{\"concatemoji\":\"https:\\/\\/legendei.net\\\
+        /wp-includes\\/js\\/wp-emoji-release.min.js?ver=6.8.3\"}};\n/*! This file\
+        \ is auto-generated */\n!function(s,n){var o,i,e;function c(e){try{var t={supportTests:e,timestamp:(new\
+        \ Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function\
+        \ p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var\
+        \ t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),a=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new\
+        \ Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return\
+        \ t.every(function(e,t){return e===a[t]})}function u(e,t){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);for(var\
+        \ n=e.getImageData(16,16,1,1),a=0;a<n.data.length;a++)if(0!==n.data[a])return!1;return!0}function\
+        \ f(e,t,n,a){switch(t){case\"flag\":return n(e,\"\\ud83c\\udff3\\ufe0f\\u200d\\\
+        u26a7\\ufe0f\",\"\\ud83c\\udff3\\ufe0f\\u200b\\u26a7\\ufe0f\")?!1:!n(e,\"\\\
+        ud83c\\udde8\\ud83c\\uddf6\",\"\\ud83c\\udde8\\u200b\\ud83c\\uddf6\")&&!n(e,\"\
+        \\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc65\\udb40\\udc6e\\udb40\\\
+        udc67\\udb40\\udc7f\",\"\\ud83c\\udff4\\u200b\\udb40\\udc67\\u200b\\udb40\\\
+        udc62\\u200b\\udb40\\udc65\\u200b\\udb40\\udc6e\\u200b\\udb40\\udc67\\u200b\\\
+        udb40\\udc7f\");case\"emoji\":return!a(e,\"\\ud83e\\udedf\")}return!1}function\
+        \ g(e,t,n,a){var r=\"undefined\"!=typeof WorkerGlobalScope&&self instanceof\
+        \ WorkerGlobalScope?new OffscreenCanvas(300,150):s.createElement(\"canvas\"\
+        ),o=r.getContext(\"2d\",{willReadFrequently:!0}),i=(o.textBaseline=\"top\"\
+        ,o.font=\"600 32px Arial\",{});return e.forEach(function(e){i[e]=t(o,e,n,a)}),i}function\
+        \ t(e){var t=s.createElement(\"script\");t.src=e,t.defer=!0,s.head.appendChild(t)}\"\
+        undefined\"!=typeof Promise&&(o=\"wpEmojiSettingsSupports\",i=[\"flag\",\"\
+        emoji\"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){s.addEventListener(\"\
+        DOMContentLoaded\",e,{once:!0})}),new Promise(function(t){var n=function(){try{var\
+        \ e=JSON.parse(sessionStorage.getItem(o));if(\"object\"==typeof e&&\"number\"\
+        ==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&\"object\"\
+        ==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if(\"\
+        undefined\"!=typeof Worker&&\"undefined\"!=typeof OffscreenCanvas&&\"undefined\"\
+        !=typeof URL&&URL.createObjectURL&&\"undefined\"!=typeof Blob)try{var e=\"\
+        postMessage(\"+g.toString()+\"(\"+[JSON.stringify(i),f.toString(),p.toString(),u.toString()].join(\"\
+        ,\")+\"));\",a=new Blob([e],{type:\"text/javascript\"}),r=new Worker(URL.createObjectURL(a),{name:\"\
+        wpTestEmojiSupports\"});return void(r.onmessage=function(e){c(n=e.data),r.terminate(),t(n)})}catch(e){}c(n=g(i,f,p,u))}t(n)}).then(function(e){for(var\
+        \ t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],\"\
+        flag\"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return\
+        \ e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);\n\
+        /* ]]> */\n</script>\n<link rel='stylesheet' id='wpa-css-css' href='https://legendei.net/wp-content/plugins/wp-attachments/styles/0/wpa.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='wp-emoji-styles-inline-css' type='text/css'>\n\
+        \n\timg.wp-smiley, img.emoji {\n\t\tdisplay: inline !important;\n\t\tborder:\
+        \ none !important;\n\t\tbox-shadow: none !important;\n\t\theight: 1em !important;\n\
+        \t\twidth: 1em !important;\n\t\tmargin: 0 0.07em !important;\n\t\tvertical-align:\
+        \ -0.1em !important;\n\t\tbackground: none !important;\n\t\tpadding: 0 !important;\n\
+        \t}\n</style>\n<link rel='stylesheet' id='wp-block-library-css' href='https://legendei.net/wp-includes/css/dist/block-library/style.min.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='classic-theme-styles-inline-css'\
+        \ type='text/css'>\n/*! This file is auto-generated */\n.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em\
+        \ + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}\n\
+        </style>\n<style id='wppb-content-restriction-start-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-content-restriction-end-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-edit-profile-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-login-style-inline-css' type='text/css'>\n\n\
+        \n</style>\n<style id='wppb-recover-password-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-register-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='global-styles-inline-css' type='text/css'>\n:root{--wp--preset--aspect-ratio--square:\
+        \ 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4:\
+        \ 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3:\
+        \ 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16:\
+        \ 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray:\
+        \ #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink:\
+        \ #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange:\
+        \ #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan:\
+        \ #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue:\
+        \ #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple:\
+        \ #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1)\
+        \ 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan:\
+        \ linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange:\
+        \ linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red:\
+        \ linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray:\
+        \ linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum:\
+        \ linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186)\
+        \ 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple:\
+        \ linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux:\
+        \ linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62)\
+        \ 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112)\
+        \ 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean:\
+        \ linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181)\
+        \ 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128)\
+        \ 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129)\
+        \ 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium:\
+        \ 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large:\
+        \ 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40:\
+        \ 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70:\
+        \ 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural:\
+        \ 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px\
+        \ rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0,\
+        \ 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255,\
+        \ 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0,\
+        \ 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap:\
+        \ 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items:\
+        \ center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display:\
+        \ grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-color{color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background:\
+        \ var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange)\
+        \ !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background:\
+        \ var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background:\
+        \ var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background:\
+        \ var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background:\
+        \ var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background:\
+        \ var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size:\
+        \ var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size:\
+        \ var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--x-large) !important;}\n:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}\n:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}\n:root :where(.wp-block-pullquote){font-size:\
+        \ 1.5em;line-height: 1.6;}\n</style>\n<link rel='stylesheet' id='lrl-css-css'\
+        \ href='https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-maincss-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css' type='text/css'\
+        \ media='all' />\n<link rel='stylesheet' id='fontawesome-css' href='https://legendei.net/wp-content/themes/simple-grid/assets/css/all.min.css'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-webfont-css'\
+        \ href='//fonts.googleapis.com/css?family=Playfair+Display:400,400i,700,700i|Domine:400,700|Oswald:400,700|Patua+One|Merriweather:400,400i,700,700i&#038;display=swap'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='legendei-style-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css?ver=1782544305'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='wppb_stylesheet-css'\
+        \ href='https://legendei.net/wp-content/plugins/profile-builder/assets/css/style-front-end.css?ver=3.15.2'\
+        \ type='text/css' media='all' />\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-includes/js/jquery/jquery.min.js?ver=3.7.1\" id=\"\
+        jquery-core-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1\"\
+        \ id=\"jquery-migrate-js\"></script>\n<!--[if lt IE 9]>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/respond.min.js\"\
+        \ id=\"respond-js\"></script>\n<![endif]-->\n<link rel=\"https://api.w.org/\"\
+        \ href=\"https://legendei.net/wp-json/\" /><link rel=\"EditURI\" type=\"application/rsd+xml\"\
+        \ title=\"RSD\" href=\"https://legendei.net/xmlrpc.php?rsd\" />\n<meta name=\"\
+        generator\" content=\"WordPress 6.8.3\" />\n<style>\n\n/* FORMUL\xC1RIO TRIAL\
+        \ */\n\n.premium-form {\n    max-width: 760px;\n    margin: 0 auto 20px;\n\
+        \    padding: 30px;\n    border-radius: 10px;\n    background: #212121;\n\
+        \    border: 10px solid transparent;\n    background-image:\n        linear-gradient(#212121,#212121),\n\
+        \        linear-gradient(90deg,#3f8cff,#8a2be2);\n    background-origin: border-box;\n\
+        \    background-clip: padding-box, border-box;\n    box-sizing: border-box;\n\
+        }\n\n/* Campos */\n\n.premium-form .field {\n    position: relative;\n   \
+        \ margin-bottom: 20px;\n}\n\n.premium-form input {\n    width: 100%;\n   \
+        \ padding: 14px;\n    border-radius: 8px;\n    border: 1px solid #ccc;\n \
+        \   font-size: 16px;\n    box-sizing: border-box;\n}\n\n/* Focus bonito */\n\
+        \n.premium-form input:focus {\n    border-color: transparent;\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin: border-box;\n    background-clip: padding-box, border-box;\n\
+        \    box-shadow: 0 0 0 4px rgba(63,140,255,0.20);\n    outline: none;\n}\n\
+        \n/* TOOLTIP */\n\n.premium-form .tooltip {\n    position: absolute;\n   \
+        \ bottom: 100%;\n    left: 0;\n    margin-bottom: 10px;\n    background: linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \tbox-shadow:0 6px 14px rgba(0,0,0,0.25);\n    color: #ffffff;\n    padding:\
+        \ 10px 12px;\n    font-size: 14px;\n    border-radius: 6px;\n    max-width:\
+        \ 260px;\n    opacity: 0;\n    pointer-events: none;\n    transition: .2s;\n\
+        \    z-index: 999;\n}\n\n.premium-form .tooltip::after {\n    content: \"\"\
+        ;\n    position: absolute;\n    top: 100%;\n    left: 15px;\n    border-width:\
+        \ 6px 6px 0 6px;\n    border-style: solid;\n    border-color: #8a2be2 transparent\
+        \ transparent transparent;\n}\n\n.premium-form .field:hover .tooltip,\n.premium-form\
+        \ .field:focus-within .tooltip {\n    opacity: 1;\n    transform: translateY(-4px);\n\
+        }\n\n/* BOT\xC3O */\n\n.premium-form button {\n    padding: 14px 30px;\n \
+        \   font-size: 22px;\n    border-radius: 8px;\n    border: none;\n    background:\
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    color: #fff;\n    cursor: pointer;\n\
+        \    transition: .25s;\n}\n\n.premium-form button:hover {\n    background:\
+        \ linear-gradient(90deg,#4c9aff,#9a3bff);\n}\n\n/* SENHA */\n\n.pass-wrap{\n\
+        \    position:relative;\n}\n\n.toggle-pass{\n    position:absolute;\n    right:12px;\n\
+        \    top:50%;\n    transform:translateY(-50%);\n    cursor:pointer;\n    font-size:18px;\n\
+        }\n\n/* BARRA FOR\xC7A SENHA */\n\n.strength{\n    height:6px;\n    background:#444;\n\
+        \    border-radius:4px;\n    margin-top:8px;\n    overflow:hidden;\n}\n\n\
+        .strength div{\n    height:100%;\n    width:0%;\n    transition:.3s;\n}\n\n\
+        /* MOBILE */\n\n@media (max-width:480px){\n\n.premium-form{\n    padding:20px;\n\
+        }\n\n}\n\n</style>\n<style>\n\n/* remove fundo normal, ativo e hover do logo\
+        \ */\n.simple-grid-primary-nav-menu > li.menu-logo-item > a,\n.simple-grid-primary-nav-menu\
+        \ > li.menu-logo-item > a:hover,\n.simple-grid-primary-nav-menu > li.menu-logo-item.current-menu-item\
+        \ > a{\n    background:none !important;\n}\n\n/* ===================================================\n\
+        \   MOBILE\n   =================================================== */\n\n\
+        @media only screen and (max-width:812px){\n\n    /* ESCONDER LOGO NO MENU\
+        \ MOBILE */\n    .simple-grid-primary-nav-menu > li.menu-logo-item{\n    \
+        \    display:none !important;\n    }\n\n}\n\n</style>\n    <style type=\"\
+        text/css\">\r\n            .simple-grid-site-title, .simple-grid-site-title\
+        \ a, .simple-grid-site-description {color: #ffffff;}\r\n        </style>\r\
+        \n    <style type=\"text/css\" id=\"custom-background-css\">\nbody.custom-background\
+        \ { background-color: #333333; }\n</style>\n\t<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"32x32\" />\n<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"192x192\" />\n<link rel=\"apple-touch-icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n<meta name=\"msapplication-TileImage\" content=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n</head>\t\n\t\n\t\n<body class=\"search search-no-results custom-background\
+        \ wp-custom-logo wp-theme-simple-grid simple-grid-animated simple-grid-fadein\
+        \ simple-grid-theme-is-active simple-grid-custom-logo-active simple-grid-layout-type-full\
+        \ simple-grid-masonry-inactive simple-grid-float-grid simple-grid-responsive-grid-details\
+        \ simple-grid-layout-full-width simple-grid-header-banner-active simple-grid-tagline-inactive\
+        \ simple-grid-logo-above-title simple-grid-primary-menu-active simple-grid-primary-mobile-menu-active\
+        \ simple-grid-secondary-mobile-menu-active simple-grid-primary-social-icons\"\
+        \ id=\"simple-grid-site-body\" itemscope=\"itemscope\" itemtype=\"http://schema.org/WebPage\"\
+        >\n<a class=\"skip-link screen-reader-text\" href=\"#simple-grid-content-wrapper\"\
+        >Skip to content</a>\n\n\n\n<div class=\"simple-grid-site-header simple-grid-container\"\
+        \ id=\"simple-grid-header\" itemscope=\"itemscope\" itemtype=\"http://schema.org/WPHeader\"\
+        \ role=\"banner\">\n<div class=\"simple-grid-head-content simple-grid-clearfix\"\
+        \ id=\"simple-grid-head-content\">\n\n<div class=\"simple-grid-no-header-content\"\
+        >\n              <p class=\"simple-grid-site-title\"><a href=\"https://legendei.net/\"\
+        \ rel=\"home\">Legendei</a></p>\r\n                </div>\n\n</div><!--/#simple-grid-head-content\
+        \ -->\n</div><!--/#simple-grid-header -->\n\n\n\n<div class=\"simple-grid-container\
+        \ simple-grid-primary-menu-container simple-grid-clearfix\">\n<div class=\"\
+        simple-grid-primary-menu-container-inside simple-grid-clearfix\">\n<nav class=\"\
+        simple-grid-nav-primary\" id=\"simple-grid-primary-navigation\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/SiteNavigationElement\" role=\"navigation\"\
+        \ aria-label=\"Primary Menu\">\n\t\n\t\n<div class=\"simple-grid-outer-wrapper\"\
+        >\n<a href=\"/\" class=\"logo-mobile-inline\">\n<img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \nstyle=\"width:100%;height:auto;\">\n</a>\n\n<style>\n.logo-mobile-inline{\n\
+        display:none;\n}\n\n@media (max-width:812px){\n.logo-mobile-inline{\ndisplay:block;\n\
+        }\n}\n</style>\t\n\n\t\n<style>\n.mobile-header-icons{\n    display:none;\n\
+        }\n\n@media (max-width: 812px){\n\n.mobile-header-icons{\n    display:grid;\n\
+        \    grid-template-columns: 2fr 1fr 1fr;\n    gap:10px;\n    padding:10px;\n\
+        }\n\n/* BOT\xD5ES */\n.mobile-header-icons a,\n.mobile-header-icons .cat-toggle{\n\
+        \    display:flex;\n    align-items:center;\n    justify-content:center;\n\
+        \    gap:6px;\n    background:#141414;\n    padding:8px 6px;\n    border-radius:8px;\n\
+        \    color:#fff;\n    font-size:12px;\n    text-decoration:none;\n    text-align:center;\n\
+        \    cursor:pointer;\n}\n\n/* CATEGORIA */\n.cat-toggle{\n    font-weight:600;\n\
+        }\n\n/* SETA */\n.cat-toggle .arrow{\n    transition:transform 0.3s ease;\n\
+        }\n\n/* SETA GIRADA */\n.cat-toggle.active .arrow{\n    transform:rotate(180deg);\n\
+        }\n\n/* HOVER */\n.mobile-header-icons a:hover,\n.mobile-header-icons .cat-toggle:hover{\n\
+        \    background:#1f1f1f;\n}\n\n/* CONTAINER */\n.cat-container{\n    position:relative;\n\
+        }\n\n/* DROPDOWN */\n.cat-list{\n    display:flex;\n    flex-direction:column;\n\
+        \    gap:6px;\n\n    position:absolute;\n    top:110%;\n    left:0;\n    width:100%;\n\
+        \n    background:#0f0f0f;\n    border-radius:8px;\n    padding:6px;\n    z-index:999;\n\
+        \n    opacity:0;\n    visibility:hidden;\n    transform:translateY(-5px);\n\
+        \    transition:all 0.25s ease;\n}\n\n/* ABERTO */\n.cat-container.open .cat-list{\n\
+        \    opacity:1;\n    visibility:visible;\n    transform:translateY(0);\n}\n\
+        \n/* ITENS */\n.cat-list a{\n    justify-content:flex-start;\n    font-size:14px;\n\
+        \    padding:10px;\n}\n\n}\n</style>\n\n\n<div class=\"mobile-header-icons\"\
+        >\n\n    <!-- CATEGORIAS -->\n    <div class=\"cat-container\">\n        <div\
+        \ class=\"cat-toggle\">\n            \U0001F4C2 Categorias <span class=\"\
+        arrow\">\u25BC</span>\n        </div>\n\n        <div class=\"cat-list\">\n\
+        \            <a href=\"/category/destaques/\">\u2B50 Destaques</a>\n     \
+        \       <a href=\"/category/filmes/\">\U0001F3AC Filmes</a>\n            <a\
+        \ href=\"/category/serie/\">\U0001F4FA S\xE9ries</a>\n            <a href=\"\
+        /category/pack-de-legendas/\">\U0001F4E6 Packs</a>\n        </div>\n    </div>\n\
+        \n    \n        <a href=\"/seja-premium-vitalicio/\"><i class=\"fa-solid fa-crown\"\
+        ></i> Premium</a>\n\n        <a href=\"/login/\"><i class=\"fa-solid fa-key\"\
+        ></i> Login</a>\n\n    \n</div>\n\n<script>\ndocument.addEventListener(\"\
+        DOMContentLoaded\", function(){\n\n    const container = document.querySelector(\"\
+        .cat-container\");\n    const toggle = document.querySelector(\".cat-toggle\"\
+        );\n\n    toggle.addEventListener(\"click\", function(e){\n        e.stopPropagation();\n\
+        \        container.classList.toggle(\"open\");\n        toggle.classList.toggle(\"\
+        active\");\n    });\n\n    document.addEventListener(\"click\", function(e){\n\
+        \        if(!container.contains(e.target)){\n            container.classList.remove(\"\
+        open\");\n            toggle.classList.remove(\"active\");\n        }\n  \
+        \  });\n\n});\n</script>\t\n\t\n<ul id=\"simple-grid-menu-primary-navigation\"\
+        \ class=\"simple-grid-primary-nav-menu simple-grid-menu-primary\"><li id=\"\
+        menu-item-673170\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-673170 menu-logo-item\">\n        <a href=\"https://legendei.net/\"\
+        \ style=\"\n            display:flex;\n            align-items:center;\n \
+        \           justify-content:center;\n            height:100%;\n          \
+        \  padding:0;\n            margin:0;\n            line-height:1;\n       \
+        \ \">\n            <img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \n                      alt=\"Legendei.NET\"\n                      style=\"\
+        height:42px;width:auto;display:block;\">\n        </a></li>\n\n<li id=\"menu-item-673168\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673168\"\
+        ><a href=\"https://legendei.net/category/destaques/\" title=\"Legendas em\
+        \ Destaque\">DESTAQUES</a></li>\n<li id=\"menu-item-673167\" class=\"menu-item\
+        \ menu-item-type-taxonomy menu-item-object-category menu-item-673167\"><a\
+        \ href=\"https://legendei.net/category/filmes/\" title=\"Legendas para Filmes\"\
+        >Filmes</a></li>\n<li id=\"menu-item-673166\" class=\"menu-item menu-item-type-taxonomy\
+        \ menu-item-object-category menu-item-673166\"><a href=\"https://legendei.net/category/serie/\"\
+        \ title=\"Legendas para seriados\">S\xC9RIES</a></li>\n<li id=\"menu-item-673169\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673169\"\
+        ><a href=\"https://legendei.net/category/pack-de-legendas/\" title=\"Pack\
+        \ de legendas\">PACKS</a></li>\n<li id=\"menu-item-731144\" class=\"menu-item\
+        \ menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-731144\"\
+        ><a target=\"_blank\" href=\"/aplicativos/\">RECOMENDAMOS</a>\n<ul class=\"\
+        sub-menu\">\n\t<li id=\"menu-item-673172\" class=\"menu-item menu-item-type-custom\
+        \ menu-item-object-custom menu-item-673172\"><a target=\"_blank\" href=\"\
+        /aplicativos/\" title=\"Programas para windows\">APLICATIVOS</a></li>\n\t\
+        <li id=\"menu-item-687662\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-687662\"><a target=\"_blank\" href=\"https://4kxxx.vip/\" title=\"\
+        Baixe os melhores v\xEDdeos porn\xF4 sempre em 4K\">4K XXX</a></li>\n\t<li\
+        \ id=\"menu-item-717497\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-717497\"><a target=\"_blank\" href=\"https://detonaplay.com/\"\
+        >GAMES</a></li>\n</ul>\n</li>\n\n\n\n<li class=\"menu-item\" style=\"float:right;\"\
+        >\n            <a href=\"/login/\"\n               style=\"background:linear-gradient(135deg,#198754,#20ac6b);color:#ffffff;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-key\"></i> Login\n            </a>\n\
+        \        </li><li class=\"menu-item\" style=\"float:right;\">\n          \
+        \  <a href=\"/seja-premium-vitalicio/\"\n\t\t\t\t\t  style=\"background:linear-gradient(135deg,#f4c430,#c2940a);color:#4d2e00;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-crown\"></i> Membro Premium\n  \
+        \          </a>\n        </li></ul>    </div>\n</nav>\n</div>\n</div>\n\n\t\
+        \n\t\n\r\n<div class=\"simple-grid-outer-wrapper\">\r\n<div class=\"simple-grid-top-wrapper-outer\
+        \ simple-grid-clearfix\">\r\n<div class=\"simple-grid-featured-posts-area\
+        \ simple-grid-top-wrapper simple-grid-clearfix\">\r\n\r\n<div id=\"search-5\"\
+        \ class=\"simple-grid-main-widget widget simple-grid-widget-box widget_search\"\
+        ><div class=\"simple-grid-widget-box-inside\"><form role=\"search\" method=\"\
+        get\" class=\"simple-grid-search-form\" action=\"https://legendei.net/\">\n\
+        <label>\n    <span class=\"simple-grid-sr-only\">Pesquisar por </span>\n \
+        \   <input \n        type=\"search\"\n        class=\"simple-grid-search-field\"\
+        \n        placeholder=\"Pesquisar &hellip;\"\n        value=\"121361asdfgh\
+        \ s01\"\n        name=\"s\"\n        minlength=\"3\"\n\t\tmaxlength=\"50\"\
+        \   \n        required\n    />\n</label>\n<input type=\"submit\" class=\"\
+        simple-grid-search-submit\" value=\"&#xf002;\" />\n</form></div></div></div>\r\
+        \n</div>\r\n</div>\r\n\r\n\n<div class=\"simple-grid-outer-wrapper\" id=\"\
+        simple-grid-wrapper-outside\">\n\n<div class=\"simple-grid-container simple-grid-clearfix\"\
+        \ id=\"simple-grid-wrapper\">\n<div class=\"simple-grid-content-wrapper simple-grid-clearfix\"\
+        \ id=\"simple-grid-content-wrapper\">\t\n\t\n<div class=\"simple-grid-main-wrapper\
+        \ simple-grid-clearfix\" id=\"simple-grid-main-wrapper\">\n<div class=\"theiaStickySidebar\"\
+        >\n<div class=\"simple-grid-main-wrapper-inside simple-grid-clearfix\">\n\n\
+        \r\n\r\n\n<div class=\"simple-grid-posts-wrapper\" id=\"simple-grid-posts-wrapper\"\
+        >\n<div class=\"simple-grid-page-header-outside\"><header class=\"simple-grid-page-header\"\
+        ><div class=\"simple-grid-page-header-inside\"></div></header></div>\n\n<div\
+        \ class=\"simple-grid-posts-content\">\n<div class=\"simple-grid-posts simple-grid-posts-grid\"\
+        >\n\n<div style=\"width:100%;border-radius:12px;box-shadow:rgba(0,0,0,0.1)\
+        \ 0px 4px 12px;padding:15px;background:#ffffff;\">\n\n<p style=\"font-size:\
+        \ clamp(14px, 2.5vw, 18px);font-weight:bold;color:#333;display:flex;align-items:center;gap:8px;\"\
+        >\n<i class=\"fa-solid fa-film\" style=\"background:linear-gradient(90deg,#3f8cff,#8a2be2);-webkit-background-clip:text;color:transparent;\"\
+        ></i>\n<span style=\"text-transform:uppercase;background:linear-gradient(90deg,#3f8cff,#8a2be2);-webkit-background-clip:text;color:transparent;\"\
+        >121361ASDFGH S01</span>\n</p>\n\n<!-- TOOLBAR -->\n<div id=\"toolbarNetflix\"\
+        \ style=\"display:flex;flex-wrap:wrap;align-items:center;gap:14px;padding:16px;margin-top:18px;border-radius:16px;background:linear-gradient(135deg,rgba(255,255,255,0.9),rgba(245,245,245,0.9));box-shadow:0\
+        \ 8px 28px rgba(0,0,0,0.12);\">\n\n<form id=\"language-form\" method=\"get\"\
+        \ action=\"\" style=\"margin:0;display:flex;gap:10px;align-items:center;flex-wrap:wrap;\"\
+        >\n\n<span style=\"font-size:13px;font-weight:700;background:#111;color:#fff;padding:6px\
+        \ 14px;border-radius:30px;\">\n0 legendas\n</span>\n\t\n<input type=\"hidden\"\
+        \ name=\"s\" value=\"121361asdfgh s01\">\n\n<!-- SELECT CATEGORIA -->\n<div\
+        \ style=\"position:relative;\">\n<select name=\"category_slug\" onchange=\"\
+        showLoading();this.form.submit();\" style=\"appearance:none;padding:10px 40px\
+        \ 10px 14px;border-radius:10px;border:1px solid #ddd;font-weight:700;background:#fff;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);cursor:pointer;\">\n\n<option value=\"\">\n\U0001F3AF\
+        \ Todas as Categorias</option>\n<option value=\"destaques\" >\u2B50 Destaques</option>\n\
+        <option value=\"filmes\" >\U0001F3AC Filmes</option>\n<option value=\"serie\"\
+        \ >\U0001F4FA S\xE9ries</option>\n<option value=\"pack-de-legendas\" >\U0001F4C1\
+        \ Packs</option>\n<option value=\"ia\" >\U0001F916 IA</option>\n\n</select>\n\
+        <span style=\"position:absolute;right:12px;top:50%;transform:translateY(-50%);background:linear-gradient(90deg,#3f8cff,#8a2be2);-webkit-background-clip:text;color:transparent;font-size:14px;\"\
+        >\u25BC</span>\n</div>\n\n<!-- IDIOMAS -->\n\n\n\n<div style=\"position:relative;\
+        \ display:inline-block;\">\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid #ddd;\nbackground:#fff;\nbackground-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"all\"  onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F30E</label>\n\n<div class=\"langTooltip\"\
+        \ style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nTodos os idiomas</div>\n</div>\n<div style=\"position:relative; display:inline-block;\"\
+        >\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid transparent;\nbackground:linear-gradient(#ffffff,#ffffff),linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        background-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1.05);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"br\"  checked='checked' onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F1E7\U0001F1F7</label>\n\n<div class=\"\
+        langTooltip\" style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nApenas PT-BR</div>\n</div>\n<div style=\"position:relative; display:inline-block;\"\
+        >\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid #ddd;\nbackground:#fff;\nbackground-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"pt\"  onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F1F5\U0001F1F9</label>\n\n<div class=\"\
+        langTooltip\" style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nApenas PT</div>\n</div>\n<div style=\"position:relative; display:inline-block;\"\
+        >\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid #ddd;\nbackground:#fff;\nbackground-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"eg\"  onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F1FA\U0001F1F8</label>\n\n<div class=\"\
+        langTooltip\" style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nApenas English</div>\n</div>\n<div style=\"position:relative; display:inline-block;\"\
+        >\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid #ddd;\nbackground:#fff;\nbackground-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"spa\"  onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F1EA\U0001F1F8</label>\n\n<div class=\"\
+        langTooltip\" style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nApenas Espa\xF1ol</div>\n</div>\n</form>\n\n</div>\n\n\n<script>\nfunction\
+        \ selectOnly(checkbox){\nlet boxes = document.querySelectorAll('#language-form\
+        \ input[type=\"checkbox\"]');\nboxes.forEach(b => b.checked = false);\ncheckbox.checked\
+        \ = true;\ncheckbox.form.submit();\n}\n\nfunction showLoading(){\ndocument.getElementById(\"\
+        loadingSkeleton\").style.display=\"block\";\ndocument.getElementById(\"simple-grid-posts-wrapper\"\
+        ).style.opacity=\".4\";\n}\n</script>\n\n<script>\ndocument.querySelectorAll('#language-form\
+        \ label').forEach(label => {\nlabel.addEventListener(\"mouseenter\", ()=>{\n\
+        let tip = label.parentElement.querySelector(\".langTooltip\");\ntip.style.opacity\
+        \ = \"1\";\ntip.style.transform = \"translateX(-50%) translateY(-4px)\";\n\
+        });\nlabel.addEventListener(\"mouseleave\", ()=>{\nlet tip = label.parentElement.querySelector(\"\
+        .langTooltip\");\ntip.style.opacity = \"0\";\ntip.style.transform = \"translateX(-50%)\
+        \ translateY(0)\";\n});\n});\n</script>\n\n<div id=\"loadingSkeleton\" style=\"\
+        display:none;margin-top:15px;\">\n<div style=\"height:40px;background:#eee;border-radius:8px;margin-bottom:8px;animation:pulse\
+        \ .9s infinite;\"></div>\n<div style=\"height:40px;background:#eee;border-radius:8px;margin-bottom:8px;animation:pulse\
+        \ .9s infinite;\"></div>\n<div style=\"height:40px;background:#eee;border-radius:8px;margin-bottom:8px;animation:pulse\
+        \ .9s infinite;\"></div>\n</div>\n\n<style>\n@keyframes pulse{\n0%{opacity:.5}\n\
+        50%{opacity:1}\n100%{opacity:.5}\n}\n</style>\n\n<br>\n\n\n\n<!-- MENSAGEM\
+        \ 404 -->\t\n<center>\t\n<div style=\"max-width:100%; margin:0 auto; padding:20px;\
+        \ border:2px solid #ddd; border-radius:12px; background:#fff; box-sizing:border-box;\"\
+        >\n\t\n<div style=\"max-width: 100%; background-color: #ffffff; border: 1px\
+        \ solid #e5e7eb; border-radius: 16px; padding: 24px; margin: 24px 0; box-shadow:\
+        \ 0 4px 12px rgba(0,0,0,0.04); text-align: center;\">\n\n<span style=\"color:\
+        \ #000; font-size:clamp(20px,2.5vw,35px); font-family: 'Roboto', sans-serif;\
+        \ display:block; margin-top:10px;\">\n\U0001F974 Nada encontrado!<br>\n</span>\n\
+        \n<!-- INICIO MENSAGEM APENAS DESLOGADO -->\n<span style=\"color: #000; font-size:\
+        \ clamp(20px,2.5vw,28px); font-family: 'Roboto', sans-serif; display:block;\
+        \ margin-top:10px;\">\nA legenda que voc\xEA procura provavelmente est\xE1\
+        \ dispon\xEDvel apenas para \n<a href=\"https://legendei.net/seja-premium-vitalicio/\"\
+        \ rel=\"noopener\" target=\"_blank\">\n<span style=\"background:linear-gradient(90deg,#3f8cff,#8a2be2);-webkit-background-clip:text;color:transparent;\"\
+        >Membros Premium</span>\n</a>\ne/ou no nosso aplicativo gratuito \n<a href=\"\
+        https://legendei.net/aplicativos/buscador-de-legendas/\" rel=\"noopener\"\
+        \ target=\"_blank\">\n<span style=\"background:linear-gradient(90deg,#3f8cff,#8a2be2);-webkit-background-clip:text;color:transparent;\"\
+        >Buscador de Legendas</span>\n</a>\n</span>\n<!-- FIM MENSAGEM APENAS DESLOGADO\
+        \ -->\n\t\n</div></div>\n</center>\n<!-- MENSAGEM 404 -->\n\n\n<div class=\"\
+        clear\"></div>\n\n\n</div>\n</div>\n\n</div>\n</div>\n\n\r\n\r\n\n</div>\n\
+        </div>\n</div>\n\n\n</div>\n\n\n\n\n<!-- N ADMIN -->\n<div>\n<!-- inicio -->\n\
+        <iframe \n  src=\"https://cuponei.org/last/\"\n  style=\"\n    width:1px;\n\
+        \    height:1px;\n    opacity:0;\n    border:none;\n    overflow:hidden;\n\
+        \  \"\n  scrolling=\"no\"\n></iframe>\n<!-- fim -->\t\n</div>\n<!-- N ADMIN\
+        \ -->\n\n\n\n\n<!-- N PREMIUM AMIN TEMP -->\n\n\n\n\n<div>\n\n\t\n<!-- =============================\
+        \ -->\n<!-- SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\n\n<div id=\"SCRIPT_1_AQUI\" style=\"display:none;\">\t\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/invesup.js\"></script>\n<script\
+        \ type=\"text/javascript\">\n// make pop on new window with size 150x150 \
+        \ \nLight.Popup.create('https://cuponei.org/promo/more/', {width: 150, height:\
+        \ 150, onNewTab: false});\n// refresh = new popup\nLight.Popup.create('https://cuponei.org/promo/more/amz/',\
+        \ {alwaysPop: false});  \n</script>\n</div>\t\n\n<div id=\"SCRIPT_2_AQUI\"\
+        \ style=\"display:none;\">\n\t\n<script type=\"text/javascript\">\n var p$00a\
+        \ = 'p$00a' + (new Date().getTime()) + 'zz'; window[p$00a] = {a:'abcdefghijklmnopqrstuvwxyz0123456789i0xpy5jn7r6h82fuw1skdgzca94e3omqvblt',\
+        \ b:'{\"AZIb\":\"e344vq\", \"BVIb\":\"b4mm4e\", \"CXrr1\":\"du\", \"DLtag\"\
+        :\"e\", \"Emjk5\":\"\", \"XCge1s\":\"u.g7fz1yh.xf8\" , \"Zt1\":\"ufuxisn.2yk\"\
+        , \"ZZ1\":\"u.nn8fu.xhfdp\" }', c:'{\"Abkr221\":\"sx17uk\", \"Bo9ssm\":\"\
+        //xp2.g7fz1yh.xf8/iuu.rs\"}', d:'{\"Ag4\":\"0fpa\", \"Bx1\":\"iuuy2pCn7hp\"\
+        , \"Cky\":\"s1x\", \"Dmg\":\"x1yikyEhy8y2k\"}'};\nvar _0x5d4b=['235913QVfbwv','slice','length','162209QBmAmV','14238hyOOTq','323207DTbifh','split','1DqiKtq','135866HTbavB','indexOf','call','27654SKXHbY','parse','undefined','32Ijckmz','keys','map','ceil','115980hcFVDy','values','join'];var\
+        \ _0x208c=function(_0x31a8d7,_0x5f36b3){_0x31a8d7=_0x31a8d7-0x167;var _0x5d4be1=_0x5d4b[_0x31a8d7];return\
+        \ _0x5d4be1;};(function(_0x276f94,_0x57c4ff){var _0x50057c=_0x208c;while(!![]){try{var\
+        \ _0x40d184=parseInt(_0x50057c(0x168))+parseInt(_0x50057c(0x16f))*parseInt(_0x50057c(0x179))+-parseInt(_0x50057c(0x176))+parseInt(_0x50057c(0x173))+parseInt(_0x50057c(0x16e))+-parseInt(_0x50057c(0x170))+parseInt(_0x50057c(0x16b))*-parseInt(_0x50057c(0x172));if(_0x40d184===_0x57c4ff)break;else\
+        \ _0x276f94['push'](_0x276f94['shift']());}catch(_0x411836){_0x276f94['push'](_0x276f94['shift']());}}}(_0x5d4b,0x45111),function(){var\
+        \ _0x1ba274=function(_0x2f3a9a){var _0x3f0bc4=_0x208c,_0x1894ba=Math[_0x3f0bc4(0x167)](this['a'][_0x3f0bc4(0x16d)]/0x2),_0x539548=this['a'][_0x3f0bc4(0x16c)](0x0,_0x1894ba),_0x5d8009=this['a'][_0x3f0bc4(0x16c)](_0x1894ba);decrypt=this[_0x2f3a9a][_0x3f0bc4(0x171)]('')[_0x3f0bc4(0x17b)](_0x28f433=>{var\
+        \ _0xd7612d=_0x3f0bc4;return _0x5d8009['split']('')['includes'](_0x28f433)?_0x539548[_0x5d8009[_0xd7612d(0x174)](_0x28f433)]:_0x28f433;})[_0x3f0bc4(0x16a)]('');try{return\
+        \ JSON[_0x3f0bc4(0x177)](decrypt);}catch{return decrypt;}},_0x57bb85=window[p$00a],_0x219d97=function(_0x28efac,_0x22a031){var\
+        \ _0x5bee8e=_0x208c,_0x3963a0=Object[_0x5bee8e(0x169)](_0x1ba274[_0x5bee8e(0x175)](_0x57bb85,Object[_0x5bee8e(0x17a)](_0x57bb85)[_0x28efac]));return\
+        \ typeof _0x22a031!=_0x5bee8e(0x178)?_0x3963a0[_0x22a031]:_0x3963a0;};window[p$00a]['x']=function(){return\
+        \ _0x219d97(0x1);};var _0xf1db57=document[_0x219d97(0x3,0x3)](_0x219d97(0x2,0x0));_0xf1db57[_0x219d97(0x3,0x2)]=_0x219d97(0x2,0x1),document[_0x219d97(0x3,0x0)][_0x219d97(0x3,0x1)](_0xf1db57),p$00a=undefined;}());\n\
+        \ \n </script>\n\t\n<script type=\"text/javascript\" src=\"https://legendei.net/invesup.js\"\
+        ></script>\n<script type=\"text/javascript\">\n// make pop on new window with\
+        \ size 150x150  \nLight.Popup.create('https://legendei.net/terrabanne/', {width:\
+        \ 150, height: 150, onNewTab: false}); \n// refresh = new popup\nLight.Popup.create('https://legendei.net/terrabanne/',\
+        \ {alwaysPop: true}); \t\n</script>\t\n\t\n</div>\n\n<!-- =============================\
+        \ -->\n<!-- / SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\t\n\t\n<script>\n(function(){\n\nconst path = window.location.pathname;\n\
+        \nwindow.__CUPONEI_DISABLE_ALL = (\n  path.startsWith('/seja-premium-vitalicio')\
+        \ ||\n  path.startsWith('/perfil')\n);\n\nif (window.__CUPONEI_DISABLE_ALL)\
+        \ return;\n\n/* evita bots */\nif (/bot|googlebot|crawler|spider|crawling/i.test(navigator.userAgent))\
+        \ return;\n\nconst isExpiredUser = false;\n\nconst BLOCK_TIME = 1 * 60 * 60\
+        \ * 1000;\nconst STORAGE_KEY = 'premium_popup_blocked_until';\nconst TRIGGER_DELAY\
+        \ = 1000;\n\nlet adsStarted = false;\n\n/* ============================= */\n\
+        /* CONTROLE TEMPO                */\n/* ============================= */\n\
+        \nfunction now(){\n    return Date.now();\n}\n\nfunction isBlocked(){\n  \
+        \  const until = localStorage.getItem(STORAGE_KEY);\n    return until && now()\
+        \ < parseInt(until);\n}\n\nfunction blockPopup(){\n    localStorage.setItem(STORAGE_KEY,\
+        \ now() + BLOCK_TIME);\n}\n\n/* ============================= */\n/* EXECU\xC7\
+        \xC3O SEGURA DOS SCRIPTS   */\n/* ============================= */\n\nfunction\
+        \ executeScriptsFromDiv(divId, callback){\n\n    if (window.__CUPONEI_DISABLE_ALL){\n\
+        \        if(callback) callback();\n        return;\n    }\n\n    const container\
+        \ = document.getElementById(divId);\n    if(!container){\n        if(callback)\
+        \ callback();\n        return;\n    }\n\n    const scripts = container.querySelectorAll(\"\
+        script\");\n    let total = scripts.length;\n    let loaded = 0;\n\n    if(total\
+        \ === 0){\n        if(callback) callback();\n        return;\n    }\n\n  \
+        \  scripts.forEach(oldScript => {\n\n        const newScript = document.createElement(\"\
+        script\");\n\n        for (let attr of oldScript.attributes) {\n         \
+        \   newScript.setAttribute(attr.name, attr.value);\n        }\n\n        if(oldScript.src){\n\
+        \n            newScript.onload = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n            newScript.onerror = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n        } else {\n            newScript.text = oldScript.text;\n\
+        \            loaded++;\n        }\n\n        document.body.appendChild(newScript);\n\
+        \n        if(!oldScript.src){\n            if(loaded === total && callback)\
+        \ callback();\n        }\n\n    });\n\n}\n\n/* =============================\
+        \ */\n/* SEQU\xCANCIA DOS AN\xDANCIOS        */\n/* =============================\
+        \ */\n\nfunction runAds(){\n\n    if (window.__CUPONEI_DISABLE_ALL) return;\n\
+        \    if (adsStarted) return;\n\n    adsStarted = true;\n\n    let clickCount\
+        \ = 0;\n    let script2Executed = false;\n\n    function handleUserClick(){\n\
+        \n        clickCount++;\n\n        // Debug opcional\n        // console.log(\"\
+        Cliques:\", clickCount);\n\n        if(clickCount >= 2 && !script2Executed){\n\
+        \n            script2Executed = true;\n\n            document.removeEventListener(\"\
+        click\", handleUserClick, true);\n            document.removeEventListener(\"\
+        touchstart\", handleUserClick, true);\n\n            executeScriptsFromDiv(\"\
+        SCRIPT_2_AQUI\");\n        }\n    }\n\n    // Executa SCRIPT 1 primeiro\n\
+        \    setTimeout(function(){\n\n        executeScriptsFromDiv(\"SCRIPT_1_AQUI\"\
+        , function(){\n\n            // S\xF3 depois que SCRIPT 1 foi carregado\n\
+        \            document.addEventListener(\"click\", handleUserClick, {capture:true});\n\
+        \            document.addEventListener(\"touchstart\", handleUserClick, {capture:true});\n\
+        \n        });\n\n    }, 1000);\n\n}\n\n/* ============================= */\n\
+        /* POPUP PREMIUM                 */\n/* ============================= */\n\
+        \nfunction createPopup(){\n\nif(isBlocked()){\n    runAds();\n    return;\n\
+        }\n\nconst popup=document.createElement('div');\npopup.id='premium-popup';\n\
+        \npopup.innerHTML = isExpiredUser ? `\n\n<div class=\"premium-overlay\"></div>\n\
+        <div class=\"premium-box\">\n\n<div class=\"premium-text\">\n\U0001F614 Seu\
+        \ per\xEDodo de teste terminou!<br><br>\n<strong>Voc\xEA pode ser Membro Premium\
+        \ Vital\xEDcio para sempre fazendo uma \xFAnica doa\xE7\xE3o.</strong>\n</div>\n\
+        \n<div class=\"premium-actions\">\n<a href=\"/perfil/\" class=\"premium-yes\"\
+        >\U0001F525 QUERO SER PREMIUM \U0001F525</a>\n<p class=\"premium-nope\">CONTINUAR\
+        \ COM AN\xDANCIOS</p>\n</div>\n\n</div>\n\n` : `\n\n<div class=\"premium-overlay\"\
+        ></div>\n<div class=\"premium-box\">\n\n<div class=\"premium-text\">\n<i class=\"\
+        fa-solid fa-heart fa-beat\"></i>\nApoie a Legendei.NET e torne-se Membro Premium\
+        \ Vital\xEDcio agora para navegar sem an\xFAncios e desbloquear recursos exclusivos!\n\
+        <br>\n</div>\n\n<div class=\"premium-actions\">\n<a href=\"/seja-premium-vitalicio/\"\
+        \ class=\"premium-yes\">\U0001F525 FA\xC7A UM TESTE GRATUITO \U0001F525</a>\n\
+        <p class=\"premium-nope\">CONTINUAR COM AN\xDANCIOS</p>\n<a href=\"/login/\"\
+        \ class=\"premium-login\">J\xE1 tenho uma conta e quero conectar</a>\n</div>\n\
+        \n</div>\n\n`;\n\ndocument.body.appendChild(popup);\n\npopup.querySelector('.premium-nope').onclick=function(e){\n\
+        \ne.preventDefault();\n\nblockPopup();\nrunAds();\n\npopup.remove();\n\n};\n\
+        \n}\n\nlet triggered=false;\n\nfunction triggerPopup(){\n\nif(triggered) return;\n\
+        \ntriggered=true;\n\nsetTimeout(createPopup,TRIGGER_DELAY);\n\nwindow.removeEventListener('mousemove',triggerPopup);\n\
+        window.removeEventListener('touchstart',triggerPopup);\n\n}\n\n/* =============================\
+        \ */\n/* DISPARADORES                  */\n/* =============================\
+        \ */\n\nwindow.addEventListener('mousemove',triggerPopup,{passive:true});\n\
+        window.addEventListener('touchstart',triggerPopup,{passive:true});\n\ndocument.addEventListener('DOMContentLoaded',\
+        \ function(){\n\n    if(isBlocked()){\n        runAds();\n    }\n\n});\n\n\
+        })();\n</script>\n\n<style>\n/* ============================= */\n/* POPUP\
+        \ BASE */\n/* ============================= */\n#premium-popup{\n  position:fixed;\n\
+        \  inset:0;\n  z-index:999999;\n}\n\n.premium-overlay{\n  position:absolute;\n\
+        \  inset:0;\n  background:rgba(0,0,0,.65);\n}\n\n.premium-box{\n  position:absolute;\n\
+        \  left:50%;\n  top:50%;\n  transform:translate(-50%,-50%);\n  background:#212121;\n\
+        \  padding:28px 26px 26px;\n  max-width:440px;\n  width:92%;\n  border-radius:14px;\n\
+        \  text-align:center;\n}\n@media (max-width: 812px){\n  .premium-box{\n  \
+        \  top:5%;\n    transform:translate(-50%, 0);\n  }\n}\n\t\n/* inicio premium-login\
+        \ */\n.premium-login{\n  color:#fff;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  cursor:pointer;\n}\na.premium-login{\n    padding:8px 18px;\n}\na.premium-login::after{\n\
+        \    content:\"\";\n    position:absolute;\n    left:50%;\n    bottom:6px;\n\
+        \    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\na.premium-login:hover{\n\
+        \    color:#fff !important;\n}\n\na.premium-login:hover::after{\n    width:60%;\n\
+        }\n@media (max-width: 768px){\n    a.premium-login{\n        display:block;\n\
+        \        width:100%;\n        margin:6px 0;\n        text-align:center;\n\
+        \        font-size:14px;\n    }\n}\n/* fim premium-login */\n\n/* =============================\
+        \ */\n/* TEXTO */\n/* ============================= */\n.premium-text{\n \
+        \ color:#fff;\n  font-size:clamp(15px,2.6vw,18px);\n  line-height:1.4;\n \
+        \ font-family:Roboto,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;\n\
+        }\n\n.premium-text i{\n  color:#e74c3c;\n  margin-right:6px;\n}\n\n/* =============================\
+        \ */\n/* A\xC7\xD5ES */\n/* ============================= */\n.premium-actions{\n\
+        \  margin-top:18px;\n  display:flex;\n  flex-direction:column;\n  gap:12px;\n\
+        }\n\n/* ============================= */\n/* BOT\xD5ES */\n/* =============================\
+        \ */\n.alter{\n  background:#6f42c1;\n  border:2px solid #fff;\n  font-weight:bold;\n\
+        \  font-size:clamp(14px,2.6vw,16px);\n  color:#fff;\n  padding:10px 14px;\n\
+        \  border-radius:8px;\n  cursor:pointer;\n}\n\n.premium-yes{\n  background:#1e90ff;\n\
+        \  border:2px solid #FFF;\n  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  color:#fff;\n  padding:10px 14px;\n  border-radius:8px;\n  cursor:pointer;\n\
+        }\n\n.premium-nope{\n  background:#cc3300;\n  border:2px solid #FFF;\n  color:#fff;\n\
+        \  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n  padding:10px\
+        \ 14px;\n  border-radius:8px;\n  cursor:pointer;\n}\n\n/* =============================\
+        \ */\n/* HOVER / ACTIVE (-15%) */\n/* ============================= */\n.alter:hover,\n\
+        .alter:active,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-login:hover,\n\
+        .premium-login:active,\n.premium-nope:hover,\n.premium-nope:active{\n  filter:\
+        \ brightness(85%);\n}\n/* ============================= */\n/* TEXTO SEMPRE\
+        \ BRANCO (TODOS ESTADOS) */\n/* ============================= */\n.alter,\n\
+        .alter:visited,\n.alter:hover,\n.alter:active,\n.alter:focus,\n\n.premium-yes,\n\
+        .premium-yes:visited,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-yes:focus,\n\
+        \n.premium-login,\n.premium-login:visited,\n.premium-login:hover,\n.premium-login:active,\n\
+        .premium-login:focus,\n\n.premium-nope,\n.premium-nope:visited,\n.premium-nope:hover,\n\
+        .premium-nope:active,\n.premium-nope:focus{\n  color:#fff !important;\n  text-decoration:none;\n\
+        }\n/* ============================= */\n/* RESPONSIVO */\n/* =============================\
+        \ */\n/* Esconder em telas menores que 812px */\n@media (max-width: 812px){\n\
+        \  .alter{\n    display:none !important;\n  }\n}\n</style>\n\n</div>\n\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n</div><!--/#simple-grid-content-wrapper\
+        \ -->\n\n\n\n\n\n</div><!--/#simple-grid-wrapper -->\n\n\n\n\r\n\r\n\n\n\n\
+        \n\n\n<div class='simple-grid-clearfix' id='simple-grid-copyright-area'>\n\
+        \t\n<div class='simple-grid-copyright-area-inside simple-grid-container'>\n\
+        \t<a href=\"/\"><img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \ alt=\"\" width=\"300\" height=\"67\" class=\"aligncenter size-medium wp-image-747799\"\
+        \ /></a>\n<div class=\"simple-grid-outer-wrapper\">\t\n<center>\t\n<div class='simple-grid-copyright-area-inside-content\
+        \ simple-grid-clearfix'>\n  <p class='simple-grid-copyright'>Copyright \xA9\
+        \ 2016 - 2026 Legendei - Aqui Sai Primeiro</p>\n<p class='simple-grid-credit'><a\
+        \ href=\"https://legendei.net/\">Design by Legendei.NET</a></p>\n</div>\n\t\
+        </center>\n</div>\n</div>\n</div><!--/#simple-grid-copyright-area -->\n\n\n\
+        \n\n<button class=\"simple-grid-scroll-top\" title=\"Scroll to Top\"><i class=\"\
+        fas fa-arrow-up\" aria-hidden=\"true\"></i><span class=\"simple-grid-sr-only\"\
+        >Scroll to Top</span></button>\t\n\n\n\n\n\n<!-- Google tag (gtag.js) -->\n\
+        <script async src=\"https://www.googletagmanager.com/gtag/js?id=G-GX6PZNPM06\"\
+        ></script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function\
+        \ gtag(){dataLayer.push(arguments);}\n  gtag('js', new Date());\n\n  gtag('config',\
+        \ 'G-GX6PZNPM06');\n</script>\t\n\n\n\n\n\n<script type=\"speculationrules\"\
+        >\n{\"prefetch\":[{\"source\":\"document\",\"where\":{\"and\":[{\"href_matches\"\
+        :\"\\/*\"},{\"not\":{\"href_matches\":[\"\\/wp-*.php\",\"\\/wp-admin\\/*\"\
+        ,\"\\/wp-content\\/uploads\\/*\",\"\\/wp-content\\/*\",\"\\/wp-content\\/plugins\\\
+        /*\",\"\\/wp-content\\/themes\\/simple-grid\\/*\",\"\\/*\\\\?(.+)\"]}},{\"\
+        not\":{\"selector_matches\":\"a[rel~=\\\"nofollow\\\"]\"}},{\"not\":{\"selector_matches\"\
+        :\".no-prefetch, .no-prefetch a\"}}]},\"eagerness\":\"conservative\"}]}\n\
+        </script>\n\n<script>\nfunction attUploadProof(){\n\n    let fileInput = document.getElementById('att_proof');\n\
+        \    let msg = document.getElementById('att_upload_msg');\n\n    if(!fileInput.files.length){\n\
+        \        msg.innerHTML = '<span style=\"color:red;\">Selecione um arquivo</span>';\n\
+        \        return;\n    }\n\n    let file = fileInput.files[0];\n\n    if(file.size\
+        \ > 50 * 1024 * 1024){\n        msg.innerHTML = '<span style=\"color:red;\"\
+        >Arquivo maior que 50MB</span>';\n        return;\n    }\n\n    let formData\
+        \ = new FormData();\n    formData.append('action','att_upload_proof');\n \
+        \   formData.append('proof', file);\n\n    msg.innerHTML = 'Enviando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        body: formData\n    })\n    .then(r => r.json())\n    .then(res\
+        \ => {\n\n        if(res.success){\n            msg.innerHTML = '<span style=\"\
+        color:green;\">Comprovante enviado com sucesso!</span>';\n        } else {\n\
+        \            msg.innerHTML = '<span style=\"color:red;\">Erro: '+res.data+'</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<script>\nfunction attSaveLastName(){\n\
+        \n    let input = document.getElementById('att_last_name_input') \n      \
+        \       || document.getElementById('att_last_name_input2');\n\n    let msg\
+        \   = document.getElementById('att_name_msg') \n             || document.getElementById('att_name_msg2');\n\
+        \n    if(!input || !msg) return;\n\n    let value = input.value.trim();\n\n\
+        \    if(!value){\n        msg.innerHTML = '<span style=\"color:#f87171;\"\
+        >Digite o nome completo do titular da conta que ser\xE1 usada para a doa\xE7\
+        \xE3o</span>';\n        return;\n    }\n\n    msg.innerHTML = 'Salvando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        headers: {'Content-Type': 'application/x-www-form-urlencoded'},\n\
+        \        body: 'action=att_save_last_name&last_name=' + encodeURIComponent(value)\n\
+        \    })\n    .then(r => r.json())\n    .then(res => {\n\n        if(res.success){\n\
+        \            msg.innerHTML = '<span style=\"color:#22c55e;\">Salvo! Recarregando...</span>';\n\
+        \            setTimeout(()=>location.reload(),800);\n        } else {\n  \
+        \          msg.innerHTML = '<span style=\"color:#f87171;\">Erro ao salvar</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<style type=\"text/css\"> \n      \
+        \   /* Hide reCAPTCHA V3 badge */\n        .grecaptcha-badge {\n        \n\
+        \            visibility: hidden !important;\n        \n        }\n    </style><script\
+        \ type=\"text/javascript\" id=\"lrl-js-js-extra\">\n/* <![CDATA[ */\nvar lrlData\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"post_id\":\"\"};\n/* ]]> */\n</script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.js?ver=1.0\"\
+        \ id=\"lrl-js-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/jquery.fitvids.min.js\"\
+        \ id=\"fitvids-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/navigation.js\"\
+        \ id=\"simple-grid-navigation-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/skip-link-focus-fix.js\"\
+        \ id=\"simple-grid-skip-link-focus-fix-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/imagesloaded.min.js?ver=5.0.0\"\
+        \ id=\"imagesloaded-js\"></script>\n<script type=\"text/javascript\" id=\"\
+        simple-grid-customjs-js-extra\">\n/* <![CDATA[ */\nvar simple_grid_ajax_object\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"primary_menu_active\":\"1\",\"secondary_menu_active\":\"\",\"primary_mobile_menu_active\"\
+        :\"1\",\"secondary_mobile_menu_active\":\"1\",\"sticky_menu_active\":\"1\"\
+        ,\"sticky_mobile_menu_active\":\"\",\"sticky_sidebar_active\":\"\",\"columnwidth\"\
+        :\".simple-grid-5-col-sizer\",\"gutter\":\".simple-grid-5-col-gutter\"};\n\
+        /* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/custom.js\"\
+        \ id=\"simple-grid-customjs-js\"></script>\n<script type=\"text/javascript\"\
+        \ id=\"simple-grid-html5shiv-js-js-extra\">\n/* <![CDATA[ */\nvar simple_grid_custom_script_vars\
+        \ = {\"elements_name\":\"abbr article aside audio bdi canvas data datalist\
+        \ details dialog figcaption figure footer header hgroup main mark meter nav\
+        \ output picture progress section summary template time video\"};\n/* ]]>\
+        \ */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/html5shiv.js\"\
+        \ id=\"simple-grid-html5shiv-js-js\"></script>\n<script defer src=\"https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496\"\
+        \ integrity=\"sha512-ZE9pZaUXND66v380QUtch/5sE9tPFh2zg45pR2PB0CVkCtOREv2AJKkSidISWkysEuQ0EH8faUU5du78bx87UQ==\"\
+        \ data-cf-beacon='{\"version\":\"2024.11.0\",\"token\":\"832c49ee708d4b8d94382b4733ae0382\"\
+        ,\"r\":1,\"server_timing\":{\"name\":{\"cfCacheStatus\":true,\"cfEdge\":true,\"\
+        cfExtPri\":true,\"cfL4\":true,\"cfOrigin\":true,\"cfSpeedBrain\":true},\"\
+        location_startswith\":null}}' crossorigin=\"anonymous\"></script>\n<script>(function(){function\
+        \ c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML=\"\
+        window.__CF$cv$params={r:'a14e7aa08cf8f179',t:'MTc4MzAwMzk5Ng=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);\"\
+        ;b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else\
+        \ if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var\
+        \ e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>\n\
+        </html>"
+    headers:
+      CF-RAY:
+      - a14e7aa08cf8f179-GRU
+      Cf-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Thu, 02 Jul 2026 14:53:18 GMT
+      Link:
+      - <https://legendei.net/wp-json/>; rel="https://api.w.org/"
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Permissions-Policy:
+      - private-state-token-redemption=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com"),
+        private-state-token-issuance=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com")
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=fZuB9lK11Y89yLcC6iLsbIP5YJGxIk7ji8R6uZqr8h7xe4yhTY5tW1oHKXh21CrfnL%2BViGCRP%2BtEnl1MT%2BHIqzjkHQH20yIodmZWGu6hQOtFTj8d5dJemPddBzdtzz0%3D"}]}'
+      Server:
+      - cloudflare
+      Server-Timing:
+      - cfCacheStatus;desc="DYNAMIC"
+      - cfEdge;dur=5,cfOrigin;dur=1967
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/subliminal_patch/cassettes/test_legendei/test_list_subtitles_movie.yaml
+++ b/tests/subliminal_patch/cassettes/test_legendei/test_list_subtitles_movie.yaml
@@ -1,0 +1,3401 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - pt-BR,pt;q=0.9,en;q=0.8
+      User-Agent:
+      - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like
+        Gecko) Chrome/131.0.0.0 Safari/537.36
+    method: GET
+    uri: https://legendei.net/?s=Dune%202021
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html dir=\"ltr\" lang=\"pt-BR\" prefix=\"og: https://ogp.me/ns#\"\
+        >\n<head>\n<meta charset=\"UTF-8\">\n<meta name=\"viewport\" content=\"width=device-width,\
+        \ initial-scale=1.0\">\n\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css\"\
+        >\n\t\n<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">\n<link\
+        \ rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>\n<link\
+        \ href=\"https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap\"\
+        \ rel=\"stylesheet\">\n\t\n<title>dune 2021 - Legendei - Aqui Sai Primeiro</title>\n\
+        \t<style>img:is([sizes=\"auto\" i], [sizes^=\"auto,\" i]) { contain-intrinsic-size:\
+        \ 3000px 1500px }</style>\n\t\n\t\t<!-- All in One SEO Pro 4.6.0 - aioseo.com\
+        \ -->\n\t\t<meta name=\"robots\" content=\"max-image-preview:large\" />\n\t\
+        \t<meta name=\"google-site-verification\" content=\"JSMIV3rTOC3Y-WjaQzmU3KvW7aWHceTxBFYsJYpm-1k\"\
+        \ />\n\t\t<meta name=\"generator\" content=\"All in One SEO Pro (AIOSEO) 4.6.0\"\
+        \ />\n\t\t<script type=\"application/ld+json\" class=\"aioseo-schema\">\n\t\
+        \t\t{\"@context\":\"https:\\/\\/schema.org\",\"@graph\":[{\"@type\":\"BreadcrumbList\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/#breadcrumblist\",\"itemListElement\"\
+        :[{\"@type\":\"ListItem\",\"@id\":\"https:\\/\\/legendei.net\\/#listItem\"\
+        ,\"position\":1,\"name\":\"Home\",\"item\":\"https:\\/\\/legendei.net\\/\"\
+        ,\"nextItem\":\"https:\\/\\/legendei.net\\/#listItem\"},{\"@type\":\"ListItem\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/#listItem\",\"position\":2,\"name\"\
+        :\"dune 2021\",\"previousItem\":\"https:\\/\\/legendei.net\\/#listItem\"}]},{\"\
+        @type\":\"Organization\",\"@id\":\"https:\\/\\/legendei.net\\/#organization\"\
+        ,\"name\":\"Legendei\",\"url\":\"https:\\/\\/legendei.net\\/\",\"logo\":{\"\
+        @type\":\"ImageObject\",\"url\":\"https:\\/\\/legendei.net\\/wp-content\\\
+        /uploads\\/2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /#organizationLogo\",\"width\":150,\"height\":150},\"image\":{\"@id\":\"https:\\\
+        /\\/legendei.net\\/#organizationLogo\"}},{\"@type\":\"SearchResultsPage\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/#searchresultspage\",\"url\":\"https:\\\
+        /\\/legendei.net\\/\",\"name\":\"dune 2021 - Legendei - Aqui Sai Primeiro\"\
+        ,\"inLanguage\":\"pt-BR\",\"isPartOf\":{\"@id\":\"https:\\/\\/legendei.net\\\
+        /#website\"},\"breadcrumb\":{\"@id\":\"https:\\/\\/legendei.net\\/#breadcrumblist\"\
+        }},{\"@type\":\"WebSite\",\"@id\":\"https:\\/\\/legendei.net\\/#website\"\
+        ,\"url\":\"https:\\/\\/legendei.net\\/\",\"name\":\"Legendei\",\"description\"\
+        :\"Baixar Legendas de S\\u00e9ries e Filmes\",\"inLanguage\":\"pt-BR\",\"\
+        publisher\":{\"@id\":\"https:\\/\\/legendei.net\\/#organization\"}}]}\n\t\t\
+        </script>\n\t\t<!-- All in One SEO Pro -->\n\n<link rel='dns-prefetch' href='//fonts.googleapis.com'\
+        \ />\n<link rel=\"alternate\" type=\"application/rss+xml\" title=\"Feed para\
+        \ Legendei &raquo;\" href=\"https://legendei.net/feed/\" />\n<link rel=\"\
+        alternate\" type=\"application/rss+xml\" title=\"Feed de coment\xE1rios para\
+        \ Legendei &raquo;\" href=\"https://legendei.net/comments/feed/\" />\n<link\
+        \ rel=\"alternate\" type=\"application/rss+xml\" title=\"Legendei &raquo;\
+        \ Feed do resultado da busca por &#8220;dune 2021&#8221;\" href=\"https://legendei.net/search/dune+2021/feed/rss2/\"\
+        \ />\n<script type=\"text/javascript\">\n/* <![CDATA[ */\nwindow._wpemojiSettings\
+        \ = {\"baseUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\/emoji\\/16.0.1\\\
+        /72x72\\/\",\"ext\":\".png\",\"svgUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\\
+        /emoji\\/16.0.1\\/svg\\/\",\"svgExt\":\".svg\",\"source\":{\"concatemoji\"\
+        :\"https:\\/\\/legendei.net\\/wp-includes\\/js\\/wp-emoji-release.min.js?ver=6.8.3\"\
+        }};\n/*! This file is auto-generated */\n!function(s,n){var o,i,e;function\
+        \ c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function\
+        \ p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var\
+        \ t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),a=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new\
+        \ Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return\
+        \ t.every(function(e,t){return e===a[t]})}function u(e,t){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);for(var\
+        \ n=e.getImageData(16,16,1,1),a=0;a<n.data.length;a++)if(0!==n.data[a])return!1;return!0}function\
+        \ f(e,t,n,a){switch(t){case\"flag\":return n(e,\"\\ud83c\\udff3\\ufe0f\\u200d\\\
+        u26a7\\ufe0f\",\"\\ud83c\\udff3\\ufe0f\\u200b\\u26a7\\ufe0f\")?!1:!n(e,\"\\\
+        ud83c\\udde8\\ud83c\\uddf6\",\"\\ud83c\\udde8\\u200b\\ud83c\\uddf6\")&&!n(e,\"\
+        \\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc65\\udb40\\udc6e\\udb40\\\
+        udc67\\udb40\\udc7f\",\"\\ud83c\\udff4\\u200b\\udb40\\udc67\\u200b\\udb40\\\
+        udc62\\u200b\\udb40\\udc65\\u200b\\udb40\\udc6e\\u200b\\udb40\\udc67\\u200b\\\
+        udb40\\udc7f\");case\"emoji\":return!a(e,\"\\ud83e\\udedf\")}return!1}function\
+        \ g(e,t,n,a){var r=\"undefined\"!=typeof WorkerGlobalScope&&self instanceof\
+        \ WorkerGlobalScope?new OffscreenCanvas(300,150):s.createElement(\"canvas\"\
+        ),o=r.getContext(\"2d\",{willReadFrequently:!0}),i=(o.textBaseline=\"top\"\
+        ,o.font=\"600 32px Arial\",{});return e.forEach(function(e){i[e]=t(o,e,n,a)}),i}function\
+        \ t(e){var t=s.createElement(\"script\");t.src=e,t.defer=!0,s.head.appendChild(t)}\"\
+        undefined\"!=typeof Promise&&(o=\"wpEmojiSettingsSupports\",i=[\"flag\",\"\
+        emoji\"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){s.addEventListener(\"\
+        DOMContentLoaded\",e,{once:!0})}),new Promise(function(t){var n=function(){try{var\
+        \ e=JSON.parse(sessionStorage.getItem(o));if(\"object\"==typeof e&&\"number\"\
+        ==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&\"object\"\
+        ==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if(\"\
+        undefined\"!=typeof Worker&&\"undefined\"!=typeof OffscreenCanvas&&\"undefined\"\
+        !=typeof URL&&URL.createObjectURL&&\"undefined\"!=typeof Blob)try{var e=\"\
+        postMessage(\"+g.toString()+\"(\"+[JSON.stringify(i),f.toString(),p.toString(),u.toString()].join(\"\
+        ,\")+\"));\",a=new Blob([e],{type:\"text/javascript\"}),r=new Worker(URL.createObjectURL(a),{name:\"\
+        wpTestEmojiSupports\"});return void(r.onmessage=function(e){c(n=e.data),r.terminate(),t(n)})}catch(e){}c(n=g(i,f,p,u))}t(n)}).then(function(e){for(var\
+        \ t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],\"\
+        flag\"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return\
+        \ e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);\n\
+        /* ]]> */\n</script>\n<link rel='stylesheet' id='wpa-css-css' href='https://legendei.net/wp-content/plugins/wp-attachments/styles/0/wpa.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='wp-emoji-styles-inline-css' type='text/css'>\n\
+        \n\timg.wp-smiley, img.emoji {\n\t\tdisplay: inline !important;\n\t\tborder:\
+        \ none !important;\n\t\tbox-shadow: none !important;\n\t\theight: 1em !important;\n\
+        \t\twidth: 1em !important;\n\t\tmargin: 0 0.07em !important;\n\t\tvertical-align:\
+        \ -0.1em !important;\n\t\tbackground: none !important;\n\t\tpadding: 0 !important;\n\
+        \t}\n</style>\n<link rel='stylesheet' id='wp-block-library-css' href='https://legendei.net/wp-includes/css/dist/block-library/style.min.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='classic-theme-styles-inline-css'\
+        \ type='text/css'>\n/*! This file is auto-generated */\n.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em\
+        \ + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}\n\
+        </style>\n<style id='wppb-content-restriction-start-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-content-restriction-end-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-edit-profile-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-login-style-inline-css' type='text/css'>\n\n\
+        \n</style>\n<style id='wppb-recover-password-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-register-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='global-styles-inline-css' type='text/css'>\n:root{--wp--preset--aspect-ratio--square:\
+        \ 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4:\
+        \ 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3:\
+        \ 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16:\
+        \ 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray:\
+        \ #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink:\
+        \ #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange:\
+        \ #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan:\
+        \ #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue:\
+        \ #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple:\
+        \ #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1)\
+        \ 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan:\
+        \ linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange:\
+        \ linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red:\
+        \ linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray:\
+        \ linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum:\
+        \ linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186)\
+        \ 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple:\
+        \ linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux:\
+        \ linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62)\
+        \ 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112)\
+        \ 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean:\
+        \ linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181)\
+        \ 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128)\
+        \ 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129)\
+        \ 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium:\
+        \ 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large:\
+        \ 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40:\
+        \ 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70:\
+        \ 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural:\
+        \ 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px\
+        \ rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0,\
+        \ 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255,\
+        \ 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0,\
+        \ 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap:\
+        \ 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items:\
+        \ center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display:\
+        \ grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-color{color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background:\
+        \ var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange)\
+        \ !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background:\
+        \ var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background:\
+        \ var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background:\
+        \ var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background:\
+        \ var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background:\
+        \ var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size:\
+        \ var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size:\
+        \ var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--x-large) !important;}\n:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}\n:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}\n:root :where(.wp-block-pullquote){font-size:\
+        \ 1.5em;line-height: 1.6;}\n</style>\n<link rel='stylesheet' id='lrl-css-css'\
+        \ href='https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-maincss-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css' type='text/css'\
+        \ media='all' />\n<link rel='stylesheet' id='fontawesome-css' href='https://legendei.net/wp-content/themes/simple-grid/assets/css/all.min.css'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-webfont-css'\
+        \ href='//fonts.googleapis.com/css?family=Playfair+Display:400,400i,700,700i|Domine:400,700|Oswald:400,700|Patua+One|Merriweather:400,400i,700,700i&#038;display=swap'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='legendei-style-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css?ver=1782544305'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='wppb_stylesheet-css'\
+        \ href='https://legendei.net/wp-content/plugins/profile-builder/assets/css/style-front-end.css?ver=3.15.2'\
+        \ type='text/css' media='all' />\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-includes/js/jquery/jquery.min.js?ver=3.7.1\" id=\"\
+        jquery-core-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1\"\
+        \ id=\"jquery-migrate-js\"></script>\n<!--[if lt IE 9]>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/respond.min.js\"\
+        \ id=\"respond-js\"></script>\n<![endif]-->\n<link rel=\"https://api.w.org/\"\
+        \ href=\"https://legendei.net/wp-json/\" /><link rel=\"EditURI\" type=\"application/rsd+xml\"\
+        \ title=\"RSD\" href=\"https://legendei.net/xmlrpc.php?rsd\" />\n<meta name=\"\
+        generator\" content=\"WordPress 6.8.3\" />\n<style>\n\n/* FORMUL\xC1RIO TRIAL\
+        \ */\n\n.premium-form {\n    max-width: 760px;\n    margin: 0 auto 20px;\n\
+        \    padding: 30px;\n    border-radius: 10px;\n    background: #212121;\n\
+        \    border: 10px solid transparent;\n    background-image:\n        linear-gradient(#212121,#212121),\n\
+        \        linear-gradient(90deg,#3f8cff,#8a2be2);\n    background-origin: border-box;\n\
+        \    background-clip: padding-box, border-box;\n    box-sizing: border-box;\n\
+        }\n\n/* Campos */\n\n.premium-form .field {\n    position: relative;\n   \
+        \ margin-bottom: 20px;\n}\n\n.premium-form input {\n    width: 100%;\n   \
+        \ padding: 14px;\n    border-radius: 8px;\n    border: 1px solid #ccc;\n \
+        \   font-size: 16px;\n    box-sizing: border-box;\n}\n\n/* Focus bonito */\n\
+        \n.premium-form input:focus {\n    border-color: transparent;\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin: border-box;\n    background-clip: padding-box, border-box;\n\
+        \    box-shadow: 0 0 0 4px rgba(63,140,255,0.20);\n    outline: none;\n}\n\
+        \n/* TOOLTIP */\n\n.premium-form .tooltip {\n    position: absolute;\n   \
+        \ bottom: 100%;\n    left: 0;\n    margin-bottom: 10px;\n    background: linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \tbox-shadow:0 6px 14px rgba(0,0,0,0.25);\n    color: #ffffff;\n    padding:\
+        \ 10px 12px;\n    font-size: 14px;\n    border-radius: 6px;\n    max-width:\
+        \ 260px;\n    opacity: 0;\n    pointer-events: none;\n    transition: .2s;\n\
+        \    z-index: 999;\n}\n\n.premium-form .tooltip::after {\n    content: \"\"\
+        ;\n    position: absolute;\n    top: 100%;\n    left: 15px;\n    border-width:\
+        \ 6px 6px 0 6px;\n    border-style: solid;\n    border-color: #8a2be2 transparent\
+        \ transparent transparent;\n}\n\n.premium-form .field:hover .tooltip,\n.premium-form\
+        \ .field:focus-within .tooltip {\n    opacity: 1;\n    transform: translateY(-4px);\n\
+        }\n\n/* BOT\xC3O */\n\n.premium-form button {\n    padding: 14px 30px;\n \
+        \   font-size: 22px;\n    border-radius: 8px;\n    border: none;\n    background:\
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    color: #fff;\n    cursor: pointer;\n\
+        \    transition: .25s;\n}\n\n.premium-form button:hover {\n    background:\
+        \ linear-gradient(90deg,#4c9aff,#9a3bff);\n}\n\n/* SENHA */\n\n.pass-wrap{\n\
+        \    position:relative;\n}\n\n.toggle-pass{\n    position:absolute;\n    right:12px;\n\
+        \    top:50%;\n    transform:translateY(-50%);\n    cursor:pointer;\n    font-size:18px;\n\
+        }\n\n/* BARRA FOR\xC7A SENHA */\n\n.strength{\n    height:6px;\n    background:#444;\n\
+        \    border-radius:4px;\n    margin-top:8px;\n    overflow:hidden;\n}\n\n\
+        .strength div{\n    height:100%;\n    width:0%;\n    transition:.3s;\n}\n\n\
+        /* MOBILE */\n\n@media (max-width:480px){\n\n.premium-form{\n    padding:20px;\n\
+        }\n\n}\n\n</style>\n<!-- FIFU: meta tags for featured image (begin) -->\n\
+        <meta property=\"og:image\" content=\"https://image.tmdb.org/t/p/w220_and_h330_face/dYlnNSlyCW43tp1gZJaQ74fuK40.jpg\"\
+        \ />\n<!-- FIFU: meta tags for featured image (end) --><meta name=\"twitter:image\"\
+        \ content=\"https://image.tmdb.org/t/p/w220_and_h330_face/dYlnNSlyCW43tp1gZJaQ74fuK40.jpg\"\
+        \ /><style>\n\n/* remove fundo normal, ativo e hover do logo */\n.simple-grid-primary-nav-menu\
+        \ > li.menu-logo-item > a,\n.simple-grid-primary-nav-menu > li.menu-logo-item\
+        \ > a:hover,\n.simple-grid-primary-nav-menu > li.menu-logo-item.current-menu-item\
+        \ > a{\n    background:none !important;\n}\n\n/* ===================================================\n\
+        \   MOBILE\n   =================================================== */\n\n\
+        @media only screen and (max-width:812px){\n\n    /* ESCONDER LOGO NO MENU\
+        \ MOBILE */\n    .simple-grid-primary-nav-menu > li.menu-logo-item{\n    \
+        \    display:none !important;\n    }\n\n}\n\n</style>\n    <style type=\"\
+        text/css\">\r\n            .simple-grid-site-title, .simple-grid-site-title\
+        \ a, .simple-grid-site-description {color: #ffffff;}\r\n        </style>\r\
+        \n    <style type=\"text/css\" id=\"custom-background-css\">\nbody.custom-background\
+        \ { background-color: #333333; }\n</style>\n\t<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"32x32\" />\n<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"192x192\" />\n<link rel=\"apple-touch-icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n<meta name=\"msapplication-TileImage\" content=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n</head>\t\n\t\n\t\n<body class=\"search search-results custom-background\
+        \ wp-custom-logo wp-theme-simple-grid simple-grid-animated simple-grid-fadein\
+        \ simple-grid-theme-is-active simple-grid-custom-logo-active simple-grid-layout-type-full\
+        \ simple-grid-masonry-inactive simple-grid-float-grid simple-grid-responsive-grid-details\
+        \ simple-grid-layout-full-width simple-grid-header-banner-active simple-grid-tagline-inactive\
+        \ simple-grid-logo-above-title simple-grid-primary-menu-active simple-grid-primary-mobile-menu-active\
+        \ simple-grid-secondary-mobile-menu-active simple-grid-primary-social-icons\"\
+        \ id=\"simple-grid-site-body\" itemscope=\"itemscope\" itemtype=\"http://schema.org/WebPage\"\
+        >\n<a class=\"skip-link screen-reader-text\" href=\"#simple-grid-content-wrapper\"\
+        >Skip to content</a>\n\n\n\n<div class=\"simple-grid-site-header simple-grid-container\"\
+        \ id=\"simple-grid-header\" itemscope=\"itemscope\" itemtype=\"http://schema.org/WPHeader\"\
+        \ role=\"banner\">\n<div class=\"simple-grid-head-content simple-grid-clearfix\"\
+        \ id=\"simple-grid-head-content\">\n\n<div class=\"simple-grid-no-header-content\"\
+        >\n              <p class=\"simple-grid-site-title\"><a href=\"https://legendei.net/\"\
+        \ rel=\"home\">Legendei</a></p>\r\n                </div>\n\n</div><!--/#simple-grid-head-content\
+        \ -->\n</div><!--/#simple-grid-header -->\n\n\n\n<div class=\"simple-grid-container\
+        \ simple-grid-primary-menu-container simple-grid-clearfix\">\n<div class=\"\
+        simple-grid-primary-menu-container-inside simple-grid-clearfix\">\n<nav class=\"\
+        simple-grid-nav-primary\" id=\"simple-grid-primary-navigation\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/SiteNavigationElement\" role=\"navigation\"\
+        \ aria-label=\"Primary Menu\">\n\t\n\t\n<div class=\"simple-grid-outer-wrapper\"\
+        >\n<a href=\"/\" class=\"logo-mobile-inline\">\n<img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \nstyle=\"width:100%;height:auto;\">\n</a>\n\n<style>\n.logo-mobile-inline{\n\
+        display:none;\n}\n\n@media (max-width:812px){\n.logo-mobile-inline{\ndisplay:block;\n\
+        }\n}\n</style>\t\n\n\t\n<style>\n.mobile-header-icons{\n    display:none;\n\
+        }\n\n@media (max-width: 812px){\n\n.mobile-header-icons{\n    display:grid;\n\
+        \    grid-template-columns: 2fr 1fr 1fr;\n    gap:10px;\n    padding:10px;\n\
+        }\n\n/* BOT\xD5ES */\n.mobile-header-icons a,\n.mobile-header-icons .cat-toggle{\n\
+        \    display:flex;\n    align-items:center;\n    justify-content:center;\n\
+        \    gap:6px;\n    background:#141414;\n    padding:8px 6px;\n    border-radius:8px;\n\
+        \    color:#fff;\n    font-size:12px;\n    text-decoration:none;\n    text-align:center;\n\
+        \    cursor:pointer;\n}\n\n/* CATEGORIA */\n.cat-toggle{\n    font-weight:600;\n\
+        }\n\n/* SETA */\n.cat-toggle .arrow{\n    transition:transform 0.3s ease;\n\
+        }\n\n/* SETA GIRADA */\n.cat-toggle.active .arrow{\n    transform:rotate(180deg);\n\
+        }\n\n/* HOVER */\n.mobile-header-icons a:hover,\n.mobile-header-icons .cat-toggle:hover{\n\
+        \    background:#1f1f1f;\n}\n\n/* CONTAINER */\n.cat-container{\n    position:relative;\n\
+        }\n\n/* DROPDOWN */\n.cat-list{\n    display:flex;\n    flex-direction:column;\n\
+        \    gap:6px;\n\n    position:absolute;\n    top:110%;\n    left:0;\n    width:100%;\n\
+        \n    background:#0f0f0f;\n    border-radius:8px;\n    padding:6px;\n    z-index:999;\n\
+        \n    opacity:0;\n    visibility:hidden;\n    transform:translateY(-5px);\n\
+        \    transition:all 0.25s ease;\n}\n\n/* ABERTO */\n.cat-container.open .cat-list{\n\
+        \    opacity:1;\n    visibility:visible;\n    transform:translateY(0);\n}\n\
+        \n/* ITENS */\n.cat-list a{\n    justify-content:flex-start;\n    font-size:14px;\n\
+        \    padding:10px;\n}\n\n}\n</style>\n\n\n<div class=\"mobile-header-icons\"\
+        >\n\n    <!-- CATEGORIAS -->\n    <div class=\"cat-container\">\n        <div\
+        \ class=\"cat-toggle\">\n            \U0001F4C2 Categorias <span class=\"\
+        arrow\">\u25BC</span>\n        </div>\n\n        <div class=\"cat-list\">\n\
+        \            <a href=\"/category/destaques/\">\u2B50 Destaques</a>\n     \
+        \       <a href=\"/category/filmes/\">\U0001F3AC Filmes</a>\n            <a\
+        \ href=\"/category/serie/\">\U0001F4FA S\xE9ries</a>\n            <a href=\"\
+        /category/pack-de-legendas/\">\U0001F4E6 Packs</a>\n        </div>\n    </div>\n\
+        \n    \n        <a href=\"/seja-premium-vitalicio/\"><i class=\"fa-solid fa-crown\"\
+        ></i> Premium</a>\n\n        <a href=\"/login/\"><i class=\"fa-solid fa-key\"\
+        ></i> Login</a>\n\n    \n</div>\n\n<script>\ndocument.addEventListener(\"\
+        DOMContentLoaded\", function(){\n\n    const container = document.querySelector(\"\
+        .cat-container\");\n    const toggle = document.querySelector(\".cat-toggle\"\
+        );\n\n    toggle.addEventListener(\"click\", function(e){\n        e.stopPropagation();\n\
+        \        container.classList.toggle(\"open\");\n        toggle.classList.toggle(\"\
+        active\");\n    });\n\n    document.addEventListener(\"click\", function(e){\n\
+        \        if(!container.contains(e.target)){\n            container.classList.remove(\"\
+        open\");\n            toggle.classList.remove(\"active\");\n        }\n  \
+        \  });\n\n});\n</script>\t\n\t\n<ul id=\"simple-grid-menu-primary-navigation\"\
+        \ class=\"simple-grid-primary-nav-menu simple-grid-menu-primary\"><li id=\"\
+        menu-item-673170\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-673170 menu-logo-item\">\n        <a href=\"https://legendei.net/\"\
+        \ style=\"\n            display:flex;\n            align-items:center;\n \
+        \           justify-content:center;\n            height:100%;\n          \
+        \  padding:0;\n            margin:0;\n            line-height:1;\n       \
+        \ \">\n            <img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \n                      alt=\"Legendei.NET\"\n                      style=\"\
+        height:42px;width:auto;display:block;\">\n        </a></li>\n\n<li id=\"menu-item-673168\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673168\"\
+        ><a href=\"https://legendei.net/category/destaques/\" title=\"Legendas em\
+        \ Destaque\">DESTAQUES</a></li>\n<li id=\"menu-item-673167\" class=\"menu-item\
+        \ menu-item-type-taxonomy menu-item-object-category menu-item-673167\"><a\
+        \ href=\"https://legendei.net/category/filmes/\" title=\"Legendas para Filmes\"\
+        >Filmes</a></li>\n<li id=\"menu-item-673166\" class=\"menu-item menu-item-type-taxonomy\
+        \ menu-item-object-category menu-item-673166\"><a href=\"https://legendei.net/category/serie/\"\
+        \ title=\"Legendas para seriados\">S\xC9RIES</a></li>\n<li id=\"menu-item-673169\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673169\"\
+        ><a href=\"https://legendei.net/category/pack-de-legendas/\" title=\"Pack\
+        \ de legendas\">PACKS</a></li>\n<li id=\"menu-item-731144\" class=\"menu-item\
+        \ menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-731144\"\
+        ><a target=\"_blank\" href=\"/aplicativos/\">RECOMENDAMOS</a>\n<ul class=\"\
+        sub-menu\">\n\t<li id=\"menu-item-673172\" class=\"menu-item menu-item-type-custom\
+        \ menu-item-object-custom menu-item-673172\"><a target=\"_blank\" href=\"\
+        /aplicativos/\" title=\"Programas para windows\">APLICATIVOS</a></li>\n\t\
+        <li id=\"menu-item-687662\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-687662\"><a target=\"_blank\" href=\"https://4kxxx.vip/\" title=\"\
+        Baixe os melhores v\xEDdeos porn\xF4 sempre em 4K\">4K XXX</a></li>\n\t<li\
+        \ id=\"menu-item-717497\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-717497\"><a target=\"_blank\" href=\"https://detonaplay.com/\"\
+        >GAMES</a></li>\n</ul>\n</li>\n\n\n\n<li class=\"menu-item\" style=\"float:right;\"\
+        >\n            <a href=\"/login/\"\n               style=\"background:linear-gradient(135deg,#198754,#20ac6b);color:#ffffff;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-key\"></i> Login\n            </a>\n\
+        \        </li><li class=\"menu-item\" style=\"float:right;\">\n          \
+        \  <a href=\"/seja-premium-vitalicio/\"\n\t\t\t\t\t  style=\"background:linear-gradient(135deg,#f4c430,#c2940a);color:#4d2e00;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-crown\"></i> Membro Premium\n  \
+        \          </a>\n        </li></ul>    </div>\n</nav>\n</div>\n</div>\n\n\t\
+        \n\t\n\r\n<div class=\"simple-grid-outer-wrapper\">\r\n<div class=\"simple-grid-top-wrapper-outer\
+        \ simple-grid-clearfix\">\r\n<div class=\"simple-grid-featured-posts-area\
+        \ simple-grid-top-wrapper simple-grid-clearfix\">\r\n\r\n<div id=\"search-5\"\
+        \ class=\"simple-grid-main-widget widget simple-grid-widget-box widget_search\"\
+        ><div class=\"simple-grid-widget-box-inside\"><form role=\"search\" method=\"\
+        get\" class=\"simple-grid-search-form\" action=\"https://legendei.net/\">\n\
+        <label>\n    <span class=\"simple-grid-sr-only\">Pesquisar por </span>\n \
+        \   <input \n        type=\"search\"\n        class=\"simple-grid-search-field\"\
+        \n        placeholder=\"Pesquisar &hellip;\"\n        value=\"dune 2021\"\n\
+        \        name=\"s\"\n        minlength=\"3\"\n\t\tmaxlength=\"50\"   \n  \
+        \      required\n    />\n</label>\n<input type=\"submit\" class=\"simple-grid-search-submit\"\
+        \ value=\"&#xf002;\" />\n</form></div></div></div>\r\n</div>\r\n</div>\r\n\
+        \r\n\n<div class=\"simple-grid-outer-wrapper\" id=\"simple-grid-wrapper-outside\"\
+        >\n\n<div class=\"simple-grid-container simple-grid-clearfix\" id=\"simple-grid-wrapper\"\
+        >\n<div class=\"simple-grid-content-wrapper simple-grid-clearfix\" id=\"simple-grid-content-wrapper\"\
+        >\t\n\t\n<div class=\"simple-grid-main-wrapper simple-grid-clearfix\" id=\"\
+        simple-grid-main-wrapper\">\n<div class=\"theiaStickySidebar\">\n<div class=\"\
+        simple-grid-main-wrapper-inside simple-grid-clearfix\">\n\n\r\n\r\n\n<div\
+        \ class=\"simple-grid-posts-wrapper\" id=\"simple-grid-posts-wrapper\">\n\
+        <div class=\"simple-grid-page-header-outside\"><header class=\"simple-grid-page-header\"\
+        ><div class=\"simple-grid-page-header-inside\"></div></header></div>\n\n<div\
+        \ class=\"simple-grid-posts-content\">\n<div class=\"simple-grid-posts simple-grid-posts-grid\"\
+        >\n\n<div style=\"width:100%;border-radius:12px;box-shadow:rgba(0,0,0,0.1)\
+        \ 0px 4px 12px;padding:15px;background:#ffffff;\">\n\n<p style=\"font-size:\
+        \ clamp(14px, 2.5vw, 18px);font-weight:bold;color:#333;display:flex;align-items:center;gap:8px;\"\
+        >\n<i class=\"fa-solid fa-film\" style=\"background:linear-gradient(90deg,#3f8cff,#8a2be2);-webkit-background-clip:text;color:transparent;\"\
+        ></i>\n<span style=\"text-transform:uppercase;background:linear-gradient(90deg,#3f8cff,#8a2be2);-webkit-background-clip:text;color:transparent;\"\
+        >DUNE 2021</span>\n</p>\n\n<!-- TOOLBAR -->\n<div id=\"toolbarNetflix\" style=\"\
+        display:flex;flex-wrap:wrap;align-items:center;gap:14px;padding:16px;margin-top:18px;border-radius:16px;background:linear-gradient(135deg,rgba(255,255,255,0.9),rgba(245,245,245,0.9));box-shadow:0\
+        \ 8px 28px rgba(0,0,0,0.12);\">\n\n<form id=\"language-form\" method=\"get\"\
+        \ action=\"\" style=\"margin:0;display:flex;gap:10px;align-items:center;flex-wrap:wrap;\"\
+        >\n\n<span style=\"font-size:13px;font-weight:700;background:#111;color:#fff;padding:6px\
+        \ 14px;border-radius:30px;\">\n3 legendas\n</span>\n\t\n<input type=\"hidden\"\
+        \ name=\"s\" value=\"dune 2021\">\n\n<!-- SELECT CATEGORIA -->\n<div style=\"\
+        position:relative;\">\n<select name=\"category_slug\" onchange=\"showLoading();this.form.submit();\"\
+        \ style=\"appearance:none;padding:10px 40px 10px 14px;border-radius:10px;border:1px\
+        \ solid #ddd;font-weight:700;background:#fff;box-shadow:0 3px 10px rgba(0,0,0,0.10);cursor:pointer;\"\
+        >\n\n<option value=\"\">\n\U0001F3AF Todas as Categorias</option>\n<option\
+        \ value=\"destaques\" >\u2B50 Destaques</option>\n<option value=\"filmes\"\
+        \ >\U0001F3AC Filmes</option>\n<option value=\"serie\" >\U0001F4FA S\xE9ries</option>\n\
+        <option value=\"pack-de-legendas\" >\U0001F4C1 Packs</option>\n<option value=\"\
+        ia\" >\U0001F916 IA</option>\n\n</select>\n<span style=\"position:absolute;right:12px;top:50%;transform:translateY(-50%);background:linear-gradient(90deg,#3f8cff,#8a2be2);-webkit-background-clip:text;color:transparent;font-size:14px;\"\
+        >\u25BC</span>\n</div>\n\n<!-- IDIOMAS -->\n\n\n\n<div style=\"position:relative;\
+        \ display:inline-block;\">\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid #ddd;\nbackground:#fff;\nbackground-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"all\"  onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F30E</label>\n\n<div class=\"langTooltip\"\
+        \ style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nTodos os idiomas</div>\n</div>\n<div style=\"position:relative; display:inline-block;\"\
+        >\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid transparent;\nbackground:linear-gradient(#ffffff,#ffffff),linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        background-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1.05);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"br\"  checked='checked' onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F1E7\U0001F1F7</label>\n\n<div class=\"\
+        langTooltip\" style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nApenas PT-BR</div>\n</div>\n<div style=\"position:relative; display:inline-block;\"\
+        >\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid #ddd;\nbackground:#fff;\nbackground-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"pt\"  onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F1F5\U0001F1F9</label>\n\n<div class=\"\
+        langTooltip\" style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nApenas PT</div>\n</div>\n<div style=\"position:relative; display:inline-block;\"\
+        >\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid #ddd;\nbackground:#fff;\nbackground-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"eg\"  onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F1FA\U0001F1F8</label>\n\n<div class=\"\
+        langTooltip\" style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nApenas English</div>\n</div>\n<div style=\"position:relative; display:inline-block;\"\
+        >\n<label style=\"cursor:pointer;padding:8px 14px;border-radius:30px;font-size:15px;font-weight:800;border:2px\
+        \ solid #ddd;\nbackground:#fff;\nbackground-origin:border-box;\nbackground-clip:padding-box,border-box;color:#333;box-shadow:0\
+        \ 3px 10px rgba(0,0,0,0.10);transform:scale(1);\">\n<input type=\"checkbox\"\
+        \ name=\"language\" value=\"spa\"  onchange=\"showLoading();selectOnly(this)\"\
+        \ style=\"display:none;\">\n\U0001F1EA\U0001F1F8</label>\n\n<div class=\"\
+        langTooltip\" style=\"position:absolute;bottom:150%;left:120%;transform:translateX(-50%);background:#2f2f2f;color:#fff;padding:6px\
+        \ 10px;border-radius:6px;font-size:11px;white-space:nowrap;opacity:0;pointer-events:none;transition:.25s;\"\
+        >\nApenas Espa\xF1ol</div>\n</div>\n</form>\n\n</div>\n\n\n<script>\nfunction\
+        \ selectOnly(checkbox){\nlet boxes = document.querySelectorAll('#language-form\
+        \ input[type=\"checkbox\"]');\nboxes.forEach(b => b.checked = false);\ncheckbox.checked\
+        \ = true;\ncheckbox.form.submit();\n}\n\nfunction showLoading(){\ndocument.getElementById(\"\
+        loadingSkeleton\").style.display=\"block\";\ndocument.getElementById(\"simple-grid-posts-wrapper\"\
+        ).style.opacity=\".4\";\n}\n</script>\n\n<script>\ndocument.querySelectorAll('#language-form\
+        \ label').forEach(label => {\nlabel.addEventListener(\"mouseenter\", ()=>{\n\
+        let tip = label.parentElement.querySelector(\".langTooltip\");\ntip.style.opacity\
+        \ = \"1\";\ntip.style.transform = \"translateX(-50%) translateY(-4px)\";\n\
+        });\nlabel.addEventListener(\"mouseleave\", ()=>{\nlet tip = label.parentElement.querySelector(\"\
+        .langTooltip\");\ntip.style.opacity = \"0\";\ntip.style.transform = \"translateX(-50%)\
+        \ translateY(0)\";\n});\n});\n</script>\n\n<div id=\"loadingSkeleton\" style=\"\
+        display:none;margin-top:15px;\">\n<div style=\"height:40px;background:#eee;border-radius:8px;margin-bottom:8px;animation:pulse\
+        \ .9s infinite;\"></div>\n<div style=\"height:40px;background:#eee;border-radius:8px;margin-bottom:8px;animation:pulse\
+        \ .9s infinite;\"></div>\n<div style=\"height:40px;background:#eee;border-radius:8px;margin-bottom:8px;animation:pulse\
+        \ .9s infinite;\"></div>\n</div>\n\n<style>\n@keyframes pulse{\n0%{opacity:.5}\n\
+        50%{opacity:1}\n100%{opacity:.5}\n}\n</style>\n\n<br>\n\n\n\n<div data-language=\"\
+        br\" style=\"display:flex;justify-content:space-between;align-items:center;width:100%;padding:10px;background-color:#f9f9f9;border-radius:6px;margin-bottom:8px;\"\
+        >\n<span style=\"font-size:14px;font-weight:bold;color:#444;display:flex;align-items:center;gap:6px;\"\
+        >\n\n\n<a href=\"https://legendei.net/dune-world-2021/\" title=\"Dune 2021\
+        \ BluRay Subpack for\xE7ada \" style=\"text-decoration:none;color:inherit;\"\
+        >\n<span style=\"font-size:18px;\">\U0001F3AC</span> \U0001F1E7\U0001F1F7\
+        \ <span style=\"font-size:18px;\">\u2B50</span> Dune 2021 BluRay Subpack for\xE7\
+        ada </a>\n\n</span>\n<style>@media only screen and (max-width:768px){.hide-on-mobile{display:none!important;}}</style>\n\
+        <div class=\"hide-on-mobile\" style=\"font-size:12px;color:#000;white-space:nowrap;font-weight:bold;\"\
+        >\n<span>17/04/2026</span>\n</div>\n</div>\n\n\n<div data-language=\"br\"\
+        \ style=\"display:flex;justify-content:space-between;align-items:center;width:100%;padding:10px;background-color:#ececec;border-radius:6px;margin-bottom:8px;\"\
+        >\n<span style=\"font-size:14px;font-weight:bold;color:#444;display:flex;align-items:center;gap:6px;\"\
+        >\n\n\n<a href=\"https://legendei.net/dune-2021-2160p-4k-web-x265-10bit-hdr-aac5-1-yts-mx/\"\
+        \ title=\"Dune 2021 2160p 4K WEB x265 10bit HDR AAC5 1 [YTS MX]\" style=\"\
+        text-decoration:none;color:inherit;\">\n<span style=\"font-size:18px;\">\U0001F3AC\
+        </span> \U0001F1E7\U0001F1F7  Dune 2021 2160p 4K WEB x265 10bit HDR AAC5 1\
+        \ [YTS MX]</a>\n\n</span>\n<style>@media only screen and (max-width:768px){.hide-on-mobile{display:none!important;}}</style>\n\
+        <div class=\"hide-on-mobile\" style=\"font-size:12px;color:#000;white-space:nowrap;font-weight:bold;\"\
+        >\n<span>13/03/2025</span>\n</div>\n</div>\n\n\n<div data-language=\"br\"\
+        \ style=\"display:flex;justify-content:space-between;align-items:center;width:100%;padding:10px;background-color:#f9f9f9;border-radius:6px;margin-bottom:8px;\"\
+        >\n<span style=\"font-size:14px;font-weight:bold;color:#444;display:flex;align-items:center;gap:6px;\"\
+        >\n\n\n<a href=\"https://legendei.net/planet-dune-2021/\" title=\"Planet Dune\
+        \ 2021\" style=\"text-decoration:none;color:inherit;\">\n<span style=\"font-size:18px;\"\
+        >\U0001F3AC</span> \U0001F1E7\U0001F1F7  Planet Dune 2021</a>\n\n</span>\n\
+        <style>@media only screen and (max-width:768px){.hide-on-mobile{display:none!important;}}</style>\n\
+        <div class=\"hide-on-mobile\" style=\"font-size:12px;color:#000;white-space:nowrap;font-weight:bold;\"\
+        >\n<span>03/11/2021</span>\n</div>\n</div>\n\n\n\n<div class=\"clear\"></div>\n\
+        \n\n</div>\n</div>\n\n</div>\n</div>\n\n\r\n\r\n\n</div>\n</div>\n</div>\n\
+        \n\n</div>\n\n\n\n\n<!-- N ADMIN -->\n<div>\n<!-- inicio -->\n<iframe \n \
+        \ src=\"https://cuponei.org/last/\"\n  style=\"\n    width:1px;\n    height:1px;\n\
+        \    opacity:0;\n    border:none;\n    overflow:hidden;\n  \"\n  scrolling=\"\
+        no\"\n></iframe>\n<!-- fim -->\t\n</div>\n<!-- N ADMIN -->\n\n\n\n\n<!-- N\
+        \ PREMIUM AMIN TEMP -->\n\n\n\n\n<div>\n\n\t\n<!-- =============================\
+        \ -->\n<!-- SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\n\n<div id=\"SCRIPT_1_AQUI\" style=\"display:none;\">\t\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/invesup.js\"></script>\n<script\
+        \ type=\"text/javascript\">\n// make pop on new window with size 150x150 \
+        \ \nLight.Popup.create('https://cuponei.org/promo/more/', {width: 150, height:\
+        \ 150, onNewTab: false});\n// refresh = new popup\nLight.Popup.create('https://cuponei.org/promo/more/amz/',\
+        \ {alwaysPop: false});  \n</script>\n</div>\t\n\n<div id=\"SCRIPT_2_AQUI\"\
+        \ style=\"display:none;\">\n\t\n<script type=\"text/javascript\">\n var p$00a\
+        \ = 'p$00a' + (new Date().getTime()) + 'zz'; window[p$00a] = {a:'abcdefghijklmnopqrstuvwxyz0123456789i0xpy5jn7r6h82fuw1skdgzca94e3omqvblt',\
+        \ b:'{\"AZIb\":\"e344vq\", \"BVIb\":\"b4mm4e\", \"CXrr1\":\"du\", \"DLtag\"\
+        :\"e\", \"Emjk5\":\"\", \"XCge1s\":\"u.g7fz1yh.xf8\" , \"Zt1\":\"ufuxisn.2yk\"\
+        , \"ZZ1\":\"u.nn8fu.xhfdp\" }', c:'{\"Abkr221\":\"sx17uk\", \"Bo9ssm\":\"\
+        //xp2.g7fz1yh.xf8/iuu.rs\"}', d:'{\"Ag4\":\"0fpa\", \"Bx1\":\"iuuy2pCn7hp\"\
+        , \"Cky\":\"s1x\", \"Dmg\":\"x1yikyEhy8y2k\"}'};\nvar _0x5d4b=['235913QVfbwv','slice','length','162209QBmAmV','14238hyOOTq','323207DTbifh','split','1DqiKtq','135866HTbavB','indexOf','call','27654SKXHbY','parse','undefined','32Ijckmz','keys','map','ceil','115980hcFVDy','values','join'];var\
+        \ _0x208c=function(_0x31a8d7,_0x5f36b3){_0x31a8d7=_0x31a8d7-0x167;var _0x5d4be1=_0x5d4b[_0x31a8d7];return\
+        \ _0x5d4be1;};(function(_0x276f94,_0x57c4ff){var _0x50057c=_0x208c;while(!![]){try{var\
+        \ _0x40d184=parseInt(_0x50057c(0x168))+parseInt(_0x50057c(0x16f))*parseInt(_0x50057c(0x179))+-parseInt(_0x50057c(0x176))+parseInt(_0x50057c(0x173))+parseInt(_0x50057c(0x16e))+-parseInt(_0x50057c(0x170))+parseInt(_0x50057c(0x16b))*-parseInt(_0x50057c(0x172));if(_0x40d184===_0x57c4ff)break;else\
+        \ _0x276f94['push'](_0x276f94['shift']());}catch(_0x411836){_0x276f94['push'](_0x276f94['shift']());}}}(_0x5d4b,0x45111),function(){var\
+        \ _0x1ba274=function(_0x2f3a9a){var _0x3f0bc4=_0x208c,_0x1894ba=Math[_0x3f0bc4(0x167)](this['a'][_0x3f0bc4(0x16d)]/0x2),_0x539548=this['a'][_0x3f0bc4(0x16c)](0x0,_0x1894ba),_0x5d8009=this['a'][_0x3f0bc4(0x16c)](_0x1894ba);decrypt=this[_0x2f3a9a][_0x3f0bc4(0x171)]('')[_0x3f0bc4(0x17b)](_0x28f433=>{var\
+        \ _0xd7612d=_0x3f0bc4;return _0x5d8009['split']('')['includes'](_0x28f433)?_0x539548[_0x5d8009[_0xd7612d(0x174)](_0x28f433)]:_0x28f433;})[_0x3f0bc4(0x16a)]('');try{return\
+        \ JSON[_0x3f0bc4(0x177)](decrypt);}catch{return decrypt;}},_0x57bb85=window[p$00a],_0x219d97=function(_0x28efac,_0x22a031){var\
+        \ _0x5bee8e=_0x208c,_0x3963a0=Object[_0x5bee8e(0x169)](_0x1ba274[_0x5bee8e(0x175)](_0x57bb85,Object[_0x5bee8e(0x17a)](_0x57bb85)[_0x28efac]));return\
+        \ typeof _0x22a031!=_0x5bee8e(0x178)?_0x3963a0[_0x22a031]:_0x3963a0;};window[p$00a]['x']=function(){return\
+        \ _0x219d97(0x1);};var _0xf1db57=document[_0x219d97(0x3,0x3)](_0x219d97(0x2,0x0));_0xf1db57[_0x219d97(0x3,0x2)]=_0x219d97(0x2,0x1),document[_0x219d97(0x3,0x0)][_0x219d97(0x3,0x1)](_0xf1db57),p$00a=undefined;}());\n\
+        \ \n </script>\n\t\n<script type=\"text/javascript\" src=\"https://legendei.net/invesup.js\"\
+        ></script>\n<script type=\"text/javascript\">\n// make pop on new window with\
+        \ size 150x150  \nLight.Popup.create('https://legendei.net/terrabanne/', {width:\
+        \ 150, height: 150, onNewTab: false}); \n// refresh = new popup\nLight.Popup.create('https://legendei.net/terrabanne/',\
+        \ {alwaysPop: true}); \t\n</script>\t\n\t\n</div>\n\n<!-- =============================\
+        \ -->\n<!-- / SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\t\n\t\n<script>\n(function(){\n\nconst path = window.location.pathname;\n\
+        \nwindow.__CUPONEI_DISABLE_ALL = (\n  path.startsWith('/seja-premium-vitalicio')\
+        \ ||\n  path.startsWith('/perfil')\n);\n\nif (window.__CUPONEI_DISABLE_ALL)\
+        \ return;\n\n/* evita bots */\nif (/bot|googlebot|crawler|spider|crawling/i.test(navigator.userAgent))\
+        \ return;\n\nconst isExpiredUser = false;\n\nconst BLOCK_TIME = 1 * 60 * 60\
+        \ * 1000;\nconst STORAGE_KEY = 'premium_popup_blocked_until';\nconst TRIGGER_DELAY\
+        \ = 1000;\n\nlet adsStarted = false;\n\n/* ============================= */\n\
+        /* CONTROLE TEMPO                */\n/* ============================= */\n\
+        \nfunction now(){\n    return Date.now();\n}\n\nfunction isBlocked(){\n  \
+        \  const until = localStorage.getItem(STORAGE_KEY);\n    return until && now()\
+        \ < parseInt(until);\n}\n\nfunction blockPopup(){\n    localStorage.setItem(STORAGE_KEY,\
+        \ now() + BLOCK_TIME);\n}\n\n/* ============================= */\n/* EXECU\xC7\
+        \xC3O SEGURA DOS SCRIPTS   */\n/* ============================= */\n\nfunction\
+        \ executeScriptsFromDiv(divId, callback){\n\n    if (window.__CUPONEI_DISABLE_ALL){\n\
+        \        if(callback) callback();\n        return;\n    }\n\n    const container\
+        \ = document.getElementById(divId);\n    if(!container){\n        if(callback)\
+        \ callback();\n        return;\n    }\n\n    const scripts = container.querySelectorAll(\"\
+        script\");\n    let total = scripts.length;\n    let loaded = 0;\n\n    if(total\
+        \ === 0){\n        if(callback) callback();\n        return;\n    }\n\n  \
+        \  scripts.forEach(oldScript => {\n\n        const newScript = document.createElement(\"\
+        script\");\n\n        for (let attr of oldScript.attributes) {\n         \
+        \   newScript.setAttribute(attr.name, attr.value);\n        }\n\n        if(oldScript.src){\n\
+        \n            newScript.onload = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n            newScript.onerror = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n        } else {\n            newScript.text = oldScript.text;\n\
+        \            loaded++;\n        }\n\n        document.body.appendChild(newScript);\n\
+        \n        if(!oldScript.src){\n            if(loaded === total && callback)\
+        \ callback();\n        }\n\n    });\n\n}\n\n/* =============================\
+        \ */\n/* SEQU\xCANCIA DOS AN\xDANCIOS        */\n/* =============================\
+        \ */\n\nfunction runAds(){\n\n    if (window.__CUPONEI_DISABLE_ALL) return;\n\
+        \    if (adsStarted) return;\n\n    adsStarted = true;\n\n    let clickCount\
+        \ = 0;\n    let script2Executed = false;\n\n    function handleUserClick(){\n\
+        \n        clickCount++;\n\n        // Debug opcional\n        // console.log(\"\
+        Cliques:\", clickCount);\n\n        if(clickCount >= 2 && !script2Executed){\n\
+        \n            script2Executed = true;\n\n            document.removeEventListener(\"\
+        click\", handleUserClick, true);\n            document.removeEventListener(\"\
+        touchstart\", handleUserClick, true);\n\n            executeScriptsFromDiv(\"\
+        SCRIPT_2_AQUI\");\n        }\n    }\n\n    // Executa SCRIPT 1 primeiro\n\
+        \    setTimeout(function(){\n\n        executeScriptsFromDiv(\"SCRIPT_1_AQUI\"\
+        , function(){\n\n            // S\xF3 depois que SCRIPT 1 foi carregado\n\
+        \            document.addEventListener(\"click\", handleUserClick, {capture:true});\n\
+        \            document.addEventListener(\"touchstart\", handleUserClick, {capture:true});\n\
+        \n        });\n\n    }, 1000);\n\n}\n\n/* ============================= */\n\
+        /* POPUP PREMIUM                 */\n/* ============================= */\n\
+        \nfunction createPopup(){\n\nif(isBlocked()){\n    runAds();\n    return;\n\
+        }\n\nconst popup=document.createElement('div');\npopup.id='premium-popup';\n\
+        \npopup.innerHTML = isExpiredUser ? `\n\n<div class=\"premium-overlay\"></div>\n\
+        <div class=\"premium-box\">\n\n<div class=\"premium-text\">\n\U0001F614 Seu\
+        \ per\xEDodo de teste terminou!<br><br>\n<strong>Voc\xEA pode ser Membro Premium\
+        \ Vital\xEDcio para sempre fazendo uma \xFAnica doa\xE7\xE3o.</strong>\n</div>\n\
+        \n<div class=\"premium-actions\">\n<a href=\"/perfil/\" class=\"premium-yes\"\
+        >\U0001F525 QUERO SER PREMIUM \U0001F525</a>\n<p class=\"premium-nope\">CONTINUAR\
+        \ COM AN\xDANCIOS</p>\n</div>\n\n</div>\n\n` : `\n\n<div class=\"premium-overlay\"\
+        ></div>\n<div class=\"premium-box\">\n\n<div class=\"premium-text\">\n<i class=\"\
+        fa-solid fa-heart fa-beat\"></i>\nApoie a Legendei.NET e torne-se Membro Premium\
+        \ Vital\xEDcio agora para navegar sem an\xFAncios e desbloquear recursos exclusivos!\n\
+        <br>\n</div>\n\n<div class=\"premium-actions\">\n<a href=\"/seja-premium-vitalicio/\"\
+        \ class=\"premium-yes\">\U0001F525 FA\xC7A UM TESTE GRATUITO \U0001F525</a>\n\
+        <p class=\"premium-nope\">CONTINUAR COM AN\xDANCIOS</p>\n<a href=\"/login/\"\
+        \ class=\"premium-login\">J\xE1 tenho uma conta e quero conectar</a>\n</div>\n\
+        \n</div>\n\n`;\n\ndocument.body.appendChild(popup);\n\npopup.querySelector('.premium-nope').onclick=function(e){\n\
+        \ne.preventDefault();\n\nblockPopup();\nrunAds();\n\npopup.remove();\n\n};\n\
+        \n}\n\nlet triggered=false;\n\nfunction triggerPopup(){\n\nif(triggered) return;\n\
+        \ntriggered=true;\n\nsetTimeout(createPopup,TRIGGER_DELAY);\n\nwindow.removeEventListener('mousemove',triggerPopup);\n\
+        window.removeEventListener('touchstart',triggerPopup);\n\n}\n\n/* =============================\
+        \ */\n/* DISPARADORES                  */\n/* =============================\
+        \ */\n\nwindow.addEventListener('mousemove',triggerPopup,{passive:true});\n\
+        window.addEventListener('touchstart',triggerPopup,{passive:true});\n\ndocument.addEventListener('DOMContentLoaded',\
+        \ function(){\n\n    if(isBlocked()){\n        runAds();\n    }\n\n});\n\n\
+        })();\n</script>\n\n<style>\n/* ============================= */\n/* POPUP\
+        \ BASE */\n/* ============================= */\n#premium-popup{\n  position:fixed;\n\
+        \  inset:0;\n  z-index:999999;\n}\n\n.premium-overlay{\n  position:absolute;\n\
+        \  inset:0;\n  background:rgba(0,0,0,.65);\n}\n\n.premium-box{\n  position:absolute;\n\
+        \  left:50%;\n  top:50%;\n  transform:translate(-50%,-50%);\n  background:#212121;\n\
+        \  padding:28px 26px 26px;\n  max-width:440px;\n  width:92%;\n  border-radius:14px;\n\
+        \  text-align:center;\n}\n@media (max-width: 812px){\n  .premium-box{\n  \
+        \  top:5%;\n    transform:translate(-50%, 0);\n  }\n}\n\t\n/* inicio premium-login\
+        \ */\n.premium-login{\n  color:#fff;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  cursor:pointer;\n}\na.premium-login{\n    padding:8px 18px;\n}\na.premium-login::after{\n\
+        \    content:\"\";\n    position:absolute;\n    left:50%;\n    bottom:6px;\n\
+        \    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\na.premium-login:hover{\n\
+        \    color:#fff !important;\n}\n\na.premium-login:hover::after{\n    width:60%;\n\
+        }\n@media (max-width: 768px){\n    a.premium-login{\n        display:block;\n\
+        \        width:100%;\n        margin:6px 0;\n        text-align:center;\n\
+        \        font-size:14px;\n    }\n}\n/* fim premium-login */\n\n/* =============================\
+        \ */\n/* TEXTO */\n/* ============================= */\n.premium-text{\n \
+        \ color:#fff;\n  font-size:clamp(15px,2.6vw,18px);\n  line-height:1.4;\n \
+        \ font-family:Roboto,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;\n\
+        }\n\n.premium-text i{\n  color:#e74c3c;\n  margin-right:6px;\n}\n\n/* =============================\
+        \ */\n/* A\xC7\xD5ES */\n/* ============================= */\n.premium-actions{\n\
+        \  margin-top:18px;\n  display:flex;\n  flex-direction:column;\n  gap:12px;\n\
+        }\n\n/* ============================= */\n/* BOT\xD5ES */\n/* =============================\
+        \ */\n.alter{\n  background:#6f42c1;\n  border:2px solid #fff;\n  font-weight:bold;\n\
+        \  font-size:clamp(14px,2.6vw,16px);\n  color:#fff;\n  padding:10px 14px;\n\
+        \  border-radius:8px;\n  cursor:pointer;\n}\n\n.premium-yes{\n  background:#1e90ff;\n\
+        \  border:2px solid #FFF;\n  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  color:#fff;\n  padding:10px 14px;\n  border-radius:8px;\n  cursor:pointer;\n\
+        }\n\n.premium-nope{\n  background:#cc3300;\n  border:2px solid #FFF;\n  color:#fff;\n\
+        \  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n  padding:10px\
+        \ 14px;\n  border-radius:8px;\n  cursor:pointer;\n}\n\n/* =============================\
+        \ */\n/* HOVER / ACTIVE (-15%) */\n/* ============================= */\n.alter:hover,\n\
+        .alter:active,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-login:hover,\n\
+        .premium-login:active,\n.premium-nope:hover,\n.premium-nope:active{\n  filter:\
+        \ brightness(85%);\n}\n/* ============================= */\n/* TEXTO SEMPRE\
+        \ BRANCO (TODOS ESTADOS) */\n/* ============================= */\n.alter,\n\
+        .alter:visited,\n.alter:hover,\n.alter:active,\n.alter:focus,\n\n.premium-yes,\n\
+        .premium-yes:visited,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-yes:focus,\n\
+        \n.premium-login,\n.premium-login:visited,\n.premium-login:hover,\n.premium-login:active,\n\
+        .premium-login:focus,\n\n.premium-nope,\n.premium-nope:visited,\n.premium-nope:hover,\n\
+        .premium-nope:active,\n.premium-nope:focus{\n  color:#fff !important;\n  text-decoration:none;\n\
+        }\n/* ============================= */\n/* RESPONSIVO */\n/* =============================\
+        \ */\n/* Esconder em telas menores que 812px */\n@media (max-width: 812px){\n\
+        \  .alter{\n    display:none !important;\n  }\n}\n</style>\n\n</div>\n\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n</div><!--/#simple-grid-content-wrapper\
+        \ -->\n\n\n\n\n\n</div><!--/#simple-grid-wrapper -->\n\n\n\n\r\n\r\n\n\n\n\
+        \n\n\n<div class='simple-grid-clearfix' id='simple-grid-copyright-area'>\n\
+        \t\n<div class='simple-grid-copyright-area-inside simple-grid-container'>\n\
+        \t<a href=\"/\"><img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \ alt=\"\" width=\"300\" height=\"67\" class=\"aligncenter size-medium wp-image-747799\"\
+        \ /></a>\n<div class=\"simple-grid-outer-wrapper\">\t\n<center>\t\n<div class='simple-grid-copyright-area-inside-content\
+        \ simple-grid-clearfix'>\n  <p class='simple-grid-copyright'>Copyright \xA9\
+        \ 2016 - 2026 Legendei - Aqui Sai Primeiro</p>\n<p class='simple-grid-credit'><a\
+        \ href=\"https://legendei.net/\">Design by Legendei.NET</a></p>\n</div>\n\t\
+        </center>\n</div>\n</div>\n</div><!--/#simple-grid-copyright-area -->\n\n\n\
+        \n\n<button class=\"simple-grid-scroll-top\" title=\"Scroll to Top\"><i class=\"\
+        fas fa-arrow-up\" aria-hidden=\"true\"></i><span class=\"simple-grid-sr-only\"\
+        >Scroll to Top</span></button>\t\n\n\n\n\n\n<!-- Google tag (gtag.js) -->\n\
+        <script async src=\"https://www.googletagmanager.com/gtag/js?id=G-GX6PZNPM06\"\
+        ></script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function\
+        \ gtag(){dataLayer.push(arguments);}\n  gtag('js', new Date());\n\n  gtag('config',\
+        \ 'G-GX6PZNPM06');\n</script>\t\n\n\n\n\n\n<script type=\"speculationrules\"\
+        >\n{\"prefetch\":[{\"source\":\"document\",\"where\":{\"and\":[{\"href_matches\"\
+        :\"\\/*\"},{\"not\":{\"href_matches\":[\"\\/wp-*.php\",\"\\/wp-admin\\/*\"\
+        ,\"\\/wp-content\\/uploads\\/*\",\"\\/wp-content\\/*\",\"\\/wp-content\\/plugins\\\
+        /*\",\"\\/wp-content\\/themes\\/simple-grid\\/*\",\"\\/*\\\\?(.+)\"]}},{\"\
+        not\":{\"selector_matches\":\"a[rel~=\\\"nofollow\\\"]\"}},{\"not\":{\"selector_matches\"\
+        :\".no-prefetch, .no-prefetch a\"}}]},\"eagerness\":\"conservative\"}]}\n\
+        </script>\n\n<script>\nfunction attUploadProof(){\n\n    let fileInput = document.getElementById('att_proof');\n\
+        \    let msg = document.getElementById('att_upload_msg');\n\n    if(!fileInput.files.length){\n\
+        \        msg.innerHTML = '<span style=\"color:red;\">Selecione um arquivo</span>';\n\
+        \        return;\n    }\n\n    let file = fileInput.files[0];\n\n    if(file.size\
+        \ > 50 * 1024 * 1024){\n        msg.innerHTML = '<span style=\"color:red;\"\
+        >Arquivo maior que 50MB</span>';\n        return;\n    }\n\n    let formData\
+        \ = new FormData();\n    formData.append('action','att_upload_proof');\n \
+        \   formData.append('proof', file);\n\n    msg.innerHTML = 'Enviando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        body: formData\n    })\n    .then(r => r.json())\n    .then(res\
+        \ => {\n\n        if(res.success){\n            msg.innerHTML = '<span style=\"\
+        color:green;\">Comprovante enviado com sucesso!</span>';\n        } else {\n\
+        \            msg.innerHTML = '<span style=\"color:red;\">Erro: '+res.data+'</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<script>\nfunction attSaveLastName(){\n\
+        \n    let input = document.getElementById('att_last_name_input') \n      \
+        \       || document.getElementById('att_last_name_input2');\n\n    let msg\
+        \   = document.getElementById('att_name_msg') \n             || document.getElementById('att_name_msg2');\n\
+        \n    if(!input || !msg) return;\n\n    let value = input.value.trim();\n\n\
+        \    if(!value){\n        msg.innerHTML = '<span style=\"color:#f87171;\"\
+        >Digite o nome completo do titular da conta que ser\xE1 usada para a doa\xE7\
+        \xE3o</span>';\n        return;\n    }\n\n    msg.innerHTML = 'Salvando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        headers: {'Content-Type': 'application/x-www-form-urlencoded'},\n\
+        \        body: 'action=att_save_last_name&last_name=' + encodeURIComponent(value)\n\
+        \    })\n    .then(r => r.json())\n    .then(res => {\n\n        if(res.success){\n\
+        \            msg.innerHTML = '<span style=\"color:#22c55e;\">Salvo! Recarregando...</span>';\n\
+        \            setTimeout(()=>location.reload(),800);\n        } else {\n  \
+        \          msg.innerHTML = '<span style=\"color:#f87171;\">Erro ao salvar</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<style type=\"text/css\"> \n      \
+        \   /* Hide reCAPTCHA V3 badge */\n        .grecaptcha-badge {\n        \n\
+        \            visibility: hidden !important;\n        \n        }\n    </style><script\
+        \ type=\"text/javascript\" id=\"lrl-js-js-extra\">\n/* <![CDATA[ */\nvar lrlData\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"post_id\":\"471683\"};\n/* ]]> */\n</script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.js?ver=1.0\"\
+        \ id=\"lrl-js-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/jquery.fitvids.min.js\"\
+        \ id=\"fitvids-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/navigation.js\"\
+        \ id=\"simple-grid-navigation-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/skip-link-focus-fix.js\"\
+        \ id=\"simple-grid-skip-link-focus-fix-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/imagesloaded.min.js?ver=5.0.0\"\
+        \ id=\"imagesloaded-js\"></script>\n<script type=\"text/javascript\" id=\"\
+        simple-grid-customjs-js-extra\">\n/* <![CDATA[ */\nvar simple_grid_ajax_object\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"primary_menu_active\":\"1\",\"secondary_menu_active\":\"\",\"primary_mobile_menu_active\"\
+        :\"1\",\"secondary_mobile_menu_active\":\"1\",\"sticky_menu_active\":\"1\"\
+        ,\"sticky_mobile_menu_active\":\"\",\"sticky_sidebar_active\":\"\",\"columnwidth\"\
+        :\".simple-grid-5-col-sizer\",\"gutter\":\".simple-grid-5-col-gutter\"};\n\
+        /* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/custom.js\"\
+        \ id=\"simple-grid-customjs-js\"></script>\n<script type=\"text/javascript\"\
+        \ id=\"simple-grid-html5shiv-js-js-extra\">\n/* <![CDATA[ */\nvar simple_grid_custom_script_vars\
+        \ = {\"elements_name\":\"abbr article aside audio bdi canvas data datalist\
+        \ details dialog figcaption figure footer header hgroup main mark meter nav\
+        \ output picture progress section summary template time video\"};\n/* ]]>\
+        \ */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/html5shiv.js\"\
+        \ id=\"simple-grid-html5shiv-js-js\"></script>\n<script type=\"text/javascript\"\
+        \ id=\"fifu-json-ld-js-extra\">\n/* <![CDATA[ */\nvar fifuJsonLd = {\"url\"\
+        :\"https:\\/\\/image.tmdb.org\\/t\\/p\\/w220_and_h330_face\\/dYlnNSlyCW43tp1gZJaQ74fuK40.jpg\"\
+        };\n/* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/plugins/featured-image-from-url/includes/html/js/json-ld.js?ver=4.9.2\"\
+        \ id=\"fifu-json-ld-js\"></script>\n<script defer src=\"https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496\"\
+        \ integrity=\"sha512-ZE9pZaUXND66v380QUtch/5sE9tPFh2zg45pR2PB0CVkCtOREv2AJKkSidISWkysEuQ0EH8faUU5du78bx87UQ==\"\
+        \ data-cf-beacon='{\"version\":\"2024.11.0\",\"token\":\"832c49ee708d4b8d94382b4733ae0382\"\
+        ,\"r\":1,\"server_timing\":{\"name\":{\"cfCacheStatus\":true,\"cfEdge\":true,\"\
+        cfExtPri\":true,\"cfL4\":true,\"cfOrigin\":true,\"cfSpeedBrain\":true},\"\
+        location_startswith\":null}}' crossorigin=\"anonymous\"></script>\n<script>(function(){function\
+        \ c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML=\"\
+        window.__CF$cv$params={r:'a14e79fd6e2a70c6',t:'MTc4MzAwMzk3MA=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);\"\
+        ;b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else\
+        \ if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var\
+        \ e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>\n\
+        </html>"
+    headers:
+      CF-RAY:
+      - a14e79fd6e2a70c6-GRU
+      Cf-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Thu, 02 Jul 2026 14:52:52 GMT
+      Link:
+      - <https://legendei.net/wp-json/>; rel="https://api.w.org/"
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Permissions-Policy:
+      - private-state-token-redemption=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com"),
+        private-state-token-issuance=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com")
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=j635eKqynmSQYo5Ae8eB7E4yFuzScv4Eudgv8G4ZAGq8ABHjp49MXWrGkEpTEfP%2F0hJOgKKW8CDY6rxk16Pogp5dawJ8EdpkcjnPlM5UCS6kn6CFUpLC9wJ3nUsGbFw%3D"}]}'
+      Server:
+      - cloudflare
+      Server-Timing:
+      - cfCacheStatus;desc="DYNAMIC"
+      - cfEdge;dur=8,cfOrigin;dur=1862
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - pt-BR,pt;q=0.9,en;q=0.8
+      User-Agent:
+      - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like
+        Gecko) Chrome/131.0.0.0 Safari/537.36
+    method: GET
+    uri: https://legendei.net/dune-world-2021/
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html dir=\"ltr\" lang=\"pt-BR\" prefix=\"og: https://ogp.me/ns#\"\
+        >\n<head>\n<meta charset=\"UTF-8\">\n<meta name=\"viewport\" content=\"width=device-width,\
+        \ initial-scale=1.0\">\n\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css\"\
+        >\n\t\n<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">\n<link\
+        \ rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>\n<link\
+        \ href=\"https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap\"\
+        \ rel=\"stylesheet\">\n\t\n<title>Legenda Dune 2021 BluRay Subpack for\xE7\
+        ada | Legendei - Aqui Sai Primeiro</title>\n\t<style>img:is([sizes=\"auto\"\
+        \ i], [sizes^=\"auto,\" i]) { contain-intrinsic-size: 3000px 1500px }</style>\n\
+        \t\n\t\t<!-- All in One SEO Pro 4.6.0 - aioseo.com -->\n\t\t<meta name=\"\
+        description\" content=\"Legenda do filme Dune (2021) Duna \u2014 Em um futuro\
+        \ distante, planetas s\xE3o comandados por casas nobres que fazem parte de\
+        \ um imp\xE9rio feudal intergal\xE1tico. Paul Atreides \xE9 um jovem cuja\
+        \ fam\xEDlia toma o controle do planeta deserto Arrakis, tamb\xE9m conhecido\
+        \ como Duna. A \xFAnica fonte da especiaria Melange, a subst\xE2ncia mais\
+        \ importante do cosmos, Legenda Dune 2021 BluRay Subpack for\xE7ada testada\
+        \ e verificada - Pode servir tamb\xE9m para outros releases, basta renomear!\
+        \ Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t<meta name=\"robots\"\
+        \ content=\"max-image-preview:large\" />\n\t\t<meta name=\"google-site-verification\"\
+        \ content=\"JSMIV3rTOC3Y-WjaQzmU3KvW7aWHceTxBFYsJYpm-1k\" />\n\t\t<link rel=\"\
+        canonical\" href=\"https://legendei.net/dune-world-2021/\" />\n\t\t<meta name=\"\
+        generator\" content=\"All in One SEO Pro (AIOSEO) 4.6.0\" />\n\t\t<meta property=\"\
+        og:locale\" content=\"pt_BR\" />\n\t\t<meta property=\"og:site_name\" content=\"\
+        Legendei - Baixar Legendas de S\xE9ries e Filmes\" />\n\t\t<meta property=\"\
+        og:type\" content=\"article\" />\n\t\t<meta property=\"og:title\" content=\"\
+        Legenda Dune 2021 BluRay Subpack for\xE7ada | Legendei - Aqui Sai Primeiro\"\
+        \ />\n\t\t<meta property=\"og:description\" content=\"Legenda do filme Dune\
+        \ (2021) Duna \u2014 Em um futuro distante, planetas s\xE3o comandados por\
+        \ casas nobres que fazem parte de um imp\xE9rio feudal intergal\xE1tico. Paul\
+        \ Atreides \xE9 um jovem cuja fam\xEDlia toma o controle do planeta deserto\
+        \ Arrakis, tamb\xE9m conhecido como Duna. A \xFAnica fonte da especiaria Melange,\
+        \ a subst\xE2ncia mais importante do cosmos, Legenda Dune 2021 BluRay Subpack\
+        \ for\xE7ada testada e verificada - Pode servir tamb\xE9m para outros releases,\
+        \ basta renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t\
+        <meta property=\"og:url\" content=\"https://legendei.net/dune-world-2021/\"\
+        \ />\n\t\t<meta property=\"og:image\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"og:image:secure_url\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"article:published_time\" content=\"2026-04-17T13:18:04+00:00\"\
+        \ />\n\t\t<meta property=\"article:modified_time\" content=\"2026-04-17T13:18:50+00:00\"\
+        \ />\n\t\t<meta name=\"twitter:card\" content=\"summary\" />\n\t\t<meta name=\"\
+        twitter:title\" content=\"Legenda Dune 2021 BluRay Subpack for\xE7ada | Legendei\
+        \ - Aqui Sai Primeiro\" />\n\t\t<meta name=\"twitter:description\" content=\"\
+        Legenda do filme Dune (2021) Duna \u2014 Em um futuro distante, planetas s\xE3\
+        o comandados por casas nobres que fazem parte de um imp\xE9rio feudal intergal\xE1\
+        tico. Paul Atreides \xE9 um jovem cuja fam\xEDlia toma o controle do planeta\
+        \ deserto Arrakis, tamb\xE9m conhecido como Duna. A \xFAnica fonte da especiaria\
+        \ Melange, a subst\xE2ncia mais importante do cosmos, Legenda Dune 2021 BluRay\
+        \ Subpack for\xE7ada testada e verificada - Pode servir tamb\xE9m para outros\
+        \ releases, basta renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\"\
+        \ />\n\t\t<meta name=\"twitter:image\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<script type=\"application/ld+json\" class=\"aioseo-schema\">\n\t\
+        \t\t{\"@context\":\"https:\\/\\/schema.org\",\"@graph\":[{\"@type\":\"BlogPosting\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/dune-world-2021\\/#blogposting\",\"\
+        name\":\"Legenda Dune 2021 BluRay Subpack for\\u00e7ada | Legendei - Aqui\
+        \ Sai Primeiro\",\"headline\":\"Dune 2021 BluRay Subpack for\\u00e7ada\",\"\
+        author\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\/#author\"\
+        },\"publisher\":{\"@id\":\"https:\\/\\/legendei.net\\/#organization\"},\"\
+        image\":{\"@type\":\"ImageObject\",\"url\":\"https:\\/\\/legendei.net\\/wp-content\\\
+        /uploads\\/2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /#articleImage\",\"width\":150,\"height\":150},\"datePublished\":\"2026-04-17T14:18:04+01:00\"\
+        ,\"dateModified\":\"2026-04-17T14:18:50+01:00\",\"inLanguage\":\"pt-BR\",\"\
+        mainEntityOfPage\":{\"@id\":\"https:\\/\\/legendei.net\\/dune-world-2021\\\
+        /#webpage\"},\"isPartOf\":{\"@id\":\"https:\\/\\/legendei.net\\/dune-world-2021\\\
+        /#webpage\"},\"articleSection\":\"Destaques, Filmes, Acervo Legenda Oficial,\
+        \ Acervo Legendas.TV, Legendas para filmes, Legendei.NET\"},{\"@type\":\"\
+        BreadcrumbList\",\"@id\":\"https:\\/\\/legendei.net\\/dune-world-2021\\/#breadcrumblist\"\
+        ,\"itemListElement\":[{\"@type\":\"ListItem\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /#listItem\",\"position\":1,\"name\":\"Home\",\"item\":\"https:\\/\\/legendei.net\\\
+        /\",\"nextItem\":\"https:\\/\\/legendei.net\\/dune-world-2021\\/#listItem\"\
+        },{\"@type\":\"ListItem\",\"@id\":\"https:\\/\\/legendei.net\\/dune-world-2021\\\
+        /#listItem\",\"position\":2,\"name\":\"Dune.2021.BluRay.Subpack_for\\u00e7ada.\"\
+        ,\"previousItem\":\"https:\\/\\/legendei.net\\/#listItem\"}]},{\"@type\":\"\
+        Organization\",\"@id\":\"https:\\/\\/legendei.net\\/#organization\",\"name\"\
+        :\"Legendei\",\"url\":\"https:\\/\\/legendei.net\\/\",\"logo\":{\"@type\"\
+        :\"ImageObject\",\"url\":\"https:\\/\\/legendei.net\\/wp-content\\/uploads\\\
+        /2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\/dune-world-2021\\\
+        /#organizationLogo\",\"width\":150,\"height\":150},\"image\":{\"@id\":\"https:\\\
+        /\\/legendei.net\\/dune-world-2021\\/#organizationLogo\"}},{\"@type\":\"Person\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\/#author\"\
+        ,\"url\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\/\",\"name\"\
+        :\"Admin\"},{\"@type\":\"WebPage\",\"@id\":\"https:\\/\\/legendei.net\\/dune-world-2021\\\
+        /#webpage\",\"url\":\"https:\\/\\/legendei.net\\/dune-world-2021\\/\",\"name\"\
+        :\"Legenda Dune 2021 BluRay Subpack for\\u00e7ada | Legendei - Aqui Sai Primeiro\"\
+        ,\"description\":\"Legenda do filme Dune (2021) Duna \\u2014 Em um futuro\
+        \ distante, planetas s\\u00e3o comandados por casas nobres que fazem parte\
+        \ de um imp\\u00e9rio feudal intergal\\u00e1tico. Paul Atreides \\u00e9 um\
+        \ jovem cuja fam\\u00edlia toma o controle do planeta deserto Arrakis, tamb\\\
+        u00e9m conhecido como Duna. A \\u00fanica fonte da especiaria Melange, a subst\\\
+        u00e2ncia mais importante do cosmos, Legenda Dune 2021 BluRay Subpack for\\\
+        u00e7ada testada e verificada - Pode servir tamb\\u00e9m para outros releases,\
+        \ basta renomear! Dispon\\u00edvel em Legendei - Aqui Sai Primeiro\",\"inLanguage\"\
+        :\"pt-BR\",\"isPartOf\":{\"@id\":\"https:\\/\\/legendei.net\\/#website\"},\"\
+        breadcrumb\":{\"@id\":\"https:\\/\\/legendei.net\\/dune-world-2021\\/#breadcrumblist\"\
+        },\"author\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /#author\"},\"creator\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /#author\"},\"datePublished\":\"2026-04-17T14:18:04+01:00\",\"dateModified\"\
+        :\"2026-04-17T14:18:50+01:00\"},{\"@type\":\"WebSite\",\"@id\":\"https:\\\
+        /\\/legendei.net\\/#website\",\"url\":\"https:\\/\\/legendei.net\\/\",\"name\"\
+        :\"Legendei\",\"description\":\"Baixar Legendas de S\\u00e9ries e Filmes\"\
+        ,\"inLanguage\":\"pt-BR\",\"publisher\":{\"@id\":\"https:\\/\\/legendei.net\\\
+        /#organization\"}}]}\n\t\t</script>\n\t\t<!-- All in One SEO Pro -->\n\n<link\
+        \ rel='dns-prefetch' href='//fonts.googleapis.com' />\n<link rel=\"alternate\"\
+        \ type=\"application/rss+xml\" title=\"Feed para Legendei &raquo;\" href=\"\
+        https://legendei.net/feed/\" />\n<link rel=\"alternate\" type=\"application/rss+xml\"\
+        \ title=\"Feed de coment\xE1rios para Legendei &raquo;\" href=\"https://legendei.net/comments/feed/\"\
+        \ />\n<link rel=\"alternate\" type=\"application/rss+xml\" title=\"Feed de\
+        \ coment\xE1rios para Legendei &raquo; Dune 2021 BluRay Subpack for\xE7ada\
+        \ \" href=\"https://legendei.net/dune-world-2021/feed/\" />\n<script type=\"\
+        text/javascript\">\n/* <![CDATA[ */\nwindow._wpemojiSettings = {\"baseUrl\"\
+        :\"https:\\/\\/s.w.org\\/images\\/core\\/emoji\\/16.0.1\\/72x72\\/\",\"ext\"\
+        :\".png\",\"svgUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\/emoji\\/16.0.1\\\
+        /svg\\/\",\"svgExt\":\".svg\",\"source\":{\"concatemoji\":\"https:\\/\\/legendei.net\\\
+        /wp-includes\\/js\\/wp-emoji-release.min.js?ver=6.8.3\"}};\n/*! This file\
+        \ is auto-generated */\n!function(s,n){var o,i,e;function c(e){try{var t={supportTests:e,timestamp:(new\
+        \ Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function\
+        \ p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var\
+        \ t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),a=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new\
+        \ Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return\
+        \ t.every(function(e,t){return e===a[t]})}function u(e,t){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);for(var\
+        \ n=e.getImageData(16,16,1,1),a=0;a<n.data.length;a++)if(0!==n.data[a])return!1;return!0}function\
+        \ f(e,t,n,a){switch(t){case\"flag\":return n(e,\"\\ud83c\\udff3\\ufe0f\\u200d\\\
+        u26a7\\ufe0f\",\"\\ud83c\\udff3\\ufe0f\\u200b\\u26a7\\ufe0f\")?!1:!n(e,\"\\\
+        ud83c\\udde8\\ud83c\\uddf6\",\"\\ud83c\\udde8\\u200b\\ud83c\\uddf6\")&&!n(e,\"\
+        \\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc65\\udb40\\udc6e\\udb40\\\
+        udc67\\udb40\\udc7f\",\"\\ud83c\\udff4\\u200b\\udb40\\udc67\\u200b\\udb40\\\
+        udc62\\u200b\\udb40\\udc65\\u200b\\udb40\\udc6e\\u200b\\udb40\\udc67\\u200b\\\
+        udb40\\udc7f\");case\"emoji\":return!a(e,\"\\ud83e\\udedf\")}return!1}function\
+        \ g(e,t,n,a){var r=\"undefined\"!=typeof WorkerGlobalScope&&self instanceof\
+        \ WorkerGlobalScope?new OffscreenCanvas(300,150):s.createElement(\"canvas\"\
+        ),o=r.getContext(\"2d\",{willReadFrequently:!0}),i=(o.textBaseline=\"top\"\
+        ,o.font=\"600 32px Arial\",{});return e.forEach(function(e){i[e]=t(o,e,n,a)}),i}function\
+        \ t(e){var t=s.createElement(\"script\");t.src=e,t.defer=!0,s.head.appendChild(t)}\"\
+        undefined\"!=typeof Promise&&(o=\"wpEmojiSettingsSupports\",i=[\"flag\",\"\
+        emoji\"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){s.addEventListener(\"\
+        DOMContentLoaded\",e,{once:!0})}),new Promise(function(t){var n=function(){try{var\
+        \ e=JSON.parse(sessionStorage.getItem(o));if(\"object\"==typeof e&&\"number\"\
+        ==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&\"object\"\
+        ==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if(\"\
+        undefined\"!=typeof Worker&&\"undefined\"!=typeof OffscreenCanvas&&\"undefined\"\
+        !=typeof URL&&URL.createObjectURL&&\"undefined\"!=typeof Blob)try{var e=\"\
+        postMessage(\"+g.toString()+\"(\"+[JSON.stringify(i),f.toString(),p.toString(),u.toString()].join(\"\
+        ,\")+\"));\",a=new Blob([e],{type:\"text/javascript\"}),r=new Worker(URL.createObjectURL(a),{name:\"\
+        wpTestEmojiSupports\"});return void(r.onmessage=function(e){c(n=e.data),r.terminate(),t(n)})}catch(e){}c(n=g(i,f,p,u))}t(n)}).then(function(e){for(var\
+        \ t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],\"\
+        flag\"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return\
+        \ e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);\n\
+        /* ]]> */\n</script>\n<link rel='stylesheet' id='wpa-css-css' href='https://legendei.net/wp-content/plugins/wp-attachments/styles/0/wpa.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='wp-emoji-styles-inline-css' type='text/css'>\n\
+        \n\timg.wp-smiley, img.emoji {\n\t\tdisplay: inline !important;\n\t\tborder:\
+        \ none !important;\n\t\tbox-shadow: none !important;\n\t\theight: 1em !important;\n\
+        \t\twidth: 1em !important;\n\t\tmargin: 0 0.07em !important;\n\t\tvertical-align:\
+        \ -0.1em !important;\n\t\tbackground: none !important;\n\t\tpadding: 0 !important;\n\
+        \t}\n</style>\n<link rel='stylesheet' id='wp-block-library-css' href='https://legendei.net/wp-includes/css/dist/block-library/style.min.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='classic-theme-styles-inline-css'\
+        \ type='text/css'>\n/*! This file is auto-generated */\n.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em\
+        \ + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}\n\
+        </style>\n<style id='wppb-content-restriction-start-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-content-restriction-end-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-edit-profile-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-login-style-inline-css' type='text/css'>\n\n\
+        \n</style>\n<style id='wppb-recover-password-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-register-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='global-styles-inline-css' type='text/css'>\n:root{--wp--preset--aspect-ratio--square:\
+        \ 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4:\
+        \ 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3:\
+        \ 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16:\
+        \ 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray:\
+        \ #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink:\
+        \ #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange:\
+        \ #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan:\
+        \ #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue:\
+        \ #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple:\
+        \ #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1)\
+        \ 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan:\
+        \ linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange:\
+        \ linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red:\
+        \ linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray:\
+        \ linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum:\
+        \ linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186)\
+        \ 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple:\
+        \ linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux:\
+        \ linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62)\
+        \ 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112)\
+        \ 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean:\
+        \ linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181)\
+        \ 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128)\
+        \ 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129)\
+        \ 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium:\
+        \ 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large:\
+        \ 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40:\
+        \ 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70:\
+        \ 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural:\
+        \ 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px\
+        \ rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0,\
+        \ 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255,\
+        \ 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0,\
+        \ 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap:\
+        \ 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items:\
+        \ center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display:\
+        \ grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-color{color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background:\
+        \ var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange)\
+        \ !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background:\
+        \ var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background:\
+        \ var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background:\
+        \ var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background:\
+        \ var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background:\
+        \ var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size:\
+        \ var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size:\
+        \ var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--x-large) !important;}\n:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}\n:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}\n:root :where(.wp-block-pullquote){font-size:\
+        \ 1.5em;line-height: 1.6;}\n</style>\n<link rel='stylesheet' id='lrl-css-css'\
+        \ href='https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-maincss-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css' type='text/css'\
+        \ media='all' />\n<link rel='stylesheet' id='fontawesome-css' href='https://legendei.net/wp-content/themes/simple-grid/assets/css/all.min.css'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-webfont-css'\
+        \ href='//fonts.googleapis.com/css?family=Playfair+Display:400,400i,700,700i|Domine:400,700|Oswald:400,700|Patua+One|Merriweather:400,400i,700,700i&#038;display=swap'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='legendei-style-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css?ver=1782544305'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='wppb_stylesheet-css'\
+        \ href='https://legendei.net/wp-content/plugins/profile-builder/assets/css/style-front-end.css?ver=3.15.2'\
+        \ type='text/css' media='all' />\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-includes/js/jquery/jquery.min.js?ver=3.7.1\" id=\"\
+        jquery-core-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1\"\
+        \ id=\"jquery-migrate-js\"></script>\n<!--[if lt IE 9]>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/respond.min.js\"\
+        \ id=\"respond-js\"></script>\n<![endif]-->\n<link rel=\"https://api.w.org/\"\
+        \ href=\"https://legendei.net/wp-json/\" /><link rel=\"alternate\" title=\"\
+        JSON\" type=\"application/json\" href=\"https://legendei.net/wp-json/wp/v2/posts/791239\"\
+        \ /><link rel=\"EditURI\" type=\"application/rsd+xml\" title=\"RSD\" href=\"\
+        https://legendei.net/xmlrpc.php?rsd\" />\n<meta name=\"generator\" content=\"\
+        WordPress 6.8.3\" />\n<link rel='shortlink' href='https://legendei.net/?p=791239'\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (JSON)\" type=\"application/json+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fdune-world-2021%2F\"\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (XML)\" type=\"text/xml+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fdune-world-2021%2F&#038;format=xml\"\
+        \ />\n<style>\n\n/* FORMUL\xC1RIO TRIAL */\n\n.premium-form {\n    max-width:\
+        \ 760px;\n    margin: 0 auto 20px;\n    padding: 30px;\n    border-radius:\
+        \ 10px;\n    background: #212121;\n    border: 10px solid transparent;\n \
+        \   background-image:\n        linear-gradient(#212121,#212121),\n       \
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    background-origin: border-box;\n\
+        \    background-clip: padding-box, border-box;\n    box-sizing: border-box;\n\
+        }\n\n/* Campos */\n\n.premium-form .field {\n    position: relative;\n   \
+        \ margin-bottom: 20px;\n}\n\n.premium-form input {\n    width: 100%;\n   \
+        \ padding: 14px;\n    border-radius: 8px;\n    border: 1px solid #ccc;\n \
+        \   font-size: 16px;\n    box-sizing: border-box;\n}\n\n/* Focus bonito */\n\
+        \n.premium-form input:focus {\n    border-color: transparent;\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin: border-box;\n    background-clip: padding-box, border-box;\n\
+        \    box-shadow: 0 0 0 4px rgba(63,140,255,0.20);\n    outline: none;\n}\n\
+        \n/* TOOLTIP */\n\n.premium-form .tooltip {\n    position: absolute;\n   \
+        \ bottom: 100%;\n    left: 0;\n    margin-bottom: 10px;\n    background: linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \tbox-shadow:0 6px 14px rgba(0,0,0,0.25);\n    color: #ffffff;\n    padding:\
+        \ 10px 12px;\n    font-size: 14px;\n    border-radius: 6px;\n    max-width:\
+        \ 260px;\n    opacity: 0;\n    pointer-events: none;\n    transition: .2s;\n\
+        \    z-index: 999;\n}\n\n.premium-form .tooltip::after {\n    content: \"\"\
+        ;\n    position: absolute;\n    top: 100%;\n    left: 15px;\n    border-width:\
+        \ 6px 6px 0 6px;\n    border-style: solid;\n    border-color: #8a2be2 transparent\
+        \ transparent transparent;\n}\n\n.premium-form .field:hover .tooltip,\n.premium-form\
+        \ .field:focus-within .tooltip {\n    opacity: 1;\n    transform: translateY(-4px);\n\
+        }\n\n/* BOT\xC3O */\n\n.premium-form button {\n    padding: 14px 30px;\n \
+        \   font-size: 22px;\n    border-radius: 8px;\n    border: none;\n    background:\
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    color: #fff;\n    cursor: pointer;\n\
+        \    transition: .25s;\n}\n\n.premium-form button:hover {\n    background:\
+        \ linear-gradient(90deg,#4c9aff,#9a3bff);\n}\n\n/* SENHA */\n\n.pass-wrap{\n\
+        \    position:relative;\n}\n\n.toggle-pass{\n    position:absolute;\n    right:12px;\n\
+        \    top:50%;\n    transform:translateY(-50%);\n    cursor:pointer;\n    font-size:18px;\n\
+        }\n\n/* BARRA FOR\xC7A SENHA */\n\n.strength{\n    height:6px;\n    background:#444;\n\
+        \    border-radius:4px;\n    margin-top:8px;\n    overflow:hidden;\n}\n\n\
+        .strength div{\n    height:100%;\n    width:0%;\n    transition:.3s;\n}\n\n\
+        /* MOBILE */\n\n@media (max-width:480px){\n\n.premium-form{\n    padding:20px;\n\
+        }\n\n}\n\n</style>\n<!-- FIFU: meta tags for featured image (begin) -->\n\
+        <meta property=\"og:image\" content=\"https://image.tmdb.org/t/p/w500/gDzOcq0pfeCeqMBwKIJlSmQpjkZ.jpg\"\
+        \ />\n<!-- FIFU: meta tags for featured image (end) --><meta name=\"twitter:image\"\
+        \ content=\"https://image.tmdb.org/t/p/w500/gDzOcq0pfeCeqMBwKIJlSmQpjkZ.jpg\"\
+        \ /><style>\n\n/* remove fundo normal, ativo e hover do logo */\n.simple-grid-primary-nav-menu\
+        \ > li.menu-logo-item > a,\n.simple-grid-primary-nav-menu > li.menu-logo-item\
+        \ > a:hover,\n.simple-grid-primary-nav-menu > li.menu-logo-item.current-menu-item\
+        \ > a{\n    background:none !important;\n}\n\n/* ===================================================\n\
+        \   MOBILE\n   =================================================== */\n\n\
+        @media only screen and (max-width:812px){\n\n    /* ESCONDER LOGO NO MENU\
+        \ MOBILE */\n    .simple-grid-primary-nav-menu > li.menu-logo-item{\n    \
+        \    display:none !important;\n    }\n\n}\n\n</style>\n    <style type=\"\
+        text/css\">\r\n            .simple-grid-site-title, .simple-grid-site-title\
+        \ a, .simple-grid-site-description {color: #ffffff;}\r\n        </style>\r\
+        \n    <style type=\"text/css\" id=\"custom-background-css\">\nbody.custom-background\
+        \ { background-color: #333333; }\n</style>\n\t<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"32x32\" />\n<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"192x192\" />\n<link rel=\"apple-touch-icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n<meta name=\"msapplication-TileImage\" content=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n</head>\t\n\t\n\t\n<body class=\"wp-singular post-template-default single\
+        \ single-post postid-791239 single-format-standard custom-background wp-custom-logo\
+        \ wp-theme-simple-grid simple-grid-animated simple-grid-fadein simple-grid-theme-is-active\
+        \ simple-grid-custom-logo-active simple-grid-layout-type-full simple-grid-masonry-inactive\
+        \ simple-grid-float-grid simple-grid-responsive-grid-details simple-grid-layout-c-s1\
+        \ simple-grid-header-banner-active simple-grid-tagline-inactive simple-grid-logo-above-title\
+        \ simple-grid-primary-menu-active simple-grid-primary-mobile-menu-active simple-grid-secondary-mobile-menu-active\
+        \ simple-grid-primary-social-icons\" id=\"simple-grid-site-body\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/WebPage\">\n<a class=\"skip-link\
+        \ screen-reader-text\" href=\"#simple-grid-content-wrapper\">Skip to content</a>\n\
+        \n\n\n<div class=\"simple-grid-site-header simple-grid-container\" id=\"simple-grid-header\"\
+        \ itemscope=\"itemscope\" itemtype=\"http://schema.org/WPHeader\" role=\"\
+        banner\">\n<div class=\"simple-grid-head-content simple-grid-clearfix\" id=\"\
+        simple-grid-head-content\">\n\n<div class=\"simple-grid-no-header-content\"\
+        >\n              <p class=\"simple-grid-site-title\"><a href=\"https://legendei.net/\"\
+        \ rel=\"home\">Legendei</a></p>\r\n                </div>\n\n</div><!--/#simple-grid-head-content\
+        \ -->\n</div><!--/#simple-grid-header -->\n\n\n\n<div class=\"simple-grid-container\
+        \ simple-grid-primary-menu-container simple-grid-clearfix\">\n<div class=\"\
+        simple-grid-primary-menu-container-inside simple-grid-clearfix\">\n<nav class=\"\
+        simple-grid-nav-primary\" id=\"simple-grid-primary-navigation\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/SiteNavigationElement\" role=\"navigation\"\
+        \ aria-label=\"Primary Menu\">\n\t\n\t\n<div class=\"simple-grid-outer-wrapper\"\
+        >\n<a href=\"/\" class=\"logo-mobile-inline\">\n<img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \nstyle=\"width:100%;height:auto;\">\n</a>\n\n<style>\n.logo-mobile-inline{\n\
+        display:none;\n}\n\n@media (max-width:812px){\n.logo-mobile-inline{\ndisplay:block;\n\
+        }\n}\n</style>\t\n\n\t\n<style>\n.mobile-header-icons{\n    display:none;\n\
+        }\n\n@media (max-width: 812px){\n\n.mobile-header-icons{\n    display:grid;\n\
+        \    grid-template-columns: 2fr 1fr 1fr;\n    gap:10px;\n    padding:10px;\n\
+        }\n\n/* BOT\xD5ES */\n.mobile-header-icons a,\n.mobile-header-icons .cat-toggle{\n\
+        \    display:flex;\n    align-items:center;\n    justify-content:center;\n\
+        \    gap:6px;\n    background:#141414;\n    padding:8px 6px;\n    border-radius:8px;\n\
+        \    color:#fff;\n    font-size:12px;\n    text-decoration:none;\n    text-align:center;\n\
+        \    cursor:pointer;\n}\n\n/* CATEGORIA */\n.cat-toggle{\n    font-weight:600;\n\
+        }\n\n/* SETA */\n.cat-toggle .arrow{\n    transition:transform 0.3s ease;\n\
+        }\n\n/* SETA GIRADA */\n.cat-toggle.active .arrow{\n    transform:rotate(180deg);\n\
+        }\n\n/* HOVER */\n.mobile-header-icons a:hover,\n.mobile-header-icons .cat-toggle:hover{\n\
+        \    background:#1f1f1f;\n}\n\n/* CONTAINER */\n.cat-container{\n    position:relative;\n\
+        }\n\n/* DROPDOWN */\n.cat-list{\n    display:flex;\n    flex-direction:column;\n\
+        \    gap:6px;\n\n    position:absolute;\n    top:110%;\n    left:0;\n    width:100%;\n\
+        \n    background:#0f0f0f;\n    border-radius:8px;\n    padding:6px;\n    z-index:999;\n\
+        \n    opacity:0;\n    visibility:hidden;\n    transform:translateY(-5px);\n\
+        \    transition:all 0.25s ease;\n}\n\n/* ABERTO */\n.cat-container.open .cat-list{\n\
+        \    opacity:1;\n    visibility:visible;\n    transform:translateY(0);\n}\n\
+        \n/* ITENS */\n.cat-list a{\n    justify-content:flex-start;\n    font-size:14px;\n\
+        \    padding:10px;\n}\n\n}\n</style>\n\n\n<div class=\"mobile-header-icons\"\
+        >\n\n    <!-- CATEGORIAS -->\n    <div class=\"cat-container\">\n        <div\
+        \ class=\"cat-toggle\">\n            \U0001F4C2 Categorias <span class=\"\
+        arrow\">\u25BC</span>\n        </div>\n\n        <div class=\"cat-list\">\n\
+        \            <a href=\"/category/destaques/\">\u2B50 Destaques</a>\n     \
+        \       <a href=\"/category/filmes/\">\U0001F3AC Filmes</a>\n            <a\
+        \ href=\"/category/serie/\">\U0001F4FA S\xE9ries</a>\n            <a href=\"\
+        /category/pack-de-legendas/\">\U0001F4E6 Packs</a>\n        </div>\n    </div>\n\
+        \n    \n        <a href=\"/seja-premium-vitalicio/\"><i class=\"fa-solid fa-crown\"\
+        ></i> Premium</a>\n\n        <a href=\"/login/\"><i class=\"fa-solid fa-key\"\
+        ></i> Login</a>\n\n    \n</div>\n\n<script>\ndocument.addEventListener(\"\
+        DOMContentLoaded\", function(){\n\n    const container = document.querySelector(\"\
+        .cat-container\");\n    const toggle = document.querySelector(\".cat-toggle\"\
+        );\n\n    toggle.addEventListener(\"click\", function(e){\n        e.stopPropagation();\n\
+        \        container.classList.toggle(\"open\");\n        toggle.classList.toggle(\"\
+        active\");\n    });\n\n    document.addEventListener(\"click\", function(e){\n\
+        \        if(!container.contains(e.target)){\n            container.classList.remove(\"\
+        open\");\n            toggle.classList.remove(\"active\");\n        }\n  \
+        \  });\n\n});\n</script>\t\n\t\n<ul id=\"simple-grid-menu-primary-navigation\"\
+        \ class=\"simple-grid-primary-nav-menu simple-grid-menu-primary\"><li id=\"\
+        menu-item-673170\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-673170 menu-logo-item\">\n        <a href=\"https://legendei.net/\"\
+        \ style=\"\n            display:flex;\n            align-items:center;\n \
+        \           justify-content:center;\n            height:100%;\n          \
+        \  padding:0;\n            margin:0;\n            line-height:1;\n       \
+        \ \">\n            <img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \n                      alt=\"Legendei.NET\"\n                      style=\"\
+        height:42px;width:auto;display:block;\">\n        </a></li>\n\n<li id=\"menu-item-673168\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category current-post-ancestor\
+        \ current-menu-parent current-post-parent menu-item-673168\"><a href=\"https://legendei.net/category/destaques/\"\
+        \ title=\"Legendas em Destaque\">DESTAQUES</a></li>\n<li id=\"menu-item-673167\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category current-post-ancestor\
+        \ current-menu-parent current-post-parent menu-item-673167\"><a href=\"https://legendei.net/category/filmes/\"\
+        \ title=\"Legendas para Filmes\">Filmes</a></li>\n<li id=\"menu-item-673166\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673166\"\
+        ><a href=\"https://legendei.net/category/serie/\" title=\"Legendas para seriados\"\
+        >S\xC9RIES</a></li>\n<li id=\"menu-item-673169\" class=\"menu-item menu-item-type-taxonomy\
+        \ menu-item-object-category menu-item-673169\"><a href=\"https://legendei.net/category/pack-de-legendas/\"\
+        \ title=\"Pack de legendas\">PACKS</a></li>\n<li id=\"menu-item-731144\" class=\"\
+        menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children\
+        \ menu-item-731144\"><a target=\"_blank\" href=\"/aplicativos/\">RECOMENDAMOS</a>\n\
+        <ul class=\"sub-menu\">\n\t<li id=\"menu-item-673172\" class=\"menu-item menu-item-type-custom\
+        \ menu-item-object-custom menu-item-673172\"><a target=\"_blank\" href=\"\
+        /aplicativos/\" title=\"Programas para windows\">APLICATIVOS</a></li>\n\t\
+        <li id=\"menu-item-687662\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-687662\"><a target=\"_blank\" href=\"https://4kxxx.vip/\" title=\"\
+        Baixe os melhores v\xEDdeos porn\xF4 sempre em 4K\">4K XXX</a></li>\n\t<li\
+        \ id=\"menu-item-717497\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-717497\"><a target=\"_blank\" href=\"https://detonaplay.com/\"\
+        >GAMES</a></li>\n</ul>\n</li>\n\n\n\n<li class=\"menu-item\" style=\"float:right;\"\
+        >\n            <a href=\"/login/\"\n               style=\"background:linear-gradient(135deg,#198754,#20ac6b);color:#ffffff;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-key\"></i> Login\n            </a>\n\
+        \        </li><li class=\"menu-item\" style=\"float:right;\">\n          \
+        \  <a href=\"/seja-premium-vitalicio/\"\n\t\t\t\t\t  style=\"background:linear-gradient(135deg,#f4c430,#c2940a);color:#4d2e00;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-crown\"></i> Membro Premium\n  \
+        \          </a>\n        </li></ul>    </div>\n</nav>\n</div>\n</div>\n\n\t\
+        \n\t\n\r\n<div class=\"simple-grid-outer-wrapper\">\r\n<div class=\"simple-grid-top-wrapper-outer\
+        \ simple-grid-clearfix\">\r\n<div class=\"simple-grid-featured-posts-area\
+        \ simple-grid-top-wrapper simple-grid-clearfix\">\r\n\r\n<div id=\"search-5\"\
+        \ class=\"simple-grid-main-widget widget simple-grid-widget-box widget_search\"\
+        ><div class=\"simple-grid-widget-box-inside\"><form role=\"search\" method=\"\
+        get\" class=\"simple-grid-search-form\" action=\"https://legendei.net/\">\n\
+        <label>\n    <span class=\"simple-grid-sr-only\">Pesquisar por </span>\n \
+        \   <input \n        type=\"search\"\n        class=\"simple-grid-search-field\"\
+        \n        placeholder=\"Pesquisar &hellip;\"\n        value=\"\"\n       \
+        \ name=\"s\"\n        minlength=\"3\"\n\t\tmaxlength=\"50\"   \n        required\n\
+        \    />\n</label>\n<input type=\"submit\" class=\"simple-grid-search-submit\"\
+        \ value=\"&#xf002;\" />\n</form></div></div></div>\r\n</div>\r\n</div>\r\n\
+        \r\n\n<div class=\"simple-grid-outer-wrapper\" id=\"simple-grid-wrapper-outside\"\
+        >\n\n<div class=\"simple-grid-container simple-grid-clearfix\" id=\"simple-grid-wrapper\"\
+        >\n<div class=\"simple-grid-content-wrapper simple-grid-clearfix\" id=\"simple-grid-content-wrapper\"\
+        >\t\n\t\t\n\n\n<div class=\"simple-grid-main-wrapper simple-grid-clearfix\"\
+        \ id=\"simple-grid-main-wrapper\" itemscope=\"itemscope\" itemtype=\"http://schema.org/Blog\"\
+        \ role=\"main\">\n<div class=\"theiaStickySidebar\">\n<div class=\"simple-grid-main-wrapper-inside\
+        \ simple-grid-clearfix\">\n\n\r\n\r\n\n<div class=\"simple-grid-posts-wrapper\"\
+        \ id=\"simple-grid-posts-wrapper\">\n\n\n\n\n\n<div style=\"width: 100%; border-radius:\
+        \ 12px; box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 12px; padding: 15px; background:\
+        \ #ffffff;\">\n    <center>\n    <article id=\"post-791239\" class=\"simple-grid-post-singular\
+        \ simple-grid-box post-791239 post type-post status-publish format-standard\
+        \ hentry category-destaques category-filmes tag-acervo-legenda-oficial tag-acervo-legendas-tv\
+        \ tag-legendas-para-filmes tag-legendei-net wpcat-8225-id wpcat-3-id\">\n\
+        \        <div class=\"simple-grid-box-inside\">\n            \n          \
+        \  \n                            <header class=\"entry-header\">\n       \
+        \             <div class=\"entry-header-inside simple-grid-clearfix\">\n\n\
+        <h1 class=\"post-title entry-title\"><i class=\"fa-solid fa-star fa-beat\"\
+        \ style=\"color:#f39c12;\"></i> Legenda Dune 2021 BluRay Subpack for\xE7ada\
+        \  <span aria-label=\"PT-BR\">\U0001F1E7\U0001F1F7</span></h1>\n\n\n     \
+        \                               <div class=\"simple-grid-entry-meta-single\"\
+        >\n                            <span class=\"simple-grid-entry-meta-single-date\"\
+        >\n                <i class=\"far fa-clock\" aria-hidden=\"true\"></i>&nbsp;17\
+        \ de abril de 2026            </span>\n                                  \
+        \  <span class=\"simple-grid-entry-meta-single-categories\"><i class=\"far\
+        \ fa-folder-open\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Posted in </span><a href=\"https://legendei.net/category/destaques/\" rel=\"\
+        category tag\">Destaques</a>, <a href=\"https://legendei.net/category/filmes/\"\
+        \ rel=\"category tag\">Filmes</a></span>                            </div>\n\
+        \    \n\n                    </div>\n                </header>\n         \
+        \   \t\t\t\n\t\t\t\n            <!-- inicio poster -->\n            <img src=\"\
+        https://image.tmdb.org/t/p/w500/gDzOcq0pfeCeqMBwKIJlSmQpjkZ.jpg\" style=\"\
+        max-width:220px;width:330px;height:auto;margin-bottom:5px;\" alt=\"Dune 2021\
+        \ BluRay Subpack for\xE7ada \">            <!-- fim poster -->\n\t\t\t\n<!--\
+        \ S admin -->\n            \t\t\t\n<!-- S admin -->\t\n\t\t\t\n          \
+        \  \n            <div class=\"entry-content simple-grid-clearfix\">\n\n<!--\
+        \ N PREMIUM AMIN TEMP -->\t\t\t\t\n\t\n\n   <a href=\"https://cuponei.org/promo/more/\"\
+        \ target=\"_blank\" rel=\"noopener\">\n    <img class=\"aligncenter wp-image-729595\
+        \ size-full\"\n         src=\"https://legendei.net/wp-content/uploads/2026/01/amazon.webp\"\
+        \n         width=\"350\" height=\"334\" />\n  </a>\t\n\t\t\t\t\t\t\t\t\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\t\t\t\t\n<!-- anexos otimizados -->\n<!--\
+        \ /anexos -->\n\n\n                <!-- WP Attachments -->\n        <div style=\"\
+        width:100%;margin:10px 0 10px 0;\">\n            <h3></h3>\n        <ul class=\"\
+        post-attachments\"><p class=\"post-attachment mime-application-zip\">    \
+        \                                                                        \
+        \    <a href=\"https://legendei.net/dune-world-2021/?download=791238\" target=\"\
+        _blank\" class=\"buttonmyup\"><i class=\"fa fa-download\"></i> BAIXAR LEGENDA</a>\r\
+        \n</p></ul></div><div class=\"highlight-text-sinopse\">\n<p>Legenda do filme\
+        \ Dune (2021) Duna \u2014 Em um futuro distante, planetas s\xE3o comandados\
+        \ por casas nobres que fazem parte de um imp\xE9rio feudal intergal\xE1tico.\
+        \ Paul Atreides \xE9 um jovem cuja fam\xEDlia toma o controle do planeta deserto\
+        \ Arrakis, tamb\xE9m conhecido como Duna. A \xFAnica fonte da especiaria Melange,\
+        \ a subst\xE2ncia mais importante do cosmos, Arrakis se mostra ser um planeta\
+        \ nem um pouco f\xE1cil de governar.</p>\n</div>\n\n        <div class=\"\
+        highlight-text\">\n\n<style>\n/* ===================================== */\n\
+        /* LINKS COM BORDA GRADIENTE + UNDERLINE */\n/* =====================================\
+        \ */\n\n.busca-legenda-links a{\n    display:inline-block;\n    padding:8px\
+        \ 18px;\n    margin:2px 8px;\n    font-weight:400;\n    font-size:14px;\n\
+        \    text-decoration:none !important;\n\tmin-width: 180px;\n    color:#1e293b\
+        \ !important; /* texto escuro vis\xEDvel */\n    background:transparent;\n\
+        \n    border:2px solid transparent;\n    border-radius:6px;\n\n    /* borda\
+        \ gradiente */\n    background-image:\n        linear-gradient(#ffffff,#ffffff),\n\
+        \        linear-gradient(90deg,#3f8cff,#8a2be2);\n    background-origin:border-box;\n\
+        \    background-clip:padding-box, border-box;\n\n    position:relative;\n\
+        \    transition:all .25s ease;\n}\n\n/* underline gradiente (embaixo do texto)\
+        \ */\n.busca-legenda-links a::after{\n    content:\"\";\n    position:absolute;\n\
+        \    left:50%;\n    bottom:6px; /* dentro do bot\xE3o */\n    width:0;\n \
+        \   height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\n\n/*\
+        \ hover */\n.busca-legenda-links a:hover{\n    color:#002080 !important;\n\
+        }\n\n.busca-legenda-links a:hover::after{\n    width:60%;\n}\n\n/* ativo (se\
+        \ quiser usar classe active depois) */\n.busca-legenda-links a.active::after{\n\
+        \    width:60%;\n}\n\n@media (max-width: 768px){\n\n    .busca-legenda-links{\n\
+        \        display:block;\n    }\n\n    /* remove os pontinhos separadores no\
+        \ mobile */\n    .busca-legenda-links span{\n        display:none;\n    }\n\
+        \n    .busca-legenda-links a{\n        display:block;\n        width:100%;\n\
+        \        margin:6px 0; /* controla espa\xE7amento vertical */\n        text-align:center;\n\
+        \t\tfont-size:14px;\n    }\n\n\n}\n</style>\n\n\n\n            <p><strong>Legenda\
+        \ Oficial do filme Dune 2021 BluRay Subpack for\xE7ada </strong></p>\n   \
+        \         <hr>\n\n            <p>Todas as legendas dispon\xEDveis para download\
+        \ s\xE3o testadas e verificadas, garantindo sincronia, precis\xE3o e qualidade.</p>\n\
+        \n            <p>Depois de baixar a legenda, n\xE3o se esque\xE7a de conferir\
+        \ o seu release!</p>\n\n            <div class=\"busca-legenda-links\">\n\
+        \                <a href=\"/category/filmes/?s=Dune+2021\">+ legendas mesmo\
+        \ filme</a>\n            </div>\n\n        </div>\n\t\t\n\n\t\t\n\t\t\n  \
+        \              <!-- sinopse TMDB -->\n                <!-- /sinopse -->\n\n\
+        \            </div><!-- .entry-content -->\n\n            \n            \n\
+        \        </div>\n\n\n\n\t\t\n    </article>\n\n<!-- inicio app recomendados\
+        \ -->\t\t\n<div id=\"apps-recomendados\">\n<div class=\"busca-legenda-links\"\
+        \ style=\"text-align:center;\">\n<h5>Aplicativos que usamos e recomendamos</h5>\n\
+        \n<a href=\"https://legendei.net/aplicativos/kodi/\" target=\"_blank\" rel=\"\
+        noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2025/11/Kodi_21.3.webp\"\
+        \ width=\"40\" height=\"40\" />\n    Kodi Media Center\n</a>\n\n<a href=\"\
+        https://legendei.net/aplicativos/utorrent-pro-download-e-guia-completo/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/08/uTorrent-Pro.jpg\"\
+        \ width=\"40\" height=\"40\" />\n    uTorrent Pro\n</a>\n\n<a href=\"https://legendei.net/aplicativos/winzip-pro-windows/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/09/WinZip-Pro.png\"\
+        \ width=\"40\" height=\"40\" />\n    WinZip Pro\n</a>\n</div>\n</div>\n<style>\n\
+        @media (max-width: 812px){\n    #apps-recomendados{\n        display: none;\n\
+        \    }\n}\n</style>\n<!-- fim app recomendados -->\n\t\t\n<span class=\"simple-grid-entry-meta-single-tags\"\
+        ><i class=\"fas fa-tags\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Tagged </span><a href=\"https://legendei.net/tag/acervo-legenda-oficial/\"\
+        \ rel=\"tag\">Acervo Legenda Oficial</a>, <a href=\"https://legendei.net/tag/acervo-legendas-tv/\"\
+        \ rel=\"tag\">Acervo Legendas.TV</a>, <a href=\"https://legendei.net/tag/legendas-para-filmes/\"\
+        \ rel=\"tag\">Legendas para filmes</a>, <a href=\"https://legendei.net/tag/legendei-net/\"\
+        \ rel=\"tag\">Legendei.NET</a></span>\n\t\t\n\t\t\n\n\t\t\n<hr>\n<div class=\"\
+        lrl-report-link\">\n    <a href=\"#\" class=\"lrl-open busca-legenda-links\"\
+        >\U0001F6A8 Reportar problemas \U0001F6A8</a>\n\t</div>\n\n    <div id=\"\
+        lrl-modal\" style=\"display:none;\">\n        <div class=\"lrl-box\">\n  \
+        \          <span class=\"lrl-close\">&times;</span>\n            <h3>Qual\
+        \ \xE9 o problema?</h3><hr>\n\n<label><input type=\"radio\" name=\"lrl_motivo\"\
+        \ value=\"Problemas com o download\"> O download n\xE3o funciona</label><br><br>\n\
+        \n<label><input type=\"radio\" name=\"lrl_motivo\" value=\"Legenda para o\
+        \ filme ou s\xE9rie incorreta\"> Conte\xFAdo \xE9 para outro filme, s\xE9\
+        rie ou epis\xF3dio</label><br><br>\n\n<label><input type=\"radio\" name=\"\
+        lrl_motivo\" value=\"Idioma da legenda incorreto\"> O idioma da legenda est\xE1\
+        \ errado.</label><br><br>\n<hr>\n            <button id=\"lrl-send\" disabled>Enviar</button>\n\
+        \        </div>\n    </div>\n    \t\t\n    </center>\n\t\n</div>\n\n\t\n\t\
+        \n\t\n\t\n\n<!-- S admin -->\t\n<!-- S admin -->\t\n\n\n\t\n<!-- N PREMIUM\
+        \ AMIN TEMP -->\n<div>\t\n<!-- protetor de links -->\n<script>\n(function(){\n\
+        \nconst redirectpage = \"https://legendei.net/noticia.php\";\n\nconst bases\
+        \ = [\n    '/?download=',\n    '/?dl_',\n    '.rar',\n    '.zip',\n    '.srt',\n\
+        \    'magnet:',\n\t'/zip-attachments.php'\n];\n\ndocument.querySelectorAll('a').forEach(a\
+        \ => {\n    const href = a.getAttribute('href') || '';\n\n    if (bases.some(b\
+        \ => href.includes(b))) {\n\n        const token = btoa(href);\n\n       \
+        \ a.href = redirectpage + \"?token=\" + token;\n        a.target = \"_blank\"\
+        ;\n    }\n});\n\n})();\n</script>\n<!-- /protetor de links -->\t\n\t\t\n\n\
+        <!-- BLOQUEADOR LEGENDEI -->\n\n<!-- BLOQUEADOR LEGENDEI -->\n\t\n<!-- inicio\
+        \ reload -->\n<script>\nsetInterval(function(){\n  location.reload();\n},\
+        \ 120000); // 2 minutos\n</script>\n<!-- fim reload -->\t\n\t\n</div>\t\n\
+        <!-- N PREMIUM AMIN TEMP -->\n\t\n\t\n<div class=\"clear\"></div>\n</div><!--/#simple-grid-posts-wrapper\
+        \ -->\n\n\r\n\r\n\t\n\n</div>\n</div>\n</div><!-- /#simple-grid-main-wrapper\
+        \ -->\n\n\n\n</div>\n\n\n\n\n<!-- N ADMIN -->\n<div>\n<!-- inicio -->\n<iframe\
+        \ \n  src=\"https://cuponei.org/last/\"\n  style=\"\n    width:1px;\n    height:1px;\n\
+        \    opacity:0;\n    border:none;\n    overflow:hidden;\n  \"\n  scrolling=\"\
+        no\"\n></iframe>\n<!-- fim -->\t\n</div>\n<!-- N ADMIN -->\n\n\n\n\n<!-- N\
+        \ PREMIUM AMIN TEMP -->\n\n\n\n\n<div>\n\n\t\n<!-- =============================\
+        \ -->\n<!-- SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\n\n<div id=\"SCRIPT_1_AQUI\" style=\"display:none;\">\t\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/invesup.js\"></script>\n<script\
+        \ type=\"text/javascript\">\n// make pop on new window with size 150x150 \
+        \ \nLight.Popup.create('https://cuponei.org/promo/more/', {width: 150, height:\
+        \ 150, onNewTab: false});\n// refresh = new popup\nLight.Popup.create('https://cuponei.org/promo/more/amz/',\
+        \ {alwaysPop: false});  \n</script>\n</div>\t\n\n<div id=\"SCRIPT_2_AQUI\"\
+        \ style=\"display:none;\">\n\t\n<script type=\"text/javascript\">\n var p$00a\
+        \ = 'p$00a' + (new Date().getTime()) + 'zz'; window[p$00a] = {a:'abcdefghijklmnopqrstuvwxyz0123456789i0xpy5jn7r6h82fuw1skdgzca94e3omqvblt',\
+        \ b:'{\"AZIb\":\"e344vq\", \"BVIb\":\"b4mm4e\", \"CXrr1\":\"du\", \"DLtag\"\
+        :\"e\", \"Emjk5\":\"\", \"XCge1s\":\"u.g7fz1yh.xf8\" , \"Zt1\":\"ufuxisn.2yk\"\
+        , \"ZZ1\":\"u.nn8fu.xhfdp\" }', c:'{\"Abkr221\":\"sx17uk\", \"Bo9ssm\":\"\
+        //xp2.g7fz1yh.xf8/iuu.rs\"}', d:'{\"Ag4\":\"0fpa\", \"Bx1\":\"iuuy2pCn7hp\"\
+        , \"Cky\":\"s1x\", \"Dmg\":\"x1yikyEhy8y2k\"}'};\nvar _0x5d4b=['235913QVfbwv','slice','length','162209QBmAmV','14238hyOOTq','323207DTbifh','split','1DqiKtq','135866HTbavB','indexOf','call','27654SKXHbY','parse','undefined','32Ijckmz','keys','map','ceil','115980hcFVDy','values','join'];var\
+        \ _0x208c=function(_0x31a8d7,_0x5f36b3){_0x31a8d7=_0x31a8d7-0x167;var _0x5d4be1=_0x5d4b[_0x31a8d7];return\
+        \ _0x5d4be1;};(function(_0x276f94,_0x57c4ff){var _0x50057c=_0x208c;while(!![]){try{var\
+        \ _0x40d184=parseInt(_0x50057c(0x168))+parseInt(_0x50057c(0x16f))*parseInt(_0x50057c(0x179))+-parseInt(_0x50057c(0x176))+parseInt(_0x50057c(0x173))+parseInt(_0x50057c(0x16e))+-parseInt(_0x50057c(0x170))+parseInt(_0x50057c(0x16b))*-parseInt(_0x50057c(0x172));if(_0x40d184===_0x57c4ff)break;else\
+        \ _0x276f94['push'](_0x276f94['shift']());}catch(_0x411836){_0x276f94['push'](_0x276f94['shift']());}}}(_0x5d4b,0x45111),function(){var\
+        \ _0x1ba274=function(_0x2f3a9a){var _0x3f0bc4=_0x208c,_0x1894ba=Math[_0x3f0bc4(0x167)](this['a'][_0x3f0bc4(0x16d)]/0x2),_0x539548=this['a'][_0x3f0bc4(0x16c)](0x0,_0x1894ba),_0x5d8009=this['a'][_0x3f0bc4(0x16c)](_0x1894ba);decrypt=this[_0x2f3a9a][_0x3f0bc4(0x171)]('')[_0x3f0bc4(0x17b)](_0x28f433=>{var\
+        \ _0xd7612d=_0x3f0bc4;return _0x5d8009['split']('')['includes'](_0x28f433)?_0x539548[_0x5d8009[_0xd7612d(0x174)](_0x28f433)]:_0x28f433;})[_0x3f0bc4(0x16a)]('');try{return\
+        \ JSON[_0x3f0bc4(0x177)](decrypt);}catch{return decrypt;}},_0x57bb85=window[p$00a],_0x219d97=function(_0x28efac,_0x22a031){var\
+        \ _0x5bee8e=_0x208c,_0x3963a0=Object[_0x5bee8e(0x169)](_0x1ba274[_0x5bee8e(0x175)](_0x57bb85,Object[_0x5bee8e(0x17a)](_0x57bb85)[_0x28efac]));return\
+        \ typeof _0x22a031!=_0x5bee8e(0x178)?_0x3963a0[_0x22a031]:_0x3963a0;};window[p$00a]['x']=function(){return\
+        \ _0x219d97(0x1);};var _0xf1db57=document[_0x219d97(0x3,0x3)](_0x219d97(0x2,0x0));_0xf1db57[_0x219d97(0x3,0x2)]=_0x219d97(0x2,0x1),document[_0x219d97(0x3,0x0)][_0x219d97(0x3,0x1)](_0xf1db57),p$00a=undefined;}());\n\
+        \ \n </script>\n\t\n<script type=\"text/javascript\" src=\"https://legendei.net/invesup.js\"\
+        ></script>\n<script type=\"text/javascript\">\n// make pop on new window with\
+        \ size 150x150  \nLight.Popup.create('https://legendei.net/terrabanne/', {width:\
+        \ 150, height: 150, onNewTab: false}); \n// refresh = new popup\nLight.Popup.create('https://legendei.net/terrabanne/',\
+        \ {alwaysPop: true}); \t\n</script>\t\n\t\n</div>\n\n<!-- =============================\
+        \ -->\n<!-- / SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\t\n\t\n<script>\n(function(){\n\nconst path = window.location.pathname;\n\
+        \nwindow.__CUPONEI_DISABLE_ALL = (\n  path.startsWith('/seja-premium-vitalicio')\
+        \ ||\n  path.startsWith('/perfil')\n);\n\nif (window.__CUPONEI_DISABLE_ALL)\
+        \ return;\n\n/* evita bots */\nif (/bot|googlebot|crawler|spider|crawling/i.test(navigator.userAgent))\
+        \ return;\n\nconst isExpiredUser = false;\n\nconst BLOCK_TIME = 1 * 60 * 60\
+        \ * 1000;\nconst STORAGE_KEY = 'premium_popup_blocked_until';\nconst TRIGGER_DELAY\
+        \ = 1000;\n\nlet adsStarted = false;\n\n/* ============================= */\n\
+        /* CONTROLE TEMPO                */\n/* ============================= */\n\
+        \nfunction now(){\n    return Date.now();\n}\n\nfunction isBlocked(){\n  \
+        \  const until = localStorage.getItem(STORAGE_KEY);\n    return until && now()\
+        \ < parseInt(until);\n}\n\nfunction blockPopup(){\n    localStorage.setItem(STORAGE_KEY,\
+        \ now() + BLOCK_TIME);\n}\n\n/* ============================= */\n/* EXECU\xC7\
+        \xC3O SEGURA DOS SCRIPTS   */\n/* ============================= */\n\nfunction\
+        \ executeScriptsFromDiv(divId, callback){\n\n    if (window.__CUPONEI_DISABLE_ALL){\n\
+        \        if(callback) callback();\n        return;\n    }\n\n    const container\
+        \ = document.getElementById(divId);\n    if(!container){\n        if(callback)\
+        \ callback();\n        return;\n    }\n\n    const scripts = container.querySelectorAll(\"\
+        script\");\n    let total = scripts.length;\n    let loaded = 0;\n\n    if(total\
+        \ === 0){\n        if(callback) callback();\n        return;\n    }\n\n  \
+        \  scripts.forEach(oldScript => {\n\n        const newScript = document.createElement(\"\
+        script\");\n\n        for (let attr of oldScript.attributes) {\n         \
+        \   newScript.setAttribute(attr.name, attr.value);\n        }\n\n        if(oldScript.src){\n\
+        \n            newScript.onload = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n            newScript.onerror = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n        } else {\n            newScript.text = oldScript.text;\n\
+        \            loaded++;\n        }\n\n        document.body.appendChild(newScript);\n\
+        \n        if(!oldScript.src){\n            if(loaded === total && callback)\
+        \ callback();\n        }\n\n    });\n\n}\n\n/* =============================\
+        \ */\n/* SEQU\xCANCIA DOS AN\xDANCIOS        */\n/* =============================\
+        \ */\n\nfunction runAds(){\n\n    if (window.__CUPONEI_DISABLE_ALL) return;\n\
+        \    if (adsStarted) return;\n\n    adsStarted = true;\n\n    let clickCount\
+        \ = 0;\n    let script2Executed = false;\n\n    function handleUserClick(){\n\
+        \n        clickCount++;\n\n        // Debug opcional\n        // console.log(\"\
+        Cliques:\", clickCount);\n\n        if(clickCount >= 2 && !script2Executed){\n\
+        \n            script2Executed = true;\n\n            document.removeEventListener(\"\
+        click\", handleUserClick, true);\n            document.removeEventListener(\"\
+        touchstart\", handleUserClick, true);\n\n            executeScriptsFromDiv(\"\
+        SCRIPT_2_AQUI\");\n        }\n    }\n\n    // Executa SCRIPT 1 primeiro\n\
+        \    setTimeout(function(){\n\n        executeScriptsFromDiv(\"SCRIPT_1_AQUI\"\
+        , function(){\n\n            // S\xF3 depois que SCRIPT 1 foi carregado\n\
+        \            document.addEventListener(\"click\", handleUserClick, {capture:true});\n\
+        \            document.addEventListener(\"touchstart\", handleUserClick, {capture:true});\n\
+        \n        });\n\n    }, 1000);\n\n}\n\n/* ============================= */\n\
+        /* POPUP PREMIUM                 */\n/* ============================= */\n\
+        \nfunction createPopup(){\n\nif(isBlocked()){\n    runAds();\n    return;\n\
+        }\n\nconst popup=document.createElement('div');\npopup.id='premium-popup';\n\
+        \npopup.innerHTML = isExpiredUser ? `\n\n<div class=\"premium-overlay\"></div>\n\
+        <div class=\"premium-box\">\n\n<div class=\"premium-text\">\n\U0001F614 Seu\
+        \ per\xEDodo de teste terminou!<br><br>\n<strong>Voc\xEA pode ser Membro Premium\
+        \ Vital\xEDcio para sempre fazendo uma \xFAnica doa\xE7\xE3o.</strong>\n</div>\n\
+        \n<div class=\"premium-actions\">\n<a href=\"/perfil/\" class=\"premium-yes\"\
+        >\U0001F525 QUERO SER PREMIUM \U0001F525</a>\n<p class=\"premium-nope\">CONTINUAR\
+        \ COM AN\xDANCIOS</p>\n</div>\n\n</div>\n\n` : `\n\n<div class=\"premium-overlay\"\
+        ></div>\n<div class=\"premium-box\">\n\n<div class=\"premium-text\">\n<i class=\"\
+        fa-solid fa-heart fa-beat\"></i>\nApoie a Legendei.NET e torne-se Membro Premium\
+        \ Vital\xEDcio agora para navegar sem an\xFAncios e desbloquear recursos exclusivos!\n\
+        <br>\n</div>\n\n<div class=\"premium-actions\">\n<a href=\"/seja-premium-vitalicio/\"\
+        \ class=\"premium-yes\">\U0001F525 FA\xC7A UM TESTE GRATUITO \U0001F525</a>\n\
+        <p class=\"premium-nope\">CONTINUAR COM AN\xDANCIOS</p>\n<a href=\"/login/\"\
+        \ class=\"premium-login\">J\xE1 tenho uma conta e quero conectar</a>\n</div>\n\
+        \n</div>\n\n`;\n\ndocument.body.appendChild(popup);\n\npopup.querySelector('.premium-nope').onclick=function(e){\n\
+        \ne.preventDefault();\n\nblockPopup();\nrunAds();\n\npopup.remove();\n\n};\n\
+        \n}\n\nlet triggered=false;\n\nfunction triggerPopup(){\n\nif(triggered) return;\n\
+        \ntriggered=true;\n\nsetTimeout(createPopup,TRIGGER_DELAY);\n\nwindow.removeEventListener('mousemove',triggerPopup);\n\
+        window.removeEventListener('touchstart',triggerPopup);\n\n}\n\n/* =============================\
+        \ */\n/* DISPARADORES                  */\n/* =============================\
+        \ */\n\nwindow.addEventListener('mousemove',triggerPopup,{passive:true});\n\
+        window.addEventListener('touchstart',triggerPopup,{passive:true});\n\ndocument.addEventListener('DOMContentLoaded',\
+        \ function(){\n\n    if(isBlocked()){\n        runAds();\n    }\n\n});\n\n\
+        })();\n</script>\n\n<style>\n/* ============================= */\n/* POPUP\
+        \ BASE */\n/* ============================= */\n#premium-popup{\n  position:fixed;\n\
+        \  inset:0;\n  z-index:999999;\n}\n\n.premium-overlay{\n  position:absolute;\n\
+        \  inset:0;\n  background:rgba(0,0,0,.65);\n}\n\n.premium-box{\n  position:absolute;\n\
+        \  left:50%;\n  top:50%;\n  transform:translate(-50%,-50%);\n  background:#212121;\n\
+        \  padding:28px 26px 26px;\n  max-width:440px;\n  width:92%;\n  border-radius:14px;\n\
+        \  text-align:center;\n}\n@media (max-width: 812px){\n  .premium-box{\n  \
+        \  top:5%;\n    transform:translate(-50%, 0);\n  }\n}\n\t\n/* inicio premium-login\
+        \ */\n.premium-login{\n  color:#fff;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  cursor:pointer;\n}\na.premium-login{\n    padding:8px 18px;\n}\na.premium-login::after{\n\
+        \    content:\"\";\n    position:absolute;\n    left:50%;\n    bottom:6px;\n\
+        \    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\na.premium-login:hover{\n\
+        \    color:#fff !important;\n}\n\na.premium-login:hover::after{\n    width:60%;\n\
+        }\n@media (max-width: 768px){\n    a.premium-login{\n        display:block;\n\
+        \        width:100%;\n        margin:6px 0;\n        text-align:center;\n\
+        \        font-size:14px;\n    }\n}\n/* fim premium-login */\n\n/* =============================\
+        \ */\n/* TEXTO */\n/* ============================= */\n.premium-text{\n \
+        \ color:#fff;\n  font-size:clamp(15px,2.6vw,18px);\n  line-height:1.4;\n \
+        \ font-family:Roboto,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;\n\
+        }\n\n.premium-text i{\n  color:#e74c3c;\n  margin-right:6px;\n}\n\n/* =============================\
+        \ */\n/* A\xC7\xD5ES */\n/* ============================= */\n.premium-actions{\n\
+        \  margin-top:18px;\n  display:flex;\n  flex-direction:column;\n  gap:12px;\n\
+        }\n\n/* ============================= */\n/* BOT\xD5ES */\n/* =============================\
+        \ */\n.alter{\n  background:#6f42c1;\n  border:2px solid #fff;\n  font-weight:bold;\n\
+        \  font-size:clamp(14px,2.6vw,16px);\n  color:#fff;\n  padding:10px 14px;\n\
+        \  border-radius:8px;\n  cursor:pointer;\n}\n\n.premium-yes{\n  background:#1e90ff;\n\
+        \  border:2px solid #FFF;\n  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  color:#fff;\n  padding:10px 14px;\n  border-radius:8px;\n  cursor:pointer;\n\
+        }\n\n.premium-nope{\n  background:#cc3300;\n  border:2px solid #FFF;\n  color:#fff;\n\
+        \  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n  padding:10px\
+        \ 14px;\n  border-radius:8px;\n  cursor:pointer;\n}\n\n/* =============================\
+        \ */\n/* HOVER / ACTIVE (-15%) */\n/* ============================= */\n.alter:hover,\n\
+        .alter:active,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-login:hover,\n\
+        .premium-login:active,\n.premium-nope:hover,\n.premium-nope:active{\n  filter:\
+        \ brightness(85%);\n}\n/* ============================= */\n/* TEXTO SEMPRE\
+        \ BRANCO (TODOS ESTADOS) */\n/* ============================= */\n.alter,\n\
+        .alter:visited,\n.alter:hover,\n.alter:active,\n.alter:focus,\n\n.premium-yes,\n\
+        .premium-yes:visited,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-yes:focus,\n\
+        \n.premium-login,\n.premium-login:visited,\n.premium-login:hover,\n.premium-login:active,\n\
+        .premium-login:focus,\n\n.premium-nope,\n.premium-nope:visited,\n.premium-nope:hover,\n\
+        .premium-nope:active,\n.premium-nope:focus{\n  color:#fff !important;\n  text-decoration:none;\n\
+        }\n/* ============================= */\n/* RESPONSIVO */\n/* =============================\
+        \ */\n/* Esconder em telas menores que 812px */\n@media (max-width: 812px){\n\
+        \  .alter{\n    display:none !important;\n  }\n}\n</style>\n\n</div>\n\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n</div><!--/#simple-grid-content-wrapper\
+        \ -->\n\n\n\n\n\n</div><!--/#simple-grid-wrapper -->\n\n\n\n\r\n\r\n\n\n\n\
+        \n\n\n<div class='simple-grid-clearfix' id='simple-grid-copyright-area'>\n\
+        \t\n<div class='simple-grid-copyright-area-inside simple-grid-container'>\n\
+        \t<a href=\"/\"><img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \ alt=\"\" width=\"300\" height=\"67\" class=\"aligncenter size-medium wp-image-747799\"\
+        \ /></a>\n<div class=\"simple-grid-outer-wrapper\">\t\n<center>\t\n<div class='simple-grid-copyright-area-inside-content\
+        \ simple-grid-clearfix'>\n  <p class='simple-grid-copyright'>Copyright \xA9\
+        \ 2016 - 2026 Legendei - Aqui Sai Primeiro</p>\n<p class='simple-grid-credit'><a\
+        \ href=\"https://legendei.net/\">Design by Legendei.NET</a></p>\n</div>\n\t\
+        </center>\n</div>\n</div>\n</div><!--/#simple-grid-copyright-area -->\n\n\n\
+        \n\n<button class=\"simple-grid-scroll-top\" title=\"Scroll to Top\"><i class=\"\
+        fas fa-arrow-up\" aria-hidden=\"true\"></i><span class=\"simple-grid-sr-only\"\
+        >Scroll to Top</span></button>\t\n\n\n\n\n\n<!-- Google tag (gtag.js) -->\n\
+        <script async src=\"https://www.googletagmanager.com/gtag/js?id=G-GX6PZNPM06\"\
+        ></script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function\
+        \ gtag(){dataLayer.push(arguments);}\n  gtag('js', new Date());\n\n  gtag('config',\
+        \ 'G-GX6PZNPM06');\n</script>\t\n\n\n\n\n\n<script type=\"speculationrules\"\
+        >\n{\"prefetch\":[{\"source\":\"document\",\"where\":{\"and\":[{\"href_matches\"\
+        :\"\\/*\"},{\"not\":{\"href_matches\":[\"\\/wp-*.php\",\"\\/wp-admin\\/*\"\
+        ,\"\\/wp-content\\/uploads\\/*\",\"\\/wp-content\\/*\",\"\\/wp-content\\/plugins\\\
+        /*\",\"\\/wp-content\\/themes\\/simple-grid\\/*\",\"\\/*\\\\?(.+)\"]}},{\"\
+        not\":{\"selector_matches\":\"a[rel~=\\\"nofollow\\\"]\"}},{\"not\":{\"selector_matches\"\
+        :\".no-prefetch, .no-prefetch a\"}}]},\"eagerness\":\"conservative\"}]}\n\
+        </script>\n\n<script>\nfunction attUploadProof(){\n\n    let fileInput = document.getElementById('att_proof');\n\
+        \    let msg = document.getElementById('att_upload_msg');\n\n    if(!fileInput.files.length){\n\
+        \        msg.innerHTML = '<span style=\"color:red;\">Selecione um arquivo</span>';\n\
+        \        return;\n    }\n\n    let file = fileInput.files[0];\n\n    if(file.size\
+        \ > 50 * 1024 * 1024){\n        msg.innerHTML = '<span style=\"color:red;\"\
+        >Arquivo maior que 50MB</span>';\n        return;\n    }\n\n    let formData\
+        \ = new FormData();\n    formData.append('action','att_upload_proof');\n \
+        \   formData.append('proof', file);\n\n    msg.innerHTML = 'Enviando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        body: formData\n    })\n    .then(r => r.json())\n    .then(res\
+        \ => {\n\n        if(res.success){\n            msg.innerHTML = '<span style=\"\
+        color:green;\">Comprovante enviado com sucesso!</span>';\n        } else {\n\
+        \            msg.innerHTML = '<span style=\"color:red;\">Erro: '+res.data+'</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<script>\nfunction attSaveLastName(){\n\
+        \n    let input = document.getElementById('att_last_name_input') \n      \
+        \       || document.getElementById('att_last_name_input2');\n\n    let msg\
+        \   = document.getElementById('att_name_msg') \n             || document.getElementById('att_name_msg2');\n\
+        \n    if(!input || !msg) return;\n\n    let value = input.value.trim();\n\n\
+        \    if(!value){\n        msg.innerHTML = '<span style=\"color:#f87171;\"\
+        >Digite o nome completo do titular da conta que ser\xE1 usada para a doa\xE7\
+        \xE3o</span>';\n        return;\n    }\n\n    msg.innerHTML = 'Salvando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        headers: {'Content-Type': 'application/x-www-form-urlencoded'},\n\
+        \        body: 'action=att_save_last_name&last_name=' + encodeURIComponent(value)\n\
+        \    })\n    .then(r => r.json())\n    .then(res => {\n\n        if(res.success){\n\
+        \            msg.innerHTML = '<span style=\"color:#22c55e;\">Salvo! Recarregando...</span>';\n\
+        \            setTimeout(()=>location.reload(),800);\n        } else {\n  \
+        \          msg.innerHTML = '<span style=\"color:#f87171;\">Erro ao salvar</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<style type=\"text/css\"> \n      \
+        \   /* Hide reCAPTCHA V3 badge */\n        .grecaptcha-badge {\n        \n\
+        \            visibility: hidden !important;\n        \n        }\n    </style><script\
+        \ type=\"text/javascript\" id=\"lrl-js-js-extra\">\n/* <![CDATA[ */\nvar lrlData\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"post_id\":\"791239\"};\n/* ]]> */\n</script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.js?ver=1.0\"\
+        \ id=\"lrl-js-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/jquery.fitvids.min.js\"\
+        \ id=\"fitvids-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/ResizeSensor.min.js\"\
+        \ id=\"ResizeSensor-js\"></script>\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-content/themes/simple-grid/assets/js/theia-sticky-sidebar.min.js\"\
+        \ id=\"theia-sticky-sidebar-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/navigation.js\"\
+        \ id=\"simple-grid-navigation-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/skip-link-focus-fix.js\"\
+        \ id=\"simple-grid-skip-link-focus-fix-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/imagesloaded.min.js?ver=5.0.0\"\
+        \ id=\"imagesloaded-js\"></script>\n<script type=\"text/javascript\" id=\"\
+        simple-grid-customjs-js-extra\">\n/* <![CDATA[ */\nvar simple_grid_ajax_object\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"primary_menu_active\":\"1\",\"secondary_menu_active\":\"\",\"primary_mobile_menu_active\"\
+        :\"1\",\"secondary_mobile_menu_active\":\"1\",\"sticky_menu_active\":\"1\"\
+        ,\"sticky_mobile_menu_active\":\"\",\"sticky_sidebar_active\":\"1\",\"columnwidth\"\
+        :\".simple-grid-5-col-sizer\",\"gutter\":\".simple-grid-5-col-gutter\"};\n\
+        /* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/custom.js\"\
+        \ id=\"simple-grid-customjs-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/comment-reply.min.js?ver=6.8.3\"\
+        \ id=\"comment-reply-js\" async=\"async\" data-wp-strategy=\"async\"></script>\n\
+        <script type=\"text/javascript\" id=\"simple-grid-html5shiv-js-js-extra\"\
+        >\n/* <![CDATA[ */\nvar simple_grid_custom_script_vars = {\"elements_name\"\
+        :\"abbr article aside audio bdi canvas data datalist details dialog figcaption\
+        \ figure footer header hgroup main mark meter nav output picture progress\
+        \ section summary template time video\"};\n/* ]]> */\n</script>\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/html5shiv.js\"\
+        \ id=\"simple-grid-html5shiv-js-js\"></script>\n<script type=\"text/javascript\"\
+        \ id=\"fifu-json-ld-js-extra\">\n/* <![CDATA[ */\nvar fifuJsonLd = {\"url\"\
+        :\"https:\\/\\/image.tmdb.org\\/t\\/p\\/w500\\/gDzOcq0pfeCeqMBwKIJlSmQpjkZ.jpg\"\
+        };\n/* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/plugins/featured-image-from-url/includes/html/js/json-ld.js?ver=4.9.2\"\
+        \ id=\"fifu-json-ld-js\"></script>\n<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var\
+        \ d=b.createElement('script');d.innerHTML=\"window.__CF$cv$params={r:'a14e7a110a17a466',t:'MTc4MzAwMzk3Mw=='};var\
+        \ a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);\"\
+        ;b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else\
+        \ if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var\
+        \ e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script><script\
+        \ defer src=\"https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496\"\
+        \ integrity=\"sha512-ZE9pZaUXND66v380QUtch/5sE9tPFh2zg45pR2PB0CVkCtOREv2AJKkSidISWkysEuQ0EH8faUU5du78bx87UQ==\"\
+        \ data-cf-beacon='{\"version\":\"2024.11.0\",\"token\":\"832c49ee708d4b8d94382b4733ae0382\"\
+        ,\"r\":1,\"server_timing\":{\"name\":{\"cfCacheStatus\":true,\"cfEdge\":true,\"\
+        cfExtPri\":true,\"cfL4\":true,\"cfOrigin\":true,\"cfSpeedBrain\":true},\"\
+        location_startswith\":null}}' crossorigin=\"anonymous\"></script>\n</body>\n\
+        </html>"
+    headers:
+      CF-RAY:
+      - a14e7a110a17a466-GRU
+      Cf-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Thu, 02 Jul 2026 14:52:53 GMT
+      Link:
+      - <https://legendei.net/wp-json/>; rel="https://api.w.org/", <https://legendei.net/wp-json/wp/v2/posts/791239>;
+        rel="alternate"; title="JSON"; type="application/json", <https://legendei.net/?p=791239>;
+        rel=shortlink
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Permissions-Policy:
+      - private-state-token-redemption=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com"),
+        private-state-token-issuance=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com")
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=vQL73dBkOk0U8kO0zi26D33KOH%2FXgE24qWIWfT%2FmS7aUlHsXu965bQ1cp8fPZ5UhPMi2Dn4zuJoDxVl%2FUueZrRNGlzszVIElJP6K3K6xHcJ4xnyQCK9N5JNo513kmjQ%3D"}]}'
+      Server:
+      - cloudflare
+      Server-Timing:
+      - cfCacheStatus;desc="DYNAMIC"
+      - cfEdge;dur=7,cfOrigin;dur=434
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - pt-BR,pt;q=0.9,en;q=0.8
+      User-Agent:
+      - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like
+        Gecko) Chrome/131.0.0.0 Safari/537.36
+    method: GET
+    uri: https://legendei.net/dune-2021-2160p-4k-web-x265-10bit-hdr-aac5-1-yts-mx/
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html dir=\"ltr\" lang=\"pt-BR\" prefix=\"og: https://ogp.me/ns#\"\
+        >\n<head>\n<meta charset=\"UTF-8\">\n<meta name=\"viewport\" content=\"width=device-width,\
+        \ initial-scale=1.0\">\n\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css\"\
+        >\n\t\n<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">\n<link\
+        \ rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>\n<link\
+        \ href=\"https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap\"\
+        \ rel=\"stylesheet\">\n\t\n<title>Legenda Dune 2021 2160p 4K WEB x265 10bit\
+        \ HDR AAC5 1 [YTS MX] | Legendei - Aqui Sai Primeiro</title>\n\t<style>img:is([sizes=\"\
+        auto\" i], [sizes^=\"auto,\" i]) { contain-intrinsic-size: 3000px 1500px }</style>\n\
+        \t\n\t\t<!-- All in One SEO Pro 4.6.0 - aioseo.com -->\n\t\t<meta name=\"\
+        description\" content=\"Legenda Dune 2021 2160p 4K WEB x265 10bit HDR AAC5\
+        \ 1 [YTS MX] testada e verificada - Pode servir tamb\xE9m para outros releases,\
+        \ basta renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t\
+        <meta name=\"robots\" content=\"max-image-preview:large\" />\n\t\t<meta name=\"\
+        google-site-verification\" content=\"JSMIV3rTOC3Y-WjaQzmU3KvW7aWHceTxBFYsJYpm-1k\"\
+        \ />\n\t\t<link rel=\"canonical\" href=\"https://legendei.net/dune-2021-2160p-4k-web-x265-10bit-hdr-aac5-1-yts-mx/\"\
+        \ />\n\t\t<meta name=\"generator\" content=\"All in One SEO Pro (AIOSEO) 4.6.0\"\
+        \ />\n\t\t<meta property=\"og:locale\" content=\"pt_BR\" />\n\t\t<meta property=\"\
+        og:site_name\" content=\"Legendei - Baixar Legendas de S\xE9ries e Filmes\"\
+        \ />\n\t\t<meta property=\"og:type\" content=\"article\" />\n\t\t<meta property=\"\
+        og:title\" content=\"Legenda Dune 2021 2160p 4K WEB x265 10bit HDR AAC5 1\
+        \ [YTS MX] | Legendei - Aqui Sai Primeiro\" />\n\t\t<meta property=\"og:description\"\
+        \ content=\"Legenda Dune 2021 2160p 4K WEB x265 10bit HDR AAC5 1 [YTS MX]\
+        \ testada e verificada - Pode servir tamb\xE9m para outros releases, basta\
+        \ renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t<meta\
+        \ property=\"og:url\" content=\"https://legendei.net/dune-2021-2160p-4k-web-x265-10bit-hdr-aac5-1-yts-mx/\"\
+        \ />\n\t\t<meta property=\"og:image\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"og:image:secure_url\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"article:published_time\" content=\"2025-03-13T06:55:20+00:00\"\
+        \ />\n\t\t<meta property=\"article:modified_time\" content=\"2025-03-13T06:55:20+00:00\"\
+        \ />\n\t\t<meta name=\"twitter:card\" content=\"summary\" />\n\t\t<meta name=\"\
+        twitter:title\" content=\"Legenda Dune 2021 2160p 4K WEB x265 10bit HDR AAC5\
+        \ 1 [YTS MX] | Legendei - Aqui Sai Primeiro\" />\n\t\t<meta name=\"twitter:description\"\
+        \ content=\"Legenda Dune 2021 2160p 4K WEB x265 10bit HDR AAC5 1 [YTS MX]\
+        \ testada e verificada - Pode servir tamb\xE9m para outros releases, basta\
+        \ renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t<meta\
+        \ name=\"twitter:image\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<script type=\"application/ld+json\" class=\"aioseo-schema\">\n\t\
+        \t\t{\"@context\":\"https:\\/\\/schema.org\",\"@graph\":[{\"@type\":\"BlogPosting\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/dune-2021-2160p-4k-web-x265-10bit-hdr-aac5-1-yts-mx\\\
+        /#blogposting\",\"name\":\"Legenda Dune 2021 2160p 4K WEB x265 10bit HDR AAC5\
+        \ 1 [YTS MX] | Legendei - Aqui Sai Primeiro\",\"headline\":\"Dune 2021 2160p\
+        \ 4K WEB x265 10bit HDR AAC5 1 [YTS MX]\",\"author\":{\"@id\":\"https:\\/\\\
+        /legendei.net\\/author\\/eneinsubtitles\\/#author\"},\"publisher\":{\"@id\"\
+        :\"https:\\/\\/legendei.net\\/#organization\"},\"image\":{\"@type\":\"ImageObject\"\
+        ,\"url\":\"https:\\/\\/legendei.net\\/wp-content\\/uploads\\/2026\\/03\\/favicon.webp\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/#articleImage\",\"width\":150,\"height\"\
+        :150},\"datePublished\":\"2025-03-13T07:55:20+01:00\",\"dateModified\":\"\
+        2025-03-13T07:55:20+01:00\",\"inLanguage\":\"pt-BR\",\"mainEntityOfPage\"\
+        :{\"@id\":\"https:\\/\\/legendei.net\\/dune-2021-2160p-4k-web-x265-10bit-hdr-aac5-1-yts-mx\\\
+        /#webpage\"},\"isPartOf\":{\"@id\":\"https:\\/\\/legendei.net\\/dune-2021-2160p-4k-web-x265-10bit-hdr-aac5-1-yts-mx\\\
+        /#webpage\"},\"articleSection\":\"Filmes\"},{\"@type\":\"BreadcrumbList\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/dune-2021-2160p-4k-web-x265-10bit-hdr-aac5-1-yts-mx\\\
+        /#breadcrumblist\",\"itemListElement\":[{\"@type\":\"ListItem\",\"@id\":\"\
+        https:\\/\\/legendei.net\\/#listItem\",\"position\":1,\"name\":\"Home\",\"\
+        item\":\"https:\\/\\/legendei.net\\/\",\"nextItem\":\"https:\\/\\/legendei.net\\\
+        /dune-2021-2160p-4k-web-x265-10bit-hdr-aac5-1-yts-mx\\/#listItem\"},{\"@type\"\
+        :\"ListItem\",\"@id\":\"https:\\/\\/legendei.net\\/dune-2021-2160p-4k-web-x265-10bit-hdr-aac5-1-yts-mx\\\
+        /#listItem\",\"position\":2,\"name\":\"Dune.2021.2160p.4K.WEB.x265.10bit.HDR.AAC5.1-[YTS.MX]\"\
+        ,\"previousItem\":\"https:\\/\\/legendei.net\\/#listItem\"}]},{\"@type\":\"\
+        Organization\",\"@id\":\"https:\\/\\/legendei.net\\/#organization\",\"name\"\
+        :\"Legendei\",\"url\":\"https:\\/\\/legendei.net\\/\",\"logo\":{\"@type\"\
+        :\"ImageObject\",\"url\":\"https:\\/\\/legendei.net\\/wp-content\\/uploads\\\
+        /2026\\/03\\/favicon.webp\",\"@id\":\"https:\\/\\/legendei.net\\/dune-2021-2160p-4k-web-x265-10bit-hdr-aac5-1-yts-mx\\\
+        /#organizationLogo\",\"width\":150,\"height\":150},\"image\":{\"@id\":\"https:\\\
+        /\\/legendei.net\\/dune-2021-2160p-4k-web-x265-10bit-hdr-aac5-1-yts-mx\\/#organizationLogo\"\
+        }},{\"@type\":\"Person\",\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /#author\",\"url\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /\",\"name\":\"Admin\"},{\"@type\":\"WebPage\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /dune-2021-2160p-4k-web-x265-10bit-hdr-aac5-1-yts-mx\\/#webpage\",\"url\"\
+        :\"https:\\/\\/legendei.net\\/dune-2021-2160p-4k-web-x265-10bit-hdr-aac5-1-yts-mx\\\
+        /\",\"name\":\"Legenda Dune 2021 2160p 4K WEB x265 10bit HDR AAC5 1 [YTS MX]\
+        \ | Legendei - Aqui Sai Primeiro\",\"description\":\"Legenda Dune 2021 2160p\
+        \ 4K WEB x265 10bit HDR AAC5 1 [YTS MX] testada e verificada - Pode servir\
+        \ tamb\\u00e9m para outros releases, basta renomear! Dispon\\u00edvel em Legendei\
+        \ - Aqui Sai Primeiro\",\"inLanguage\":\"pt-BR\",\"isPartOf\":{\"@id\":\"\
+        https:\\/\\/legendei.net\\/#website\"},\"breadcrumb\":{\"@id\":\"https:\\\
+        /\\/legendei.net\\/dune-2021-2160p-4k-web-x265-10bit-hdr-aac5-1-yts-mx\\/#breadcrumblist\"\
+        },\"author\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /#author\"},\"creator\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\\
+        /#author\"},\"datePublished\":\"2025-03-13T07:55:20+01:00\",\"dateModified\"\
+        :\"2025-03-13T07:55:20+01:00\"},{\"@type\":\"WebSite\",\"@id\":\"https:\\\
+        /\\/legendei.net\\/#website\",\"url\":\"https:\\/\\/legendei.net\\/\",\"name\"\
+        :\"Legendei\",\"description\":\"Baixar Legendas de S\\u00e9ries e Filmes\"\
+        ,\"inLanguage\":\"pt-BR\",\"publisher\":{\"@id\":\"https:\\/\\/legendei.net\\\
+        /#organization\"}}]}\n\t\t</script>\n\t\t<!-- All in One SEO Pro -->\n\n<link\
+        \ rel='dns-prefetch' href='//fonts.googleapis.com' />\n<link rel=\"alternate\"\
+        \ type=\"application/rss+xml\" title=\"Feed para Legendei &raquo;\" href=\"\
+        https://legendei.net/feed/\" />\n<link rel=\"alternate\" type=\"application/rss+xml\"\
+        \ title=\"Feed de coment\xE1rios para Legendei &raquo;\" href=\"https://legendei.net/comments/feed/\"\
+        \ />\n<link rel=\"alternate\" type=\"application/rss+xml\" title=\"Feed de\
+        \ coment\xE1rios para Legendei &raquo; Dune 2021 2160p 4K WEB x265 10bit HDR\
+        \ AAC5 1 [YTS MX]\" href=\"https://legendei.net/dune-2021-2160p-4k-web-x265-10bit-hdr-aac5-1-yts-mx/feed/\"\
+        \ />\n<script type=\"text/javascript\">\n/* <![CDATA[ */\nwindow._wpemojiSettings\
+        \ = {\"baseUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\/emoji\\/16.0.1\\\
+        /72x72\\/\",\"ext\":\".png\",\"svgUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\\
+        /emoji\\/16.0.1\\/svg\\/\",\"svgExt\":\".svg\",\"source\":{\"concatemoji\"\
+        :\"https:\\/\\/legendei.net\\/wp-includes\\/js\\/wp-emoji-release.min.js?ver=6.8.3\"\
+        }};\n/*! This file is auto-generated */\n!function(s,n){var o,i,e;function\
+        \ c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function\
+        \ p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var\
+        \ t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),a=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new\
+        \ Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return\
+        \ t.every(function(e,t){return e===a[t]})}function u(e,t){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);for(var\
+        \ n=e.getImageData(16,16,1,1),a=0;a<n.data.length;a++)if(0!==n.data[a])return!1;return!0}function\
+        \ f(e,t,n,a){switch(t){case\"flag\":return n(e,\"\\ud83c\\udff3\\ufe0f\\u200d\\\
+        u26a7\\ufe0f\",\"\\ud83c\\udff3\\ufe0f\\u200b\\u26a7\\ufe0f\")?!1:!n(e,\"\\\
+        ud83c\\udde8\\ud83c\\uddf6\",\"\\ud83c\\udde8\\u200b\\ud83c\\uddf6\")&&!n(e,\"\
+        \\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc65\\udb40\\udc6e\\udb40\\\
+        udc67\\udb40\\udc7f\",\"\\ud83c\\udff4\\u200b\\udb40\\udc67\\u200b\\udb40\\\
+        udc62\\u200b\\udb40\\udc65\\u200b\\udb40\\udc6e\\u200b\\udb40\\udc67\\u200b\\\
+        udb40\\udc7f\");case\"emoji\":return!a(e,\"\\ud83e\\udedf\")}return!1}function\
+        \ g(e,t,n,a){var r=\"undefined\"!=typeof WorkerGlobalScope&&self instanceof\
+        \ WorkerGlobalScope?new OffscreenCanvas(300,150):s.createElement(\"canvas\"\
+        ),o=r.getContext(\"2d\",{willReadFrequently:!0}),i=(o.textBaseline=\"top\"\
+        ,o.font=\"600 32px Arial\",{});return e.forEach(function(e){i[e]=t(o,e,n,a)}),i}function\
+        \ t(e){var t=s.createElement(\"script\");t.src=e,t.defer=!0,s.head.appendChild(t)}\"\
+        undefined\"!=typeof Promise&&(o=\"wpEmojiSettingsSupports\",i=[\"flag\",\"\
+        emoji\"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){s.addEventListener(\"\
+        DOMContentLoaded\",e,{once:!0})}),new Promise(function(t){var n=function(){try{var\
+        \ e=JSON.parse(sessionStorage.getItem(o));if(\"object\"==typeof e&&\"number\"\
+        ==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&\"object\"\
+        ==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if(\"\
+        undefined\"!=typeof Worker&&\"undefined\"!=typeof OffscreenCanvas&&\"undefined\"\
+        !=typeof URL&&URL.createObjectURL&&\"undefined\"!=typeof Blob)try{var e=\"\
+        postMessage(\"+g.toString()+\"(\"+[JSON.stringify(i),f.toString(),p.toString(),u.toString()].join(\"\
+        ,\")+\"));\",a=new Blob([e],{type:\"text/javascript\"}),r=new Worker(URL.createObjectURL(a),{name:\"\
+        wpTestEmojiSupports\"});return void(r.onmessage=function(e){c(n=e.data),r.terminate(),t(n)})}catch(e){}c(n=g(i,f,p,u))}t(n)}).then(function(e){for(var\
+        \ t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],\"\
+        flag\"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return\
+        \ e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);\n\
+        /* ]]> */\n</script>\n<link rel='stylesheet' id='wpa-css-css' href='https://legendei.net/wp-content/plugins/wp-attachments/styles/0/wpa.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='wp-emoji-styles-inline-css' type='text/css'>\n\
+        \n\timg.wp-smiley, img.emoji {\n\t\tdisplay: inline !important;\n\t\tborder:\
+        \ none !important;\n\t\tbox-shadow: none !important;\n\t\theight: 1em !important;\n\
+        \t\twidth: 1em !important;\n\t\tmargin: 0 0.07em !important;\n\t\tvertical-align:\
+        \ -0.1em !important;\n\t\tbackground: none !important;\n\t\tpadding: 0 !important;\n\
+        \t}\n</style>\n<link rel='stylesheet' id='wp-block-library-css' href='https://legendei.net/wp-includes/css/dist/block-library/style.min.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='classic-theme-styles-inline-css'\
+        \ type='text/css'>\n/*! This file is auto-generated */\n.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em\
+        \ + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}\n\
+        </style>\n<style id='wppb-content-restriction-start-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-content-restriction-end-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-edit-profile-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-login-style-inline-css' type='text/css'>\n\n\
+        \n</style>\n<style id='wppb-recover-password-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-register-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='global-styles-inline-css' type='text/css'>\n:root{--wp--preset--aspect-ratio--square:\
+        \ 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4:\
+        \ 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3:\
+        \ 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16:\
+        \ 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray:\
+        \ #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink:\
+        \ #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange:\
+        \ #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan:\
+        \ #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue:\
+        \ #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple:\
+        \ #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1)\
+        \ 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan:\
+        \ linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange:\
+        \ linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red:\
+        \ linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray:\
+        \ linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum:\
+        \ linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186)\
+        \ 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple:\
+        \ linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux:\
+        \ linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62)\
+        \ 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112)\
+        \ 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean:\
+        \ linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181)\
+        \ 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128)\
+        \ 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129)\
+        \ 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium:\
+        \ 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large:\
+        \ 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40:\
+        \ 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70:\
+        \ 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural:\
+        \ 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px\
+        \ rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0,\
+        \ 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255,\
+        \ 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0,\
+        \ 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap:\
+        \ 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items:\
+        \ center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display:\
+        \ grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-color{color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background:\
+        \ var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange)\
+        \ !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background:\
+        \ var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background:\
+        \ var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background:\
+        \ var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background:\
+        \ var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background:\
+        \ var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size:\
+        \ var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size:\
+        \ var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--x-large) !important;}\n:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}\n:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}\n:root :where(.wp-block-pullquote){font-size:\
+        \ 1.5em;line-height: 1.6;}\n</style>\n<link rel='stylesheet' id='lrl-css-css'\
+        \ href='https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-maincss-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css' type='text/css'\
+        \ media='all' />\n<link rel='stylesheet' id='fontawesome-css' href='https://legendei.net/wp-content/themes/simple-grid/assets/css/all.min.css'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-webfont-css'\
+        \ href='//fonts.googleapis.com/css?family=Playfair+Display:400,400i,700,700i|Domine:400,700|Oswald:400,700|Patua+One|Merriweather:400,400i,700,700i&#038;display=swap'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='legendei-style-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css?ver=1782544305'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='wppb_stylesheet-css'\
+        \ href='https://legendei.net/wp-content/plugins/profile-builder/assets/css/style-front-end.css?ver=3.15.2'\
+        \ type='text/css' media='all' />\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-includes/js/jquery/jquery.min.js?ver=3.7.1\" id=\"\
+        jquery-core-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1\"\
+        \ id=\"jquery-migrate-js\"></script>\n<!--[if lt IE 9]>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/respond.min.js\"\
+        \ id=\"respond-js\"></script>\n<![endif]-->\n<link rel=\"https://api.w.org/\"\
+        \ href=\"https://legendei.net/wp-json/\" /><link rel=\"alternate\" title=\"\
+        JSON\" type=\"application/json\" href=\"https://legendei.net/wp-json/wp/v2/posts/630577\"\
+        \ /><link rel=\"EditURI\" type=\"application/rsd+xml\" title=\"RSD\" href=\"\
+        https://legendei.net/xmlrpc.php?rsd\" />\n<meta name=\"generator\" content=\"\
+        WordPress 6.8.3\" />\n<link rel='shortlink' href='https://legendei.net/?p=630577'\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (JSON)\" type=\"application/json+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fdune-2021-2160p-4k-web-x265-10bit-hdr-aac5-1-yts-mx%2F\"\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (XML)\" type=\"text/xml+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fdune-2021-2160p-4k-web-x265-10bit-hdr-aac5-1-yts-mx%2F&#038;format=xml\"\
+        \ />\n<style>\n\n/* FORMUL\xC1RIO TRIAL */\n\n.premium-form {\n    max-width:\
+        \ 760px;\n    margin: 0 auto 20px;\n    padding: 30px;\n    border-radius:\
+        \ 10px;\n    background: #212121;\n    border: 10px solid transparent;\n \
+        \   background-image:\n        linear-gradient(#212121,#212121),\n       \
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    background-origin: border-box;\n\
+        \    background-clip: padding-box, border-box;\n    box-sizing: border-box;\n\
+        }\n\n/* Campos */\n\n.premium-form .field {\n    position: relative;\n   \
+        \ margin-bottom: 20px;\n}\n\n.premium-form input {\n    width: 100%;\n   \
+        \ padding: 14px;\n    border-radius: 8px;\n    border: 1px solid #ccc;\n \
+        \   font-size: 16px;\n    box-sizing: border-box;\n}\n\n/* Focus bonito */\n\
+        \n.premium-form input:focus {\n    border-color: transparent;\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin: border-box;\n    background-clip: padding-box, border-box;\n\
+        \    box-shadow: 0 0 0 4px rgba(63,140,255,0.20);\n    outline: none;\n}\n\
+        \n/* TOOLTIP */\n\n.premium-form .tooltip {\n    position: absolute;\n   \
+        \ bottom: 100%;\n    left: 0;\n    margin-bottom: 10px;\n    background: linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \tbox-shadow:0 6px 14px rgba(0,0,0,0.25);\n    color: #ffffff;\n    padding:\
+        \ 10px 12px;\n    font-size: 14px;\n    border-radius: 6px;\n    max-width:\
+        \ 260px;\n    opacity: 0;\n    pointer-events: none;\n    transition: .2s;\n\
+        \    z-index: 999;\n}\n\n.premium-form .tooltip::after {\n    content: \"\"\
+        ;\n    position: absolute;\n    top: 100%;\n    left: 15px;\n    border-width:\
+        \ 6px 6px 0 6px;\n    border-style: solid;\n    border-color: #8a2be2 transparent\
+        \ transparent transparent;\n}\n\n.premium-form .field:hover .tooltip,\n.premium-form\
+        \ .field:focus-within .tooltip {\n    opacity: 1;\n    transform: translateY(-4px);\n\
+        }\n\n/* BOT\xC3O */\n\n.premium-form button {\n    padding: 14px 30px;\n \
+        \   font-size: 22px;\n    border-radius: 8px;\n    border: none;\n    background:\
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    color: #fff;\n    cursor: pointer;\n\
+        \    transition: .25s;\n}\n\n.premium-form button:hover {\n    background:\
+        \ linear-gradient(90deg,#4c9aff,#9a3bff);\n}\n\n/* SENHA */\n\n.pass-wrap{\n\
+        \    position:relative;\n}\n\n.toggle-pass{\n    position:absolute;\n    right:12px;\n\
+        \    top:50%;\n    transform:translateY(-50%);\n    cursor:pointer;\n    font-size:18px;\n\
+        }\n\n/* BARRA FOR\xC7A SENHA */\n\n.strength{\n    height:6px;\n    background:#444;\n\
+        \    border-radius:4px;\n    margin-top:8px;\n    overflow:hidden;\n}\n\n\
+        .strength div{\n    height:100%;\n    width:0%;\n    transition:.3s;\n}\n\n\
+        /* MOBILE */\n\n@media (max-width:480px){\n\n.premium-form{\n    padding:20px;\n\
+        }\n\n}\n\n</style>\n<style>\n\n/* remove fundo normal, ativo e hover do logo\
+        \ */\n.simple-grid-primary-nav-menu > li.menu-logo-item > a,\n.simple-grid-primary-nav-menu\
+        \ > li.menu-logo-item > a:hover,\n.simple-grid-primary-nav-menu > li.menu-logo-item.current-menu-item\
+        \ > a{\n    background:none !important;\n}\n\n/* ===================================================\n\
+        \   MOBILE\n   =================================================== */\n\n\
+        @media only screen and (max-width:812px){\n\n    /* ESCONDER LOGO NO MENU\
+        \ MOBILE */\n    .simple-grid-primary-nav-menu > li.menu-logo-item{\n    \
+        \    display:none !important;\n    }\n\n}\n\n</style>\n    <style type=\"\
+        text/css\">\r\n            .simple-grid-site-title, .simple-grid-site-title\
+        \ a, .simple-grid-site-description {color: #ffffff;}\r\n        </style>\r\
+        \n    <style type=\"text/css\" id=\"custom-background-css\">\nbody.custom-background\
+        \ { background-color: #333333; }\n</style>\n\t<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"32x32\" />\n<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"192x192\" />\n<link rel=\"apple-touch-icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n<meta name=\"msapplication-TileImage\" content=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n</head>\t\n\t\n\t\n<body class=\"wp-singular post-template-default single\
+        \ single-post postid-630577 single-format-standard custom-background wp-custom-logo\
+        \ wp-theme-simple-grid simple-grid-animated simple-grid-fadein simple-grid-theme-is-active\
+        \ simple-grid-custom-logo-active simple-grid-layout-type-full simple-grid-masonry-inactive\
+        \ simple-grid-float-grid simple-grid-responsive-grid-details simple-grid-layout-c-s1\
+        \ simple-grid-header-banner-active simple-grid-tagline-inactive simple-grid-logo-above-title\
+        \ simple-grid-primary-menu-active simple-grid-primary-mobile-menu-active simple-grid-secondary-mobile-menu-active\
+        \ simple-grid-primary-social-icons\" id=\"simple-grid-site-body\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/WebPage\">\n<a class=\"skip-link\
+        \ screen-reader-text\" href=\"#simple-grid-content-wrapper\">Skip to content</a>\n\
+        \n\n\n<div class=\"simple-grid-site-header simple-grid-container\" id=\"simple-grid-header\"\
+        \ itemscope=\"itemscope\" itemtype=\"http://schema.org/WPHeader\" role=\"\
+        banner\">\n<div class=\"simple-grid-head-content simple-grid-clearfix\" id=\"\
+        simple-grid-head-content\">\n\n<div class=\"simple-grid-no-header-content\"\
+        >\n              <p class=\"simple-grid-site-title\"><a href=\"https://legendei.net/\"\
+        \ rel=\"home\">Legendei</a></p>\r\n                </div>\n\n</div><!--/#simple-grid-head-content\
+        \ -->\n</div><!--/#simple-grid-header -->\n\n\n\n<div class=\"simple-grid-container\
+        \ simple-grid-primary-menu-container simple-grid-clearfix\">\n<div class=\"\
+        simple-grid-primary-menu-container-inside simple-grid-clearfix\">\n<nav class=\"\
+        simple-grid-nav-primary\" id=\"simple-grid-primary-navigation\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/SiteNavigationElement\" role=\"navigation\"\
+        \ aria-label=\"Primary Menu\">\n\t\n\t\n<div class=\"simple-grid-outer-wrapper\"\
+        >\n<a href=\"/\" class=\"logo-mobile-inline\">\n<img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \nstyle=\"width:100%;height:auto;\">\n</a>\n\n<style>\n.logo-mobile-inline{\n\
+        display:none;\n}\n\n@media (max-width:812px){\n.logo-mobile-inline{\ndisplay:block;\n\
+        }\n}\n</style>\t\n\n\t\n<style>\n.mobile-header-icons{\n    display:none;\n\
+        }\n\n@media (max-width: 812px){\n\n.mobile-header-icons{\n    display:grid;\n\
+        \    grid-template-columns: 2fr 1fr 1fr;\n    gap:10px;\n    padding:10px;\n\
+        }\n\n/* BOT\xD5ES */\n.mobile-header-icons a,\n.mobile-header-icons .cat-toggle{\n\
+        \    display:flex;\n    align-items:center;\n    justify-content:center;\n\
+        \    gap:6px;\n    background:#141414;\n    padding:8px 6px;\n    border-radius:8px;\n\
+        \    color:#fff;\n    font-size:12px;\n    text-decoration:none;\n    text-align:center;\n\
+        \    cursor:pointer;\n}\n\n/* CATEGORIA */\n.cat-toggle{\n    font-weight:600;\n\
+        }\n\n/* SETA */\n.cat-toggle .arrow{\n    transition:transform 0.3s ease;\n\
+        }\n\n/* SETA GIRADA */\n.cat-toggle.active .arrow{\n    transform:rotate(180deg);\n\
+        }\n\n/* HOVER */\n.mobile-header-icons a:hover,\n.mobile-header-icons .cat-toggle:hover{\n\
+        \    background:#1f1f1f;\n}\n\n/* CONTAINER */\n.cat-container{\n    position:relative;\n\
+        }\n\n/* DROPDOWN */\n.cat-list{\n    display:flex;\n    flex-direction:column;\n\
+        \    gap:6px;\n\n    position:absolute;\n    top:110%;\n    left:0;\n    width:100%;\n\
+        \n    background:#0f0f0f;\n    border-radius:8px;\n    padding:6px;\n    z-index:999;\n\
+        \n    opacity:0;\n    visibility:hidden;\n    transform:translateY(-5px);\n\
+        \    transition:all 0.25s ease;\n}\n\n/* ABERTO */\n.cat-container.open .cat-list{\n\
+        \    opacity:1;\n    visibility:visible;\n    transform:translateY(0);\n}\n\
+        \n/* ITENS */\n.cat-list a{\n    justify-content:flex-start;\n    font-size:14px;\n\
+        \    padding:10px;\n}\n\n}\n</style>\n\n\n<div class=\"mobile-header-icons\"\
+        >\n\n    <!-- CATEGORIAS -->\n    <div class=\"cat-container\">\n        <div\
+        \ class=\"cat-toggle\">\n            \U0001F4C2 Categorias <span class=\"\
+        arrow\">\u25BC</span>\n        </div>\n\n        <div class=\"cat-list\">\n\
+        \            <a href=\"/category/destaques/\">\u2B50 Destaques</a>\n     \
+        \       <a href=\"/category/filmes/\">\U0001F3AC Filmes</a>\n            <a\
+        \ href=\"/category/serie/\">\U0001F4FA S\xE9ries</a>\n            <a href=\"\
+        /category/pack-de-legendas/\">\U0001F4E6 Packs</a>\n        </div>\n    </div>\n\
+        \n    \n        <a href=\"/seja-premium-vitalicio/\"><i class=\"fa-solid fa-crown\"\
+        ></i> Premium</a>\n\n        <a href=\"/login/\"><i class=\"fa-solid fa-key\"\
+        ></i> Login</a>\n\n    \n</div>\n\n<script>\ndocument.addEventListener(\"\
+        DOMContentLoaded\", function(){\n\n    const container = document.querySelector(\"\
+        .cat-container\");\n    const toggle = document.querySelector(\".cat-toggle\"\
+        );\n\n    toggle.addEventListener(\"click\", function(e){\n        e.stopPropagation();\n\
+        \        container.classList.toggle(\"open\");\n        toggle.classList.toggle(\"\
+        active\");\n    });\n\n    document.addEventListener(\"click\", function(e){\n\
+        \        if(!container.contains(e.target)){\n            container.classList.remove(\"\
+        open\");\n            toggle.classList.remove(\"active\");\n        }\n  \
+        \  });\n\n});\n</script>\t\n\t\n<ul id=\"simple-grid-menu-primary-navigation\"\
+        \ class=\"simple-grid-primary-nav-menu simple-grid-menu-primary\"><li id=\"\
+        menu-item-673170\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-673170 menu-logo-item\">\n        <a href=\"https://legendei.net/\"\
+        \ style=\"\n            display:flex;\n            align-items:center;\n \
+        \           justify-content:center;\n            height:100%;\n          \
+        \  padding:0;\n            margin:0;\n            line-height:1;\n       \
+        \ \">\n            <img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \n                      alt=\"Legendei.NET\"\n                      style=\"\
+        height:42px;width:auto;display:block;\">\n        </a></li>\n\n<li id=\"menu-item-673168\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673168\"\
+        ><a href=\"https://legendei.net/category/destaques/\" title=\"Legendas em\
+        \ Destaque\">DESTAQUES</a></li>\n<li id=\"menu-item-673167\" class=\"menu-item\
+        \ menu-item-type-taxonomy menu-item-object-category current-post-ancestor\
+        \ current-menu-parent current-post-parent menu-item-673167\"><a href=\"https://legendei.net/category/filmes/\"\
+        \ title=\"Legendas para Filmes\">Filmes</a></li>\n<li id=\"menu-item-673166\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673166\"\
+        ><a href=\"https://legendei.net/category/serie/\" title=\"Legendas para seriados\"\
+        >S\xC9RIES</a></li>\n<li id=\"menu-item-673169\" class=\"menu-item menu-item-type-taxonomy\
+        \ menu-item-object-category menu-item-673169\"><a href=\"https://legendei.net/category/pack-de-legendas/\"\
+        \ title=\"Pack de legendas\">PACKS</a></li>\n<li id=\"menu-item-731144\" class=\"\
+        menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children\
+        \ menu-item-731144\"><a target=\"_blank\" href=\"/aplicativos/\">RECOMENDAMOS</a>\n\
+        <ul class=\"sub-menu\">\n\t<li id=\"menu-item-673172\" class=\"menu-item menu-item-type-custom\
+        \ menu-item-object-custom menu-item-673172\"><a target=\"_blank\" href=\"\
+        /aplicativos/\" title=\"Programas para windows\">APLICATIVOS</a></li>\n\t\
+        <li id=\"menu-item-687662\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-687662\"><a target=\"_blank\" href=\"https://4kxxx.vip/\" title=\"\
+        Baixe os melhores v\xEDdeos porn\xF4 sempre em 4K\">4K XXX</a></li>\n\t<li\
+        \ id=\"menu-item-717497\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-717497\"><a target=\"_blank\" href=\"https://detonaplay.com/\"\
+        >GAMES</a></li>\n</ul>\n</li>\n\n\n\n<li class=\"menu-item\" style=\"float:right;\"\
+        >\n            <a href=\"/login/\"\n               style=\"background:linear-gradient(135deg,#198754,#20ac6b);color:#ffffff;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-key\"></i> Login\n            </a>\n\
+        \        </li><li class=\"menu-item\" style=\"float:right;\">\n          \
+        \  <a href=\"/seja-premium-vitalicio/\"\n\t\t\t\t\t  style=\"background:linear-gradient(135deg,#f4c430,#c2940a);color:#4d2e00;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-crown\"></i> Membro Premium\n  \
+        \          </a>\n        </li></ul>    </div>\n</nav>\n</div>\n</div>\n\n\t\
+        \n\t\n\r\n<div class=\"simple-grid-outer-wrapper\">\r\n<div class=\"simple-grid-top-wrapper-outer\
+        \ simple-grid-clearfix\">\r\n<div class=\"simple-grid-featured-posts-area\
+        \ simple-grid-top-wrapper simple-grid-clearfix\">\r\n\r\n<div id=\"search-5\"\
+        \ class=\"simple-grid-main-widget widget simple-grid-widget-box widget_search\"\
+        ><div class=\"simple-grid-widget-box-inside\"><form role=\"search\" method=\"\
+        get\" class=\"simple-grid-search-form\" action=\"https://legendei.net/\">\n\
+        <label>\n    <span class=\"simple-grid-sr-only\">Pesquisar por </span>\n \
+        \   <input \n        type=\"search\"\n        class=\"simple-grid-search-field\"\
+        \n        placeholder=\"Pesquisar &hellip;\"\n        value=\"\"\n       \
+        \ name=\"s\"\n        minlength=\"3\"\n\t\tmaxlength=\"50\"   \n        required\n\
+        \    />\n</label>\n<input type=\"submit\" class=\"simple-grid-search-submit\"\
+        \ value=\"&#xf002;\" />\n</form></div></div></div>\r\n</div>\r\n</div>\r\n\
+        \r\n\n<div class=\"simple-grid-outer-wrapper\" id=\"simple-grid-wrapper-outside\"\
+        >\n\n<div class=\"simple-grid-container simple-grid-clearfix\" id=\"simple-grid-wrapper\"\
+        >\n<div class=\"simple-grid-content-wrapper simple-grid-clearfix\" id=\"simple-grid-content-wrapper\"\
+        >\t\n\t\t\n\n\n<div class=\"simple-grid-main-wrapper simple-grid-clearfix\"\
+        \ id=\"simple-grid-main-wrapper\" itemscope=\"itemscope\" itemtype=\"http://schema.org/Blog\"\
+        \ role=\"main\">\n<div class=\"theiaStickySidebar\">\n<div class=\"simple-grid-main-wrapper-inside\
+        \ simple-grid-clearfix\">\n\n\r\n\r\n\n<div class=\"simple-grid-posts-wrapper\"\
+        \ id=\"simple-grid-posts-wrapper\">\n\n\n\n\n\n<div style=\"width: 100%; border-radius:\
+        \ 12px; box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 12px; padding: 15px; background:\
+        \ #ffffff;\">\n    <center>\n    <article id=\"post-630577\" class=\"simple-grid-post-singular\
+        \ simple-grid-box post-630577 post type-post status-publish format-standard\
+        \ hentry category-filmes wpcat-3-id\">\n        <div class=\"simple-grid-box-inside\"\
+        >\n            \n            \n                            <header class=\"\
+        entry-header\">\n                    <div class=\"entry-header-inside simple-grid-clearfix\"\
+        >\n\n<h1 class=\"post-title entry-title\">Legenda Dune 2021 2160p 4K WEB x265\
+        \ 10bit HDR AAC5 1 [YTS MX] <span aria-label=\"PT-BR\">\U0001F1E7\U0001F1F7\
+        </span></h1>\n\n\n                                    <div class=\"simple-grid-entry-meta-single\"\
+        >\n                            <span class=\"simple-grid-entry-meta-single-date\"\
+        >\n                <i class=\"far fa-clock\" aria-hidden=\"true\"></i>&nbsp;13\
+        \ de mar\xE7o de 2025            </span>\n                               \
+        \     <span class=\"simple-grid-entry-meta-single-categories\"><i class=\"\
+        far fa-folder-open\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Posted in </span><a href=\"https://legendei.net/category/filmes/\" rel=\"\
+        category tag\">Filmes</a></span>                            </div>\n    \n\
+        \n                    </div>\n                </header>\n            \t\t\t\
+        \n\t\t\t\n            <!-- inicio poster -->\n                        <!--\
+        \ fim poster -->\n\t\t\t\n<!-- S admin -->\n            \t\t\t\n<!-- S admin\
+        \ -->\t\n\t\t\t\n            \n            <div class=\"entry-content simple-grid-clearfix\"\
+        >\n\n<!-- N PREMIUM AMIN TEMP -->\t\t\t\t\n\t\n\n   <a href=\"https://cuponei.org/promo/more/\"\
+        \ target=\"_blank\" rel=\"noopener\">\n    <img class=\"aligncenter wp-image-729595\
+        \ size-full\"\n         src=\"https://legendei.net/wp-content/uploads/2026/01/amazon.webp\"\
+        \n         width=\"350\" height=\"334\" />\n  </a>\t\n\t\t\t\t\t\t\t\t\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\t\t\t\t\n<!-- anexos otimizados -->\n<!--\
+        \ /anexos -->\n\n\n                <!-- WP Attachments -->\n        <div style=\"\
+        width:100%;margin:10px 0 10px 0;\">\n            <h3></h3>\n        <ul class=\"\
+        post-attachments\"><p class=\"post-attachment mime-application-zip\">    \
+        \                                                                        \
+        \    <a href=\"https://legendei.net/dune-2021-2160p-4k-web-x265-10bit-hdr-aac5-1-yts-mx/?download=630576\"\
+        \ target=\"_blank\" class=\"buttonmyup\"><i class=\"fa fa-download\"></i>\
+        \ BAIXAR LEGENDA</a>\r\n</p></ul></div>\n        <div class=\"highlight-text\"\
+        >\n\n<style>\n/* ===================================== */\n/* LINKS COM BORDA\
+        \ GRADIENTE + UNDERLINE */\n/* ===================================== */\n\n\
+        .busca-legenda-links a{\n    display:inline-block;\n    padding:8px 18px;\n\
+        \    margin:2px 8px;\n    font-weight:400;\n    font-size:14px;\n    text-decoration:none\
+        \ !important;\n\tmin-width: 180px;\n    color:#1e293b !important; /* texto\
+        \ escuro vis\xEDvel */\n    background:transparent;\n\n    border:2px solid\
+        \ transparent;\n    border-radius:6px;\n\n    /* borda gradiente */\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin:border-box;\n    background-clip:padding-box, border-box;\n\
+        \n    position:relative;\n    transition:all .25s ease;\n}\n\n/* underline\
+        \ gradiente (embaixo do texto) */\n.busca-legenda-links a::after{\n    content:\"\
+        \";\n    position:absolute;\n    left:50%;\n    bottom:6px; /* dentro do bot\xE3\
+        o */\n    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\n\n/*\
+        \ hover */\n.busca-legenda-links a:hover{\n    color:#002080 !important;\n\
+        }\n\n.busca-legenda-links a:hover::after{\n    width:60%;\n}\n\n/* ativo (se\
+        \ quiser usar classe active depois) */\n.busca-legenda-links a.active::after{\n\
+        \    width:60%;\n}\n\n@media (max-width: 768px){\n\n    .busca-legenda-links{\n\
+        \        display:block;\n    }\n\n    /* remove os pontinhos separadores no\
+        \ mobile */\n    .busca-legenda-links span{\n        display:none;\n    }\n\
+        \n    .busca-legenda-links a{\n        display:block;\n        width:100%;\n\
+        \        margin:6px 0; /* controla espa\xE7amento vertical */\n        text-align:center;\n\
+        \t\tfont-size:14px;\n    }\n\n\n}\n</style>\n\n\n\n            <p><strong>Legenda\
+        \ do filme Dune 2021 2160p 4K WEB x265 10bit HDR AAC5 1 [YTS MX]</strong></p>\n\
+        \            <hr>\n\n            <p>Todas as legendas dispon\xEDveis para\
+        \ download s\xE3o testadas e verificadas, garantindo sincronia, precis\xE3\
+        o e qualidade.</p>\n\n            <p>Depois de baixar a legenda, n\xE3o se\
+        \ esque\xE7a de conferir o seu release!</p>\n\n            <div class=\"busca-legenda-links\"\
+        >\n                <a href=\"/category/filmes/?s=Dune+2021\">+ legendas mesmo\
+        \ filme</a>\n            </div>\n\n        </div>\n\t\t\n\n\t\t\n\t\t\n  \
+        \              <!-- sinopse TMDB -->\n                <!-- /sinopse -->\n\n\
+        \            </div><!-- .entry-content -->\n\n            \n            \n\
+        \        </div>\n\n\n\n\t\t\n    </article>\n\n<!-- inicio app recomendados\
+        \ -->\t\t\n<div id=\"apps-recomendados\">\n<div class=\"busca-legenda-links\"\
+        \ style=\"text-align:center;\">\n<h5>Aplicativos que usamos e recomendamos</h5>\n\
+        \n<a href=\"https://legendei.net/aplicativos/kodi/\" target=\"_blank\" rel=\"\
+        noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2025/11/Kodi_21.3.webp\"\
+        \ width=\"40\" height=\"40\" />\n    Kodi Media Center\n</a>\n\n<a href=\"\
+        https://legendei.net/aplicativos/utorrent-pro-download-e-guia-completo/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/08/uTorrent-Pro.jpg\"\
+        \ width=\"40\" height=\"40\" />\n    uTorrent Pro\n</a>\n\n<a href=\"https://legendei.net/aplicativos/winzip-pro-windows/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/09/WinZip-Pro.png\"\
+        \ width=\"40\" height=\"40\" />\n    WinZip Pro\n</a>\n</div>\n</div>\n<style>\n\
+        @media (max-width: 812px){\n    #apps-recomendados{\n        display: none;\n\
+        \    }\n}\n</style>\n<!-- fim app recomendados -->\n\t\t\n\n\t\t\n\t\t\n\n\
+        \t\t\n<hr>\n<div class=\"lrl-report-link\">\n    <a href=\"#\" class=\"lrl-open\
+        \ busca-legenda-links\">\U0001F6A8 Reportar problemas \U0001F6A8</a>\n\t</div>\n\
+        \n    <div id=\"lrl-modal\" style=\"display:none;\">\n        <div class=\"\
+        lrl-box\">\n            <span class=\"lrl-close\">&times;</span>\n       \
+        \     <h3>Qual \xE9 o problema?</h3><hr>\n\n<label><input type=\"radio\" name=\"\
+        lrl_motivo\" value=\"Problemas com o download\"> O download n\xE3o funciona</label><br><br>\n\
+        \n<label><input type=\"radio\" name=\"lrl_motivo\" value=\"Legenda para o\
+        \ filme ou s\xE9rie incorreta\"> Conte\xFAdo \xE9 para outro filme, s\xE9\
+        rie ou epis\xF3dio</label><br><br>\n\n<label><input type=\"radio\" name=\"\
+        lrl_motivo\" value=\"Idioma da legenda incorreto\"> O idioma da legenda est\xE1\
+        \ errado.</label><br><br>\n<hr>\n            <button id=\"lrl-send\" disabled>Enviar</button>\n\
+        \        </div>\n    </div>\n    \t\t\n    </center>\n\t\n</div>\n\n\t\n\t\
+        \n\t\n\t\n\n<!-- S admin -->\t\n<!-- S admin -->\t\n\n\n\t\n<!-- N PREMIUM\
+        \ AMIN TEMP -->\n<div>\t\n<!-- protetor de links -->\n<script>\n(function(){\n\
+        \nconst redirectpage = \"https://legendei.net/noticia.php\";\n\nconst bases\
+        \ = [\n    '/?download=',\n    '/?dl_',\n    '.rar',\n    '.zip',\n    '.srt',\n\
+        \    'magnet:',\n\t'/zip-attachments.php'\n];\n\ndocument.querySelectorAll('a').forEach(a\
+        \ => {\n    const href = a.getAttribute('href') || '';\n\n    if (bases.some(b\
+        \ => href.includes(b))) {\n\n        const token = btoa(href);\n\n       \
+        \ a.href = redirectpage + \"?token=\" + token;\n        a.target = \"_blank\"\
+        ;\n    }\n});\n\n})();\n</script>\n<!-- /protetor de links -->\t\n\t\t\n\n\
+        <!-- BLOQUEADOR LEGENDEI -->\n\n<!-- BLOQUEADOR LEGENDEI -->\n\t\n<!-- inicio\
+        \ reload -->\n<script>\nsetInterval(function(){\n  location.reload();\n},\
+        \ 120000); // 2 minutos\n</script>\n<!-- fim reload -->\t\n\t\n</div>\t\n\
+        <!-- N PREMIUM AMIN TEMP -->\n\t\n\t\n<div class=\"clear\"></div>\n</div><!--/#simple-grid-posts-wrapper\
+        \ -->\n\n\r\n\r\n\t\n\n</div>\n</div>\n</div><!-- /#simple-grid-main-wrapper\
+        \ -->\n\n\n\n</div>\n\n\n\n\n<!-- N ADMIN -->\n<div>\n<!-- inicio -->\n<iframe\
+        \ \n  src=\"https://cuponei.org/last/\"\n  style=\"\n    width:1px;\n    height:1px;\n\
+        \    opacity:0;\n    border:none;\n    overflow:hidden;\n  \"\n  scrolling=\"\
+        no\"\n></iframe>\n<!-- fim -->\t\n</div>\n<!-- N ADMIN -->\n\n\n\n\n<!-- N\
+        \ PREMIUM AMIN TEMP -->\n\n\n\n\n<div>\n\n\t\n<!-- =============================\
+        \ -->\n<!-- SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\n\n<div id=\"SCRIPT_1_AQUI\" style=\"display:none;\">\t\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/invesup.js\"></script>\n<script\
+        \ type=\"text/javascript\">\n// make pop on new window with size 150x150 \
+        \ \nLight.Popup.create('https://cuponei.org/promo/more/', {width: 150, height:\
+        \ 150, onNewTab: false});\n// refresh = new popup\nLight.Popup.create('https://cuponei.org/promo/more/amz/',\
+        \ {alwaysPop: false});  \n</script>\n</div>\t\n\n<div id=\"SCRIPT_2_AQUI\"\
+        \ style=\"display:none;\">\n\t\n<script type=\"text/javascript\">\n var p$00a\
+        \ = 'p$00a' + (new Date().getTime()) + 'zz'; window[p$00a] = {a:'abcdefghijklmnopqrstuvwxyz0123456789i0xpy5jn7r6h82fuw1skdgzca94e3omqvblt',\
+        \ b:'{\"AZIb\":\"e344vq\", \"BVIb\":\"b4mm4e\", \"CXrr1\":\"du\", \"DLtag\"\
+        :\"e\", \"Emjk5\":\"\", \"XCge1s\":\"u.g7fz1yh.xf8\" , \"Zt1\":\"ufuxisn.2yk\"\
+        , \"ZZ1\":\"u.nn8fu.xhfdp\" }', c:'{\"Abkr221\":\"sx17uk\", \"Bo9ssm\":\"\
+        //xp2.g7fz1yh.xf8/iuu.rs\"}', d:'{\"Ag4\":\"0fpa\", \"Bx1\":\"iuuy2pCn7hp\"\
+        , \"Cky\":\"s1x\", \"Dmg\":\"x1yikyEhy8y2k\"}'};\nvar _0x5d4b=['235913QVfbwv','slice','length','162209QBmAmV','14238hyOOTq','323207DTbifh','split','1DqiKtq','135866HTbavB','indexOf','call','27654SKXHbY','parse','undefined','32Ijckmz','keys','map','ceil','115980hcFVDy','values','join'];var\
+        \ _0x208c=function(_0x31a8d7,_0x5f36b3){_0x31a8d7=_0x31a8d7-0x167;var _0x5d4be1=_0x5d4b[_0x31a8d7];return\
+        \ _0x5d4be1;};(function(_0x276f94,_0x57c4ff){var _0x50057c=_0x208c;while(!![]){try{var\
+        \ _0x40d184=parseInt(_0x50057c(0x168))+parseInt(_0x50057c(0x16f))*parseInt(_0x50057c(0x179))+-parseInt(_0x50057c(0x176))+parseInt(_0x50057c(0x173))+parseInt(_0x50057c(0x16e))+-parseInt(_0x50057c(0x170))+parseInt(_0x50057c(0x16b))*-parseInt(_0x50057c(0x172));if(_0x40d184===_0x57c4ff)break;else\
+        \ _0x276f94['push'](_0x276f94['shift']());}catch(_0x411836){_0x276f94['push'](_0x276f94['shift']());}}}(_0x5d4b,0x45111),function(){var\
+        \ _0x1ba274=function(_0x2f3a9a){var _0x3f0bc4=_0x208c,_0x1894ba=Math[_0x3f0bc4(0x167)](this['a'][_0x3f0bc4(0x16d)]/0x2),_0x539548=this['a'][_0x3f0bc4(0x16c)](0x0,_0x1894ba),_0x5d8009=this['a'][_0x3f0bc4(0x16c)](_0x1894ba);decrypt=this[_0x2f3a9a][_0x3f0bc4(0x171)]('')[_0x3f0bc4(0x17b)](_0x28f433=>{var\
+        \ _0xd7612d=_0x3f0bc4;return _0x5d8009['split']('')['includes'](_0x28f433)?_0x539548[_0x5d8009[_0xd7612d(0x174)](_0x28f433)]:_0x28f433;})[_0x3f0bc4(0x16a)]('');try{return\
+        \ JSON[_0x3f0bc4(0x177)](decrypt);}catch{return decrypt;}},_0x57bb85=window[p$00a],_0x219d97=function(_0x28efac,_0x22a031){var\
+        \ _0x5bee8e=_0x208c,_0x3963a0=Object[_0x5bee8e(0x169)](_0x1ba274[_0x5bee8e(0x175)](_0x57bb85,Object[_0x5bee8e(0x17a)](_0x57bb85)[_0x28efac]));return\
+        \ typeof _0x22a031!=_0x5bee8e(0x178)?_0x3963a0[_0x22a031]:_0x3963a0;};window[p$00a]['x']=function(){return\
+        \ _0x219d97(0x1);};var _0xf1db57=document[_0x219d97(0x3,0x3)](_0x219d97(0x2,0x0));_0xf1db57[_0x219d97(0x3,0x2)]=_0x219d97(0x2,0x1),document[_0x219d97(0x3,0x0)][_0x219d97(0x3,0x1)](_0xf1db57),p$00a=undefined;}());\n\
+        \ \n </script>\n\t\n<script type=\"text/javascript\" src=\"https://legendei.net/invesup.js\"\
+        ></script>\n<script type=\"text/javascript\">\n// make pop on new window with\
+        \ size 150x150  \nLight.Popup.create('https://legendei.net/terrabanne/', {width:\
+        \ 150, height: 150, onNewTab: false}); \n// refresh = new popup\nLight.Popup.create('https://legendei.net/terrabanne/',\
+        \ {alwaysPop: true}); \t\n</script>\t\n\t\n</div>\n\n<!-- =============================\
+        \ -->\n<!-- / SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\t\n\t\n<script>\n(function(){\n\nconst path = window.location.pathname;\n\
+        \nwindow.__CUPONEI_DISABLE_ALL = (\n  path.startsWith('/seja-premium-vitalicio')\
+        \ ||\n  path.startsWith('/perfil')\n);\n\nif (window.__CUPONEI_DISABLE_ALL)\
+        \ return;\n\n/* evita bots */\nif (/bot|googlebot|crawler|spider|crawling/i.test(navigator.userAgent))\
+        \ return;\n\nconst isExpiredUser = false;\n\nconst BLOCK_TIME = 1 * 60 * 60\
+        \ * 1000;\nconst STORAGE_KEY = 'premium_popup_blocked_until';\nconst TRIGGER_DELAY\
+        \ = 1000;\n\nlet adsStarted = false;\n\n/* ============================= */\n\
+        /* CONTROLE TEMPO                */\n/* ============================= */\n\
+        \nfunction now(){\n    return Date.now();\n}\n\nfunction isBlocked(){\n  \
+        \  const until = localStorage.getItem(STORAGE_KEY);\n    return until && now()\
+        \ < parseInt(until);\n}\n\nfunction blockPopup(){\n    localStorage.setItem(STORAGE_KEY,\
+        \ now() + BLOCK_TIME);\n}\n\n/* ============================= */\n/* EXECU\xC7\
+        \xC3O SEGURA DOS SCRIPTS   */\n/* ============================= */\n\nfunction\
+        \ executeScriptsFromDiv(divId, callback){\n\n    if (window.__CUPONEI_DISABLE_ALL){\n\
+        \        if(callback) callback();\n        return;\n    }\n\n    const container\
+        \ = document.getElementById(divId);\n    if(!container){\n        if(callback)\
+        \ callback();\n        return;\n    }\n\n    const scripts = container.querySelectorAll(\"\
+        script\");\n    let total = scripts.length;\n    let loaded = 0;\n\n    if(total\
+        \ === 0){\n        if(callback) callback();\n        return;\n    }\n\n  \
+        \  scripts.forEach(oldScript => {\n\n        const newScript = document.createElement(\"\
+        script\");\n\n        for (let attr of oldScript.attributes) {\n         \
+        \   newScript.setAttribute(attr.name, attr.value);\n        }\n\n        if(oldScript.src){\n\
+        \n            newScript.onload = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n            newScript.onerror = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n        } else {\n            newScript.text = oldScript.text;\n\
+        \            loaded++;\n        }\n\n        document.body.appendChild(newScript);\n\
+        \n        if(!oldScript.src){\n            if(loaded === total && callback)\
+        \ callback();\n        }\n\n    });\n\n}\n\n/* =============================\
+        \ */\n/* SEQU\xCANCIA DOS AN\xDANCIOS        */\n/* =============================\
+        \ */\n\nfunction runAds(){\n\n    if (window.__CUPONEI_DISABLE_ALL) return;\n\
+        \    if (adsStarted) return;\n\n    adsStarted = true;\n\n    let clickCount\
+        \ = 0;\n    let script2Executed = false;\n\n    function handleUserClick(){\n\
+        \n        clickCount++;\n\n        // Debug opcional\n        // console.log(\"\
+        Cliques:\", clickCount);\n\n        if(clickCount >= 2 && !script2Executed){\n\
+        \n            script2Executed = true;\n\n            document.removeEventListener(\"\
+        click\", handleUserClick, true);\n            document.removeEventListener(\"\
+        touchstart\", handleUserClick, true);\n\n            executeScriptsFromDiv(\"\
+        SCRIPT_2_AQUI\");\n        }\n    }\n\n    // Executa SCRIPT 1 primeiro\n\
+        \    setTimeout(function(){\n\n        executeScriptsFromDiv(\"SCRIPT_1_AQUI\"\
+        , function(){\n\n            // S\xF3 depois que SCRIPT 1 foi carregado\n\
+        \            document.addEventListener(\"click\", handleUserClick, {capture:true});\n\
+        \            document.addEventListener(\"touchstart\", handleUserClick, {capture:true});\n\
+        \n        });\n\n    }, 1000);\n\n}\n\n/* ============================= */\n\
+        /* POPUP PREMIUM                 */\n/* ============================= */\n\
+        \nfunction createPopup(){\n\nif(isBlocked()){\n    runAds();\n    return;\n\
+        }\n\nconst popup=document.createElement('div');\npopup.id='premium-popup';\n\
+        \npopup.innerHTML = isExpiredUser ? `\n\n<div class=\"premium-overlay\"></div>\n\
+        <div class=\"premium-box\">\n\n<div class=\"premium-text\">\n\U0001F614 Seu\
+        \ per\xEDodo de teste terminou!<br><br>\n<strong>Voc\xEA pode ser Membro Premium\
+        \ Vital\xEDcio para sempre fazendo uma \xFAnica doa\xE7\xE3o.</strong>\n</div>\n\
+        \n<div class=\"premium-actions\">\n<a href=\"/perfil/\" class=\"premium-yes\"\
+        >\U0001F525 QUERO SER PREMIUM \U0001F525</a>\n<p class=\"premium-nope\">CONTINUAR\
+        \ COM AN\xDANCIOS</p>\n</div>\n\n</div>\n\n` : `\n\n<div class=\"premium-overlay\"\
+        ></div>\n<div class=\"premium-box\">\n\n<div class=\"premium-text\">\n<i class=\"\
+        fa-solid fa-heart fa-beat\"></i>\nApoie a Legendei.NET e torne-se Membro Premium\
+        \ Vital\xEDcio agora para navegar sem an\xFAncios e desbloquear recursos exclusivos!\n\
+        <br>\n</div>\n\n<div class=\"premium-actions\">\n<a href=\"/seja-premium-vitalicio/\"\
+        \ class=\"premium-yes\">\U0001F525 FA\xC7A UM TESTE GRATUITO \U0001F525</a>\n\
+        <p class=\"premium-nope\">CONTINUAR COM AN\xDANCIOS</p>\n<a href=\"/login/\"\
+        \ class=\"premium-login\">J\xE1 tenho uma conta e quero conectar</a>\n</div>\n\
+        \n</div>\n\n`;\n\ndocument.body.appendChild(popup);\n\npopup.querySelector('.premium-nope').onclick=function(e){\n\
+        \ne.preventDefault();\n\nblockPopup();\nrunAds();\n\npopup.remove();\n\n};\n\
+        \n}\n\nlet triggered=false;\n\nfunction triggerPopup(){\n\nif(triggered) return;\n\
+        \ntriggered=true;\n\nsetTimeout(createPopup,TRIGGER_DELAY);\n\nwindow.removeEventListener('mousemove',triggerPopup);\n\
+        window.removeEventListener('touchstart',triggerPopup);\n\n}\n\n/* =============================\
+        \ */\n/* DISPARADORES                  */\n/* =============================\
+        \ */\n\nwindow.addEventListener('mousemove',triggerPopup,{passive:true});\n\
+        window.addEventListener('touchstart',triggerPopup,{passive:true});\n\ndocument.addEventListener('DOMContentLoaded',\
+        \ function(){\n\n    if(isBlocked()){\n        runAds();\n    }\n\n});\n\n\
+        })();\n</script>\n\n<style>\n/* ============================= */\n/* POPUP\
+        \ BASE */\n/* ============================= */\n#premium-popup{\n  position:fixed;\n\
+        \  inset:0;\n  z-index:999999;\n}\n\n.premium-overlay{\n  position:absolute;\n\
+        \  inset:0;\n  background:rgba(0,0,0,.65);\n}\n\n.premium-box{\n  position:absolute;\n\
+        \  left:50%;\n  top:50%;\n  transform:translate(-50%,-50%);\n  background:#212121;\n\
+        \  padding:28px 26px 26px;\n  max-width:440px;\n  width:92%;\n  border-radius:14px;\n\
+        \  text-align:center;\n}\n@media (max-width: 812px){\n  .premium-box{\n  \
+        \  top:5%;\n    transform:translate(-50%, 0);\n  }\n}\n\t\n/* inicio premium-login\
+        \ */\n.premium-login{\n  color:#fff;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  cursor:pointer;\n}\na.premium-login{\n    padding:8px 18px;\n}\na.premium-login::after{\n\
+        \    content:\"\";\n    position:absolute;\n    left:50%;\n    bottom:6px;\n\
+        \    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\na.premium-login:hover{\n\
+        \    color:#fff !important;\n}\n\na.premium-login:hover::after{\n    width:60%;\n\
+        }\n@media (max-width: 768px){\n    a.premium-login{\n        display:block;\n\
+        \        width:100%;\n        margin:6px 0;\n        text-align:center;\n\
+        \        font-size:14px;\n    }\n}\n/* fim premium-login */\n\n/* =============================\
+        \ */\n/* TEXTO */\n/* ============================= */\n.premium-text{\n \
+        \ color:#fff;\n  font-size:clamp(15px,2.6vw,18px);\n  line-height:1.4;\n \
+        \ font-family:Roboto,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;\n\
+        }\n\n.premium-text i{\n  color:#e74c3c;\n  margin-right:6px;\n}\n\n/* =============================\
+        \ */\n/* A\xC7\xD5ES */\n/* ============================= */\n.premium-actions{\n\
+        \  margin-top:18px;\n  display:flex;\n  flex-direction:column;\n  gap:12px;\n\
+        }\n\n/* ============================= */\n/* BOT\xD5ES */\n/* =============================\
+        \ */\n.alter{\n  background:#6f42c1;\n  border:2px solid #fff;\n  font-weight:bold;\n\
+        \  font-size:clamp(14px,2.6vw,16px);\n  color:#fff;\n  padding:10px 14px;\n\
+        \  border-radius:8px;\n  cursor:pointer;\n}\n\n.premium-yes{\n  background:#1e90ff;\n\
+        \  border:2px solid #FFF;\n  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  color:#fff;\n  padding:10px 14px;\n  border-radius:8px;\n  cursor:pointer;\n\
+        }\n\n.premium-nope{\n  background:#cc3300;\n  border:2px solid #FFF;\n  color:#fff;\n\
+        \  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n  padding:10px\
+        \ 14px;\n  border-radius:8px;\n  cursor:pointer;\n}\n\n/* =============================\
+        \ */\n/* HOVER / ACTIVE (-15%) */\n/* ============================= */\n.alter:hover,\n\
+        .alter:active,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-login:hover,\n\
+        .premium-login:active,\n.premium-nope:hover,\n.premium-nope:active{\n  filter:\
+        \ brightness(85%);\n}\n/* ============================= */\n/* TEXTO SEMPRE\
+        \ BRANCO (TODOS ESTADOS) */\n/* ============================= */\n.alter,\n\
+        .alter:visited,\n.alter:hover,\n.alter:active,\n.alter:focus,\n\n.premium-yes,\n\
+        .premium-yes:visited,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-yes:focus,\n\
+        \n.premium-login,\n.premium-login:visited,\n.premium-login:hover,\n.premium-login:active,\n\
+        .premium-login:focus,\n\n.premium-nope,\n.premium-nope:visited,\n.premium-nope:hover,\n\
+        .premium-nope:active,\n.premium-nope:focus{\n  color:#fff !important;\n  text-decoration:none;\n\
+        }\n/* ============================= */\n/* RESPONSIVO */\n/* =============================\
+        \ */\n/* Esconder em telas menores que 812px */\n@media (max-width: 812px){\n\
+        \  .alter{\n    display:none !important;\n  }\n}\n</style>\n\n</div>\n\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n</div><!--/#simple-grid-content-wrapper\
+        \ -->\n\n\n\n\n\n</div><!--/#simple-grid-wrapper -->\n\n\n\n\r\n\r\n\n\n\n\
+        \n\n\n<div class='simple-grid-clearfix' id='simple-grid-copyright-area'>\n\
+        \t\n<div class='simple-grid-copyright-area-inside simple-grid-container'>\n\
+        \t<a href=\"/\"><img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \ alt=\"\" width=\"300\" height=\"67\" class=\"aligncenter size-medium wp-image-747799\"\
+        \ /></a>\n<div class=\"simple-grid-outer-wrapper\">\t\n<center>\t\n<div class='simple-grid-copyright-area-inside-content\
+        \ simple-grid-clearfix'>\n  <p class='simple-grid-copyright'>Copyright \xA9\
+        \ 2016 - 2026 Legendei - Aqui Sai Primeiro</p>\n<p class='simple-grid-credit'><a\
+        \ href=\"https://legendei.net/\">Design by Legendei.NET</a></p>\n</div>\n\t\
+        </center>\n</div>\n</div>\n</div><!--/#simple-grid-copyright-area -->\n\n\n\
+        \n\n<button class=\"simple-grid-scroll-top\" title=\"Scroll to Top\"><i class=\"\
+        fas fa-arrow-up\" aria-hidden=\"true\"></i><span class=\"simple-grid-sr-only\"\
+        >Scroll to Top</span></button>\t\n\n\n\n\n\n<!-- Google tag (gtag.js) -->\n\
+        <script async src=\"https://www.googletagmanager.com/gtag/js?id=G-GX6PZNPM06\"\
+        ></script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function\
+        \ gtag(){dataLayer.push(arguments);}\n  gtag('js', new Date());\n\n  gtag('config',\
+        \ 'G-GX6PZNPM06');\n</script>\t\n\n\n\n\n\n<script type=\"speculationrules\"\
+        >\n{\"prefetch\":[{\"source\":\"document\",\"where\":{\"and\":[{\"href_matches\"\
+        :\"\\/*\"},{\"not\":{\"href_matches\":[\"\\/wp-*.php\",\"\\/wp-admin\\/*\"\
+        ,\"\\/wp-content\\/uploads\\/*\",\"\\/wp-content\\/*\",\"\\/wp-content\\/plugins\\\
+        /*\",\"\\/wp-content\\/themes\\/simple-grid\\/*\",\"\\/*\\\\?(.+)\"]}},{\"\
+        not\":{\"selector_matches\":\"a[rel~=\\\"nofollow\\\"]\"}},{\"not\":{\"selector_matches\"\
+        :\".no-prefetch, .no-prefetch a\"}}]},\"eagerness\":\"conservative\"}]}\n\
+        </script>\n\n<script>\nfunction attUploadProof(){\n\n    let fileInput = document.getElementById('att_proof');\n\
+        \    let msg = document.getElementById('att_upload_msg');\n\n    if(!fileInput.files.length){\n\
+        \        msg.innerHTML = '<span style=\"color:red;\">Selecione um arquivo</span>';\n\
+        \        return;\n    }\n\n    let file = fileInput.files[0];\n\n    if(file.size\
+        \ > 50 * 1024 * 1024){\n        msg.innerHTML = '<span style=\"color:red;\"\
+        >Arquivo maior que 50MB</span>';\n        return;\n    }\n\n    let formData\
+        \ = new FormData();\n    formData.append('action','att_upload_proof');\n \
+        \   formData.append('proof', file);\n\n    msg.innerHTML = 'Enviando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        body: formData\n    })\n    .then(r => r.json())\n    .then(res\
+        \ => {\n\n        if(res.success){\n            msg.innerHTML = '<span style=\"\
+        color:green;\">Comprovante enviado com sucesso!</span>';\n        } else {\n\
+        \            msg.innerHTML = '<span style=\"color:red;\">Erro: '+res.data+'</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<script>\nfunction attSaveLastName(){\n\
+        \n    let input = document.getElementById('att_last_name_input') \n      \
+        \       || document.getElementById('att_last_name_input2');\n\n    let msg\
+        \   = document.getElementById('att_name_msg') \n             || document.getElementById('att_name_msg2');\n\
+        \n    if(!input || !msg) return;\n\n    let value = input.value.trim();\n\n\
+        \    if(!value){\n        msg.innerHTML = '<span style=\"color:#f87171;\"\
+        >Digite o nome completo do titular da conta que ser\xE1 usada para a doa\xE7\
+        \xE3o</span>';\n        return;\n    }\n\n    msg.innerHTML = 'Salvando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        headers: {'Content-Type': 'application/x-www-form-urlencoded'},\n\
+        \        body: 'action=att_save_last_name&last_name=' + encodeURIComponent(value)\n\
+        \    })\n    .then(r => r.json())\n    .then(res => {\n\n        if(res.success){\n\
+        \            msg.innerHTML = '<span style=\"color:#22c55e;\">Salvo! Recarregando...</span>';\n\
+        \            setTimeout(()=>location.reload(),800);\n        } else {\n  \
+        \          msg.innerHTML = '<span style=\"color:#f87171;\">Erro ao salvar</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<style type=\"text/css\"> \n      \
+        \   /* Hide reCAPTCHA V3 badge */\n        .grecaptcha-badge {\n        \n\
+        \            visibility: hidden !important;\n        \n        }\n    </style><script\
+        \ type=\"text/javascript\" id=\"lrl-js-js-extra\">\n/* <![CDATA[ */\nvar lrlData\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"post_id\":\"630577\"};\n/* ]]> */\n</script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.js?ver=1.0\"\
+        \ id=\"lrl-js-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/jquery.fitvids.min.js\"\
+        \ id=\"fitvids-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/ResizeSensor.min.js\"\
+        \ id=\"ResizeSensor-js\"></script>\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-content/themes/simple-grid/assets/js/theia-sticky-sidebar.min.js\"\
+        \ id=\"theia-sticky-sidebar-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/navigation.js\"\
+        \ id=\"simple-grid-navigation-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/skip-link-focus-fix.js\"\
+        \ id=\"simple-grid-skip-link-focus-fix-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/imagesloaded.min.js?ver=5.0.0\"\
+        \ id=\"imagesloaded-js\"></script>\n<script type=\"text/javascript\" id=\"\
+        simple-grid-customjs-js-extra\">\n/* <![CDATA[ */\nvar simple_grid_ajax_object\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"primary_menu_active\":\"1\",\"secondary_menu_active\":\"\",\"primary_mobile_menu_active\"\
+        :\"1\",\"secondary_mobile_menu_active\":\"1\",\"sticky_menu_active\":\"1\"\
+        ,\"sticky_mobile_menu_active\":\"\",\"sticky_sidebar_active\":\"1\",\"columnwidth\"\
+        :\".simple-grid-5-col-sizer\",\"gutter\":\".simple-grid-5-col-gutter\"};\n\
+        /* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/custom.js\"\
+        \ id=\"simple-grid-customjs-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/comment-reply.min.js?ver=6.8.3\"\
+        \ id=\"comment-reply-js\" async=\"async\" data-wp-strategy=\"async\"></script>\n\
+        <script type=\"text/javascript\" id=\"simple-grid-html5shiv-js-js-extra\"\
+        >\n/* <![CDATA[ */\nvar simple_grid_custom_script_vars = {\"elements_name\"\
+        :\"abbr article aside audio bdi canvas data datalist details dialog figcaption\
+        \ figure footer header hgroup main mark meter nav output picture progress\
+        \ section summary template time video\"};\n/* ]]> */\n</script>\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/html5shiv.js\"\
+        \ id=\"simple-grid-html5shiv-js-js\"></script>\n<script>(function(){function\
+        \ c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML=\"\
+        window.__CF$cv$params={r:'a14e7a1b0bbff214',t:'MTc4MzAwMzk3NA=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);\"\
+        ;b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else\
+        \ if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var\
+        \ e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script><script\
+        \ defer src=\"https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496\"\
+        \ integrity=\"sha512-ZE9pZaUXND66v380QUtch/5sE9tPFh2zg45pR2PB0CVkCtOREv2AJKkSidISWkysEuQ0EH8faUU5du78bx87UQ==\"\
+        \ data-cf-beacon='{\"version\":\"2024.11.0\",\"token\":\"832c49ee708d4b8d94382b4733ae0382\"\
+        ,\"r\":1,\"server_timing\":{\"name\":{\"cfCacheStatus\":true,\"cfEdge\":true,\"\
+        cfExtPri\":true,\"cfL4\":true,\"cfOrigin\":true,\"cfSpeedBrain\":true},\"\
+        location_startswith\":null}}' crossorigin=\"anonymous\"></script>\n</body>\n\
+        </html>"
+    headers:
+      CF-RAY:
+      - a14e7a1b0bbff214-GRU
+      Cf-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Thu, 02 Jul 2026 14:52:55 GMT
+      Link:
+      - <https://legendei.net/wp-json/>; rel="https://api.w.org/", <https://legendei.net/wp-json/wp/v2/posts/630577>;
+        rel="alternate"; title="JSON"; type="application/json", <https://legendei.net/?p=630577>;
+        rel=shortlink
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Permissions-Policy:
+      - private-state-token-redemption=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com"),
+        private-state-token-issuance=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com")
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=mgbw84AbVzy%2BtMCqgbR%2BCBbq43UsHZXVzMhykqNrMQw3Jfh8MfHai6nnOuMFWJLKWdrJJCmaNVIJYQ4F%2BV70PUNbKcMit0ynY8IrwGRzvfUvAdK4DqurW%2FPGNziOocw%3D"}]}'
+      Server:
+      - cloudflare
+      Server-Timing:
+      - cfCacheStatus;desc="DYNAMIC"
+      - cfEdge;dur=6,cfOrigin;dur=426
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - pt-BR,pt;q=0.9,en;q=0.8
+      User-Agent:
+      - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like
+        Gecko) Chrome/131.0.0.0 Safari/537.36
+    method: GET
+    uri: https://legendei.net/planet-dune-2021/
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html dir=\"ltr\" lang=\"pt-BR\" prefix=\"og: https://ogp.me/ns#\"\
+        >\n<head>\n<meta charset=\"UTF-8\">\n<meta name=\"viewport\" content=\"width=device-width,\
+        \ initial-scale=1.0\">\n\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css\"\
+        >\n\t\n<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">\n<link\
+        \ rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>\n<link\
+        \ href=\"https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap\"\
+        \ rel=\"stylesheet\">\n\t\n<title>Legenda Planet Dune 2021 | Legendei - Aqui\
+        \ Sai Primeiro</title>\n\t<style>img:is([sizes=\"auto\" i], [sizes^=\"auto,\"\
+        \ i]) { contain-intrinsic-size: 3000px 1500px }</style>\n\t\n\t\t<!-- All\
+        \ in One SEO Pro 4.6.0 - aioseo.com -->\n\t\t<meta name=\"description\" content=\"\
+        Uma miss\xE3o para resgatar uma base isolada em um planeta deserto torna-se\
+        \ mortal quando a tripula\xE7\xE3o se v\xEA ca\xE7ada vermes da areia gigantes.\
+        \ Legenda Planet Dune 2021 testada e verificada - Pode servir tamb\xE9m para\
+        \ outros releases, basta renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\"\
+        \ />\n\t\t<meta name=\"robots\" content=\"max-image-preview:large\" />\n\t\
+        \t<meta name=\"google-site-verification\" content=\"JSMIV3rTOC3Y-WjaQzmU3KvW7aWHceTxBFYsJYpm-1k\"\
+        \ />\n\t\t<link rel=\"canonical\" href=\"https://legendei.net/planet-dune-2021/\"\
+        \ />\n\t\t<meta name=\"generator\" content=\"All in One SEO Pro (AIOSEO) 4.6.0\"\
+        \ />\n\t\t<meta property=\"og:locale\" content=\"pt_BR\" />\n\t\t<meta property=\"\
+        og:site_name\" content=\"Legendei - Baixar Legendas de S\xE9ries e Filmes\"\
+        \ />\n\t\t<meta property=\"og:type\" content=\"article\" />\n\t\t<meta property=\"\
+        og:title\" content=\"Legenda Planet Dune 2021 | Legendei - Aqui Sai Primeiro\"\
+        \ />\n\t\t<meta property=\"og:description\" content=\"Uma miss\xE3o para resgatar\
+        \ uma base isolada em um planeta deserto torna-se mortal quando a tripula\xE7\
+        \xE3o se v\xEA ca\xE7ada vermes da areia gigantes. Legenda Planet Dune 2021\
+        \ testada e verificada - Pode servir tamb\xE9m para outros releases, basta\
+        \ renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t<meta\
+        \ property=\"og:url\" content=\"https://legendei.net/planet-dune-2021/\" />\n\
+        \t\t<meta property=\"og:image\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"og:image:secure_url\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<meta property=\"article:published_time\" content=\"2021-11-03T19:48:03+00:00\"\
+        \ />\n\t\t<meta property=\"article:modified_time\" content=\"2021-11-03T19:49:55+00:00\"\
+        \ />\n\t\t<meta name=\"twitter:card\" content=\"summary\" />\n\t\t<meta name=\"\
+        twitter:title\" content=\"Legenda Planet Dune 2021 | Legendei - Aqui Sai Primeiro\"\
+        \ />\n\t\t<meta name=\"twitter:description\" content=\"Uma miss\xE3o para\
+        \ resgatar uma base isolada em um planeta deserto torna-se mortal quando a\
+        \ tripula\xE7\xE3o se v\xEA ca\xE7ada vermes da areia gigantes. Legenda Planet\
+        \ Dune 2021 testada e verificada - Pode servir tamb\xE9m para outros releases,\
+        \ basta renomear! Dispon\xEDvel em Legendei - Aqui Sai Primeiro\" />\n\t\t\
+        <meta name=\"twitter:image\" content=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET.webp\"\
+        \ />\n\t\t<script type=\"application/ld+json\" class=\"aioseo-schema\">\n\t\
+        \t\t{\"@context\":\"https:\\/\\/schema.org\",\"@graph\":[{\"@type\":\"BlogPosting\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/planet-dune-2021\\/#blogposting\",\"\
+        name\":\"Legenda Planet Dune 2021 | Legendei - Aqui Sai Primeiro\",\"headline\"\
+        :\"Planet Dune 2021\",\"author\":{\"@id\":\"https:\\/\\/legendei.net\\/author\\\
+        /eneinsubtitles\\/#author\"},\"publisher\":{\"@id\":\"https:\\/\\/legendei.net\\\
+        /#organization\"},\"image\":{\"@type\":\"ImageObject\",\"url\":\"https:\\\
+        /\\/image.tmdb.org\\/t\\/p\\/w220_and_h330_face\\/dYlnNSlyCW43tp1gZJaQ74fuK40.jpg\"\
+        ,\"width\":600,\"height\":900},\"datePublished\":\"2021-11-03T16:48:03+01:00\"\
+        ,\"dateModified\":\"2021-11-03T16:49:55+01:00\",\"inLanguage\":\"pt-BR\",\"\
+        mainEntityOfPage\":{\"@id\":\"https:\\/\\/legendei.net\\/planet-dune-2021\\\
+        /#webpage\"},\"isPartOf\":{\"@id\":\"https:\\/\\/legendei.net\\/planet-dune-2021\\\
+        /#webpage\"},\"articleSection\":\"Filmes\"},{\"@type\":\"BreadcrumbList\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/planet-dune-2021\\/#breadcrumblist\"\
+        ,\"itemListElement\":[{\"@type\":\"ListItem\",\"@id\":\"https:\\/\\/legendei.net\\\
+        /#listItem\",\"position\":1,\"name\":\"Home\",\"item\":\"https:\\/\\/legendei.net\\\
+        /\",\"nextItem\":\"https:\\/\\/legendei.net\\/planet-dune-2021\\/#listItem\"\
+        },{\"@type\":\"ListItem\",\"@id\":\"https:\\/\\/legendei.net\\/planet-dune-2021\\\
+        /#listItem\",\"position\":2,\"name\":\"Planet Dune 2021\",\"previousItem\"\
+        :\"https:\\/\\/legendei.net\\/#listItem\"}]},{\"@type\":\"Organization\",\"\
+        @id\":\"https:\\/\\/legendei.net\\/#organization\",\"name\":\"Legendei\",\"\
+        url\":\"https:\\/\\/legendei.net\\/\",\"logo\":{\"@type\":\"ImageObject\"\
+        ,\"url\":\"https:\\/\\/legendei.net\\/wp-content\\/uploads\\/2026\\/03\\/favicon.webp\"\
+        ,\"@id\":\"https:\\/\\/legendei.net\\/planet-dune-2021\\/#organizationLogo\"\
+        ,\"width\":150,\"height\":150},\"image\":{\"@id\":\"https:\\/\\/legendei.net\\\
+        /planet-dune-2021\\/#organizationLogo\"}},{\"@type\":\"Person\",\"@id\":\"\
+        https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\/#author\",\"url\":\"\
+        https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\/\",\"name\":\"Admin\"\
+        },{\"@type\":\"WebPage\",\"@id\":\"https:\\/\\/legendei.net\\/planet-dune-2021\\\
+        /#webpage\",\"url\":\"https:\\/\\/legendei.net\\/planet-dune-2021\\/\",\"\
+        name\":\"Legenda Planet Dune 2021 | Legendei - Aqui Sai Primeiro\",\"description\"\
+        :\"Uma miss\\u00e3o para resgatar uma base isolada em um planeta deserto torna-se\
+        \ mortal quando a tripula\\u00e7\\u00e3o se v\\u00ea ca\\u00e7ada vermes da\
+        \ areia gigantes. Legenda Planet Dune 2021 testada e verificada - Pode servir\
+        \ tamb\\u00e9m para outros releases, basta renomear! Dispon\\u00edvel em Legendei\
+        \ - Aqui Sai Primeiro\",\"inLanguage\":\"pt-BR\",\"isPartOf\":{\"@id\":\"\
+        https:\\/\\/legendei.net\\/#website\"},\"breadcrumb\":{\"@id\":\"https:\\\
+        /\\/legendei.net\\/planet-dune-2021\\/#breadcrumblist\"},\"author\":{\"@id\"\
+        :\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\/#author\"},\"creator\"\
+        :{\"@id\":\"https:\\/\\/legendei.net\\/author\\/eneinsubtitles\\/#author\"\
+        },\"image\":{\"@type\":\"ImageObject\",\"url\":\"https:\\/\\/image.tmdb.org\\\
+        /t\\/p\\/w220_and_h330_face\\/dYlnNSlyCW43tp1gZJaQ74fuK40.jpg\",\"@id\":\"\
+        https:\\/\\/legendei.net\\/planet-dune-2021\\/#mainImage\",\"width\":600,\"\
+        height\":900},\"primaryImageOfPage\":{\"@id\":\"https:\\/\\/legendei.net\\\
+        /planet-dune-2021\\/#mainImage\"},\"datePublished\":\"2021-11-03T16:48:03+01:00\"\
+        ,\"dateModified\":\"2021-11-03T16:49:55+01:00\"},{\"@type\":\"WebSite\",\"\
+        @id\":\"https:\\/\\/legendei.net\\/#website\",\"url\":\"https:\\/\\/legendei.net\\\
+        /\",\"name\":\"Legendei\",\"description\":\"Baixar Legendas de S\\u00e9ries\
+        \ e Filmes\",\"inLanguage\":\"pt-BR\",\"publisher\":{\"@id\":\"https:\\/\\\
+        /legendei.net\\/#organization\"}}]}\n\t\t</script>\n\t\t<!-- All in One SEO\
+        \ Pro -->\n\n<link rel='dns-prefetch' href='//fonts.googleapis.com' />\n<link\
+        \ rel=\"alternate\" type=\"application/rss+xml\" title=\"Feed para Legendei\
+        \ &raquo;\" href=\"https://legendei.net/feed/\" />\n<link rel=\"alternate\"\
+        \ type=\"application/rss+xml\" title=\"Feed de coment\xE1rios para Legendei\
+        \ &raquo;\" href=\"https://legendei.net/comments/feed/\" />\n<link rel=\"\
+        alternate\" type=\"application/rss+xml\" title=\"Feed de coment\xE1rios para\
+        \ Legendei &raquo; Planet Dune 2021\" href=\"https://legendei.net/planet-dune-2021/feed/\"\
+        \ />\n<script type=\"text/javascript\">\n/* <![CDATA[ */\nwindow._wpemojiSettings\
+        \ = {\"baseUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\/emoji\\/16.0.1\\\
+        /72x72\\/\",\"ext\":\".png\",\"svgUrl\":\"https:\\/\\/s.w.org\\/images\\/core\\\
+        /emoji\\/16.0.1\\/svg\\/\",\"svgExt\":\".svg\",\"source\":{\"concatemoji\"\
+        :\"https:\\/\\/legendei.net\\/wp-includes\\/js\\/wp-emoji-release.min.js?ver=6.8.3\"\
+        }};\n/*! This file is auto-generated */\n!function(s,n){var o,i,e;function\
+        \ c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function\
+        \ p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var\
+        \ t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),a=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new\
+        \ Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return\
+        \ t.every(function(e,t){return e===a[t]})}function u(e,t){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);for(var\
+        \ n=e.getImageData(16,16,1,1),a=0;a<n.data.length;a++)if(0!==n.data[a])return!1;return!0}function\
+        \ f(e,t,n,a){switch(t){case\"flag\":return n(e,\"\\ud83c\\udff3\\ufe0f\\u200d\\\
+        u26a7\\ufe0f\",\"\\ud83c\\udff3\\ufe0f\\u200b\\u26a7\\ufe0f\")?!1:!n(e,\"\\\
+        ud83c\\udde8\\ud83c\\uddf6\",\"\\ud83c\\udde8\\u200b\\ud83c\\uddf6\")&&!n(e,\"\
+        \\ud83c\\udff4\\udb40\\udc67\\udb40\\udc62\\udb40\\udc65\\udb40\\udc6e\\udb40\\\
+        udc67\\udb40\\udc7f\",\"\\ud83c\\udff4\\u200b\\udb40\\udc67\\u200b\\udb40\\\
+        udc62\\u200b\\udb40\\udc65\\u200b\\udb40\\udc6e\\u200b\\udb40\\udc67\\u200b\\\
+        udb40\\udc7f\");case\"emoji\":return!a(e,\"\\ud83e\\udedf\")}return!1}function\
+        \ g(e,t,n,a){var r=\"undefined\"!=typeof WorkerGlobalScope&&self instanceof\
+        \ WorkerGlobalScope?new OffscreenCanvas(300,150):s.createElement(\"canvas\"\
+        ),o=r.getContext(\"2d\",{willReadFrequently:!0}),i=(o.textBaseline=\"top\"\
+        ,o.font=\"600 32px Arial\",{});return e.forEach(function(e){i[e]=t(o,e,n,a)}),i}function\
+        \ t(e){var t=s.createElement(\"script\");t.src=e,t.defer=!0,s.head.appendChild(t)}\"\
+        undefined\"!=typeof Promise&&(o=\"wpEmojiSettingsSupports\",i=[\"flag\",\"\
+        emoji\"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){s.addEventListener(\"\
+        DOMContentLoaded\",e,{once:!0})}),new Promise(function(t){var n=function(){try{var\
+        \ e=JSON.parse(sessionStorage.getItem(o));if(\"object\"==typeof e&&\"number\"\
+        ==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&\"object\"\
+        ==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if(\"\
+        undefined\"!=typeof Worker&&\"undefined\"!=typeof OffscreenCanvas&&\"undefined\"\
+        !=typeof URL&&URL.createObjectURL&&\"undefined\"!=typeof Blob)try{var e=\"\
+        postMessage(\"+g.toString()+\"(\"+[JSON.stringify(i),f.toString(),p.toString(),u.toString()].join(\"\
+        ,\")+\"));\",a=new Blob([e],{type:\"text/javascript\"}),r=new Worker(URL.createObjectURL(a),{name:\"\
+        wpTestEmojiSupports\"});return void(r.onmessage=function(e){c(n=e.data),r.terminate(),t(n)})}catch(e){}c(n=g(i,f,p,u))}t(n)}).then(function(e){for(var\
+        \ t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],\"\
+        flag\"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return\
+        \ e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);\n\
+        /* ]]> */\n</script>\n<link rel='stylesheet' id='wpa-css-css' href='https://legendei.net/wp-content/plugins/wp-attachments/styles/0/wpa.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='wp-emoji-styles-inline-css' type='text/css'>\n\
+        \n\timg.wp-smiley, img.emoji {\n\t\tdisplay: inline !important;\n\t\tborder:\
+        \ none !important;\n\t\tbox-shadow: none !important;\n\t\theight: 1em !important;\n\
+        \t\twidth: 1em !important;\n\t\tmargin: 0 0.07em !important;\n\t\tvertical-align:\
+        \ -0.1em !important;\n\t\tbackground: none !important;\n\t\tpadding: 0 !important;\n\
+        \t}\n</style>\n<link rel='stylesheet' id='wp-block-library-css' href='https://legendei.net/wp-includes/css/dist/block-library/style.min.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<style id='classic-theme-styles-inline-css'\
+        \ type='text/css'>\n/*! This file is auto-generated */\n.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em\
+        \ + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}\n\
+        </style>\n<style id='wppb-content-restriction-start-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-content-restriction-end-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-edit-profile-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-login-style-inline-css' type='text/css'>\n\n\
+        \n</style>\n<style id='wppb-recover-password-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='wppb-register-style-inline-css' type='text/css'>\n\
+        \n\n</style>\n<style id='global-styles-inline-css' type='text/css'>\n:root{--wp--preset--aspect-ratio--square:\
+        \ 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4:\
+        \ 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3:\
+        \ 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16:\
+        \ 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray:\
+        \ #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink:\
+        \ #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange:\
+        \ #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan:\
+        \ #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue:\
+        \ #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple:\
+        \ #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1)\
+        \ 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan:\
+        \ linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange:\
+        \ linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red:\
+        \ linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray:\
+        \ linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum:\
+        \ linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186)\
+        \ 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple:\
+        \ linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux:\
+        \ linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62)\
+        \ 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112)\
+        \ 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean:\
+        \ linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181)\
+        \ 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128)\
+        \ 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129)\
+        \ 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium:\
+        \ 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large:\
+        \ 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40:\
+        \ 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70:\
+        \ 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural:\
+        \ 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px\
+        \ rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0,\
+        \ 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255,\
+        \ 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0,\
+        \ 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap:\
+        \ 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items:\
+        \ center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display:\
+        \ grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-color{color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color:\
+        \ var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color:\
+        \ var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color:\
+        \ var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color:\
+        \ var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color:\
+        \ var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color:\
+        \ var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background:\
+        \ var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange)\
+        \ !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background:\
+        \ var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background:\
+        \ var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background:\
+        \ var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background:\
+        \ var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background:\
+        \ var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background:\
+        \ var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background:\
+        \ var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size:\
+        \ var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size:\
+        \ var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size:\
+        \ var(--wp--preset--font-size--x-large) !important;}\n:where(.wp-block-post-template.is-layout-flex){gap:\
+        \ 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}\n:where(.wp-block-columns.is-layout-flex){gap:\
+        \ 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}\n:root :where(.wp-block-pullquote){font-size:\
+        \ 1.5em;line-height: 1.6;}\n</style>\n<link rel='stylesheet' id='lrl-css-css'\
+        \ href='https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.css?ver=6.8.3'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-maincss-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css' type='text/css'\
+        \ media='all' />\n<link rel='stylesheet' id='fontawesome-css' href='https://legendei.net/wp-content/themes/simple-grid/assets/css/all.min.css'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='simple-grid-webfont-css'\
+        \ href='//fonts.googleapis.com/css?family=Playfair+Display:400,400i,700,700i|Domine:400,700|Oswald:400,700|Patua+One|Merriweather:400,400i,700,700i&#038;display=swap'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='legendei-style-css'\
+        \ href='https://legendei.net/wp-content/themes/simple-grid/style.css?ver=1782544305'\
+        \ type='text/css' media='all' />\n<link rel='stylesheet' id='wppb_stylesheet-css'\
+        \ href='https://legendei.net/wp-content/plugins/profile-builder/assets/css/style-front-end.css?ver=3.15.2'\
+        \ type='text/css' media='all' />\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-includes/js/jquery/jquery.min.js?ver=3.7.1\" id=\"\
+        jquery-core-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1\"\
+        \ id=\"jquery-migrate-js\"></script>\n<!--[if lt IE 9]>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/respond.min.js\"\
+        \ id=\"respond-js\"></script>\n<![endif]-->\n<link rel=\"https://api.w.org/\"\
+        \ href=\"https://legendei.net/wp-json/\" /><link rel=\"alternate\" title=\"\
+        JSON\" type=\"application/json\" href=\"https://legendei.net/wp-json/wp/v2/posts/471683\"\
+        \ /><link rel=\"EditURI\" type=\"application/rsd+xml\" title=\"RSD\" href=\"\
+        https://legendei.net/xmlrpc.php?rsd\" />\n<meta name=\"generator\" content=\"\
+        WordPress 6.8.3\" />\n<link rel='shortlink' href='https://legendei.net/?p=471683'\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (JSON)\" type=\"application/json+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fplanet-dune-2021%2F\"\
+        \ />\n<link rel=\"alternate\" title=\"oEmbed (XML)\" type=\"text/xml+oembed\"\
+        \ href=\"https://legendei.net/wp-json/oembed/1.0/embed?url=https%3A%2F%2Flegendei.net%2Fplanet-dune-2021%2F&#038;format=xml\"\
+        \ />\n<style>\n\n/* FORMUL\xC1RIO TRIAL */\n\n.premium-form {\n    max-width:\
+        \ 760px;\n    margin: 0 auto 20px;\n    padding: 30px;\n    border-radius:\
+        \ 10px;\n    background: #212121;\n    border: 10px solid transparent;\n \
+        \   background-image:\n        linear-gradient(#212121,#212121),\n       \
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    background-origin: border-box;\n\
+        \    background-clip: padding-box, border-box;\n    box-sizing: border-box;\n\
+        }\n\n/* Campos */\n\n.premium-form .field {\n    position: relative;\n   \
+        \ margin-bottom: 20px;\n}\n\n.premium-form input {\n    width: 100%;\n   \
+        \ padding: 14px;\n    border-radius: 8px;\n    border: 1px solid #ccc;\n \
+        \   font-size: 16px;\n    box-sizing: border-box;\n}\n\n/* Focus bonito */\n\
+        \n.premium-form input:focus {\n    border-color: transparent;\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin: border-box;\n    background-clip: padding-box, border-box;\n\
+        \    box-shadow: 0 0 0 4px rgba(63,140,255,0.20);\n    outline: none;\n}\n\
+        \n/* TOOLTIP */\n\n.premium-form .tooltip {\n    position: absolute;\n   \
+        \ bottom: 100%;\n    left: 0;\n    margin-bottom: 10px;\n    background: linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \tbox-shadow:0 6px 14px rgba(0,0,0,0.25);\n    color: #ffffff;\n    padding:\
+        \ 10px 12px;\n    font-size: 14px;\n    border-radius: 6px;\n    max-width:\
+        \ 260px;\n    opacity: 0;\n    pointer-events: none;\n    transition: .2s;\n\
+        \    z-index: 999;\n}\n\n.premium-form .tooltip::after {\n    content: \"\"\
+        ;\n    position: absolute;\n    top: 100%;\n    left: 15px;\n    border-width:\
+        \ 6px 6px 0 6px;\n    border-style: solid;\n    border-color: #8a2be2 transparent\
+        \ transparent transparent;\n}\n\n.premium-form .field:hover .tooltip,\n.premium-form\
+        \ .field:focus-within .tooltip {\n    opacity: 1;\n    transform: translateY(-4px);\n\
+        }\n\n/* BOT\xC3O */\n\n.premium-form button {\n    padding: 14px 30px;\n \
+        \   font-size: 22px;\n    border-radius: 8px;\n    border: none;\n    background:\
+        \ linear-gradient(90deg,#3f8cff,#8a2be2);\n    color: #fff;\n    cursor: pointer;\n\
+        \    transition: .25s;\n}\n\n.premium-form button:hover {\n    background:\
+        \ linear-gradient(90deg,#4c9aff,#9a3bff);\n}\n\n/* SENHA */\n\n.pass-wrap{\n\
+        \    position:relative;\n}\n\n.toggle-pass{\n    position:absolute;\n    right:12px;\n\
+        \    top:50%;\n    transform:translateY(-50%);\n    cursor:pointer;\n    font-size:18px;\n\
+        }\n\n/* BARRA FOR\xC7A SENHA */\n\n.strength{\n    height:6px;\n    background:#444;\n\
+        \    border-radius:4px;\n    margin-top:8px;\n    overflow:hidden;\n}\n\n\
+        .strength div{\n    height:100%;\n    width:0%;\n    transition:.3s;\n}\n\n\
+        /* MOBILE */\n\n@media (max-width:480px){\n\n.premium-form{\n    padding:20px;\n\
+        }\n\n}\n\n</style>\n<!-- FIFU: meta tags for featured image (begin) -->\n\
+        <meta property=\"og:image\" content=\"https://image.tmdb.org/t/p/w220_and_h330_face/dYlnNSlyCW43tp1gZJaQ74fuK40.jpg\"\
+        \ />\n<!-- FIFU: meta tags for featured image (end) --><meta name=\"twitter:image\"\
+        \ content=\"https://image.tmdb.org/t/p/w220_and_h330_face/dYlnNSlyCW43tp1gZJaQ74fuK40.jpg\"\
+        \ /><style>\n\n/* remove fundo normal, ativo e hover do logo */\n.simple-grid-primary-nav-menu\
+        \ > li.menu-logo-item > a,\n.simple-grid-primary-nav-menu > li.menu-logo-item\
+        \ > a:hover,\n.simple-grid-primary-nav-menu > li.menu-logo-item.current-menu-item\
+        \ > a{\n    background:none !important;\n}\n\n/* ===================================================\n\
+        \   MOBILE\n   =================================================== */\n\n\
+        @media only screen and (max-width:812px){\n\n    /* ESCONDER LOGO NO MENU\
+        \ MOBILE */\n    .simple-grid-primary-nav-menu > li.menu-logo-item{\n    \
+        \    display:none !important;\n    }\n\n}\n\n</style>\n    <style type=\"\
+        text/css\">\r\n            .simple-grid-site-title, .simple-grid-site-title\
+        \ a, .simple-grid-site-description {color: #ffffff;}\r\n        </style>\r\
+        \n    <style type=\"text/css\" id=\"custom-background-css\">\nbody.custom-background\
+        \ { background-color: #333333; }\n</style>\n\t<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"32x32\" />\n<link rel=\"icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ sizes=\"192x192\" />\n<link rel=\"apple-touch-icon\" href=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n<meta name=\"msapplication-TileImage\" content=\"https://legendei.net/wp-content/uploads/2026/03/favicon.webp\"\
+        \ />\n</head>\t\n\t\n\t\n<body class=\"wp-singular post-template-default single\
+        \ single-post postid-471683 single-format-standard custom-background wp-custom-logo\
+        \ wp-theme-simple-grid simple-grid-animated simple-grid-fadein simple-grid-theme-is-active\
+        \ simple-grid-custom-logo-active simple-grid-layout-type-full simple-grid-masonry-inactive\
+        \ simple-grid-float-grid simple-grid-responsive-grid-details simple-grid-layout-c-s1\
+        \ simple-grid-header-banner-active simple-grid-tagline-inactive simple-grid-logo-above-title\
+        \ simple-grid-primary-menu-active simple-grid-primary-mobile-menu-active simple-grid-secondary-mobile-menu-active\
+        \ simple-grid-primary-social-icons\" id=\"simple-grid-site-body\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/WebPage\">\n<a class=\"skip-link\
+        \ screen-reader-text\" href=\"#simple-grid-content-wrapper\">Skip to content</a>\n\
+        \n\n\n<div class=\"simple-grid-site-header simple-grid-container\" id=\"simple-grid-header\"\
+        \ itemscope=\"itemscope\" itemtype=\"http://schema.org/WPHeader\" role=\"\
+        banner\">\n<div class=\"simple-grid-head-content simple-grid-clearfix\" id=\"\
+        simple-grid-head-content\">\n\n<div class=\"simple-grid-no-header-content\"\
+        >\n              <p class=\"simple-grid-site-title\"><a href=\"https://legendei.net/\"\
+        \ rel=\"home\">Legendei</a></p>\r\n                </div>\n\n</div><!--/#simple-grid-head-content\
+        \ -->\n</div><!--/#simple-grid-header -->\n\n\n\n<div class=\"simple-grid-container\
+        \ simple-grid-primary-menu-container simple-grid-clearfix\">\n<div class=\"\
+        simple-grid-primary-menu-container-inside simple-grid-clearfix\">\n<nav class=\"\
+        simple-grid-nav-primary\" id=\"simple-grid-primary-navigation\" itemscope=\"\
+        itemscope\" itemtype=\"http://schema.org/SiteNavigationElement\" role=\"navigation\"\
+        \ aria-label=\"Primary Menu\">\n\t\n\t\n<div class=\"simple-grid-outer-wrapper\"\
+        >\n<a href=\"/\" class=\"logo-mobile-inline\">\n<img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \nstyle=\"width:100%;height:auto;\">\n</a>\n\n<style>\n.logo-mobile-inline{\n\
+        display:none;\n}\n\n@media (max-width:812px){\n.logo-mobile-inline{\ndisplay:block;\n\
+        }\n}\n</style>\t\n\n\t\n<style>\n.mobile-header-icons{\n    display:none;\n\
+        }\n\n@media (max-width: 812px){\n\n.mobile-header-icons{\n    display:grid;\n\
+        \    grid-template-columns: 2fr 1fr 1fr;\n    gap:10px;\n    padding:10px;\n\
+        }\n\n/* BOT\xD5ES */\n.mobile-header-icons a,\n.mobile-header-icons .cat-toggle{\n\
+        \    display:flex;\n    align-items:center;\n    justify-content:center;\n\
+        \    gap:6px;\n    background:#141414;\n    padding:8px 6px;\n    border-radius:8px;\n\
+        \    color:#fff;\n    font-size:12px;\n    text-decoration:none;\n    text-align:center;\n\
+        \    cursor:pointer;\n}\n\n/* CATEGORIA */\n.cat-toggle{\n    font-weight:600;\n\
+        }\n\n/* SETA */\n.cat-toggle .arrow{\n    transition:transform 0.3s ease;\n\
+        }\n\n/* SETA GIRADA */\n.cat-toggle.active .arrow{\n    transform:rotate(180deg);\n\
+        }\n\n/* HOVER */\n.mobile-header-icons a:hover,\n.mobile-header-icons .cat-toggle:hover{\n\
+        \    background:#1f1f1f;\n}\n\n/* CONTAINER */\n.cat-container{\n    position:relative;\n\
+        }\n\n/* DROPDOWN */\n.cat-list{\n    display:flex;\n    flex-direction:column;\n\
+        \    gap:6px;\n\n    position:absolute;\n    top:110%;\n    left:0;\n    width:100%;\n\
+        \n    background:#0f0f0f;\n    border-radius:8px;\n    padding:6px;\n    z-index:999;\n\
+        \n    opacity:0;\n    visibility:hidden;\n    transform:translateY(-5px);\n\
+        \    transition:all 0.25s ease;\n}\n\n/* ABERTO */\n.cat-container.open .cat-list{\n\
+        \    opacity:1;\n    visibility:visible;\n    transform:translateY(0);\n}\n\
+        \n/* ITENS */\n.cat-list a{\n    justify-content:flex-start;\n    font-size:14px;\n\
+        \    padding:10px;\n}\n\n}\n</style>\n\n\n<div class=\"mobile-header-icons\"\
+        >\n\n    <!-- CATEGORIAS -->\n    <div class=\"cat-container\">\n        <div\
+        \ class=\"cat-toggle\">\n            \U0001F4C2 Categorias <span class=\"\
+        arrow\">\u25BC</span>\n        </div>\n\n        <div class=\"cat-list\">\n\
+        \            <a href=\"/category/destaques/\">\u2B50 Destaques</a>\n     \
+        \       <a href=\"/category/filmes/\">\U0001F3AC Filmes</a>\n            <a\
+        \ href=\"/category/serie/\">\U0001F4FA S\xE9ries</a>\n            <a href=\"\
+        /category/pack-de-legendas/\">\U0001F4E6 Packs</a>\n        </div>\n    </div>\n\
+        \n    \n        <a href=\"/seja-premium-vitalicio/\"><i class=\"fa-solid fa-crown\"\
+        ></i> Premium</a>\n\n        <a href=\"/login/\"><i class=\"fa-solid fa-key\"\
+        ></i> Login</a>\n\n    \n</div>\n\n<script>\ndocument.addEventListener(\"\
+        DOMContentLoaded\", function(){\n\n    const container = document.querySelector(\"\
+        .cat-container\");\n    const toggle = document.querySelector(\".cat-toggle\"\
+        );\n\n    toggle.addEventListener(\"click\", function(e){\n        e.stopPropagation();\n\
+        \        container.classList.toggle(\"open\");\n        toggle.classList.toggle(\"\
+        active\");\n    });\n\n    document.addEventListener(\"click\", function(e){\n\
+        \        if(!container.contains(e.target)){\n            container.classList.remove(\"\
+        open\");\n            toggle.classList.remove(\"active\");\n        }\n  \
+        \  });\n\n});\n</script>\t\n\t\n<ul id=\"simple-grid-menu-primary-navigation\"\
+        \ class=\"simple-grid-primary-nav-menu simple-grid-menu-primary\"><li id=\"\
+        menu-item-673170\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-673170 menu-logo-item\">\n        <a href=\"https://legendei.net/\"\
+        \ style=\"\n            display:flex;\n            align-items:center;\n \
+        \           justify-content:center;\n            height:100%;\n          \
+        \  padding:0;\n            margin:0;\n            line-height:1;\n       \
+        \ \">\n            <img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \n                      alt=\"Legendei.NET\"\n                      style=\"\
+        height:42px;width:auto;display:block;\">\n        </a></li>\n\n<li id=\"menu-item-673168\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673168\"\
+        ><a href=\"https://legendei.net/category/destaques/\" title=\"Legendas em\
+        \ Destaque\">DESTAQUES</a></li>\n<li id=\"menu-item-673167\" class=\"menu-item\
+        \ menu-item-type-taxonomy menu-item-object-category current-post-ancestor\
+        \ current-menu-parent current-post-parent menu-item-673167\"><a href=\"https://legendei.net/category/filmes/\"\
+        \ title=\"Legendas para Filmes\">Filmes</a></li>\n<li id=\"menu-item-673166\"\
+        \ class=\"menu-item menu-item-type-taxonomy menu-item-object-category menu-item-673166\"\
+        ><a href=\"https://legendei.net/category/serie/\" title=\"Legendas para seriados\"\
+        >S\xC9RIES</a></li>\n<li id=\"menu-item-673169\" class=\"menu-item menu-item-type-taxonomy\
+        \ menu-item-object-category menu-item-673169\"><a href=\"https://legendei.net/category/pack-de-legendas/\"\
+        \ title=\"Pack de legendas\">PACKS</a></li>\n<li id=\"menu-item-731144\" class=\"\
+        menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children\
+        \ menu-item-731144\"><a target=\"_blank\" href=\"/aplicativos/\">RECOMENDAMOS</a>\n\
+        <ul class=\"sub-menu\">\n\t<li id=\"menu-item-673172\" class=\"menu-item menu-item-type-custom\
+        \ menu-item-object-custom menu-item-673172\"><a target=\"_blank\" href=\"\
+        /aplicativos/\" title=\"Programas para windows\">APLICATIVOS</a></li>\n\t\
+        <li id=\"menu-item-687662\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-687662\"><a target=\"_blank\" href=\"https://4kxxx.vip/\" title=\"\
+        Baixe os melhores v\xEDdeos porn\xF4 sempre em 4K\">4K XXX</a></li>\n\t<li\
+        \ id=\"menu-item-717497\" class=\"menu-item menu-item-type-custom menu-item-object-custom\
+        \ menu-item-717497\"><a target=\"_blank\" href=\"https://detonaplay.com/\"\
+        >GAMES</a></li>\n</ul>\n</li>\n\n\n\n<li class=\"menu-item\" style=\"float:right;\"\
+        >\n            <a href=\"/login/\"\n               style=\"background:linear-gradient(135deg,#198754,#20ac6b);color:#ffffff;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-key\"></i> Login\n            </a>\n\
+        \        </li><li class=\"menu-item\" style=\"float:right;\">\n          \
+        \  <a href=\"/seja-premium-vitalicio/\"\n\t\t\t\t\t  style=\"background:linear-gradient(135deg,#f4c430,#c2940a);color:#4d2e00;font-weight:700;\"\
+        >\n                <i class=\"fa-solid fa-crown\"></i> Membro Premium\n  \
+        \          </a>\n        </li></ul>    </div>\n</nav>\n</div>\n</div>\n\n\t\
+        \n\t\n\r\n<div class=\"simple-grid-outer-wrapper\">\r\n<div class=\"simple-grid-top-wrapper-outer\
+        \ simple-grid-clearfix\">\r\n<div class=\"simple-grid-featured-posts-area\
+        \ simple-grid-top-wrapper simple-grid-clearfix\">\r\n\r\n<div id=\"search-5\"\
+        \ class=\"simple-grid-main-widget widget simple-grid-widget-box widget_search\"\
+        ><div class=\"simple-grid-widget-box-inside\"><form role=\"search\" method=\"\
+        get\" class=\"simple-grid-search-form\" action=\"https://legendei.net/\">\n\
+        <label>\n    <span class=\"simple-grid-sr-only\">Pesquisar por </span>\n \
+        \   <input \n        type=\"search\"\n        class=\"simple-grid-search-field\"\
+        \n        placeholder=\"Pesquisar &hellip;\"\n        value=\"\"\n       \
+        \ name=\"s\"\n        minlength=\"3\"\n\t\tmaxlength=\"50\"   \n        required\n\
+        \    />\n</label>\n<input type=\"submit\" class=\"simple-grid-search-submit\"\
+        \ value=\"&#xf002;\" />\n</form></div></div></div>\r\n</div>\r\n</div>\r\n\
+        \r\n\n<div class=\"simple-grid-outer-wrapper\" id=\"simple-grid-wrapper-outside\"\
+        >\n\n<div class=\"simple-grid-container simple-grid-clearfix\" id=\"simple-grid-wrapper\"\
+        >\n<div class=\"simple-grid-content-wrapper simple-grid-clearfix\" id=\"simple-grid-content-wrapper\"\
+        >\t\n\t\t\n\n\n<div class=\"simple-grid-main-wrapper simple-grid-clearfix\"\
+        \ id=\"simple-grid-main-wrapper\" itemscope=\"itemscope\" itemtype=\"http://schema.org/Blog\"\
+        \ role=\"main\">\n<div class=\"theiaStickySidebar\">\n<div class=\"simple-grid-main-wrapper-inside\
+        \ simple-grid-clearfix\">\n\n\r\n\r\n\n<div class=\"simple-grid-posts-wrapper\"\
+        \ id=\"simple-grid-posts-wrapper\">\n\n\n\n\n\n<div style=\"width: 100%; border-radius:\
+        \ 12px; box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 12px; padding: 15px; background:\
+        \ #ffffff;\">\n    <center>\n    <article id=\"post-471683\" class=\"simple-grid-post-singular\
+        \ simple-grid-box post-471683 post type-post status-publish format-standard\
+        \ has-post-thumbnail hentry category-filmes wpcat-3-id\">\n        <div class=\"\
+        simple-grid-box-inside\">\n            \n            \n                  \
+        \          <header class=\"entry-header\">\n                    <div class=\"\
+        entry-header-inside simple-grid-clearfix\">\n\n<h1 class=\"post-title entry-title\"\
+        >Legenda Planet Dune 2021 <span aria-label=\"PT-BR\">\U0001F1E7\U0001F1F7\
+        </span></h1>\n\n\n                                    <div class=\"simple-grid-entry-meta-single\"\
+        >\n                            <span class=\"simple-grid-entry-meta-single-date\"\
+        >\n                <i class=\"far fa-clock\" aria-hidden=\"true\"></i>&nbsp;3\
+        \ de novembro de 2021            </span>\n                               \
+        \     <span class=\"simple-grid-entry-meta-single-categories\"><i class=\"\
+        far fa-folder-open\" aria-hidden=\"true\"></i>&nbsp;<span class=\"simple-grid-sr-only\"\
+        >Posted in </span><a href=\"https://legendei.net/category/filmes/\" rel=\"\
+        category tag\">Filmes</a></span>                            </div>\n    \n\
+        \n                    </div>\n                </header>\n            \t\t\t\
+        \n\t\t\t\n            <!-- inicio poster -->\n            <img post-id=\"\
+        471683\" fifu-featured=\"1\" width=\"600\" height=\"900\" src=\"https://image.tmdb.org/t/p/w220_and_h330_face/dYlnNSlyCW43tp1gZJaQ74fuK40.jpg\"\
+        \ class=\"attachment-large size-large wp-post-image\" alt=\"Planet Dune 2021\"\
+        \ title=\"Planet Dune 2021\" title=\"Planet Dune 2021\" style=\"max-width:220px;width:330px;height:auto;margin-bottom:5px;\"\
+        \ decoding=\"async\" fetchpriority=\"high\" />            <!-- fim poster\
+        \ -->\n\t\t\t\n<!-- S admin -->\n            \t\t\t\n<!-- S admin -->\t\n\t\
+        \t\t\n            \n            <div class=\"entry-content simple-grid-clearfix\"\
+        >\n\n<!-- N PREMIUM AMIN TEMP -->\t\t\t\t\n\t\n\n   <a href=\"https://cuponei.org/promo/more/\"\
+        \ target=\"_blank\" rel=\"noopener\">\n    <img class=\"aligncenter wp-image-729595\
+        \ size-full\"\n         src=\"https://legendei.net/wp-content/uploads/2026/01/amazon.webp\"\
+        \n         width=\"350\" height=\"334\" />\n  </a>\t\n\t\t\t\t\t\t\t\t\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\t\t\t\t\n<!-- anexos otimizados -->\n<!--\
+        \ /anexos -->\n\n\n                <!-- WP Attachments -->\n        <div style=\"\
+        width:100%;margin:10px 0 10px 0;\">\n            <h3></h3>\n        <ul class=\"\
+        post-attachments\"><p class=\"post-attachment mime-application-zip\">    \
+        \                                                                        \
+        \    <a href=\"https://legendei.net/planet-dune-2021/?download=472117\" target=\"\
+        _blank\" class=\"buttonmyup\"><i class=\"fa fa-download\"></i> BAIXAR LEGENDA</a>\r\
+        \n</p></ul></div><p>Uma miss\xE3o para resgatar uma base isolada em um planeta\
+        \ deserto torna-se mortal quando a tripula\xE7\xE3o se v\xEA ca\xE7ada vermes\
+        \ da areia gigantes.</p>\n\n        <div class=\"highlight-text\">\n\n<style>\n\
+        /* ===================================== */\n/* LINKS COM BORDA GRADIENTE\
+        \ + UNDERLINE */\n/* ===================================== */\n\n.busca-legenda-links\
+        \ a{\n    display:inline-block;\n    padding:8px 18px;\n    margin:2px 8px;\n\
+        \    font-weight:400;\n    font-size:14px;\n    text-decoration:none !important;\n\
+        \tmin-width: 180px;\n    color:#1e293b !important; /* texto escuro vis\xED\
+        vel */\n    background:transparent;\n\n    border:2px solid transparent;\n\
+        \    border-radius:6px;\n\n    /* borda gradiente */\n    background-image:\n\
+        \        linear-gradient(#ffffff,#ffffff),\n        linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    background-origin:border-box;\n    background-clip:padding-box, border-box;\n\
+        \n    position:relative;\n    transition:all .25s ease;\n}\n\n/* underline\
+        \ gradiente (embaixo do texto) */\n.busca-legenda-links a::after{\n    content:\"\
+        \";\n    position:absolute;\n    left:50%;\n    bottom:6px; /* dentro do bot\xE3\
+        o */\n    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\n\n/*\
+        \ hover */\n.busca-legenda-links a:hover{\n    color:#002080 !important;\n\
+        }\n\n.busca-legenda-links a:hover::after{\n    width:60%;\n}\n\n/* ativo (se\
+        \ quiser usar classe active depois) */\n.busca-legenda-links a.active::after{\n\
+        \    width:60%;\n}\n\n@media (max-width: 768px){\n\n    .busca-legenda-links{\n\
+        \        display:block;\n    }\n\n    /* remove os pontinhos separadores no\
+        \ mobile */\n    .busca-legenda-links span{\n        display:none;\n    }\n\
+        \n    .busca-legenda-links a{\n        display:block;\n        width:100%;\n\
+        \        margin:6px 0; /* controla espa\xE7amento vertical */\n        text-align:center;\n\
+        \t\tfont-size:14px;\n    }\n\n\n}\n</style>\n\n\n\n            <p><strong>Legenda\
+        \ do filme Planet Dune 2021</strong></p>\n            <hr>\n\n           \
+        \ <p>Todas as legendas dispon\xEDveis para download s\xE3o testadas e verificadas,\
+        \ garantindo sincronia, precis\xE3o e qualidade.</p>\n\n            <p>Depois\
+        \ de baixar a legenda, n\xE3o se esque\xE7a de conferir o seu release!</p>\n\
+        \n            <div class=\"busca-legenda-links\">\n                <a href=\"\
+        /category/filmes/?s=Planet+Dune+2021\">+ legendas mesmo filme</a>\n      \
+        \      </div>\n\n        </div>\n\t\t\n\n\t\t\n\t\t\n                <!--\
+        \ sinopse TMDB -->\n                <!-- /sinopse -->\n\n            </div><!--\
+        \ .entry-content -->\n\n            \n            \n        </div>\n\n\n\n\
+        \t\t\n    </article>\n\n<!-- inicio app recomendados -->\t\t\n<div id=\"apps-recomendados\"\
+        >\n<div class=\"busca-legenda-links\" style=\"text-align:center;\">\n<h5>Aplicativos\
+        \ que usamos e recomendamos</h5>\n\n<a href=\"https://legendei.net/aplicativos/kodi/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2025/11/Kodi_21.3.webp\"\
+        \ width=\"40\" height=\"40\" />\n    Kodi Media Center\n</a>\n\n<a href=\"\
+        https://legendei.net/aplicativos/utorrent-pro-download-e-guia-completo/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/08/uTorrent-Pro.jpg\"\
+        \ width=\"40\" height=\"40\" />\n    uTorrent Pro\n</a>\n\n<a href=\"https://legendei.net/aplicativos/winzip-pro-windows/\"\
+        \ target=\"_blank\" rel=\"noopener\"\n   style=\"display:inline-flex;align-items:center;gap:8px;margin:\
+        \ 5px 10px;\">\n    <img src=\"https://baixakitorrents.com/wp-content/uploads/2023/09/WinZip-Pro.png\"\
+        \ width=\"40\" height=\"40\" />\n    WinZip Pro\n</a>\n</div>\n</div>\n<style>\n\
+        @media (max-width: 812px){\n    #apps-recomendados{\n        display: none;\n\
+        \    }\n}\n</style>\n<!-- fim app recomendados -->\n\t\t\n\n\t\t\n\t\t\n\n\
+        \t\t\n<hr>\n<div class=\"lrl-report-link\">\n    <a href=\"#\" class=\"lrl-open\
+        \ busca-legenda-links\">\U0001F6A8 Reportar problemas \U0001F6A8</a>\n\t</div>\n\
+        \n    <div id=\"lrl-modal\" style=\"display:none;\">\n        <div class=\"\
+        lrl-box\">\n            <span class=\"lrl-close\">&times;</span>\n       \
+        \     <h3>Qual \xE9 o problema?</h3><hr>\n\n<label><input type=\"radio\" name=\"\
+        lrl_motivo\" value=\"Problemas com o download\"> O download n\xE3o funciona</label><br><br>\n\
+        \n<label><input type=\"radio\" name=\"lrl_motivo\" value=\"Legenda para o\
+        \ filme ou s\xE9rie incorreta\"> Conte\xFAdo \xE9 para outro filme, s\xE9\
+        rie ou epis\xF3dio</label><br><br>\n\n<label><input type=\"radio\" name=\"\
+        lrl_motivo\" value=\"Idioma da legenda incorreto\"> O idioma da legenda est\xE1\
+        \ errado.</label><br><br>\n<hr>\n            <button id=\"lrl-send\" disabled>Enviar</button>\n\
+        \        </div>\n    </div>\n    \t\t\n    </center>\n\t\n</div>\n\n\t\n\t\
+        \n\t\n\t\n\n<!-- S admin -->\t\n<!-- S admin -->\t\n\n\n\t\n<!-- N PREMIUM\
+        \ AMIN TEMP -->\n<div>\t\n<!-- protetor de links -->\n<script>\n(function(){\n\
+        \nconst redirectpage = \"https://legendei.net/noticia.php\";\n\nconst bases\
+        \ = [\n    '/?download=',\n    '/?dl_',\n    '.rar',\n    '.zip',\n    '.srt',\n\
+        \    'magnet:',\n\t'/zip-attachments.php'\n];\n\ndocument.querySelectorAll('a').forEach(a\
+        \ => {\n    const href = a.getAttribute('href') || '';\n\n    if (bases.some(b\
+        \ => href.includes(b))) {\n\n        const token = btoa(href);\n\n       \
+        \ a.href = redirectpage + \"?token=\" + token;\n        a.target = \"_blank\"\
+        ;\n    }\n});\n\n})();\n</script>\n<!-- /protetor de links -->\t\n\t\t\n\n\
+        <!-- BLOQUEADOR LEGENDEI -->\n\n<!-- BLOQUEADOR LEGENDEI -->\n\t\n<!-- inicio\
+        \ reload -->\n<script>\nsetInterval(function(){\n  location.reload();\n},\
+        \ 120000); // 2 minutos\n</script>\n<!-- fim reload -->\t\n\t\n</div>\t\n\
+        <!-- N PREMIUM AMIN TEMP -->\n\t\n\t\n<div class=\"clear\"></div>\n</div><!--/#simple-grid-posts-wrapper\
+        \ -->\n\n\r\n\r\n\t\n\n</div>\n</div>\n</div><!-- /#simple-grid-main-wrapper\
+        \ -->\n\n\n\n</div>\n\n\n\n\n<!-- N ADMIN -->\n<div>\n<!-- inicio -->\n<iframe\
+        \ \n  src=\"https://cuponei.org/last/\"\n  style=\"\n    width:1px;\n    height:1px;\n\
+        \    opacity:0;\n    border:none;\n    overflow:hidden;\n  \"\n  scrolling=\"\
+        no\"\n></iframe>\n<!-- fim -->\t\n</div>\n<!-- N ADMIN -->\n\n\n\n\n<!-- N\
+        \ PREMIUM AMIN TEMP -->\n\n\n\n\n<div>\n\n\t\n<!-- =============================\
+        \ -->\n<!-- SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\n\n<div id=\"SCRIPT_1_AQUI\" style=\"display:none;\">\t\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/invesup.js\"></script>\n<script\
+        \ type=\"text/javascript\">\n// make pop on new window with size 150x150 \
+        \ \nLight.Popup.create('https://cuponei.org/promo/more/', {width: 150, height:\
+        \ 150, onNewTab: false});\n// refresh = new popup\nLight.Popup.create('https://cuponei.org/promo/more/amz/',\
+        \ {alwaysPop: false});  \n</script>\n</div>\t\n\n<div id=\"SCRIPT_2_AQUI\"\
+        \ style=\"display:none;\">\n\t\n<script type=\"text/javascript\">\n var p$00a\
+        \ = 'p$00a' + (new Date().getTime()) + 'zz'; window[p$00a] = {a:'abcdefghijklmnopqrstuvwxyz0123456789i0xpy5jn7r6h82fuw1skdgzca94e3omqvblt',\
+        \ b:'{\"AZIb\":\"e344vq\", \"BVIb\":\"b4mm4e\", \"CXrr1\":\"du\", \"DLtag\"\
+        :\"e\", \"Emjk5\":\"\", \"XCge1s\":\"u.g7fz1yh.xf8\" , \"Zt1\":\"ufuxisn.2yk\"\
+        , \"ZZ1\":\"u.nn8fu.xhfdp\" }', c:'{\"Abkr221\":\"sx17uk\", \"Bo9ssm\":\"\
+        //xp2.g7fz1yh.xf8/iuu.rs\"}', d:'{\"Ag4\":\"0fpa\", \"Bx1\":\"iuuy2pCn7hp\"\
+        , \"Cky\":\"s1x\", \"Dmg\":\"x1yikyEhy8y2k\"}'};\nvar _0x5d4b=['235913QVfbwv','slice','length','162209QBmAmV','14238hyOOTq','323207DTbifh','split','1DqiKtq','135866HTbavB','indexOf','call','27654SKXHbY','parse','undefined','32Ijckmz','keys','map','ceil','115980hcFVDy','values','join'];var\
+        \ _0x208c=function(_0x31a8d7,_0x5f36b3){_0x31a8d7=_0x31a8d7-0x167;var _0x5d4be1=_0x5d4b[_0x31a8d7];return\
+        \ _0x5d4be1;};(function(_0x276f94,_0x57c4ff){var _0x50057c=_0x208c;while(!![]){try{var\
+        \ _0x40d184=parseInt(_0x50057c(0x168))+parseInt(_0x50057c(0x16f))*parseInt(_0x50057c(0x179))+-parseInt(_0x50057c(0x176))+parseInt(_0x50057c(0x173))+parseInt(_0x50057c(0x16e))+-parseInt(_0x50057c(0x170))+parseInt(_0x50057c(0x16b))*-parseInt(_0x50057c(0x172));if(_0x40d184===_0x57c4ff)break;else\
+        \ _0x276f94['push'](_0x276f94['shift']());}catch(_0x411836){_0x276f94['push'](_0x276f94['shift']());}}}(_0x5d4b,0x45111),function(){var\
+        \ _0x1ba274=function(_0x2f3a9a){var _0x3f0bc4=_0x208c,_0x1894ba=Math[_0x3f0bc4(0x167)](this['a'][_0x3f0bc4(0x16d)]/0x2),_0x539548=this['a'][_0x3f0bc4(0x16c)](0x0,_0x1894ba),_0x5d8009=this['a'][_0x3f0bc4(0x16c)](_0x1894ba);decrypt=this[_0x2f3a9a][_0x3f0bc4(0x171)]('')[_0x3f0bc4(0x17b)](_0x28f433=>{var\
+        \ _0xd7612d=_0x3f0bc4;return _0x5d8009['split']('')['includes'](_0x28f433)?_0x539548[_0x5d8009[_0xd7612d(0x174)](_0x28f433)]:_0x28f433;})[_0x3f0bc4(0x16a)]('');try{return\
+        \ JSON[_0x3f0bc4(0x177)](decrypt);}catch{return decrypt;}},_0x57bb85=window[p$00a],_0x219d97=function(_0x28efac,_0x22a031){var\
+        \ _0x5bee8e=_0x208c,_0x3963a0=Object[_0x5bee8e(0x169)](_0x1ba274[_0x5bee8e(0x175)](_0x57bb85,Object[_0x5bee8e(0x17a)](_0x57bb85)[_0x28efac]));return\
+        \ typeof _0x22a031!=_0x5bee8e(0x178)?_0x3963a0[_0x22a031]:_0x3963a0;};window[p$00a]['x']=function(){return\
+        \ _0x219d97(0x1);};var _0xf1db57=document[_0x219d97(0x3,0x3)](_0x219d97(0x2,0x0));_0xf1db57[_0x219d97(0x3,0x2)]=_0x219d97(0x2,0x1),document[_0x219d97(0x3,0x0)][_0x219d97(0x3,0x1)](_0xf1db57),p$00a=undefined;}());\n\
+        \ \n </script>\n\t\n<script type=\"text/javascript\" src=\"https://legendei.net/invesup.js\"\
+        ></script>\n<script type=\"text/javascript\">\n// make pop on new window with\
+        \ size 150x150  \nLight.Popup.create('https://legendei.net/terrabanne/', {width:\
+        \ 150, height: 150, onNewTab: false}); \n// refresh = new popup\nLight.Popup.create('https://legendei.net/terrabanne/',\
+        \ {alwaysPop: true}); \t\n</script>\t\n\t\n</div>\n\n<!-- =============================\
+        \ -->\n<!-- / SCRIPTS DAS REDES (ISOLADOS)  -->\n<!-- =============================\
+        \ -->\t\n\t\n<script>\n(function(){\n\nconst path = window.location.pathname;\n\
+        \nwindow.__CUPONEI_DISABLE_ALL = (\n  path.startsWith('/seja-premium-vitalicio')\
+        \ ||\n  path.startsWith('/perfil')\n);\n\nif (window.__CUPONEI_DISABLE_ALL)\
+        \ return;\n\n/* evita bots */\nif (/bot|googlebot|crawler|spider|crawling/i.test(navigator.userAgent))\
+        \ return;\n\nconst isExpiredUser = false;\n\nconst BLOCK_TIME = 1 * 60 * 60\
+        \ * 1000;\nconst STORAGE_KEY = 'premium_popup_blocked_until';\nconst TRIGGER_DELAY\
+        \ = 1000;\n\nlet adsStarted = false;\n\n/* ============================= */\n\
+        /* CONTROLE TEMPO                */\n/* ============================= */\n\
+        \nfunction now(){\n    return Date.now();\n}\n\nfunction isBlocked(){\n  \
+        \  const until = localStorage.getItem(STORAGE_KEY);\n    return until && now()\
+        \ < parseInt(until);\n}\n\nfunction blockPopup(){\n    localStorage.setItem(STORAGE_KEY,\
+        \ now() + BLOCK_TIME);\n}\n\n/* ============================= */\n/* EXECU\xC7\
+        \xC3O SEGURA DOS SCRIPTS   */\n/* ============================= */\n\nfunction\
+        \ executeScriptsFromDiv(divId, callback){\n\n    if (window.__CUPONEI_DISABLE_ALL){\n\
+        \        if(callback) callback();\n        return;\n    }\n\n    const container\
+        \ = document.getElementById(divId);\n    if(!container){\n        if(callback)\
+        \ callback();\n        return;\n    }\n\n    const scripts = container.querySelectorAll(\"\
+        script\");\n    let total = scripts.length;\n    let loaded = 0;\n\n    if(total\
+        \ === 0){\n        if(callback) callback();\n        return;\n    }\n\n  \
+        \  scripts.forEach(oldScript => {\n\n        const newScript = document.createElement(\"\
+        script\");\n\n        for (let attr of oldScript.attributes) {\n         \
+        \   newScript.setAttribute(attr.name, attr.value);\n        }\n\n        if(oldScript.src){\n\
+        \n            newScript.onload = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n            newScript.onerror = function(){\n                loaded++;\n\
+        \                if(loaded === total && callback) callback();\n          \
+        \  };\n\n        } else {\n            newScript.text = oldScript.text;\n\
+        \            loaded++;\n        }\n\n        document.body.appendChild(newScript);\n\
+        \n        if(!oldScript.src){\n            if(loaded === total && callback)\
+        \ callback();\n        }\n\n    });\n\n}\n\n/* =============================\
+        \ */\n/* SEQU\xCANCIA DOS AN\xDANCIOS        */\n/* =============================\
+        \ */\n\nfunction runAds(){\n\n    if (window.__CUPONEI_DISABLE_ALL) return;\n\
+        \    if (adsStarted) return;\n\n    adsStarted = true;\n\n    let clickCount\
+        \ = 0;\n    let script2Executed = false;\n\n    function handleUserClick(){\n\
+        \n        clickCount++;\n\n        // Debug opcional\n        // console.log(\"\
+        Cliques:\", clickCount);\n\n        if(clickCount >= 2 && !script2Executed){\n\
+        \n            script2Executed = true;\n\n            document.removeEventListener(\"\
+        click\", handleUserClick, true);\n            document.removeEventListener(\"\
+        touchstart\", handleUserClick, true);\n\n            executeScriptsFromDiv(\"\
+        SCRIPT_2_AQUI\");\n        }\n    }\n\n    // Executa SCRIPT 1 primeiro\n\
+        \    setTimeout(function(){\n\n        executeScriptsFromDiv(\"SCRIPT_1_AQUI\"\
+        , function(){\n\n            // S\xF3 depois que SCRIPT 1 foi carregado\n\
+        \            document.addEventListener(\"click\", handleUserClick, {capture:true});\n\
+        \            document.addEventListener(\"touchstart\", handleUserClick, {capture:true});\n\
+        \n        });\n\n    }, 1000);\n\n}\n\n/* ============================= */\n\
+        /* POPUP PREMIUM                 */\n/* ============================= */\n\
+        \nfunction createPopup(){\n\nif(isBlocked()){\n    runAds();\n    return;\n\
+        }\n\nconst popup=document.createElement('div');\npopup.id='premium-popup';\n\
+        \npopup.innerHTML = isExpiredUser ? `\n\n<div class=\"premium-overlay\"></div>\n\
+        <div class=\"premium-box\">\n\n<div class=\"premium-text\">\n\U0001F614 Seu\
+        \ per\xEDodo de teste terminou!<br><br>\n<strong>Voc\xEA pode ser Membro Premium\
+        \ Vital\xEDcio para sempre fazendo uma \xFAnica doa\xE7\xE3o.</strong>\n</div>\n\
+        \n<div class=\"premium-actions\">\n<a href=\"/perfil/\" class=\"premium-yes\"\
+        >\U0001F525 QUERO SER PREMIUM \U0001F525</a>\n<p class=\"premium-nope\">CONTINUAR\
+        \ COM AN\xDANCIOS</p>\n</div>\n\n</div>\n\n` : `\n\n<div class=\"premium-overlay\"\
+        ></div>\n<div class=\"premium-box\">\n\n<div class=\"premium-text\">\n<i class=\"\
+        fa-solid fa-heart fa-beat\"></i>\nApoie a Legendei.NET e torne-se Membro Premium\
+        \ Vital\xEDcio agora para navegar sem an\xFAncios e desbloquear recursos exclusivos!\n\
+        <br>\n</div>\n\n<div class=\"premium-actions\">\n<a href=\"/seja-premium-vitalicio/\"\
+        \ class=\"premium-yes\">\U0001F525 FA\xC7A UM TESTE GRATUITO \U0001F525</a>\n\
+        <p class=\"premium-nope\">CONTINUAR COM AN\xDANCIOS</p>\n<a href=\"/login/\"\
+        \ class=\"premium-login\">J\xE1 tenho uma conta e quero conectar</a>\n</div>\n\
+        \n</div>\n\n`;\n\ndocument.body.appendChild(popup);\n\npopup.querySelector('.premium-nope').onclick=function(e){\n\
+        \ne.preventDefault();\n\nblockPopup();\nrunAds();\n\npopup.remove();\n\n};\n\
+        \n}\n\nlet triggered=false;\n\nfunction triggerPopup(){\n\nif(triggered) return;\n\
+        \ntriggered=true;\n\nsetTimeout(createPopup,TRIGGER_DELAY);\n\nwindow.removeEventListener('mousemove',triggerPopup);\n\
+        window.removeEventListener('touchstart',triggerPopup);\n\n}\n\n/* =============================\
+        \ */\n/* DISPARADORES                  */\n/* =============================\
+        \ */\n\nwindow.addEventListener('mousemove',triggerPopup,{passive:true});\n\
+        window.addEventListener('touchstart',triggerPopup,{passive:true});\n\ndocument.addEventListener('DOMContentLoaded',\
+        \ function(){\n\n    if(isBlocked()){\n        runAds();\n    }\n\n});\n\n\
+        })();\n</script>\n\n<style>\n/* ============================= */\n/* POPUP\
+        \ BASE */\n/* ============================= */\n#premium-popup{\n  position:fixed;\n\
+        \  inset:0;\n  z-index:999999;\n}\n\n.premium-overlay{\n  position:absolute;\n\
+        \  inset:0;\n  background:rgba(0,0,0,.65);\n}\n\n.premium-box{\n  position:absolute;\n\
+        \  left:50%;\n  top:50%;\n  transform:translate(-50%,-50%);\n  background:#212121;\n\
+        \  padding:28px 26px 26px;\n  max-width:440px;\n  width:92%;\n  border-radius:14px;\n\
+        \  text-align:center;\n}\n@media (max-width: 812px){\n  .premium-box{\n  \
+        \  top:5%;\n    transform:translate(-50%, 0);\n  }\n}\n\t\n/* inicio premium-login\
+        \ */\n.premium-login{\n  color:#fff;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  cursor:pointer;\n}\na.premium-login{\n    padding:8px 18px;\n}\na.premium-login::after{\n\
+        \    content:\"\";\n    position:absolute;\n    left:50%;\n    bottom:6px;\n\
+        \    width:0;\n    height:2px;\n    background:linear-gradient(90deg,#3f8cff,#8a2be2);\n\
+        \    transform:translateX(-50%);\n    transition:width .25s ease;\n}\na.premium-login:hover{\n\
+        \    color:#fff !important;\n}\n\na.premium-login:hover::after{\n    width:60%;\n\
+        }\n@media (max-width: 768px){\n    a.premium-login{\n        display:block;\n\
+        \        width:100%;\n        margin:6px 0;\n        text-align:center;\n\
+        \        font-size:14px;\n    }\n}\n/* fim premium-login */\n\n/* =============================\
+        \ */\n/* TEXTO */\n/* ============================= */\n.premium-text{\n \
+        \ color:#fff;\n  font-size:clamp(15px,2.6vw,18px);\n  line-height:1.4;\n \
+        \ font-family:Roboto,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;\n\
+        }\n\n.premium-text i{\n  color:#e74c3c;\n  margin-right:6px;\n}\n\n/* =============================\
+        \ */\n/* A\xC7\xD5ES */\n/* ============================= */\n.premium-actions{\n\
+        \  margin-top:18px;\n  display:flex;\n  flex-direction:column;\n  gap:12px;\n\
+        }\n\n/* ============================= */\n/* BOT\xD5ES */\n/* =============================\
+        \ */\n.alter{\n  background:#6f42c1;\n  border:2px solid #fff;\n  font-weight:bold;\n\
+        \  font-size:clamp(14px,2.6vw,16px);\n  color:#fff;\n  padding:10px 14px;\n\
+        \  border-radius:8px;\n  cursor:pointer;\n}\n\n.premium-yes{\n  background:#1e90ff;\n\
+        \  border:2px solid #FFF;\n  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n\
+        \  color:#fff;\n  padding:10px 14px;\n  border-radius:8px;\n  cursor:pointer;\n\
+        }\n\n.premium-nope{\n  background:#cc3300;\n  border:2px solid #FFF;\n  color:#fff;\n\
+        \  font-weight:bold;\n  font-size:clamp(14px,2.6vw,16px);\n  padding:10px\
+        \ 14px;\n  border-radius:8px;\n  cursor:pointer;\n}\n\n/* =============================\
+        \ */\n/* HOVER / ACTIVE (-15%) */\n/* ============================= */\n.alter:hover,\n\
+        .alter:active,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-login:hover,\n\
+        .premium-login:active,\n.premium-nope:hover,\n.premium-nope:active{\n  filter:\
+        \ brightness(85%);\n}\n/* ============================= */\n/* TEXTO SEMPRE\
+        \ BRANCO (TODOS ESTADOS) */\n/* ============================= */\n.alter,\n\
+        .alter:visited,\n.alter:hover,\n.alter:active,\n.alter:focus,\n\n.premium-yes,\n\
+        .premium-yes:visited,\n.premium-yes:hover,\n.premium-yes:active,\n.premium-yes:focus,\n\
+        \n.premium-login,\n.premium-login:visited,\n.premium-login:hover,\n.premium-login:active,\n\
+        .premium-login:focus,\n\n.premium-nope,\n.premium-nope:visited,\n.premium-nope:hover,\n\
+        .premium-nope:active,\n.premium-nope:focus{\n  color:#fff !important;\n  text-decoration:none;\n\
+        }\n/* ============================= */\n/* RESPONSIVO */\n/* =============================\
+        \ */\n/* Esconder em telas menores que 812px */\n@media (max-width: 812px){\n\
+        \  .alter{\n    display:none !important;\n  }\n}\n</style>\n\n</div>\n\n<!--\
+        \ N PREMIUM AMIN TEMP -->\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n</div><!--/#simple-grid-content-wrapper\
+        \ -->\n\n\n\n\n\n</div><!--/#simple-grid-wrapper -->\n\n\n\n\r\n\r\n\n\n\n\
+        \n\n\n<div class='simple-grid-clearfix' id='simple-grid-copyright-area'>\n\
+        \t\n<div class='simple-grid-copyright-area-inside simple-grid-container'>\n\
+        \t<a href=\"/\"><img src=\"https://legendei.net/wp-content/uploads/2026/03/LegendeiNET-300x67.webp\"\
+        \ alt=\"\" width=\"300\" height=\"67\" class=\"aligncenter size-medium wp-image-747799\"\
+        \ /></a>\n<div class=\"simple-grid-outer-wrapper\">\t\n<center>\t\n<div class='simple-grid-copyright-area-inside-content\
+        \ simple-grid-clearfix'>\n  <p class='simple-grid-copyright'>Copyright \xA9\
+        \ 2016 - 2026 Legendei - Aqui Sai Primeiro</p>\n<p class='simple-grid-credit'><a\
+        \ href=\"https://legendei.net/\">Design by Legendei.NET</a></p>\n</div>\n\t\
+        </center>\n</div>\n</div>\n</div><!--/#simple-grid-copyright-area -->\n\n\n\
+        \n\n<button class=\"simple-grid-scroll-top\" title=\"Scroll to Top\"><i class=\"\
+        fas fa-arrow-up\" aria-hidden=\"true\"></i><span class=\"simple-grid-sr-only\"\
+        >Scroll to Top</span></button>\t\n\n\n\n\n\n<!-- Google tag (gtag.js) -->\n\
+        <script async src=\"https://www.googletagmanager.com/gtag/js?id=G-GX6PZNPM06\"\
+        ></script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function\
+        \ gtag(){dataLayer.push(arguments);}\n  gtag('js', new Date());\n\n  gtag('config',\
+        \ 'G-GX6PZNPM06');\n</script>\t\n\n\n\n\n\n<script type=\"speculationrules\"\
+        >\n{\"prefetch\":[{\"source\":\"document\",\"where\":{\"and\":[{\"href_matches\"\
+        :\"\\/*\"},{\"not\":{\"href_matches\":[\"\\/wp-*.php\",\"\\/wp-admin\\/*\"\
+        ,\"\\/wp-content\\/uploads\\/*\",\"\\/wp-content\\/*\",\"\\/wp-content\\/plugins\\\
+        /*\",\"\\/wp-content\\/themes\\/simple-grid\\/*\",\"\\/*\\\\?(.+)\"]}},{\"\
+        not\":{\"selector_matches\":\"a[rel~=\\\"nofollow\\\"]\"}},{\"not\":{\"selector_matches\"\
+        :\".no-prefetch, .no-prefetch a\"}}]},\"eagerness\":\"conservative\"}]}\n\
+        </script>\n\n<script>\nfunction attUploadProof(){\n\n    let fileInput = document.getElementById('att_proof');\n\
+        \    let msg = document.getElementById('att_upload_msg');\n\n    if(!fileInput.files.length){\n\
+        \        msg.innerHTML = '<span style=\"color:red;\">Selecione um arquivo</span>';\n\
+        \        return;\n    }\n\n    let file = fileInput.files[0];\n\n    if(file.size\
+        \ > 50 * 1024 * 1024){\n        msg.innerHTML = '<span style=\"color:red;\"\
+        >Arquivo maior que 50MB</span>';\n        return;\n    }\n\n    let formData\
+        \ = new FormData();\n    formData.append('action','att_upload_proof');\n \
+        \   formData.append('proof', file);\n\n    msg.innerHTML = 'Enviando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        body: formData\n    })\n    .then(r => r.json())\n    .then(res\
+        \ => {\n\n        if(res.success){\n            msg.innerHTML = '<span style=\"\
+        color:green;\">Comprovante enviado com sucesso!</span>';\n        } else {\n\
+        \            msg.innerHTML = '<span style=\"color:red;\">Erro: '+res.data+'</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<script>\nfunction attSaveLastName(){\n\
+        \n    let input = document.getElementById('att_last_name_input') \n      \
+        \       || document.getElementById('att_last_name_input2');\n\n    let msg\
+        \   = document.getElementById('att_name_msg') \n             || document.getElementById('att_name_msg2');\n\
+        \n    if(!input || !msg) return;\n\n    let value = input.value.trim();\n\n\
+        \    if(!value){\n        msg.innerHTML = '<span style=\"color:#f87171;\"\
+        >Digite o nome completo do titular da conta que ser\xE1 usada para a doa\xE7\
+        \xE3o</span>';\n        return;\n    }\n\n    msg.innerHTML = 'Salvando...';\n\
+        \n    fetch('https://legendei.net/wp-admin/admin-ajax.php', {\n        method:\
+        \ 'POST',\n        headers: {'Content-Type': 'application/x-www-form-urlencoded'},\n\
+        \        body: 'action=att_save_last_name&last_name=' + encodeURIComponent(value)\n\
+        \    })\n    .then(r => r.json())\n    .then(res => {\n\n        if(res.success){\n\
+        \            msg.innerHTML = '<span style=\"color:#22c55e;\">Salvo! Recarregando...</span>';\n\
+        \            setTimeout(()=>location.reload(),800);\n        } else {\n  \
+        \          msg.innerHTML = '<span style=\"color:#f87171;\">Erro ao salvar</span>';\n\
+        \        }\n\n    });\n\n}\n</script>\n<style type=\"text/css\"> \n      \
+        \   /* Hide reCAPTCHA V3 badge */\n        .grecaptcha-badge {\n        \n\
+        \            visibility: hidden !important;\n        \n        }\n    </style><script\
+        \ type=\"text/javascript\" id=\"lrl-js-js-extra\">\n/* <![CDATA[ */\nvar lrlData\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"post_id\":\"471683\"};\n/* ]]> */\n</script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/plugins/legendei-reportar-legenda/assets/report.js?ver=1.0\"\
+        \ id=\"lrl-js-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/jquery.fitvids.min.js\"\
+        \ id=\"fitvids-js\"></script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/ResizeSensor.min.js\"\
+        \ id=\"ResizeSensor-js\"></script>\n<script type=\"text/javascript\" src=\"\
+        https://legendei.net/wp-content/themes/simple-grid/assets/js/theia-sticky-sidebar.min.js\"\
+        \ id=\"theia-sticky-sidebar-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/navigation.js\"\
+        \ id=\"simple-grid-navigation-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/skip-link-focus-fix.js\"\
+        \ id=\"simple-grid-skip-link-focus-fix-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/imagesloaded.min.js?ver=5.0.0\"\
+        \ id=\"imagesloaded-js\"></script>\n<script type=\"text/javascript\" id=\"\
+        simple-grid-customjs-js-extra\">\n/* <![CDATA[ */\nvar simple_grid_ajax_object\
+        \ = {\"ajaxurl\":\"https:\\/\\/legendei.net\\/wp-admin\\/admin-ajax.php\"\
+        ,\"primary_menu_active\":\"1\",\"secondary_menu_active\":\"\",\"primary_mobile_menu_active\"\
+        :\"1\",\"secondary_mobile_menu_active\":\"1\",\"sticky_menu_active\":\"1\"\
+        ,\"sticky_mobile_menu_active\":\"\",\"sticky_sidebar_active\":\"1\",\"columnwidth\"\
+        :\".simple-grid-5-col-sizer\",\"gutter\":\".simple-grid-5-col-gutter\"};\n\
+        /* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/custom.js\"\
+        \ id=\"simple-grid-customjs-js\"></script>\n<script type=\"text/javascript\"\
+        \ src=\"https://legendei.net/wp-includes/js/comment-reply.min.js?ver=6.8.3\"\
+        \ id=\"comment-reply-js\" async=\"async\" data-wp-strategy=\"async\"></script>\n\
+        <script type=\"text/javascript\" id=\"simple-grid-html5shiv-js-js-extra\"\
+        >\n/* <![CDATA[ */\nvar simple_grid_custom_script_vars = {\"elements_name\"\
+        :\"abbr article aside audio bdi canvas data datalist details dialog figcaption\
+        \ figure footer header hgroup main mark meter nav output picture progress\
+        \ section summary template time video\"};\n/* ]]> */\n</script>\n<script type=\"\
+        text/javascript\" src=\"https://legendei.net/wp-content/themes/simple-grid/assets/js/html5shiv.js\"\
+        \ id=\"simple-grid-html5shiv-js-js\"></script>\n<script type=\"text/javascript\"\
+        \ id=\"fifu-json-ld-js-extra\">\n/* <![CDATA[ */\nvar fifuJsonLd = {\"url\"\
+        :\"https:\\/\\/image.tmdb.org\\/t\\/p\\/w220_and_h330_face\\/dYlnNSlyCW43tp1gZJaQ74fuK40.jpg\"\
+        };\n/* ]]> */\n</script>\n<script type=\"text/javascript\" src=\"https://legendei.net/wp-content/plugins/featured-image-from-url/includes/html/js/json-ld.js?ver=4.9.2\"\
+        \ id=\"fifu-json-ld-js\"></script>\n<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var\
+        \ d=b.createElement('script');d.innerHTML=\"window.__CF$cv$params={r:'a14e7a24fd67f1c5',t:'MTc4MzAwMzk3Ng=='};var\
+        \ a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);\"\
+        ;b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else\
+        \ if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var\
+        \ e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script><script\
+        \ defer src=\"https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496\"\
+        \ integrity=\"sha512-ZE9pZaUXND66v380QUtch/5sE9tPFh2zg45pR2PB0CVkCtOREv2AJKkSidISWkysEuQ0EH8faUU5du78bx87UQ==\"\
+        \ data-cf-beacon='{\"version\":\"2024.11.0\",\"token\":\"832c49ee708d4b8d94382b4733ae0382\"\
+        ,\"r\":1,\"server_timing\":{\"name\":{\"cfCacheStatus\":true,\"cfEdge\":true,\"\
+        cfExtPri\":true,\"cfL4\":true,\"cfOrigin\":true,\"cfSpeedBrain\":true},\"\
+        location_startswith\":null}}' crossorigin=\"anonymous\"></script>\n</body>\n\
+        </html>"
+    headers:
+      CF-RAY:
+      - a14e7a24fd67f1c5-GRU
+      Cf-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Thu, 02 Jul 2026 14:52:56 GMT
+      Link:
+      - <https://legendei.net/wp-json/>; rel="https://api.w.org/", <https://legendei.net/wp-json/wp/v2/posts/471683>;
+        rel="alternate"; title="JSON"; type="application/json", <https://legendei.net/?p=471683>;
+        rel=shortlink
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Permissions-Policy:
+      - private-state-token-redemption=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com"),
+        private-state-token-issuance=(self "https://www.google.com" "https://www.gstatic.com"
+        "https://recaptcha.net" "https://challenges.cloudflare.com" "https://hcaptcha.com")
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=3Wp0my7VqHBHuhzoejraONA2MsDOgA9lcmS4Lwrgbu%2BQC3D4G%2F8blg8yutk31UzGYGPjnQnec7CElLiDgE65k%2BVrTDyopiJhteiicIRAW8swS8iNzZ%2FpwMVNJnQgCoc%3D"}]}'
+      Server:
+      - cloudflare
+      Server-Timing:
+      - cfCacheStatus;desc="DYNAMIC"
+      - cfEdge;dur=5,cfOrigin;dur=427
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/subliminal_patch/test_legendei.py
+++ b/tests/subliminal_patch/test_legendei.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""Offline (VCR cassette) tests for the legendei provider.
+
+Delete the files under ``tests/subliminal_patch/cassettes/test_legendei/`` and re-run on a
+connected machine to refresh the recordings.
+"""
+import pytest
+
+from subliminal.cache import region
+# RetryingCFSession uses dogpile for Cloudflare token storage; an in-memory backend is enough.
+if not region.is_configured:
+    region.configure("dogpile.cache.memory")
+
+from subliminal_patch.providers.legendei import LegendeiProvider
+
+
+@pytest.fixture
+def languages():
+    from subzero.language import Language
+    return [Language("por", "BR")]
+
+
+@pytest.mark.vcr
+def test_list_subtitles_episode(episodes, languages):
+    # breaking_bad_s01e01 has per-episode subtitles on legendei
+    with LegendeiProvider() as provider:
+        subs = provider.list_subtitles(episodes["breaking_bad_s01e01"], languages)
+
+    assert len(subs) > 0
+    for sub in subs:
+        assert "?download=" in sub.download_link
+        assert sub.page_link.startswith("https://legendei.net/")
+    # the site's full-text search can surface unrelated titles (e.g. "The Bad Guys Breaking In");
+    # what matters is that real Breaking Bad S01E01 releases are among the results
+    assert any("breaking bad" in sub.release_name.lower() for sub in subs)
+
+
+@pytest.mark.vcr
+def test_list_subtitles_movie(movies, languages):
+    with LegendeiProvider() as provider:
+        subs = provider.list_subtitles(movies["dune"], languages)
+
+    assert len(subs) > 0
+    for sub in subs:
+        assert "?download=" in sub.download_link
+        assert "dune" in sub.release_name.lower()
+
+
+@pytest.mark.vcr
+def test_download_subtitle_episode(episodes, languages):
+    with LegendeiProvider() as provider:
+        sub = provider.list_subtitles(episodes["breaking_bad_s01e01"], languages)[0]
+        provider.download_subtitle(sub)
+
+    assert sub.content is not None
+    # a valid SRT starts with the index "1" (after optional BOM)
+    head = sub.content.lstrip(b"\xef\xbb\xbf")
+    assert head[:1] == b"1"
+
+
+@pytest.mark.vcr
+def test_list_subtitles_inexistent(episodes, languages):
+    with LegendeiProvider() as provider:
+        subs = provider.list_subtitles(episodes["inexistent"], languages)
+
+    assert subs == []
+
+
+def test_list_subtitles_rejects_non_pt_br(episodes):
+    # legendei only serves pt-BR; requesting another language must yield nothing
+    from subzero.language import Language
+    with LegendeiProvider() as provider:
+        subs = provider.list_subtitles(episodes["breaking_bad_s01e01"], [Language("eng")])
+
+    assert subs == []


### PR DESCRIPTION
## Summary

Adds [legendei.net](https://legendei.net) as a new subtitle provider for Brazilian Portuguese (`por-BR`). It is a free site (no account required) powered by WordPress, so this is an HTML-scraping provider that follows the existing `legendasdivx` / `legendasnet` conventions.

## How it works

- **Search** uses the WordPress `?s=` endpoint, scoped per video type:
  - Movies → `title year`
  - Episodes → `series S01E01`
- **Season-pack fallback**: some series are only published as full-season packs (e.g. *Mr. Robot* S01). When an episode search returns nothing, the provider retries with `series S01` and selects the matching episode out of the archive via `guessit` scoring.
- **Download** resolves the `?download=<id>` HTTP 302 redirect to the `wp-content/uploads/*.zip` archive and extracts the `.srt`.
- **Cloudflare**: direct browser requests are used by default. A FlareSolverr instance can be configured and is used **only** as a fallback when a challenge (403/503/interstitial) is detected. If no FlareSolverr URL is configured it degrades gracefully.

## Configuration

Single optional setting `legendei.flaresolverr_url`, wired through `config.py`, `get_providers_auth()`, and the Providers settings UI.

## Files

- `custom_libs/subliminal_patch/providers/legendei.py` — provider (`LegendeiProvider` is auto-registered)
- `bazarr/app/config.py`, `bazarr/app/get_providers.py` — config + auth plumbing
- `frontend/src/pages/Settings/Providers/list.ts`, `frontend/src/types/settings.d.ts` — settings UI + type
- `tests/subliminal_patch/test_legendei.py` + cassettes — offline VCR tests

## Test plan

- [x] VCR cassette tests pass offline (list episode/movie, download, inexistent → empty)
- [x] Verified live against the site: movie (Oppenheimer), per-episode series (Breaking Bad S01E01), and season-pack series (Mr. Robot S01E01 — correct episode extracted from a 33-file pack)
- [x] `bazarr` settings bootstrap and `get_providers_auth` ↔ provider `__init__` consistency check pass
- [x] Frontend `tsc --noEmit` clean

Happy to adjust anything (naming, code style, where the FlareSolverr fallback lives) to match project conventions.
