### PR TITLE
Added subtitle track duration to manual search to tell same-language tracks apart

### DIFF
--- a/bazarr/subtitles/manual.py
+++ b/bazarr/subtitles/manual.py
@@ -31,6 +31,20 @@ from .utils import get_video, _get_lang_obj, _get_scores, _set_forced_providers
 from .processing import process_subtitle
 
 
+def _build_release_info(subtitle):
+    releases = []
+    if hasattr(subtitle, 'release_info') and subtitle.release_info is not None:
+        for s_item in subtitle.release_info.split(','):
+            if s_item.strip():
+                releases.append(s_item)
+
+    extra_release_info = getattr(subtitle, 'extra_release_info', None)
+    if extra_release_info:
+        releases.extend(extra_release_info)
+
+    return releases
+
+
 @update_pools
 def manual_search(path, profile_id, providers, sceneName, title, media_type):
     logging.debug(f'BAZARR Manually searching subtitles for this file: {path}')
@@ -105,12 +119,7 @@ def manual_search(path, profile_id, providers, sceneName, title, media_type):
                     s.score = score
                     not_matched = set()
 
-                releases = []
-                if hasattr(s, 'release_info'):
-                    if s.release_info is not None:
-                        for s_item in s.release_info.split(','):
-                            if s_item.strip():
-                                releases.append(s_item)
+                releases = _build_release_info(s)
 
                 if s.uploader and s.uploader.strip():
                     s_uploader = s.uploader.strip()

--- a/custom_libs/subliminal_patch/providers/embeddedsubtitles.py
+++ b/custom_libs/subliminal_patch/providers/embeddedsubtitles.py
@@ -44,6 +44,7 @@ class EmbeddedSubtitle(Subtitle):
         self.forced = stream.disposition.forced
         self.page_link = self.container.path
         self.release_info = _get_pretty_release_name(stream, container)
+        self.extra_release_info = _get_extra_release_info(stream)
         self.media_type = media_type
         self.matches = matches or set()
 
@@ -403,6 +404,27 @@ def _discard_possible_incomplete_subtitles(streams):
 def _get_pretty_release_name(stream, container):
     bname = os.path.basename(container.path)
     return f"{os.path.splitext(bname)[0]}.{stream.suffix}"
+
+
+def _get_extra_release_info(stream):
+    info = []
+    # stream.duration reflects the whole container's duration for every subtitle
+    # stream, so it can't tell same-language tracks apart. The per-track MKV
+    # DURATION tag (when present) actually differs between tracks. For same-language
+    # tracks mkvmerge/ffprobe often reports the tag language-suffixed (DURATION-eng),
+    # which fese exposes as duration_eng, so fall back to that before the container.
+    duration = getattr(stream.tags, "duration", None)
+    if duration is None:
+        duration = getattr(stream.tags, "duration_eng", None)
+    if duration is None:
+        duration = stream.duration
+    if duration:
+        info.append(f"Duration: {_format_duration(duration)}")
+    return info
+
+
+def _format_duration(duration):
+    return str(duration).split(".")[0]
 
 
 def _basename_callback(path: str):

--- a/tests/bazarr/test_subtitles_manual.py
+++ b/tests/bazarr/test_subtitles_manual.py
@@ -1,0 +1,36 @@
+from bazarr.subtitles.manual import _build_release_info
+
+
+class FakeSubtitle:
+    def __init__(self, release_info=None, extra_release_info=None):
+        self.release_info = release_info
+        if extra_release_info is not None:
+            self.extra_release_info = extra_release_info
+
+
+def test_build_release_info_plain():
+    subtitle = FakeSubtitle(release_info="Movie.en.srt")
+    assert _build_release_info(subtitle) == ["Movie.en.srt"]
+
+
+def test_build_release_info_multiple_comma_separated():
+    subtitle = FakeSubtitle(release_info="Movie.en.srt,Some.Other.Release")
+    assert _build_release_info(subtitle) == ["Movie.en.srt", "Some.Other.Release"]
+
+
+def test_build_release_info_with_extra_release_info():
+    subtitle = FakeSubtitle(
+        release_info="Movie.en.srt", extra_release_info=["Duration: 1:42:18"]
+    )
+    assert _build_release_info(subtitle) == ["Movie.en.srt", "Duration: 1:42:18"]
+
+
+def test_build_release_info_without_extra_release_info():
+    subtitle = FakeSubtitle(release_info="Movie.en.srt")
+    assert not hasattr(subtitle, "extra_release_info")
+    assert _build_release_info(subtitle) == ["Movie.en.srt"]
+
+
+def test_build_release_info_none():
+    subtitle = FakeSubtitle(release_info=None)
+    assert _build_release_info(subtitle) == []

--- a/tests/subliminal_patch/test_embeddedsubtitles.py
+++ b/tests/subliminal_patch/test_embeddedsubtitles.py
@@ -11,6 +11,7 @@ from subliminal_patch.core import Movie
 from subliminal_patch.providers.embeddedsubtitles import (
     _discard_possible_incomplete_subtitles,
 )
+from subliminal_patch.providers.embeddedsubtitles import _get_extra_release_info
 from subliminal_patch.providers.embeddedsubtitles import _get_pretty_release_name
 from subliminal_patch.providers.embeddedsubtitles import _MemoizedFFprobeVideoContainer
 from subliminal_patch.providers.embeddedsubtitles import _rebuild_langs
@@ -349,6 +350,53 @@ def test_get_pretty_release_name():
     )
     container = FFprobeVideoContainer("foo.mkv")
     assert _get_pretty_release_name(stream, container) == "foo.en.forced.srt"
+
+
+def test_get_extra_release_info_with_duration():
+    stream = FFprobeSubtitleStream(
+        {
+            "index": 1,
+            "codec_name": "subrip",
+            "duration": "6138",
+            "tags": {"language": "eng"},
+        }
+    )
+    assert _get_extra_release_info(stream) == ["Duration: 1:42:18"]
+
+
+def test_get_extra_release_info_without_duration():
+    stream = FFprobeSubtitleStream(
+        {
+            "index": 1,
+            "codec_name": "subrip",
+            "tags": {"language": "eng"},
+        }
+    )
+    assert _get_extra_release_info(stream) == []
+
+
+def test_get_extra_release_info_mkv_tag_duration_wins_over_container_duration():
+    stream = FFprobeSubtitleStream(
+        {
+            "index": 1,
+            "codec_name": "subrip",
+            "duration": "6138",
+            "tags": {"language": "eng", "DURATION": "00:05:00.000000000"},
+        }
+    )
+    assert _get_extra_release_info(stream) == ["Duration: 0:05:00"]
+
+
+def test_get_extra_release_info_mkv_language_suffixed_tag_wins_over_container_duration():
+    stream = FFprobeSubtitleStream(
+        {
+            "index": 1,
+            "codec_name": "subrip",
+            "duration": "6138",
+            "tags": {"language": "eng", "DURATION-eng": "00:05:00.000000000"},
+        }
+    )
+    assert _get_extra_release_info(stream) == ["Duration: 0:05:00"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Adds a per-track duration hint to embedded subtitle results in manual search, so tracks sharing the same language show up as distinguishable entries instead of duplicates.
- Reads the per-track MKV `DURATION` tag (falling back to the language-suffixed `DURATION-eng` tag, then the container duration) and surfaces it as `Duration: h:mm:ss` in the release info shown to the user.
- Small refactor of release-info assembly in `manual.py` into `_build_release_info()` to make room for the new hint; no behavior change for existing single-track-per-language cases.

## Context

When an MKV has multiple subtitle tracks in the same language, `embeddedsubtitles.py` only exposed `stream.duration`, which reflects the *container's* total duration for every stream — so every same-language track looked identical in manual search, with nothing to tell them apart.

Per-track MKV `DURATION` tags actually differ between tracks and are the right signal here. For same-language tracks, mkvmerge/ffprobe often reports this tag language-suffixed instead (e.g. `DURATION-eng`), which the vendored `fese` library already exposes as `stream.tags.duration_eng` (mirroring how it already falls back for `number_of_frames`/`number_of_frames_eng`). The fix stays fully scoped to Bazarr's own `custom_libs/subliminal_patch/providers/embeddedsubtitles.py` — no changes to vendored `libs/fese/*`.

#Exemple:
<img width="1654" height="376" alt="screenshot-1783183690" src="https://github.com/user-attachments/assets/eeb57b15-158a-4a34-ace1-7cceb6adb80f" />


## Test plan

- [x] Added `test_get_extra_release_info_mkv_tag_duration_wins_over_container_duration` and `test_get_extra_release_info_mkv_language_suffixed_tag_wins_over_container_duration` in `tests/subliminal_patch/test_embeddedsubtitles.py`, plus coverage for `_build_release_info()` in the new `tests/bazarr/test_subtitles_manual.py`.
- [x] Ran the targeted suites locally: `pytest tests/subliminal_patch/test_embeddedsubtitles.py tests/bazarr/test_subtitles_manual.py` → 45 passed (2 pre-existing, unrelated failures in the same file untouched by this change).
- [x] Also includes an unrelated `no log:` commit adding `ruff` to `dev-requirements.txt` + a `pyproject.toml` excluding `libs/`/`custom_libs/`/`frontend/`/`migrations/`, so `ruff check .` doesn't lint vendored code for other contributors.
