### PR TITLE
Fixed Ktuvit provider returning zero results when catalog entry has no ReleaseYear (#3420)

### DIFF
--- a/custom_libs/subliminal_patch/providers/ktuvit.py
+++ b/custom_libs/subliminal_patch/providers/ktuvit.py
@@ -281,16 +281,20 @@ class KtuvitProvider(Provider):
         # get the list of subtitles
         logger.debug("Getting the list of subtitles")
 
-        url = self.server_url + self.search_url
-        logger.debug("Calling URL: {} with request: {}".format(url, str({"request": query})))
+        results = self._search_films(query)
 
-        r = self.session.post(url, json={"request": query}, timeout=10)
-        r.raise_for_status()
-
-        if r.content:
-            results = self.parse_d_response(r, "Films", [], "Films/Series Information")
-        else:
-            return {}
+        # Ktuvit's own catalog entry for a title may have no ReleaseYear set,
+        # in which case the year-filtered search above returns zero films even
+        # though Ktuvit does carry the title. Since results are matched by exact
+        # IMDB ID below, the Year filter is only an optional pre-filter; fall
+        # back to a yearless search when it yields nothing so a missing
+        # ReleaseYear on Ktuvit's side doesn't become a false negative. (#3420)
+        if not results and query.get("Year"):
+            logger.debug(
+                "No films returned with Year filter; retrying search without Year"
+            )
+            query["Year"] = ""
+            results = self._search_films(query)
 
         # loop over results
         subtitles = {}
@@ -337,6 +341,27 @@ class KtuvitProvider(Provider):
                 subtitles[sub["sub_id"]] = subtitle
 
         return subtitles.values()
+
+    def _search_films(self, query):
+        """Send a SearchPage_search request and return its ``Films`` list.
+
+        :param dict query: the ``request`` payload to send.
+        :return: the list of films returned by Ktuvit (empty if none).
+        :rtype: list
+
+        """
+        url = self.server_url + self.search_url
+        logger.debug(
+            "Calling URL: {} with request: {}".format(url, str({"request": query}))
+        )
+
+        r = self.session.post(url, json={"request": query}, timeout=10)
+        r.raise_for_status()
+
+        if not r.content:
+            return []
+
+        return self.parse_d_response(r, "Films", [], "Films/Series Information")
 
     def _search_tvshow(self, id, season, episode):
         subs = []

--- a/tests/subliminal_patch/test_ktuvit.py
+++ b/tests/subliminal_patch/test_ktuvit.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+import json
+
+from subliminal_patch.providers.ktuvit import KtuvitProvider
+
+SEARCH_URL = "https://www.ktuvit.me/Services/ContentProvider.svc/SearchPage_search"
+MOVIE_INFO_URL = "https://www.ktuvit.me/MovieInfo.aspx?ID=KT_ID_1"
+
+IMDB_ID = "tt2866360"  # Coherence (2014)
+
+# A minimal MovieInfo.aspx page carrying a single subtitle row, enough for
+# KtuvitProvider._search_movie() to extract one subtitle.
+MOVIE_INFO_HTML = (
+    '<table id="subtitlesList"><tbody><tr>'
+    "<td>Coherence.2014.1080p.WEB</td><td></td><td></td><td></td><td></td>"
+    '<td><a data-subtitle-id="SUB_1">download</a></td>'
+    "</tr></tbody></table>"
+)
+
+
+def _films_by_year(request, context):
+    """Return zero films for a year-filtered search, one film otherwise.
+
+    Simulates a Ktuvit catalog entry whose ReleaseYear is missing server-side:
+    the year-filtered query finds nothing, while the yearless query returns the
+    exact IMDb match.
+    """
+    year = request.json()["request"]["Year"]
+    if year:
+        films = []
+    else:
+        films = [{"IMDB_Link": "http://www.imdb.com/title/%s" % IMDB_ID, "ID": "KT_ID_1"}]
+    return {"d": json.dumps({"Films": films})}
+
+
+def _make_provider():
+    provider = KtuvitProvider()
+    provider.initialize()  # creates the requests session, no login without creds
+    provider.logged_in = True
+    return provider
+
+
+def test_query_falls_back_to_yearless_search(requests_mock):
+    # Regression test for #3420: a movie whose Ktuvit entry has no ReleaseYear
+    # must still be found by falling back to a yearless search.
+    requests_mock.post(SEARCH_URL, json=_films_by_year)
+    requests_mock.get(MOVIE_INFO_URL, text=MOVIE_INFO_HTML)
+
+    provider = _make_provider()
+    subtitles = list(provider.query(title="Coherence", year=2014, imdb_id=IMDB_ID))
+
+    # both the year-filtered and the yearless search were issued
+    years_sent = [r.json()["request"]["Year"] for r in requests_mock.request_history if r.method == "POST"]
+    assert years_sent == [2014, ""]
+
+    assert len(subtitles) == 1
+    assert subtitles[0].imdb_id == IMDB_ID
+    assert subtitles[0].subtitle_id == "SUB_1"
+
+
+def test_query_does_not_fall_back_when_year_search_matches(requests_mock):
+    # When the year-filtered search already returns the film, no extra
+    # yearless request should be made (common path stays unchanged).
+    film = [{"IMDB_Link": "http://www.imdb.com/title/%s" % IMDB_ID, "ID": "KT_ID_1"}]
+    requests_mock.post(SEARCH_URL, json={"d": json.dumps({"Films": film})})
+    requests_mock.get(MOVIE_INFO_URL, text=MOVIE_INFO_HTML)
+
+    provider = _make_provider()
+    subtitles = list(provider.query(title="Coherence", year=2014, imdb_id=IMDB_ID))
+
+    post_calls = [r for r in requests_mock.request_history if r.method == "POST"]
+    assert len(post_calls) == 1
+    assert post_calls[0].json()["request"]["Year"] == 2014
+    assert len(subtitles) == 1


### PR DESCRIPTION
Fixes #3420

### Problem
`KtuvitProvider.query()` adds the video's year to the `SearchPage_search` request whenever it's known. When Ktuvit's own catalog entry for a title has no `ReleaseYear` set server-side, the year-filtered search returns zero `Films`, so the provider reports "no subtitles" even though Ktuvit does carry the title. Nothing above debug level is logged, so it's indistinguishable from a genuine miss. Reproduced with *Coherence (2014)* / `tt2866360`, where a yearless query returns the exact IMDb match.

### Fix
Results are already disambiguated by an exact IMDb-ID match after the search, so the server-side `Year` filter is only an optional pre-filter and its misses are pure loss. When the year-filtered search returns no films, fall back to a yearless search. The common case (year matches) issues exactly one request as before. The POST+parse was extracted into a small `_search_films()` helper.

### Testing
- Added `tests/subliminal_patch/test_ktuvit.py` with two offline `requests_mock` tests: the fallback path finds the film when the year-filtered search is empty, and no extra request is made when the year-filtered search already matches.
- Verified the provider imports cleanly in the full app context.
- Not validated against a live Ktuvit account; the fix rests on the reported `SearchPage_search` responses and the existing IMDb-ID match logic.

### AI disclosure
Prepared with AI assistance (Claude). The author reviewed and understands the change; the diff is minimal and preserves existing behavior on the common path.
