### PR TITLE
no log: Narrow linting and ignore property camel case

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -36,7 +36,7 @@ export default tseslint.config(
     rules: {
       ...reactHooks.configs.recommended.rules,
       "no-console": "error",
-      camelcase: "warn",
+      camelcase: ["error", { properties: "never" }],
       "no-restricted-imports": [
         "error",
         {
@@ -45,11 +45,11 @@ export default tseslint.config(
       ],
       "simple-import-sort/imports": "error",
       "@typescript-eslint/explicit-module-boundary-types": "off",
-      "@typescript-eslint/no-empty-function": "warn",
+      "@typescript-eslint/no-empty-function": "error",
       "@typescript-eslint/no-empty-interface": "off",
-      "@typescript-eslint/no-unused-vars": "warn",
+      "@typescript-eslint/no-unused-vars": "error",
       "@typescript-eslint/no-empty-object-type": "off",
-      "@typescript-eslint/no-unused-expressions": "off",
+      "@typescript-eslint/no-unused-expressions": "error",
       "no-useless-assignment": "off",
       "react-hooks/set-state-in-effect": "off",
       "react-hooks/refs": "off",

--- a/frontend/src/App/JobsManager.tsx
+++ b/frontend/src/App/JobsManager.tsx
@@ -126,11 +126,8 @@ const JobsManager: FunctionComponent<JobsManagerProps> = ({
         queryKey: [QueryKeys.System, QueryKeys.Jobs],
       });
       const actionLabels: Record<string, string> = {
-        // eslint-disable-next-line camelcase
         move_top: "Moved to top",
-        // eslint-disable-next-line camelcase
         move_bottom: "Moved to bottom",
-        // eslint-disable-next-line camelcase
         force_start: "Force started",
       };
       const label = actionLabels[variables.action] || "Action completed";

--- a/frontend/src/apis/hooks/plex.ts
+++ b/frontend/src/apis/hooks/plex.ts
@@ -18,7 +18,6 @@ export const usePlexAuthValidationQuery = () => {
         // Return a default value when API is not available
         return {
           valid: false,
-          // eslint-disable-next-line camelcase
           auth_method: "oauth",
           error: "API unavailable",
         };

--- a/frontend/src/apis/hooks/plex.ts
+++ b/frontend/src/apis/hooks/plex.ts
@@ -18,7 +18,7 @@ export const usePlexAuthValidationQuery = () => {
         // Return a default value when API is not available
         return {
           valid: false,
-          auth_method: "oauth",
+          authMethod: "oauth",
           error: "API unavailable",
         };
       }

--- a/frontend/src/apis/raw/episodes.ts
+++ b/frontend/src/apis/raw/episodes.ts
@@ -7,33 +7,39 @@ class EpisodeApi extends BaseApi {
   }
 
   async bySeriesId(seriesid: number[]) {
-    const response = await this.get<DataWrapper<Item.Episode[]>>("", {
+    const response = await this.get<DataWrapper<Item.RawEpisode[]>>("", {
       seriesid,
     });
-    return response.data;
+    return response.data.map(camelCaseKeys);
   }
 
   async byEpisodeId(episodeid: number[]) {
-    const response = await this.get<DataWrapper<Item.Episode[]>>("", {
+    const response = await this.get<DataWrapper<Item.RawEpisode[]>>("", {
       episodeid,
     });
-    return response.data;
+    return response.data.map(camelCaseKeys);
   }
 
   async wanted(params: Parameter.Range) {
-    const response = await this.get<DataWrapperWithTotal<Wanted.Episode>>(
+    const response = await this.get<DataWrapperWithTotal<Wanted.RawEpisode>>(
       "/wanted",
       params,
     );
-    return response;
+    return {
+      ...response,
+      data: response.data.map(camelCaseKeys),
+    };
   }
 
   async wantedBy(episodeid: number[]) {
-    const response = await this.get<DataWrapperWithTotal<Wanted.Episode>>(
+    const response = await this.get<DataWrapperWithTotal<Wanted.RawEpisode>>(
       "/wanted",
       { episodeid },
     );
-    return response;
+    return {
+      ...response,
+      data: response.data.map(camelCaseKeys),
+    };
   }
 
   async history(params: Parameter.Range) {

--- a/frontend/src/apis/raw/episodes.ts
+++ b/frontend/src/apis/raw/episodes.ts
@@ -1,3 +1,4 @@
+import { camelCaseKeys, snakeCaseKeys } from "@/utilities/case";
 import BaseApi from "./base";
 
 class EpisodeApi extends BaseApi {
@@ -36,19 +37,19 @@ class EpisodeApi extends BaseApi {
   }
 
   async history(params: Parameter.Range) {
-    const response = await this.get<DataWrapperWithTotal<History.Episode>>(
+    const response = await this.get<DataWrapperWithTotal<History.RawEpisode>>(
       "/history",
       params,
     );
-    return response;
+    return camelCaseKeys(response);
   }
 
   async historyBy(episodeid: number) {
-    const response = await this.get<DataWrapperWithTotal<History.Episode>>(
+    const response = await this.get<DataWrapperWithTotal<History.RawEpisode>>(
       "/history",
       { episodeid },
     );
-    return response.data;
+    return response.data.map(camelCaseKeys);
   }
 
   async downloadSubtitles(
@@ -77,8 +78,8 @@ class EpisodeApi extends BaseApi {
 
   async blacklist() {
     const response =
-      await this.get<DataWrapper<Blacklist.Episode[]>>("/blacklist");
-    return response.data;
+      await this.get<DataWrapper<Blacklist.RawEpisode[]>>("/blacklist");
+    return response.data.map(camelCaseKeys);
   }
 
   async addBlacklist(
@@ -86,11 +87,11 @@ class EpisodeApi extends BaseApi {
     episodeid: number,
     form: FormType.AddBlacklist,
   ) {
-    await this.post("/blacklist", form, { seriesid, episodeid });
+    await this.post("/blacklist", snakeCaseKeys(form), { seriesid, episodeid });
   }
 
   async deleteBlacklist(all?: boolean, form?: FormType.DeleteBlacklist) {
-    await this.delete("/blacklist", form, { all });
+    await this.delete("/blacklist", snakeCaseKeys(form), { all });
   }
 }
 

--- a/frontend/src/apis/raw/jellyfin.ts
+++ b/frontend/src/apis/raw/jellyfin.ts
@@ -1,11 +1,14 @@
+import { camelCaseKeys } from "@/utilities/case";
 import BaseApi from "./base";
 
-interface JellyfinTestResult {
+interface RawJellyfinTestResult {
   success: boolean;
   server_name?: string;
   version?: string;
   error?: string;
 }
+
+type JellyfinTestResult = CamelCaseKeys<RawJellyfinTestResult>;
 
 interface JellyfinLibrary {
   id: string;
@@ -18,13 +21,19 @@ class JellyfinApi extends BaseApi {
     super("/jellyfin");
   }
 
-  async testConnection(url: string, apikey: string) {
-    const response = await this.post<JellyfinTestResult>("/test-connection", {
-      url,
-      apikey,
-    });
+  async testConnection(
+    url: string,
+    apikey: string,
+  ): Promise<JellyfinTestResult> {
+    const response = await this.post<RawJellyfinTestResult>(
+      "/test-connection",
+      {
+        url,
+        apikey,
+      },
+    );
 
-    return response.data;
+    return camelCaseKeys(response.data);
   }
 
   async libraries(url?: string, apikey?: string) {

--- a/frontend/src/apis/raw/movies.ts
+++ b/frontend/src/apis/raw/movies.ts
@@ -1,3 +1,4 @@
+import { camelCaseKeys, snakeCaseKeys } from "@/utilities/case";
 import BaseApi from "./base";
 
 class MovieApi extends BaseApi {
@@ -7,16 +8,16 @@ class MovieApi extends BaseApi {
 
   async blacklist() {
     const response =
-      await this.get<DataWrapper<Blacklist.Movie[]>>("/blacklist");
-    return response.data;
+      await this.get<DataWrapper<Blacklist.RawMovie[]>>("/blacklist");
+    return response.data.map(camelCaseKeys);
   }
 
   async addBlacklist(radarrid: number, form: FormType.AddBlacklist) {
-    await this.post("/blacklist", form, { radarrid });
+    await this.post("/blacklist", snakeCaseKeys(form), { radarrid });
   }
 
   async deleteBlacklist(all?: boolean, form?: FormType.DeleteBlacklist) {
-    await this.delete("/blacklist", form, { all });
+    await this.delete("/blacklist", snakeCaseKeys(form), { all });
   }
 
   async movies(radarrid?: number[]) {
@@ -57,19 +58,19 @@ class MovieApi extends BaseApi {
   }
 
   async history(params: Parameter.Range) {
-    const response = await this.get<DataWrapperWithTotal<History.Movie>>(
+    const response = await this.get<DataWrapperWithTotal<History.RawMovie>>(
       "/history",
       params,
     );
-    return response;
+    return camelCaseKeys(response);
   }
 
   async historyBy(radarrid: number) {
-    const response = await this.get<DataWrapperWithTotal<History.Movie>>(
+    const response = await this.get<DataWrapperWithTotal<History.RawMovie>>(
       "/history",
       { radarrid },
     );
-    return response.data;
+    return response.data.map(camelCaseKeys);
   }
 
   async action(action: FormType.MoviesAction) {

--- a/frontend/src/apis/raw/movies.ts
+++ b/frontend/src/apis/raw/movies.ts
@@ -21,40 +21,49 @@ class MovieApi extends BaseApi {
   }
 
   async movies(radarrid?: number[]) {
-    const response = await this.get<DataWrapperWithTotal<Item.Movie>>("", {
+    const response = await this.get<DataWrapperWithTotal<Item.RawMovie>>("", {
       radarrid,
     });
-    return response.data;
+    return response.data.map(camelCaseKeys);
   }
 
   async moviesBy(params: Parameter.Range) {
-    const response = await this.get<DataWrapperWithTotal<Item.Movie>>(
+    const response = await this.get<DataWrapperWithTotal<Item.RawMovie>>(
       "",
       params,
     );
-    return response;
+    return {
+      ...response,
+      data: response.data.map(camelCaseKeys),
+    };
   }
 
   async modify(form: FormType.ModifyItem) {
-    await this.post("", { radarrid: form.id, profileid: form.profileid });
+    await this.post("", { radarrid: form.id, profileid: form.profileId });
   }
 
   async wanted(params: Parameter.Range) {
-    const response = await this.get<DataWrapperWithTotal<Wanted.Movie>>(
+    const response = await this.get<DataWrapperWithTotal<Wanted.RawMovie>>(
       "/wanted",
       params,
     );
-    return response;
+    return {
+      ...response,
+      data: response.data.map(camelCaseKeys),
+    };
   }
 
   async wantedBy(radarrid: number[]) {
-    const response = await this.get<DataWrapperWithTotal<Wanted.Movie>>(
+    const response = await this.get<DataWrapperWithTotal<Wanted.RawMovie>>(
       "/wanted",
       {
         radarrid,
       },
     );
-    return response;
+    return {
+      ...response,
+      data: response.data.map(camelCaseKeys),
+    };
   }
 
   async history(params: Parameter.Range) {
@@ -74,7 +83,7 @@ class MovieApi extends BaseApi {
   }
 
   async action(action: FormType.MoviesAction) {
-    await this.patch("", action);
+    await this.patch("", snakeCaseKeys(action));
   }
 
   async downloadSubtitles(radarrid: number, form: FormType.Subtitle) {

--- a/frontend/src/apis/raw/plex.ts
+++ b/frontend/src/apis/raw/plex.ts
@@ -76,7 +76,6 @@ class NewPlexApi extends BaseApi {
   async deleteWebhook(webhookUrl: string) {
     const response = await this.post<DataWrapper<Plex.WebhookResult>>(
       "/webhook/delete",
-      // eslint-disable-next-line camelcase
       { webhook_url: webhookUrl },
     );
 

--- a/frontend/src/apis/raw/plex.ts
+++ b/frontend/src/apis/raw/plex.ts
@@ -1,3 +1,4 @@
+import { camelCaseKeys } from "@/utilities/case";
 import BaseApi from "./base";
 
 class NewPlexApi extends BaseApi {
@@ -47,9 +48,9 @@ class NewPlexApi extends BaseApi {
 
   async validateAuth() {
     const response =
-      await this.get<DataWrapper<Plex.ValidationResult>>(`/oauth/validate`);
+      await this.get<DataWrapper<Plex.RawValidationResult>>(`/oauth/validate`);
 
-    return response.data;
+    return camelCaseKeys(response.data);
   }
 
   async libraries() {
@@ -61,16 +62,16 @@ class NewPlexApi extends BaseApi {
 
   async createWebhook() {
     const response =
-      await this.post<DataWrapper<Plex.WebhookResult>>("/webhook/create");
+      await this.post<DataWrapper<Plex.RawWebhookResult>>("/webhook/create");
 
-    return response.data;
+    return camelCaseKeys(response.data);
   }
 
   async listWebhooks() {
     const response =
-      await this.get<DataWrapper<Plex.WebhookList>>("/webhook/list");
+      await this.get<DataWrapper<Plex.RawWebhookList>>("/webhook/list");
 
-    return response.data;
+    return camelCaseKeys(response.data);
   }
 
   async deleteWebhook(webhookUrl: string) {
@@ -84,9 +85,9 @@ class NewPlexApi extends BaseApi {
 
   async getAutopulseConfig() {
     const response =
-      await this.get<DataWrapper<Plex.AutopulseConfig>>("/autopulse/config");
+      await this.get<DataWrapper<Plex.RawAutopulseConfig>>("/autopulse/config");
 
-    return response.data;
+    return camelCaseKeys(response.data);
   }
 }
 

--- a/frontend/src/apis/raw/providers.ts
+++ b/frontend/src/apis/raw/providers.ts
@@ -1,3 +1,4 @@
+import { camelCaseKeys, snakeCaseKeys } from "@/utilities/case";
 import BaseApi from "./base";
 
 class ProviderApi extends BaseApi {
@@ -17,25 +18,25 @@ class ProviderApi extends BaseApi {
   }
 
   async movies(id: number) {
-    const response = await this.get<DataWrapper<SearchResultType[]>>(
+    const response = await this.get<DataWrapper<RawSearchResultType[]>>(
       "/movies",
       { radarrid: id },
     );
-    return response.data;
+    return response.data.map(camelCaseKeys);
   }
 
   async downloadMovieSubtitle(radarrid: number, form: FormType.ManualDownload) {
-    await this.post("/movies", form, { radarrid });
+    await this.post("/movies", snakeCaseKeys(form), { radarrid });
   }
 
   async episodes(episodeid: number) {
-    const response = await this.get<DataWrapper<SearchResultType[]>>(
+    const response = await this.get<DataWrapper<RawSearchResultType[]>>(
       "/episodes",
       {
         episodeid,
       },
     );
-    return response.data;
+    return response.data.map(camelCaseKeys);
   }
 
   async downloadEpisodeSubtitle(
@@ -43,7 +44,7 @@ class ProviderApi extends BaseApi {
     episodeid: number,
     form: FormType.ManualDownload,
   ) {
-    await this.post("/episodes", form, { seriesid, episodeid });
+    await this.post("/episodes", snakeCaseKeys(form), { seriesid, episodeid });
   }
 }
 

--- a/frontend/src/apis/raw/series.ts
+++ b/frontend/src/apis/raw/series.ts
@@ -1,3 +1,4 @@
+import { camelCaseKeys, snakeCaseKeys } from "@/utilities/case";
 import BaseApi from "./base";
 
 class SeriesApi extends BaseApi {
@@ -6,26 +7,29 @@ class SeriesApi extends BaseApi {
   }
 
   async series(seriesid?: number[]) {
-    const response = await this.get<DataWrapperWithTotal<Item.Series>>("", {
+    const response = await this.get<DataWrapperWithTotal<Item.RawSeries>>("", {
       seriesid,
     });
-    return response.data;
+    return response.data.map(camelCaseKeys);
   }
 
   async seriesBy(params: Parameter.Range) {
-    const response = await this.get<DataWrapperWithTotal<Item.Series>>(
+    const response = await this.get<DataWrapperWithTotal<Item.RawSeries>>(
       "",
       params,
     );
-    return response;
+    return {
+      ...response,
+      data: response.data.map(camelCaseKeys),
+    };
   }
 
   async modify(form: FormType.ModifyItem) {
-    await this.post("", { seriesid: form.id, profileid: form.profileid });
+    await this.post("", { seriesid: form.id, profileid: form.profileId });
   }
 
   async action(form: FormType.SeriesAction) {
-    await this.patch("", form);
+    await this.patch("", snakeCaseKeys(form));
   }
 }
 

--- a/frontend/src/apis/raw/subtitles.ts
+++ b/frontend/src/apis/raw/subtitles.ts
@@ -1,3 +1,4 @@
+import { camelCaseKeys, snakeCaseKeys } from "@/utilities/case";
 import BaseApi from "./base";
 
 class SubtitlesApi extends BaseApi {
@@ -9,22 +10,22 @@ class SubtitlesApi extends BaseApi {
     subtitlesPath: string,
     sonarrEpisodeId: number,
   ) {
-    const response = await this.get<DataWrapper<Item.RefTracks>>("", {
+    const response = await this.get<DataWrapper<Item.RawRefTracks>>("", {
       subtitlesPath,
       sonarrEpisodeId,
     });
-    return response.data;
+    return camelCaseKeys(response.data);
   }
 
   async getRefTracksByMovieId(
     subtitlesPath: string,
     radarrMovieId?: number | undefined,
   ) {
-    const response = await this.get<DataWrapper<Item.RefTracks>>("", {
+    const response = await this.get<DataWrapper<Item.RawRefTracks>>("", {
       subtitlesPath,
       radarrMovieId,
     });
-    return response.data;
+    return camelCaseKeys(response.data);
   }
 
   async info(names: string[]) {
@@ -35,17 +36,17 @@ class SubtitlesApi extends BaseApi {
   }
 
   async modify(action: string, form: FormType.ModifySubtitle) {
-    await this.patch("", form, { action });
+    await this.patch("", snakeCaseKeys(form), { action });
   }
 
   async contents(subtitlePath: string) {
-    const response = await this.get<DataWrapper<SubtitleContents.Line[]>>(
+    const response = await this.get<DataWrapper<SubtitleContents.RawLine[]>>(
       "/contents",
       {
         subtitlePath,
       },
     );
-    return response.data;
+    return response.data.map((line) => camelCaseKeys(line));
   }
 }
 

--- a/frontend/src/apis/raw/system.ts
+++ b/frontend/src/apis/raw/system.ts
@@ -1,3 +1,4 @@
+import { camelCaseKeys } from "@/utilities/case";
 import BaseApi from "./base";
 
 class SystemApi extends BaseApi {
@@ -42,8 +43,10 @@ class SystemApi extends BaseApi {
   }
 
   async languagesProfileList() {
-    const response = await this.get<Language.Profile[]>("/languages/profiles");
-    return response;
+    const response = await this.get<Language.RawProfile[]>(
+      "/languages/profiles",
+    );
+    return response.map((profile) => camelCaseKeys(profile));
   }
 
   async status() {

--- a/frontend/src/components/forms/ItemEditForm.tsx
+++ b/frontend/src/components/forms/ItemEditForm.tsx
@@ -45,7 +45,7 @@ const ItemEditForm: FunctionComponent<Props> = ({
 
   // Item code2 may be undefined or null if the audio language is Unknown
   const options = useSelectorOptions(
-    item?.audio_language ?? [],
+    item?.audioLanguage ?? [],
     (v) => v.name,
     (v) => v.code2 ?? "",
   );
@@ -59,7 +59,7 @@ const ItemEditForm: FunctionComponent<Props> = ({
           const itemId = GetItemId(item);
           if (itemId) {
             mutate(
-              { id: [itemId], profileid: [profile?.profileId ?? null] },
+              { id: [itemId], profileId: [profile?.profileId ?? null] },
               {
                 onSuccess: () => {
                   showNotification(
@@ -94,7 +94,7 @@ const ItemEditForm: FunctionComponent<Props> = ({
           label="Audio Languages"
           disabled
           {...options}
-          value={item?.audio_language ?? []}
+          value={item?.audioLanguage ?? []}
         ></MultiSelector>
         <Selector
           {...profileOptions}

--- a/frontend/src/components/forms/ProfileEditForm.tsx
+++ b/frontend/src/components/forms/ProfileEditForm.tsx
@@ -28,9 +28,7 @@ const defaultCutoffOptions: SelectorOption<Language.ProfileItem>[] = [
     label: "Any",
     value: {
       id: anyCutoff,
-      // eslint-disable-next-line camelcase
       audio_exclude: "False",
-      // eslint-disable-next-line camelcase
       audio_only_include: "False",
       forced: "False",
       hi: "False",
@@ -159,9 +157,7 @@ const ProfileEditForm: FunctionComponent<Props> = ({
       const item: Language.ProfileItem = {
         id,
         language,
-        // eslint-disable-next-line camelcase
         audio_exclude: "False",
-        // eslint-disable-next-line camelcase
         audio_only_include: "False",
         hi: "False",
         forced: "False",
@@ -246,9 +242,7 @@ const ProfileEditForm: FunctionComponent<Props> = ({
             if (value) {
               action.mutate(index, {
                 ...item,
-                // eslint-disable-next-line camelcase
                 audio_exclude: value === "audio_exclude" ? "True" : "False",
-                // eslint-disable-next-line camelcase
                 audio_only_include:
                   value === "audio_only_include" ? "True" : "False",
               });

--- a/frontend/src/components/forms/ProfileEditForm.tsx
+++ b/frontend/src/components/forms/ProfileEditForm.tsx
@@ -28,8 +28,8 @@ const defaultCutoffOptions: SelectorOption<Language.ProfileItem>[] = [
     label: "Any",
     value: {
       id: anyCutoff,
-      audio_exclude: "False",
-      audio_only_include: "False",
+      audioExclude: "False",
+      audioOnlyInclude: "False",
       forced: "False",
       hi: "False",
       language: "any",
@@ -59,11 +59,11 @@ const inclusionOptions: SelectorOption<string>[] = [
   },
   {
     label: "audio track matches",
-    value: "audio_only_include",
+    value: "audioOnlyInclude",
   },
   {
     label: "no audio track matches",
-    value: "audio_exclude",
+    value: "audioExclude",
   },
 ];
 
@@ -157,8 +157,8 @@ const ProfileEditForm: FunctionComponent<Props> = ({
       const item: Language.ProfileItem = {
         id,
         language,
-        audio_exclude: "False",
-        audio_only_include: "False",
+        audioExclude: "False",
+        audioOnlyInclude: "False",
         hi: "False",
         forced: "False",
       };
@@ -225,14 +225,14 @@ const ProfileEditForm: FunctionComponent<Props> = ({
   const InclusionCell = React.memo(
     ({ item, index }: { item: Language.ProfileItem; index: number }) => {
       const selectValue = useMemo(() => {
-        if (item.audio_exclude === "True") {
-          return "audio_exclude";
-        } else if (item.audio_only_include === "True") {
-          return "audio_only_include";
+        if (item.audioExclude === "True") {
+          return "audioExclude";
+        } else if (item.audioOnlyInclude === "True") {
+          return "audioOnlyInclude";
         } else {
           return "always_include";
         }
-      }, [item.audio_exclude, item.audio_only_include]);
+      }, [item.audioExclude, item.audioOnlyInclude]);
 
       return (
         <Select
@@ -242,9 +242,9 @@ const ProfileEditForm: FunctionComponent<Props> = ({
             if (value) {
               action.mutate(index, {
                 ...item,
-                audio_exclude: value === "audio_exclude" ? "True" : "False",
-                audio_only_include:
-                  value === "audio_only_include" ? "True" : "False",
+                audioExclude: value === "audioExclude" ? "True" : "False",
+                audioOnlyInclude:
+                  value === "audioOnlyInclude" ? "True" : "False",
               });
             }
           }}
@@ -275,7 +275,7 @@ const ProfileEditForm: FunctionComponent<Props> = ({
       },
       {
         header: "Search only when...",
-        accessorKey: "audio_exclude",
+        accessorKey: "audioExclude",
         cell: ({ row: { original: item, index } }) => {
           return <InclusionCell item={item} index={index} />;
         },

--- a/frontend/src/components/forms/SyncSubtitleForm.tsx
+++ b/frontend/src/components/forms/SyncSubtitleForm.tsx
@@ -51,7 +51,7 @@ function useReferencedSubtitles(
   if (!mediaData.data) {
     return [];
   } else {
-    if (mediaData.data.audio_tracks.length > 0) {
+    if (mediaData.data.audioTracks.length > 0) {
       const embeddedAudioGroup: GroupedSelectorOptions<string> = {
         group: "Embedded audio tracks",
         items: [],
@@ -59,7 +59,7 @@ function useReferencedSubtitles(
 
       subtitles.push(embeddedAudioGroup);
 
-      mediaData.data.audio_tracks.forEach((item) => {
+      mediaData.data.audioTracks.forEach((item) => {
         embeddedAudioGroup.items.push({
           value: item.stream,
           label: `${item.name || item.language} (${item.stream})`,
@@ -67,7 +67,7 @@ function useReferencedSubtitles(
       });
     }
 
-    if (mediaData.data.embedded_subtitles_tracks.length > 0) {
+    if (mediaData.data.embeddedSubtitlesTracks.length > 0) {
       const embeddedSubtitlesTrackGroup: GroupedSelectorOptions<string> = {
         group: "Embedded subtitles tracks",
         items: [],
@@ -75,7 +75,7 @@ function useReferencedSubtitles(
 
       subtitles.push(embeddedSubtitlesTrackGroup);
 
-      mediaData.data.embedded_subtitles_tracks.forEach((item) => {
+      mediaData.data.embeddedSubtitlesTracks.forEach((item) => {
         embeddedSubtitlesTrackGroup.items.push({
           value: item.stream,
           label: `${item.name || item.language} (${item.stream})`,
@@ -83,7 +83,7 @@ function useReferencedSubtitles(
       });
     }
 
-    if (mediaData.data.external_subtitles_tracks.length > 0) {
+    if (mediaData.data.externalSubtitlesTracks.length > 0) {
       const externalSubtitlesFilesGroup: GroupedSelectorOptions<string> = {
         group: "External Subtitles files",
         items: [],
@@ -91,7 +91,7 @@ function useReferencedSubtitles(
 
       subtitles.push(externalSubtitlesFilesGroup);
 
-      mediaData.data.external_subtitles_tracks.forEach((item) => {
+      mediaData.data.externalSubtitlesTracks.forEach((item) => {
         if (item) {
           externalSubtitlesFilesGroup.items.push({
             value: item.path,
@@ -156,8 +156,8 @@ const SyncSubtitleForm: FunctionComponent<Props> = ({
               const form: FormType.ModifySubtitle = {
                 ...s,
                 reference: parameters.reference,
-                max_offset_seconds: parameters.maxOffsetSeconds,
-                no_fix_framerate: toPython(parameters.noFixFramerate),
+                maxOffsetSeconds: parameters.maxOffsetSeconds,
+                noFixFramerate: toPython(parameters.noFixFramerate),
                 gss: toPython(parameters.gss),
               };
               return mutateAsync({ action: "sync", form });

--- a/frontend/src/components/forms/SyncSubtitleForm.tsx
+++ b/frontend/src/components/forms/SyncSubtitleForm.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { FunctionComponent } from "react";
 import {
   Alert,

--- a/frontend/src/components/forms/TwoPointFit.tsx
+++ b/frontend/src/components/forms/TwoPointFit.tsx
@@ -30,7 +30,7 @@ const totalMs = (t: { hour: number; min: number; sec: number; ms: number }) =>
   t.hour * 3600000 + t.min * 60000 + t.sec * 1000 + t.ms;
 
 const lineStartMs = (t: SubtitleContents.LineTime) =>
-  t.total_seconds * 1000 + Math.round(t.microseconds / 1000);
+  t.totalSeconds * 1000 + Math.round(t.microseconds / 1000);
 
 const lineStartToTime = (t: SubtitleContents.LineTime) => ({
   hour: t.hours,

--- a/frontend/src/components/inputs/FileBrowser.tsx
+++ b/frontend/src/components/inputs/FileBrowser.tsx
@@ -74,7 +74,9 @@ export const FileBrowser: FunctionComponent<FileBrowserProps> = ({
     const newPath = extractPath(value);
     if (newPath !== path) {
       setPath(newPath);
-      onChange && onChange(newPath);
+      if (onChange) {
+        onChange(newPath);
+      }
     }
   }, [path, value, onChange]);
 

--- a/frontend/src/components/modals/HistoryModal.tsx
+++ b/frontend/src/components/modals/HistoryModal.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { FunctionComponent, useMemo } from "react";
 import { Badge, Center, Text } from "@mantine/core";
 import { faFileExcel, faInfoCircle } from "@fortawesome/free-solid-svg-icons";
@@ -77,7 +76,7 @@ const MovieHistoryView: FunctionComponent<MovieHistoryViewProps> = ({
         id: "matches",
         cell: ({
           row: {
-            original: { matches, dont_matches: dont },
+            original: { matches, dontMatches: dont },
           },
         }) => {
           if (matches.length || dont.length) {
@@ -98,7 +97,7 @@ const MovieHistoryView: FunctionComponent<MovieHistoryViewProps> = ({
         accessorKey: "timestamp",
         cell: ({
           row: {
-            original: { timestamp, parsed_timestamp: parsedTimestamp },
+            original: { timestamp, parsedTimestamp },
           },
         }) => {
           return (
@@ -117,13 +116,13 @@ const MovieHistoryView: FunctionComponent<MovieHistoryViewProps> = ({
               blacklisted,
               radarrId,
               provider,
-              subs_id,
+              subsId,
               language,
-              subtitles_path,
+              subtitlesPath,
             },
           },
         }) => {
-          if (subs_id && provider && language) {
+          if (subsId && provider && language) {
             return (
               <MutateAction
                 label="Add to Blacklist"
@@ -134,8 +133,8 @@ const MovieHistoryView: FunctionComponent<MovieHistoryViewProps> = ({
                   id: radarrId,
                   form: {
                     provider,
-                    subs_id,
-                    subtitles_path,
+                    subsId,
+                    subtitlesPath,
                     language: language.code2,
                   },
                 })}
@@ -223,7 +222,7 @@ const EpisodeHistoryView: FunctionComponent<EpisodeHistoryViewProps> = ({
       {
         id: "matches",
         cell: (row) => {
-          const { matches, dont_matches: dont } = row.row.original;
+          const { matches, dontMatches: dont } = row.row.original;
           if (matches.length || dont.length) {
             return (
               <StateIcon
@@ -242,7 +241,7 @@ const EpisodeHistoryView: FunctionComponent<EpisodeHistoryViewProps> = ({
         accessorKey: "timestamp",
         cell: ({
           row: {
-            original: { timestamp, parsed_timestamp: parsedTimestamp },
+            original: { timestamp, parsedTimestamp },
           },
         }) => {
           return (
@@ -276,13 +275,13 @@ const EpisodeHistoryView: FunctionComponent<EpisodeHistoryViewProps> = ({
               sonarrEpisodeId,
               sonarrSeriesId,
               provider,
-              subs_id,
+              subsId,
               language,
-              subtitles_path,
+              subtitlesPath,
             },
           },
         }) => {
-          if (subs_id && provider && language) {
+          if (subsId && provider && language) {
             return (
               <MutateAction
                 label="Add to Blacklist"
@@ -294,8 +293,8 @@ const EpisodeHistoryView: FunctionComponent<EpisodeHistoryViewProps> = ({
                   episodeId: sonarrEpisodeId,
                   form: {
                     provider,
-                    subs_id,
-                    subtitles_path,
+                    subsId,
+                    subtitlesPath,
                     language: language.code2,
                   },
                 })}

--- a/frontend/src/components/modals/ManualSearchModal.tsx
+++ b/frontend/src/components/modals/ManualSearchModal.tsx
@@ -104,7 +104,7 @@ function ManualSearchView<T extends SupportType>(props: Props<T>) {
         accessorKey: "language",
         cell: ({
           row: {
-            original: { language, hearing_impaired: hi, forced },
+            original: { language, hearingImpaired: hi, forced },
           },
         }) => {
           const lang: Language.Info = {
@@ -148,10 +148,10 @@ function ManualSearchView<T extends SupportType>(props: Props<T>) {
       },
       {
         header: "Release",
-        accessorKey: "release_info",
+        accessorKey: "releaseInfo",
         cell: ({
           row: {
-            original: { release_info: releaseInfo },
+            original: { releaseInfo },
           },
         }) => {
           return <ReleaseInfoCell releaseInfo={releaseInfo} />;
@@ -172,7 +172,7 @@ function ManualSearchView<T extends SupportType>(props: Props<T>) {
         header: "Match",
         accessorKey: "matches",
         cell: (row) => {
-          const { matches, dont_matches: dont } = row.row.original;
+          const { matches, dontMatches: dont } = row.row.original;
           return (
             <StateIcon
               matches={matches}

--- a/frontend/src/components/modals/SubtitleToolsModal.tsx
+++ b/frontend/src/components/modals/SubtitleToolsModal.tsx
@@ -248,7 +248,6 @@ const SubtitleToolView: FunctionComponent<SubtitleToolViewProps> = ({
                 episodeLabel,
                 language: v.code2,
                 path: v.path,
-                // eslint-disable-next-line camelcase
                 raw_language: v,
                 season: isMovie(item) ? undefined : item.season,
                 name,

--- a/frontend/src/components/modals/SubtitleToolsModal.tsx
+++ b/frontend/src/components/modals/SubtitleToolsModal.tsx
@@ -41,7 +41,7 @@ import { fromPython, isMovie, toPython } from "@/utilities";
 type SupportType = Item.Episode | Item.Movie;
 
 type TableColumnType = FormType.ModifySubtitle & {
-  raw_language: Language.Info;
+  rawLanguage: Language.Info;
   episode?: number;
   episodeLabel: string;
   seriesId: number;
@@ -115,10 +115,10 @@ function getEpisodeLabel(item: SupportType) {
 
   const {
     episode,
-    episode_number: episodeNumber,
+    episodeNumber: episodeNumber,
     season,
   } = item as Item.Episode & {
-    episode_number?: string;
+    episodeNumber?: string;
   };
 
   if (season === undefined || episode === undefined) {
@@ -184,7 +184,7 @@ const SubtitleToolView: FunctionComponent<SubtitleToolViewProps> = ({
         accessorKey: "language",
         cell: ({
           row: {
-            original: { raw_language: rawLanguage },
+            original: { rawLanguage: rawLanguage },
           },
         }) => (
           <Badge color="secondary">
@@ -248,7 +248,7 @@ const SubtitleToolView: FunctionComponent<SubtitleToolViewProps> = ({
                 episodeLabel,
                 language: v.code2,
                 path: v.path,
-                raw_language: v,
+                rawLanguage: v,
                 season: isMovie(item) ? undefined : item.season,
                 name,
                 hi: toPython(v.hi),
@@ -271,7 +271,7 @@ const SubtitleToolView: FunctionComponent<SubtitleToolViewProps> = ({
     const item = new Map<string, string>();
 
     data.forEach((row) => {
-      const languageValue = getLanguageValue(row.raw_language);
+      const languageValue = getLanguageValue(row.rawLanguage);
       language.set(languageValue, languageValue);
       item.set(row.name.toLowerCase(), row.name);
 
@@ -389,7 +389,7 @@ const SubtitleToolView: FunctionComponent<SubtitleToolViewProps> = ({
               case "item":
                 return original.name.toLowerCase().includes(filter.value);
               case "language":
-                return getLanguageValue(original.raw_language) === filter.value;
+                return getLanguageValue(original.rawLanguage) === filter.value;
               case "season":
                 return original.season?.toString() === filter.value;
             }

--- a/frontend/src/components/toolbox/Button.tsx
+++ b/frontend/src/components/toolbox/Button.tsx
@@ -49,7 +49,9 @@ export function ToolboxMutateButton<R, T extends () => Promise<R>>(
     setLoading(true);
     promise().then((val) => {
       setLoading(false);
-      onSuccess && onSuccess(val);
+      if (onSuccess) {
+        onSuccess(val);
+      }
     });
   }, [onSuccess, promise]);
 

--- a/frontend/src/modules/socketio/reducer.ts
+++ b/frontend/src/modules/socketio/reducer.ts
@@ -234,17 +234,14 @@ export function createDefaultReducer(): SocketIO.Reducer[] {
             const idx = current.findIndex((j) => j.job_id === payload.job_id);
 
             const initialJob =
-              // eslint-disable-next-line camelcase
               idx >= 0 ? { ...current[idx] } : { job_id: payload.job_id };
 
             const updatedJob = {
               ...initialJob,
               status: payload.status,
-              /* eslint-disable camelcase */
               progress_value: payload.progress_value,
               progress_max: payload.progress_max,
               progress_message: payload.progress_message,
-              /* eslint-enable camelcase */
             };
 
             const next =

--- a/frontend/src/pages/Blacklist/Movies/index.test.tsx
+++ b/frontend/src/pages/Blacklist/Movies/index.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { http } from "msw";
 import { HttpResponse } from "msw";
 import { customRender, screen, waitFor } from "@/tests";

--- a/frontend/src/pages/Blacklist/Movies/table.tsx
+++ b/frontend/src/pages/Blacklist/Movies/table.tsx
@@ -58,7 +58,7 @@ const Table: FunctionComponent<Props> = ({ blacklist }) => {
         accessorKey: "timestamp",
         cell: ({
           row: {
-            original: { timestamp, parsed_timestamp: parsedTimestamp },
+            original: { timestamp, parsedTimestamp },
           },
         }) => {
           if (timestamp) {
@@ -73,10 +73,10 @@ const Table: FunctionComponent<Props> = ({ blacklist }) => {
         },
       },
       {
-        id: "subs_id",
+        id: "subsId",
         cell: ({
           row: {
-            original: { subs_id: subsId, provider },
+            original: { subsId, provider },
           },
         }) => {
           return (
@@ -88,8 +88,7 @@ const Table: FunctionComponent<Props> = ({ blacklist }) => {
                 all: false,
                 form: {
                   provider: provider,
-                  // eslint-disable-next-line camelcase
-                  subs_id: subsId,
+                  subsId,
                 },
               })}
             ></MutateAction>

--- a/frontend/src/pages/Blacklist/Series/index.test.tsx
+++ b/frontend/src/pages/Blacklist/Series/index.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { http } from "msw";
 import { HttpResponse } from "msw";
 import { customRender, screen, waitFor } from "@/tests";

--- a/frontend/src/pages/Blacklist/Series/table.tsx
+++ b/frontend/src/pages/Blacklist/Series/table.tsx
@@ -36,7 +36,7 @@ const Table: FunctionComponent<Props> = ({ blacklist }) => {
       },
       {
         header: "Episode",
-        accessorKey: "episode_number",
+        accessorKey: "episodeNumber",
       },
       {
         id: "episodeTitle",
@@ -65,7 +65,7 @@ const Table: FunctionComponent<Props> = ({ blacklist }) => {
         accessorKey: "timestamp",
         cell: ({
           row: {
-            original: { timestamp, parsed_timestamp: parsedTimestamp },
+            original: { timestamp, parsedTimestamp },
           },
         }) => {
           if (timestamp) {
@@ -80,10 +80,10 @@ const Table: FunctionComponent<Props> = ({ blacklist }) => {
         },
       },
       {
-        id: "subs_id",
+        id: "subsId",
         cell: ({
           row: {
-            original: { subs_id: subsId, provider },
+            original: { subsId, provider },
           },
         }) => {
           return (
@@ -95,8 +95,7 @@ const Table: FunctionComponent<Props> = ({ blacklist }) => {
                 all: false,
                 form: {
                   provider: provider,
-                  // eslint-disable-next-line camelcase
-                  subs_id: subsId,
+                  subsId,
                 },
               })}
             ></MutateAction>

--- a/frontend/src/pages/Episodes/index.tsx
+++ b/frontend/src/pages/Episodes/index.tsx
@@ -148,7 +148,7 @@ const SeriesEpisodesView: FunctionComponent = () => {
                 if (series) {
                   await action({
                     action: "sync",
-                    seriesid: id,
+                    seriesId: id,
                   });
                 }
               }}
@@ -162,7 +162,7 @@ const SeriesEpisodesView: FunctionComponent = () => {
                 if (series) {
                   task.create(series.title, TaskGroup.ScanDisk, action, {
                     action: "scan-disk",
-                    seriesid: id,
+                    seriesId: id,
                   });
                 }
               }}
@@ -175,7 +175,7 @@ const SeriesEpisodesView: FunctionComponent = () => {
                 if (series) {
                   await action({
                     action: "search-missing",
-                    seriesid: id,
+                    seriesId: id,
                   });
                 }
               }}

--- a/frontend/src/pages/Episodes/table.tsx
+++ b/frontend/src/pages/Episodes/table.tsx
@@ -44,11 +44,11 @@ const Table = forwardRef<TableInstance<Item.Episode> | null, Props>(
       (item: Item.Episode, result: SearchResultType) => {
         const {
           language,
-          hearing_impaired: hi,
+          hearingImpaired: hi,
           forced,
           provider,
           subtitle,
-          original_format: originalFormat,
+          originalFormat,
         } = result;
         const { sonarrSeriesId: seriesId, sonarrEpisodeId: episodeId } = item;
 
@@ -61,7 +61,7 @@ const Table = forwardRef<TableInstance<Item.Episode> | null, Props>(
             forced,
             provider,
             subtitle,
-            original_format: originalFormat,
+            originalFormat,
           },
         });
       },
@@ -75,7 +75,7 @@ const Table = forwardRef<TableInstance<Item.Episode> | null, Props>(
         const elements = useMemo(() => {
           const episodeId = episode.sonarrEpisodeId;
 
-          const missing = episode.missing_subtitles.map((val, idx) => (
+          const missing = episode.missingSubtitles.map((val, idx) => (
             <Subtitle
               missing
               key={BuildKey(idx, val.code2, "missing")}
@@ -162,16 +162,16 @@ const Table = forwardRef<TableInstance<Item.Episode> | null, Props>(
         },
         {
           header: "Audio",
-          accessorKey: "audio_language",
+          accessorKey: "audioLanguage",
           cell: ({
             row: {
-              original: { audio_language: audioLanguage },
+              original: { audioLanguage: audioLanguage },
             },
           }) => <AudioList audios={audioLanguage}></AudioList>,
         },
         {
           header: "Subtitles",
-          accessorKey: "missing_subtitles",
+          accessorKey: "missingSubtitles",
           cell: ({ row: { original } }) => {
             return <SubtitlesCell episode={original} />;
           },

--- a/frontend/src/pages/Episodes/table.tsx
+++ b/frontend/src/pages/Episodes/table.tsx
@@ -61,7 +61,6 @@ const Table = forwardRef<TableInstance<Item.Episode> | null, Props>(
             forced,
             provider,
             subtitle,
-            // eslint-disable-next-line camelcase
             original_format: originalFormat,
           },
         });

--- a/frontend/src/pages/History/Movies/index.test.tsx
+++ b/frontend/src/pages/History/Movies/index.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { http } from "msw";
 import { HttpResponse } from "msw";
 import { customRender, screen, waitFor } from "@/tests";

--- a/frontend/src/pages/History/Movies/index.tsx
+++ b/frontend/src/pages/History/Movies/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { FunctionComponent, useMemo } from "react";
 import { Link } from "react-router";
 import { Anchor, Badge, Text } from "@mantine/core";
@@ -67,7 +66,7 @@ const MoviesHistoryView: FunctionComponent = () => {
         header: "Match",
         accessorKey: "matches",
         cell: (row) => {
-          const { matches, dont_matches: dont } = row.row.original;
+          const { matches, dontMatches: dont } = row.row.original;
           if (matches.length || dont.length) {
             return (
               <StateIcon
@@ -86,12 +85,12 @@ const MoviesHistoryView: FunctionComponent = () => {
         accessorKey: "timestamp",
         cell: ({
           row: {
-            original: { timestamp, parsed_timestamp },
+            original: { timestamp, parsedTimestamp },
           },
         }) => {
           if (timestamp) {
             return (
-              <TextPopover text={parsed_timestamp}>
+              <TextPopover text={parsedTimestamp}>
                 <Text>{timestamp}</Text>
               </TextPopover>
             );
@@ -142,12 +141,12 @@ const MoviesHistoryView: FunctionComponent = () => {
             blacklisted,
             radarrId,
             provider,
-            subs_id,
+            subsId,
             language,
-            subtitles_path,
+            subtitlesPath,
           } = row.original;
 
-          if (subs_id && provider && language) {
+          if (subsId && provider && language) {
             return (
               <MutateAction
                 label="Add to Blacklist"
@@ -158,8 +157,8 @@ const MoviesHistoryView: FunctionComponent = () => {
                   id: radarrId,
                   form: {
                     provider,
-                    subs_id,
-                    subtitles_path,
+                    subsId,
+                    subtitlesPath,
                     language: language.code2,
                   },
                 })}

--- a/frontend/src/pages/History/Series/index.test.tsx
+++ b/frontend/src/pages/History/Series/index.test.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 import { http } from "msw";
 import { HttpResponse } from "msw";
 import { customRender, screen, waitFor } from "@/tests";

--- a/frontend/src/pages/History/Series/index.tsx
+++ b/frontend/src/pages/History/Series/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { FunctionComponent, useMemo } from "react";
 import { Link } from "react-router";
 import { Anchor, Badge, Text } from "@mantine/core";
@@ -50,7 +49,7 @@ const SeriesHistoryView: FunctionComponent = () => {
       },
       {
         header: "Episode",
-        accessorKey: "episode_number",
+        accessorKey: "episodeNumber",
       },
       {
         header: "Title",
@@ -90,7 +89,7 @@ const SeriesHistoryView: FunctionComponent = () => {
         header: "Match",
         accessorKey: "matches",
         cell: (row) => {
-          const { matches, dont_matches: dont } = row.row.original;
+          const { matches, dontMatches: dont } = row.row.original;
           if (matches.length || dont.length) {
             return (
               <StateIcon
@@ -109,12 +108,12 @@ const SeriesHistoryView: FunctionComponent = () => {
         accessorKey: "timestamp",
         cell: ({
           row: {
-            original: { timestamp, parsed_timestamp },
+            original: { timestamp, parsedTimestamp },
           },
         }) => {
           if (timestamp) {
             return (
-              <TextPopover text={parsed_timestamp}>
+              <TextPopover text={parsedTimestamp}>
                 <Text>{timestamp}</Text>
               </TextPopover>
             );
@@ -165,12 +164,12 @@ const SeriesHistoryView: FunctionComponent = () => {
             sonarrEpisodeId,
             sonarrSeriesId,
             provider,
-            subs_id,
+            subsId,
             language,
-            subtitles_path,
+            subtitlesPath,
             blacklisted,
           } = row.original;
-          if (subs_id && provider && language) {
+          if (subsId && provider && language) {
             return (
               <MutateAction
                 label="Add to Blacklist"
@@ -182,8 +181,8 @@ const SeriesHistoryView: FunctionComponent = () => {
                   episodeId: sonarrEpisodeId,
                   form: {
                     provider,
-                    subs_id,
-                    subtitles_path,
+                    subsId,
+                    subtitlesPath,
                     language: language.code2,
                   },
                 })}

--- a/frontend/src/pages/Movies/Details/index.tsx
+++ b/frontend/src/pages/Movies/Details/index.tsx
@@ -75,7 +75,6 @@ const MovieDetailView: FunctionComponent = () => {
           forced,
           provider,
           subtitle,
-          // eslint-disable-next-line camelcase
           original_format: originalFormat,
         },
       });

--- a/frontend/src/pages/Movies/Details/index.tsx
+++ b/frontend/src/pages/Movies/Details/index.tsx
@@ -59,11 +59,11 @@ const MovieDetailView: FunctionComponent = () => {
     (item: Item.Movie, result: SearchResultType) => {
       const {
         language,
-        hearing_impaired: hi,
+        hearingImpaired: hi,
         forced,
         provider,
         subtitle,
-        original_format: originalFormat,
+        originalFormat,
       } = result;
       const { radarrId } = item;
 
@@ -75,7 +75,7 @@ const MovieDetailView: FunctionComponent = () => {
           forced,
           provider,
           subtitle,
-          original_format: originalFormat,
+          originalFormat,
         },
       });
     },
@@ -134,7 +134,7 @@ const MovieDetailView: FunctionComponent = () => {
                 if (movie) {
                   await action({
                     action: "sync",
-                    radarrid: id,
+                    radarrId: id,
                   });
                 }
               }}
@@ -148,7 +148,7 @@ const MovieDetailView: FunctionComponent = () => {
                 if (movie) {
                   task.create(movie.title, TaskGroup.ScanDisk, action, {
                     action: "scan-disk",
-                    radarrid: id,
+                    radarrId: id,
                   });
                 }
               }}
@@ -163,7 +163,7 @@ const MovieDetailView: FunctionComponent = () => {
                 if (movie) {
                   await action({
                     action: "search-missing",
-                    radarrid: id,
+                    radarrId: id,
                   });
                 }
               }}

--- a/frontend/src/pages/Movies/Details/table.tsx
+++ b/frontend/src/pages/Movies/Details/table.tsx
@@ -170,7 +170,7 @@ const Table: FunctionComponent<Props> = ({ movie, profile, disabled }) => {
 
   const data: Subtitle[] = useMemo(() => {
     const missing =
-      movie?.missing_subtitles.map((item) => ({
+      movie?.missingSubtitles.map((item) => ({
         ...item,
         path: missingText,
       })) ?? [];

--- a/frontend/src/pages/Movies/Editor.tsx
+++ b/frontend/src/pages/Movies/Editor.tsx
@@ -46,10 +46,10 @@ const MovieMassEditor: FunctionComponent = () => {
       },
       {
         header: "Audio",
-        accessorKey: "audio_language",
+        accessorKey: "audioLanguage",
         cell: ({
           row: {
-            original: { audio_language: audioLanguage },
+            original: { audioLanguage: audioLanguage },
           },
         }) => {
           return <AudioList audios={audioLanguage}></AudioList>;

--- a/frontend/src/pages/Movies/index.tsx
+++ b/frontend/src/pages/Movies/index.tsx
@@ -59,10 +59,10 @@ const MovieView: FunctionComponent = () => {
       },
       {
         header: "Audio",
-        accessorKey: "audio_language",
+        accessorKey: "audioLanguage",
         cell: ({
           row: {
-            original: { audio_language: audioLanguage },
+            original: { audioLanguage: audioLanguage },
           },
         }) => {
           return <AudioList audios={audioLanguage}></AudioList>;
@@ -86,10 +86,10 @@ const MovieView: FunctionComponent = () => {
       },
       {
         header: "Missing Subtitles",
-        accessorKey: "missing_subtitles",
+        accessorKey: "missingSubtitles",
         cell: ({
           row: {
-            original: { missing_subtitles: missingSubtitles },
+            original: { missingSubtitles: missingSubtitles },
           },
         }) => {
           return (

--- a/frontend/src/pages/Series/Editor.tsx
+++ b/frontend/src/pages/Series/Editor.tsx
@@ -44,10 +44,10 @@ const SeriesMassEditor: FunctionComponent = () => {
       },
       {
         header: "Audio",
-        accessorKey: "audio_language",
+        accessorKey: "audioLanguage",
         cell: ({
           row: {
-            original: { audio_language: audioLanguage },
+            original: { audioLanguage: audioLanguage },
           },
         }) => {
           return <AudioList audios={audioLanguage}></AudioList>;

--- a/frontend/src/pages/Settings/Jellyfin/index.tsx
+++ b/frontend/src/pages/Settings/Jellyfin/index.tsx
@@ -40,7 +40,7 @@ const JellyfinTestButton: FunctionComponent = () => {
       {
         onSuccess: (data) => {
           if (data.success) {
-            setTitle(`${data.server_name} (v${data.version})`);
+            setTitle(`${data.serverName} (v${data.version})`);
             setColor("success");
           } else {
             setTitle(data.error || "Connection failed");

--- a/frontend/src/pages/Settings/Languages/table.tsx
+++ b/frontend/src/pages/Settings/Languages/table.tsx
@@ -13,6 +13,7 @@ import { useModals } from "@/modules/modals";
 import { languageProfileKey } from "@/pages/Settings/keys";
 import { useFormActions } from "@/pages/Settings/utilities/FormValues";
 import { BuildKey, useArrayAction } from "@/utilities";
+import { snakeCaseKeys } from "@/utilities/case";
 import { useLatestEnabledLanguages, useLatestProfiles } from ".";
 
 const Table: FunctionComponent = () => {
@@ -33,7 +34,16 @@ const Table: FunctionComponent = () => {
 
   const submitProfiles = useCallback(
     (list: Language.Profile[]) => {
-      setValue(list, languageProfileKey, (value) => JSON.stringify(value));
+      setValue(list, languageProfileKey, (value: Language.Profile[]) => {
+        const raw: Language.RawProfile[] = value.map((profile) => ({
+          ...profile,
+          items: profile.items.map(
+            (item) => snakeCaseKeys(item) as Language.RawProfileItem,
+          ),
+        }));
+
+        return JSON.stringify(raw);
+      });
     },
     [setValue],
   );

--- a/frontend/src/pages/Settings/Plex/AuthSection.tsx
+++ b/frontend/src/pages/Settings/Plex/AuthSection.tsx
@@ -51,7 +51,7 @@ const AuthSection = () => {
   }
 
   const isAuthenticated = Boolean(
-    authData?.valid && authData?.auth_method === "oauth",
+    authData?.valid && authData?.authMethod === "oauth",
   );
 
   const handleAuth = async () => {

--- a/frontend/src/pages/Settings/Plex/AutopulseSelector.tsx
+++ b/frontend/src/pages/Settings/Plex/AutopulseSelector.tsx
@@ -33,7 +33,7 @@ const AutopulseSelector: FunctionComponent<AutopulseSelectorProps> = (
   // Check if user is authenticated with OAuth
   const { data: authData } = usePlexAuthValidationQuery();
   const isAuthenticated = Boolean(
-    authData?.valid && authData?.auth_method === "oauth",
+    authData?.valid && authData?.authMethod === "oauth",
   );
 
   const {
@@ -136,7 +136,7 @@ const AutopulseSelector: FunctionComponent<AutopulseSelectorProps> = (
                 variant="subtle"
                 size="sm"
                 onClick={async () => {
-                  const yamlContent = configData?.config_yaml;
+                  const yamlContent = configData?.configYaml;
 
                   if (!yamlContent) {
                     notifications.show({
@@ -180,7 +180,7 @@ const AutopulseSelector: FunctionComponent<AutopulseSelectorProps> = (
           </Group>
 
           <Code block className={styles.configCodeBlock}>
-            {configData.config_yaml}
+            {configData.configYaml}
           </Code>
 
           <Stack gap="xs" mt="sm">
@@ -188,12 +188,12 @@ const AutopulseSelector: FunctionComponent<AutopulseSelectorProps> = (
               <Text component="span" fw={600}>
                 Server:
               </Text>{" "}
-              {configData.server_name}
+              {configData.serverName}
             </Text>
 
-            {configData.rewrite_suggestion && (
+            {configData.rewriteSuggestion && (
               <Alert
-                color={configData.rewrite_detected ? "yellow" : "brand"}
+                color={configData.rewriteDetected ? "yellow" : "brand"}
                 variant="light"
                 className={styles.alertMessage}
               >
@@ -201,14 +201,14 @@ const AutopulseSelector: FunctionComponent<AutopulseSelectorProps> = (
                   <Text component="span" fw={600}>
                     Configuration Notes:
                   </Text>{" "}
-                  {configData.rewrite_suggestion}
+                  {configData.rewriteSuggestion}
                 </Text>
               </Alert>
             )}
 
-            {configData.template_info && (
+            {configData.templateInfo && (
               <Text size="xs" c="dimmed">
-                {configData.template_info}
+                {configData.templateInfo}
               </Text>
             )}
           </Stack>

--- a/frontend/src/pages/Settings/Plex/LibrarySelector.tsx
+++ b/frontend/src/pages/Settings/Plex/LibrarySelector.tsx
@@ -28,7 +28,7 @@ const LibrarySelector: FunctionComponent<LibrarySelectorProps> = (props) => {
 
   const { data: authData } = usePlexAuthValidationQuery();
   const isAuthenticated = Boolean(
-    authData?.valid && authData?.auth_method === "oauth",
+    authData?.valid && authData?.authMethod === "oauth",
   );
 
   const { data: servers = [] } = usePlexServersQuery();

--- a/frontend/src/pages/Settings/Plex/ServerSection.tsx
+++ b/frontend/src/pages/Settings/Plex/ServerSection.tsx
@@ -42,13 +42,13 @@ const ServerSection = () => {
   const { mutateAsync: selectServerMutation } =
     usePlexServerSelectionMutation();
   const { data: savedSelectedServer } = usePlexSelectedServerQuery({
-    enabled: Boolean(authData?.valid && authData?.auth_method === "oauth"),
+    enabled: Boolean(authData?.valid && authData?.authMethod === "oauth"),
   });
   const { setValue } = useFormActions();
 
   // Determine authentication status
   const isAuthenticated = Boolean(
-    authData?.valid && authData?.auth_method === "oauth",
+    authData?.valid && authData?.authMethod === "oauth",
   );
 
   // Reset state when authentication changes from false to true (re-authentication)

--- a/frontend/src/pages/Settings/Plex/WebhookSelector.tsx
+++ b/frontend/src/pages/Settings/Plex/WebhookSelector.tsx
@@ -25,7 +25,7 @@ const WebhookSelector: FunctionComponent<WebhookSelectorProps> = (props) => {
   // Check if user is authenticated with OAuth
   const { data: authData } = usePlexAuthValidationQuery();
   const isAuthenticated = Boolean(
-    authData?.valid && authData?.auth_method === "oauth",
+    authData?.valid && authData?.authMethod === "oauth",
   );
 
   // Fetch webhooks if authenticated
@@ -51,7 +51,7 @@ const WebhookSelector: FunctionComponent<WebhookSelectorProps> = (props) => {
 
   // Check Plex Pass subscription status for webhooks feature
   const plexPassSubscription = webhooks?.plexPassSubscription;
-  const hasWebhooksFeature = plexPassSubscription?.has_webhooks_feature ?? true;
+  const hasWebhooksFeature = plexPassSubscription?.hasWebhooksFeature ?? true;
 
   // Create select data with Bazarr webhook first if it exists
   const selectData =

--- a/frontend/src/pages/System/Tasks/index.test.tsx
+++ b/frontend/src/pages/System/Tasks/index.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { http } from "msw";
 import { HttpResponse } from "msw";
 import { customRender, screen, waitFor } from "@/tests";

--- a/frontend/src/pages/Wanted/Movies/index.test.tsx
+++ b/frontend/src/pages/Wanted/Movies/index.test.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 import { http } from "msw";
 import { HttpResponse } from "msw";
 import { customRender, screen } from "@/tests";

--- a/frontend/src/pages/Wanted/Movies/index.tsx
+++ b/frontend/src/pages/Wanted/Movies/index.tsx
@@ -36,10 +36,10 @@ const WantedMoviesView: FunctionComponent = () => {
       },
       {
         header: "Missing",
-        accessorKey: "missing_subtitles",
+        accessorKey: "missingSubtitles",
         cell: ({
           row: {
-            original: { radarrId, missing_subtitles: missingSubtitles },
+            original: { radarrId, missingSubtitles: missingSubtitles },
           },
         }) => {
           return (

--- a/frontend/src/pages/Wanted/Series/index.test.tsx
+++ b/frontend/src/pages/Wanted/Series/index.test.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 import { http } from "msw";
 import { HttpResponse } from "msw";
 import { customRender, screen } from "@/tests";

--- a/frontend/src/pages/Wanted/Series/index.tsx
+++ b/frontend/src/pages/Wanted/Series/index.tsx
@@ -36,20 +36,20 @@ const WantedSeriesView: FunctionComponent = () => {
       },
       {
         header: "Episode",
-        accessorKey: "episode_number",
+        accessorKey: "episodeNumber",
       },
       {
         accessorKey: "episodeTitle",
       },
       {
         header: "Missing",
-        accessorKey: "missing_subtitles",
+        accessorKey: "missingSubtitles",
         cell: ({
           row: {
             original: {
               sonarrSeriesId,
               sonarrEpisodeId,
-              missing_subtitles: missingSubtitles,
+              missingSubtitles: missingSubtitles,
             },
           },
         }) => {

--- a/frontend/src/pages/Wanted/Series/index.tsx
+++ b/frontend/src/pages/Wanted/Series/index.tsx
@@ -39,6 +39,7 @@ const WantedSeriesView: FunctionComponent = () => {
         accessorKey: "episodeNumber",
       },
       {
+        header: "Episode Title",
         accessorKey: "episodeTitle",
       },
       {

--- a/frontend/src/pages/views/ItemOverview.test.tsx
+++ b/frontend/src/pages/views/ItemOverview.test.tsx
@@ -14,7 +14,6 @@ const createMinimalItem = (overrides: Partial<Item.Base> = {}): Item.Base =>
     monitored: true,
     tags: [],
     alternativeTitles: [],
-    // eslint-disable-next-line camelcase
     audio_language: [],
     profileId: undefined,
     overview: "Test overview",

--- a/frontend/src/pages/views/ItemOverview.test.tsx
+++ b/frontend/src/pages/views/ItemOverview.test.tsx
@@ -14,7 +14,7 @@ const createMinimalItem = (overrides: Partial<Item.Base> = {}): Item.Base =>
     monitored: true,
     tags: [],
     alternativeTitles: [],
-    audio_language: [],
+    audioLanguage: [],
     profileId: undefined,
     overview: "Test overview",
     ...overrides,

--- a/frontend/src/pages/views/ItemOverview.tsx
+++ b/frontend/src/pages/views/ItemOverview.tsx
@@ -91,7 +91,7 @@ const ItemOverview: FunctionComponent<Props> = (props) => {
 
   const audioBadges = useMemo(
     () =>
-      item?.audio_language.map((v, idx) => (
+      item?.audioLanguage.map((v, idx) => (
         <ItemBadge
           key={BuildKey(idx, "audio", v.code2)}
           icon={faMusic}
@@ -100,7 +100,7 @@ const ItemOverview: FunctionComponent<Props> = (props) => {
           {normalizeAudioLanguage(v.name)}
         </ItemBadge>
       )) ?? [],
-    [item?.audio_language],
+    [item?.audioLanguage],
   );
 
   const profile = useLanguageProfileBy(item?.profileId);

--- a/frontend/src/pages/views/MassEditor.tsx
+++ b/frontend/src/pages/views/MassEditor.tsx
@@ -70,14 +70,14 @@ function MassEditor<T extends Item.Base>(props: MassEditorProps<T>) {
 
     const form: FormType.ModifyItem = {
       id: [],
-      profileid: [],
+      profileId: [],
     };
 
     dirties.forEach((v) => {
       const id = GetItemId(v);
       if (id) {
         form.id.push(id);
-        form.profileid.push(v.profileId);
+        form.profileId.push(v.profileId);
       }
     });
 
@@ -92,13 +92,13 @@ function MassEditor<T extends Item.Base>(props: MassEditorProps<T>) {
 
       await mutateAsync({
         id: chunkIds,
-        profileid: chunkProfileIds,
+        profileId: chunkProfileIds,
       });
 
       await mutateInChunks(ids.slice(chunkSize), profileIds.slice(chunkSize));
     };
 
-    return mutateInChunks(form.id, form.profileid);
+    return mutateInChunks(form.id, form.profileId);
   }, [dirties, mutateAsync]);
 
   const setProfiles = useCallback(

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -203,23 +203,27 @@ declare namespace Wanted {
 }
 
 declare namespace Blacklist {
-  type Base = ItemHistoryType & {
+  type RawBase = ItemHistoryType & {
     parsed_timestamp: string;
     timestamp: string;
     subs_id: string;
   };
 
-  type Movie = Base & MovieIdType & TitleType;
+  type RawMovie = RawBase & MovieIdType & TitleType;
 
-  type Episode = Base &
+  type RawEpisode = RawBase &
     EpisodeTitleType &
     SeriesIdType & {
       episode_number: string;
     };
+
+  type Base = CamelCaseKeys<RawBase>;
+  type Movie = CamelCaseKeys<RawMovie>;
+  type Episode = CamelCaseKeys<RawEpisode>;
 }
 
 declare namespace History {
-  type Base = SubtitlePathType &
+  type RawBase = SubtitlePathType &
     TagType &
     MonitoredType &
     Partial<ItemHistoryType> & {
@@ -235,13 +239,17 @@ declare namespace History {
       dont_matches: string[];
     };
 
-  type Movie = History.Base & MovieIdType & TitleType;
+  type RawMovie = RawBase & MovieIdType & TitleType;
 
-  type Episode = History.Base &
+  type RawEpisode = RawBase &
     EpisodeIdType &
     EpisodeTitleType & {
       episode_number: string;
     };
+
+  type Base = CamelCaseKeys<RawBase>;
+  type Movie = CamelCaseKeys<RawMovie>;
+  type Episode = CamelCaseKeys<RawEpisode>;
 
   type StatItem = {
     count: number;

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -24,7 +24,7 @@ declare namespace Language {
     forced?: boolean;
   }
 
-  interface ProfileItem {
+  interface RawProfileItem {
     id: number;
     audio_exclude: PythonBoolean;
     audio_only_include: PythonBoolean;
@@ -33,19 +33,23 @@ declare namespace Language {
     language: CodeType;
   }
 
-  interface Profile {
+  type ProfileItem = CamelCaseKeys<RawProfileItem>;
+
+  interface RawProfile {
     name: string;
     profileId: number;
     cutoff: number | null;
-    items: ProfileItem[];
+    items: RawProfileItem[];
     mustContain: string[];
     mustNotContain: string[];
     originalFormat: boolean | null;
     tag: string | undefined;
   }
+
+  type Profile = CamelCaseKeys<RawProfile>;
 }
 
-interface Subtitle {
+interface RawSubtitle {
   code2: Language.CodeType;
   name: string;
   forced: boolean;
@@ -54,13 +58,15 @@ interface Subtitle {
   embedded_track_id: number | null | undefined; // TODO: FIX ME!!!!!!
 }
 
+type Subtitle = CamelCaseKeys<RawSubtitle>;
+
 interface AudioTrack {
   stream: string;
   name: string;
   language: string;
 }
 
-interface SubtitleTrack {
+interface RawSubtitleTrack {
   stream: string;
   name: string;
   language: string;
@@ -68,13 +74,17 @@ interface SubtitleTrack {
   hearing_impaired: boolean;
 }
 
-interface ExternalSubtitle {
+type SubtitleTrack = CamelCaseKeys<RawSubtitleTrack>;
+
+interface RawExternalSubtitle {
   name: string;
   path: string;
   language: string;
   forced: boolean;
   hearing_impaired: boolean;
 }
+
+type ExternalSubtitle = CamelCaseKeys<RawExternalSubtitle>;
 
 interface PathType {
   path: string;
@@ -88,13 +98,17 @@ interface MonitoredType {
   monitored: boolean;
 }
 
-interface SubtitleType {
-  subtitles: Subtitle[];
+interface RawSubtitleType {
+  subtitles: RawSubtitle[];
 }
 
-interface MissingSubtitleType {
-  missing_subtitles: Subtitle[];
+type SubtitleType = CamelCaseKeys<RawSubtitleType>;
+
+interface RawMissingSubtitleType {
+  missing_subtitles: RawSubtitle[];
 }
+
+type MissingSubtitleType = CamelCaseKeys<RawMissingSubtitleType>;
 
 interface SceneNameType {
   sceneName?: string;
@@ -125,9 +139,11 @@ interface TitleType {
   title: string;
 }
 
-interface AudioLanguageType {
+interface RawAudioLanguageType {
   audio_language: Language.Info[];
 }
+
+type AudioLanguageType = CamelCaseKeys<RawAudioLanguageType>;
 
 interface ItemHistoryType {
   language: Language.Info;
@@ -135,11 +151,11 @@ interface ItemHistoryType {
 }
 
 declare namespace Item {
-  type Base = PathType &
+  type RawBase = PathType &
     TitleType &
     TagType &
     MonitoredType &
-    AudioLanguageType & {
+    RawAudioLanguageType & {
       profileId: number | null;
       fanart: string;
       overview: string;
@@ -149,7 +165,9 @@ declare namespace Item {
       year: string;
     };
 
-  type Series = Base &
+  type Base = CamelCaseKeys<RawBase>;
+
+  type RawSeries = RawBase &
     SeriesIdType & {
       episodeFileCount: number;
       episodeMissingCount: number;
@@ -159,47 +177,61 @@ declare namespace Item {
       tvdbId: number;
     };
 
-  type Movie = Base &
+  type Series = CamelCaseKeys<RawSeries>;
+
+  type RawMovie = RawBase &
     MovieIdType &
-    SubtitleType &
-    MissingSubtitleType &
+    RawSubtitleType &
+    RawMissingSubtitleType &
     SceneNameType;
 
-  type Episode = PathType &
+  type Movie = CamelCaseKeys<RawMovie>;
+
+  type RawEpisode = PathType &
     TitleType &
     MonitoredType &
     EpisodeIdType &
-    SubtitleType &
-    MissingSubtitleType &
+    RawSubtitleType &
+    RawMissingSubtitleType &
     SceneNameType &
-    AudioLanguageType & {
+    RawAudioLanguageType & {
       season: number;
       episode: number;
     };
 
-  type RefTracks = {
+  type Episode = CamelCaseKeys<RawEpisode>;
+
+  interface RawRefTracks {
     audio_tracks: AudioTrack[];
-    embedded_subtitles_tracks: SubtitleTrack[];
-    external_subtitles_tracks: ExternalSubtitle[];
-  };
+    embedded_subtitles_tracks: RawSubtitleTrack[];
+    external_subtitles_tracks: RawExternalSubtitle[];
+  }
+
+  type RefTracks = CamelCaseKeys<RawRefTracks>;
 }
 
 declare namespace Wanted {
-  type Base = MonitoredType &
+  type RawBase = MonitoredType &
     TagType &
     SceneNameType & {
       hearing_impaired: boolean;
-      missing_subtitles: Subtitle[];
+      missing_subtitles: RawSubtitle[];
     };
 
-  type Episode = Base &
+  type Base = CamelCaseKeys<RawBase>;
+
+  type RawEpisode = RawBase &
     EpisodeIdType &
     EpisodeTitleType & {
       episode_number: string;
       seriesType: SonarrSeriesType;
     };
 
-  type Movie = Base & MovieIdType & TitleType;
+  type Episode = CamelCaseKeys<RawEpisode>;
+
+  type RawMovie = RawBase & MovieIdType & TitleType;
+
+  type Movie = CamelCaseKeys<RawMovie>;
 }
 
 declare namespace Blacklist {
@@ -280,7 +312,7 @@ declare namespace Plex {
     authUrl: string;
   }
 
-  interface ValidationResult {
+  interface RawValidationResult {
     valid: boolean;
     auth_method?: string;
     username?: string;
@@ -288,6 +320,8 @@ declare namespace Plex {
     error?: string;
     code?: string;
   }
+
+  type ValidationResult = CamelCaseKeys<RawValidationResult>;
 
   interface PinCheckResult {
     authenticated: boolean;
@@ -330,41 +364,49 @@ declare namespace Plex {
     locations: string[];
   }
 
-  interface WebhookResult {
+  interface RawWebhookResult {
     success: boolean;
     message: string;
     webhook_url?: string;
     total_webhooks?: number;
   }
 
+  type WebhookResult = CamelCaseKeys<RawWebhookResult>;
+
   interface WebhookInfo {
     url: string;
   }
 
-  interface PlexPassSubscription {
+  interface RawPlexPassSubscription {
     active: boolean;
     has_webhooks_feature: boolean;
     plan: string | null;
   }
 
-  interface WebhookList {
+  type PlexPassSubscription = CamelCaseKeys<RawPlexPassSubscription>;
+
+  interface RawWebhookList {
     webhooks: WebhookInfo[];
     count: number;
-    plexPassSubscription?: PlexPassSubscription;
+    plexPassSubscription?: RawPlexPassSubscription;
   }
+
+  type WebhookList = CamelCaseKeys<RawWebhookList>;
 
   interface AutopulseResult {
     success: boolean;
     message: string;
   }
 
-  interface AutopulseConfig {
+  interface RawAutopulseConfig {
     config_yaml: string;
     server_name: string;
     rewrite_detected?: boolean;
     rewrite_suggestion?: string;
     template_info?: string;
   }
+
+  type AutopulseConfig = CamelCaseKeys<RawAutopulseConfig>;
 
   interface AutopulseLibrary {
     key: string;
@@ -374,7 +416,7 @@ declare namespace Plex {
   }
 }
 
-interface SearchResultType {
+interface RawSearchResultType {
   matches: string[];
   dont_matches: string[];
   language: string;
@@ -391,6 +433,8 @@ interface SearchResultType {
   original_format: PythonBoolean;
 }
 
+type SearchResultType = CamelCaseKeys<RawSearchResultType>;
+
 interface ReleaseInfo {
   current: boolean;
   date: string;
@@ -406,7 +450,7 @@ interface SubtitleInfo {
 }
 
 declare namespace SubtitleContents {
-  interface LineTime {
+  interface RawLineTime {
     hours: number;
     minutes: number;
     seconds: number;
@@ -414,14 +458,18 @@ declare namespace SubtitleContents {
     microseconds: number;
   }
 
-  interface Line {
+  type LineTime = CamelCaseKeys<RawLineTime>;
+
+  interface RawLine {
     index: number;
     content: string;
     proprietary: string;
-    start: LineTime;
-    end: LineTime;
+    start: RawLineTime;
+    end: RawLineTime;
     // duration: LineTime;
   }
+
+  type Line = CamelCaseKeys<RawLine>;
 
   // interface Contents extends Array<Line> {}
 }

--- a/frontend/src/types/form.d.ts
+++ b/frontend/src/types/form.d.ts
@@ -63,14 +63,14 @@ declare namespace FormType {
 
   interface AddBlacklist {
     provider: string;
-    subs_id: string;
+    subsId: string;
     language: Language.CodeType;
-    subtitles_path: string;
+    subtitlesPath: string;
   }
 
   interface DeleteBlacklist {
     provider: string;
-    subs_id: string;
+    subsId: string;
   }
 
   interface ManualDownload {

--- a/frontend/src/types/form.d.ts
+++ b/frontend/src/types/form.d.ts
@@ -1,7 +1,7 @@
 declare namespace FormType {
   interface ModifyItem {
     id: number[];
-    profileid: (number | null)[];
+    profileId: (number | null)[];
   }
 
   type SeriesAction = OneSeriesAction | SearchWantedAction;
@@ -10,12 +10,12 @@ declare namespace FormType {
 
   interface OneMovieAction {
     action: "search-missing" | "scan-disk" | "sync";
-    radarrid: number;
+    radarrId: number;
   }
 
   interface OneSeriesAction {
     action: "search-missing" | "scan-disk" | "sync";
-    seriesid: number;
+    seriesId: number;
   }
 
   interface SearchWantedAction {
@@ -43,10 +43,10 @@ declare namespace FormType {
     path: string;
     forced?: PythonBoolean;
     hi?: PythonBoolean;
-    original_format?: PythonBoolean;
+    originalFormat?: PythonBoolean;
     reference?: string;
-    max_offset_seconds?: string;
-    no_fix_framerate?: PythonBoolean;
+    maxOffsetSeconds?: string;
+    noFixFramerate?: PythonBoolean;
     gss?: PythonBoolean;
   }
 
@@ -79,7 +79,7 @@ declare namespace FormType {
     forced: PythonBoolean;
     provider: string;
     subtitle: unknown;
-    original_format: PythonBoolean;
+    originalFormat: PythonBoolean;
   }
 
   interface AddAnnouncementsDismiss {

--- a/frontend/src/types/utilities.d.ts
+++ b/frontend/src/types/utilities.d.ts
@@ -4,6 +4,31 @@ type Unpacked<D> = D extends unknown[] | readonly unknown[] ? D[number] : D;
 
 type Nullable<D> = D | null;
 
+type CamelCase<S extends string> = S extends `${infer Head}_${infer Tail}`
+  ? `${Head}${CamelCase<Capitalize<Tail>>}`
+  : S;
+
+type CamelCaseKeys<T> =
+  T extends ReadonlyArray<infer U>
+    ? CamelCaseKeys<U>[]
+    : T extends Date
+      ? T
+      : T extends File
+        ? T
+        : T extends Blob
+          ? T
+          : T extends RegExp
+            ? T
+            : T extends (...args: unknown[]) => unknown
+              ? T
+              : T extends object
+                ? {
+                    [K in keyof T as CamelCase<K & string>]: CamelCaseKeys<
+                      T[K]
+                    >;
+                  }
+                : T;
+
 type LooseObject = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;

--- a/frontend/src/types/utilities.d.ts
+++ b/frontend/src/types/utilities.d.ts
@@ -8,26 +8,17 @@ type CamelCase<S extends string> = S extends `${infer Head}_${infer Tail}`
   ? `${Head}${CamelCase<Capitalize<Tail>>}`
   : S;
 
+type CamelCaseLeaf =
+  Date | File | Blob | RegExp | ((...args: unknown[]) => unknown);
+
 type CamelCaseKeys<T> =
   T extends ReadonlyArray<infer U>
     ? CamelCaseKeys<U>[]
-    : T extends Date
+    : T extends CamelCaseLeaf
       ? T
-      : T extends File
-        ? T
-        : T extends Blob
-          ? T
-          : T extends RegExp
-            ? T
-            : T extends (...args: unknown[]) => unknown
-              ? T
-              : T extends object
-                ? {
-                    [K in keyof T as CamelCase<K & string>]: CamelCaseKeys<
-                      T[K]
-                    >;
-                  }
-                : T;
+      : T extends object
+        ? { [K in keyof T as CamelCase<K & string>]: CamelCaseKeys<T[K]> }
+        : T;
 
 type LooseObject = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/frontend/src/utilities/case.test.ts
+++ b/frontend/src/utilities/case.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  camelCaseKeys,
+  snakeCaseKeys,
+  toCamelCase,
+  toSnakeCase,
+} from "@/utilities/case";
+
+describe("case utilities", () => {
+  describe("toCamelCase", () => {
+    it("converts snake_case to camelCase", () => {
+      expect(toCamelCase("subs_id")).toBe("subsId");
+      expect(toCamelCase("subtitles_path")).toBe("subtitlesPath");
+      expect(toCamelCase("episode_number")).toBe("episodeNumber");
+    });
+
+    it("leaves camelCase unchanged", () => {
+      expect(toCamelCase("provider")).toBe("provider");
+      expect(toCamelCase("radarrId")).toBe("radarrId");
+    });
+  });
+
+  describe("toSnakeCase", () => {
+    it("converts camelCase to snake_case", () => {
+      expect(toSnakeCase("subsId")).toBe("subs_id");
+      expect(toSnakeCase("subtitlesPath")).toBe("subtitles_path");
+      expect(toSnakeCase("episodeNumber")).toBe("episode_number");
+    });
+
+    it("leaves snake_case unchanged", () => {
+      expect(toSnakeCase("provider")).toBe("provider");
+    });
+  });
+
+  describe("camelCaseKeys", () => {
+    it("maps object keys recursively", () => {
+      const result = camelCaseKeys({
+        data: [
+          {
+            subs_id: "123",
+            parsed_timestamp: "now",
+            dont_matches: ["a"],
+            nested: { raw_value: 1 },
+          },
+        ],
+        total: 1,
+      });
+
+      expect(result).toEqual({
+        data: [
+          {
+            subsId: "123",
+            parsedTimestamp: "now",
+            dontMatches: ["a"],
+            nested: { rawValue: 1 },
+          },
+        ],
+        total: 1,
+      });
+    });
+
+    it("leaves non-object values unchanged", () => {
+      const date = new Date("2024-01-01");
+      const result = camelCaseKeys({ created_at: date, count: 5 });
+
+      expect(result.createdAt).toBe(date);
+      expect(result.count).toBe(5);
+    });
+  });
+
+  describe("snakeCaseKeys", () => {
+    it("maps object keys recursively", () => {
+      const result = snakeCaseKeys({
+        subsId: "123",
+        subtitlesPath: "/path",
+        nested: { camelCaseValue: 1 },
+      });
+
+      expect(result).toEqual({
+        subs_id: "123",
+        subtitles_path: "/path",
+        nested: { camel_case_value: 1 },
+      });
+    });
+  });
+});

--- a/frontend/src/utilities/case.ts
+++ b/frontend/src/utilities/case.ts
@@ -1,10 +1,8 @@
-export const toCamelCase = (value: string): string =>
-  value.replace(/_(.)/g, (_, char) => char.toUpperCase());
+import { camelCase, snakeCase } from "lodash";
 
-export const toSnakeCase = (value: string): string =>
-  value
-    .replace(/([A-Z]+)/g, (_, chars) => `_${chars.toLowerCase()}`)
-    .replace(/^_/, "");
+export const toCamelCase = (value: string): string => camelCase(value);
+
+export const toSnakeCase = (value: string): string => snakeCase(value);
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" &&
@@ -24,7 +22,7 @@ export const camelCaseKeys = <T>(value: T): CamelCaseKeys<T> => {
     const result: Record<string, unknown> = {};
 
     for (const [key, val] of Object.entries(value)) {
-      result[toCamelCase(key)] = camelCaseKeys(val);
+      result[camelCase(key)] = camelCaseKeys(val);
     }
 
     return result as CamelCaseKeys<T>;
@@ -42,7 +40,7 @@ export const snakeCaseKeys = <T>(value: T): LooseObject => {
     const result: Record<string, unknown> = {};
 
     for (const [key, val] of Object.entries(value)) {
-      result[toSnakeCase(key)] = snakeCaseKeys(val);
+      result[snakeCase(key)] = snakeCaseKeys(val);
     }
 
     return result;

--- a/frontend/src/utilities/case.ts
+++ b/frontend/src/utilities/case.ts
@@ -1,26 +1,21 @@
-export function toCamelCase(value: string): string {
-  return value.replace(/_(.)/g, (_, char) => char.toUpperCase());
-}
+export const toCamelCase = (value: string): string =>
+  value.replace(/_(.)/g, (_, char) => char.toUpperCase());
 
-export function toSnakeCase(value: string): string {
-  return value
+export const toSnakeCase = (value: string): string =>
+  value
     .replace(/([A-Z]+)/g, (_, chars) => `_${chars.toLowerCase()}`)
     .replace(/^_/, "");
-}
 
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    !Array.isArray(value) &&
-    !(value instanceof Date) &&
-    !(value instanceof File) &&
-    !(value instanceof Blob) &&
-    !(value instanceof RegExp)
-  );
-}
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" &&
+  value !== null &&
+  !Array.isArray(value) &&
+  !(value instanceof Date) &&
+  !(value instanceof File) &&
+  !(value instanceof Blob) &&
+  !(value instanceof RegExp);
 
-export function camelCaseKeys<T>(value: T): CamelCaseKeys<T> {
+export const camelCaseKeys = <T>(value: T): CamelCaseKeys<T> => {
   if (Array.isArray(value)) {
     return value.map(camelCaseKeys) as CamelCaseKeys<T>;
   }
@@ -36,9 +31,9 @@ export function camelCaseKeys<T>(value: T): CamelCaseKeys<T> {
   }
 
   return value as CamelCaseKeys<T>;
-}
+};
 
-export function snakeCaseKeys<T>(value: T): LooseObject {
+export const snakeCaseKeys = <T>(value: T): LooseObject => {
   if (Array.isArray(value)) {
     return value.map(snakeCaseKeys);
   }
@@ -54,4 +49,4 @@ export function snakeCaseKeys<T>(value: T): LooseObject {
   }
 
   return value as LooseObject;
-}
+};

--- a/frontend/src/utilities/case.ts
+++ b/frontend/src/utilities/case.ts
@@ -1,0 +1,57 @@
+export function toCamelCase(value: string): string {
+  return value.replace(/_(.)/g, (_, char) => char.toUpperCase());
+}
+
+export function toSnakeCase(value: string): string {
+  return value
+    .replace(/([A-Z]+)/g, (_, chars) => `_${chars.toLowerCase()}`)
+    .replace(/^_/, "");
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    !(value instanceof Date) &&
+    !(value instanceof File) &&
+    !(value instanceof Blob) &&
+    !(value instanceof RegExp)
+  );
+}
+
+export function camelCaseKeys<T>(value: T): CamelCaseKeys<T> {
+  if (Array.isArray(value)) {
+    return value.map(camelCaseKeys) as CamelCaseKeys<T>;
+  }
+
+  if (isPlainObject(value)) {
+    const result: Record<string, unknown> = {};
+
+    for (const [key, val] of Object.entries(value)) {
+      result[toCamelCase(key)] = camelCaseKeys(val);
+    }
+
+    return result as CamelCaseKeys<T>;
+  }
+
+  return value as CamelCaseKeys<T>;
+}
+
+export function snakeCaseKeys<T>(value: T): LooseObject {
+  if (Array.isArray(value)) {
+    return value.map(snakeCaseKeys);
+  }
+
+  if (isPlainObject(value)) {
+    const result: Record<string, unknown> = {};
+
+    for (const [key, val] of Object.entries(value)) {
+      result[toSnakeCase(key)] = snakeCaseKeys(val);
+    }
+
+    return result;
+  }
+
+  return value as LooseObject;
+}

--- a/frontend/src/utilities/index.ts
+++ b/frontend/src/utilities/index.ts
@@ -69,4 +69,5 @@ export function toPython(value: boolean): PythonBoolean {
 
 export * from "./env";
 export * from "./hooks";
+export * from "./case";
 export * from "./validate";


### PR DESCRIPTION
This PR starts paying down the frontend's camelcase lint debt. Until now, backend snake_case fields were used directly in the UI, forcing the codebase to carry 37+ eslint-disable camelcase comments and a permissive camelcase: "warn" rule.

We introduce a small, type-safe case-conversion utility and a CamelCaseKeys<> mapped type, then pilot the pattern on the History/Blacklist vertical slice. The backend contract stays snake_case at the API boundary, but the rest of the app now consumes camelCase types.