### PR TITLE
Fixed Subsource provider querying Brazilian Portuguese as generic Portuguese

### DIFF
--- a/custom_libs/subliminal_patch/converters/subsource.py
+++ b/custom_libs/subliminal_patch/converters/subsource.py
@@ -130,6 +130,8 @@ class SubsourceConverter(LanguageReverseConverter):
     def convert(self, alpha3, country=None, script=None):
         if (alpha3, country, script) in self.to_subsource:
             return self.to_subsource[(alpha3, country, script)]
+        if country and (alpha3, country) in self.to_subsource:
+            return self.to_subsource[(alpha3, country)]
         if (alpha3,) in self.to_subsource:
             return self.to_subsource[(alpha3,)]
 

--- a/tests/subliminal_patch/test_subsource.py
+++ b/tests/subliminal_patch/test_subsource.py
@@ -1,0 +1,22 @@
+# coding=utf-8
+from babelfish import Language
+
+from subliminal_patch.converters.subsource import SubsourceConverter
+
+
+def test_convert_brazilian_portuguese():
+    # pt-BR must map to the Brazilian name, not generic Portuguese. The mapping is
+    # stored under the two-tuple key ('por', 'BR'), so convert() must look it up.
+    converter = SubsourceConverter()
+    language = Language("por", "BR")
+    assert converter.convert(language.alpha3, language.country, language.script) == "Brazillian Portuguese"
+
+
+def test_convert_plain_portuguese_still_works():
+    converter = SubsourceConverter()
+    assert converter.convert("por") == "Portuguese"
+
+
+def test_convert_brazilian_portuguese_round_trip():
+    converter = SubsourceConverter()
+    assert converter.convert(*converter.reverse("Brazillian Portuguese")) == "Brazillian Portuguese"


### PR DESCRIPTION
**What**: `SubsourceConverter.convert()` returned `Portuguese` for `pt-BR` instead of `Brazillian Portuguese`, so Subsource searches for Brazilian Portuguese were sent to the API with the wrong `language` filter (one of Bazarr's most common languages).

**Why**: The `Brazillian Portuguese` mapping is stored under the two-tuple key `('por', 'BR')`, but `convert()` only checked the three-tuple `(alpha3, country, script)` and the one-tuple `(alpha3,)`. `Language('por', 'BR')` therefore fell through to the one-tuple branch and returned generic `Portuguese`. The sibling `SubsarrConverter.convert()` already has the correct two-tuple guard; this brings `SubsourceConverter` in line.

**Fix**: Add the missing `(alpha3, country)` lookup. Added `tests/subliminal_patch/test_subsource.py` covering the pt-BR conversion, plain Portuguese, and the round-trip (fails before, passes after).

**Testing**: Isolated pytest, fail-before (`2 failed`) / pass-after (`3 passed`). AI-assisted per CONTRIBUTING; the change is a two-line fix and fully understood/reviewed by me.
