### PR TITLE
no log: Remove eslint disable

### DIFF
--- a/frontend/src/components/forms/TwoPointFit.tsx
+++ b/frontend/src/components/forms/TwoPointFit.tsx
@@ -92,8 +92,7 @@ const TwoPointFitForm: FunctionComponent<Props> = ({
     form.setFieldValue("first.to", lineStartToTime(firstLine.start));
     form.setFieldValue("last.line", lastLine);
     form.setFieldValue("last.to", lineStartToTime(lastLine.start));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [lines]);
+  }, [form, lines]);
 
   const wrongOrder = useMemo(() => {
     const { first, last } = form.values;

--- a/frontend/src/components/tables/SimpleTable.tsx
+++ b/frontend/src/components/tables/SimpleTable.tsx
@@ -1,4 +1,4 @@
-import { MutableRefObject, useEffect, useMemo } from "react";
+import { MutableRefObject, useEffect, useMemo, useRef } from "react";
 import {
   getCoreRowModel,
   Row,
@@ -48,14 +48,14 @@ export default function SimpleTable<T extends object>(
 
   const memoizedRows = useMemo(() => selectedRows, [selectedRows]);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const memoizedRowSelectionChanged = useMemo(() => onRowSelectionChanged, []);
+  const onRowSelectionChangedRef = useRef(onRowSelectionChanged);
+  onRowSelectionChangedRef.current = onRowSelectionChanged;
 
   const isAllRowsExpanded = instance.getIsAllRowsExpanded();
 
   useEffect(() => {
-    memoizedRowSelectionChanged?.(memoizedRows);
-  }, [memoizedRowSelectionChanged, memoizedRows]);
+    onRowSelectionChangedRef.current?.(memoizedRows);
+  }, [memoizedRows]);
 
   useEffect(() => {
     onAllRowsExpandedChanged?.(isAllRowsExpanded);

--- a/frontend/src/pages/Settings/Notifications/index.tsx
+++ b/frontend/src/pages/Settings/Notifications/index.tsx
@@ -1,10 +1,9 @@
-// eslint-disable-next-line simple-import-sort/imports
 import { FunctionComponent } from "react";
 import { Anchor, Blockquote, Text } from "@mantine/core";
-import { Check, Layout, Message, Section } from "@/pages/Settings/components";
-import { NotificationView } from "./components";
 import { faQuoteLeftAlt } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Check, Layout, Message, Section } from "@/pages/Settings/components";
+import { NotificationView } from "./components";
 
 const SettingsNotificationsView: FunctionComponent = () => {
   return (

--- a/frontend/src/tests/setup.tsx
+++ b/frontend/src/tests/setup.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-empty-function */
-
 import { http } from "msw";
 import { HttpResponse } from "msw";
 import { vi, vitest } from "vitest";
@@ -35,14 +33,20 @@ Object.defineProperty(window, "matchMedia", {
 
 // From https://github.com/mantinedev/mantine/blob/master/configuration/jest/jsdom.mocks.js
 class ResizeObserver {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
+  observe() {
+    return undefined;
+  }
+  unobserve() {
+    return undefined;
+  }
+  disconnect() {
+    return undefined;
+  }
 }
 
 window.ResizeObserver = ResizeObserver;
 
-window.scrollTo = () => {};
+window.scrollTo = () => undefined;
 
 beforeAll(() => {
   server.listen({ onUnhandledRequest: "error" });

--- a/frontend/src/utilities/console.ts
+++ b/frontend/src/utilities/console.ts
@@ -37,5 +37,4 @@ export function GROUP(
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-export const ASSERT = isProdEnv ? () => {} : console.assert;
+export const ASSERT = isProdEnv ? () => undefined : console.assert;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 /// <reference types="vitest" />
 /// <reference types="vite/client" />
 /// <reference types="node" />


### PR DESCRIPTION
# Description

This PR cleans up the remaining `eslint-disable` comments in `src` and removes a stale disable from `vite.config.ts`. There are no intentional runtime behavior changes; the only executable changes are internal hook fixes.