### PR TITLE
no log: Remove loose object

### DIFF
--- a/frontend/src/apis/hooks/system.ts
+++ b/frontend/src/apis/hooks/system.ts
@@ -61,7 +61,8 @@ export function useSettingsMutation() {
   const client = useQueryClient();
   return useMutation({
     mutationKey: [QueryKeys.System, QueryKeys.Settings],
-    mutationFn: (data: LooseObject) => api.system.updateSettings(data),
+    mutationFn: (data: Record<string, unknown>) =>
+      api.system.updateSettings(data),
 
     onSuccess: () => {
       void client.invalidateQueries({

--- a/frontend/src/apis/raw/base.ts
+++ b/frontend/src/apis/raw/base.ts
@@ -8,20 +8,21 @@ class BaseApi {
     this.prefix = prefix;
   }
 
-  private createFormdata(object?: LooseObject) {
-    if (object) {
+  private createFormdata(object?: unknown) {
+    const record = object as Record<string, unknown> | undefined;
+    if (record) {
       const form = new FormData();
 
-      for (const key in object) {
-        const data = object[key];
+      for (const key in record) {
+        const data = record[key];
         if (data instanceof Array) {
           if (data.length > 0) {
-            data.forEach((val) => form.append(key, val));
+            data.forEach((val) => form.append(key, val as string | Blob));
           } else {
             form.append(key, "");
           }
         } else {
-          form.append(key, object[key]);
+          form.append(key, data as string | Blob);
         }
       }
       return form;
@@ -30,39 +31,46 @@ class BaseApi {
     }
   }
 
-  protected async get<T = unknown>(path: string, params?: LooseObject) {
-    const response = await client.axios.get<T>(this.prefix + path, { params });
+  protected async get<T = unknown>(path: string, params?: unknown) {
+    const response = await client.axios.get<T>(this.prefix + path, {
+      params: params as Record<string, unknown> | undefined,
+    });
     return response.data;
   }
 
   protected post<T = void>(
     path: string,
-    formdata?: LooseObject,
-    params?: LooseObject,
+    formdata?: unknown,
+    params?: unknown,
   ): Promise<AxiosResponse<T>> {
     const form = this.createFormdata(formdata);
     return client.axios.post(this.prefix + path, form, {
-      params,
+      params: params as Record<string, unknown> | undefined,
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
     });
   }
 
   protected patch<T = void>(
     path: string,
-    formdata?: LooseObject,
-    params?: LooseObject,
+    formdata?: unknown,
+    params?: unknown,
   ): Promise<AxiosResponse<T>> {
     const form = this.createFormdata(formdata);
-    return client.axios.patch(this.prefix + path, form, { params });
+    return client.axios.patch(this.prefix + path, form, {
+      params: params as Record<string, unknown> | undefined,
+    });
   }
 
   protected delete<T = void>(
     path: string,
-    formdata?: LooseObject,
-    params?: LooseObject,
+    formdata?: unknown,
+    params?: unknown,
   ): Promise<AxiosResponse<T>> {
     const form = this.createFormdata(formdata);
-    return client.axios.delete(this.prefix + path, { params, data: form });
+    return client.axios.delete(this.prefix + path, {
+      params: params as Record<string, unknown> | undefined,
+      data: form,
+    });
   }
 }
 

--- a/frontend/src/apis/raw/system.ts
+++ b/frontend/src/apis/raw/system.ts
@@ -31,8 +31,9 @@ class SystemApi extends BaseApi {
     return response;
   }
 
-  async updateSettings(data: object) {
-    await this.post("/settings", data);
+  async updateSettings(data: unknown) {
+    const response = await this.post("/settings", data);
+    return response.data;
   }
 
   async languages(history = false) {

--- a/frontend/src/apis/raw/utils.ts
+++ b/frontend/src/apis/raw/utils.ts
@@ -13,7 +13,7 @@ type UrlTestResponse =
     };
 
 class RequestUtils {
-  async urlTest(protocol: string, url: string, params?: LooseObject) {
+  async urlTest(protocol: string, url: string, params?: unknown) {
     try {
       const result = await client.axios.get<UrlTestResponse>(
         `../test/${protocol}/${url}api/system/status`,
@@ -34,7 +34,7 @@ class RequestUtils {
     }
   }
 
-  async providerUrlTest(protocol: string, url: string, params?: LooseObject) {
+  async providerUrlTest(protocol: string, url: string, params?: unknown) {
     const result = await client.axios.get<UrlTestResponse>(
       `../test/${protocol}/${url}status`,
       { params },

--- a/frontend/src/modules/socketio/reducer.ts
+++ b/frontend/src/modules/socketio/reducer.ts
@@ -230,11 +230,13 @@ export function createDefaultReducer(): SocketIO.Reducer[] {
           // If progress_value is present (not null/undefined), apply (with progress_message and status) directly to
           // cache without an API call
           if (isNumber(payload.progress_value)) {
-            const current = queryClient.getQueryData<LooseObject[]>(keys) || [];
+            const current = queryClient.getQueryData<System.Jobs[]>(keys) || [];
             const idx = current.findIndex((j) => j.job_id === payload.job_id);
 
             const initialJob =
-              idx >= 0 ? { ...current[idx] } : { job_id: payload.job_id };
+              idx >= 0
+                ? { ...current[idx] }
+                : ({ job_id: payload.job_id } as System.Jobs);
 
             const updatedJob = {
               ...initialJob,
@@ -276,7 +278,7 @@ export function createDefaultReducer(): SocketIO.Reducer[] {
           );
           void api.system
             .jobs(payload.job_id)
-            .then((resp: LooseObject[] | undefined) => {
+            .then((resp: System.Jobs[] | undefined) => {
               const incomingJobs = isArray(resp) ? resp : [];
               if (isEmpty(incomingJobs)) {
                 return;
@@ -284,7 +286,7 @@ export function createDefaultReducer(): SocketIO.Reducer[] {
               const incoming = incomingJobs[0];
 
               const current =
-                queryClient.getQueryData<LooseObject[]>(keys) || [];
+                queryClient.getQueryData<System.Jobs[]>(keys) || [];
 
               const idx = current.findIndex(
                 (j) => j.job_id === incoming.job_id,

--- a/frontend/src/pages/Settings/Languages/table.tsx
+++ b/frontend/src/pages/Settings/Languages/table.tsx
@@ -41,7 +41,7 @@ const Table: FunctionComponent = () => {
         const raw: Language.RawProfile[] = value.map((profile) => ({
           ...profile,
           items: profile.items.map(
-            (item) => snakeCaseKeys(item) as Language.RawProfileItem,
+            (item) => snakeCaseKeys(item) as unknown as Language.RawProfileItem,
           ),
         }));
 

--- a/frontend/src/pages/Settings/Providers/components.tsx
+++ b/frontend/src/pages/Settings/Providers/components.tsx
@@ -135,9 +135,9 @@ interface ProviderToolProps {
   payload: ProviderInfo | null;
   // TODO: Find a better solution to pass this info to modal
   enabledProviders: readonly string[];
-  staged: LooseObject;
+  staged: Record<string, unknown>;
   settings: Settings;
-  onChange: (v: LooseObject) => void;
+  onChange: (v: Record<string, unknown>) => void;
   availableOptions: Readonly<ProviderInfo[]>;
   settingsKey: Readonly<SettingsKey>;
 }

--- a/frontend/src/pages/Settings/utilities/FormValues.ts
+++ b/frontend/src/pages/Settings/utilities/FormValues.ts
@@ -27,7 +27,7 @@ export function useFormActions() {
   const formRef = useRef(form);
   formRef.current = form;
 
-  const update = useCallback((object: LooseObject) => {
+  const update = useCallback((object: Record<string, unknown>) => {
     LOG("info", `Updating values`, object);
     formRef.current.setValues((values) => {
       const changes = { ...values.settings, ...object };
@@ -61,9 +61,7 @@ export type HookType = (value: unknown) => unknown;
 export type FormKey = keyof FormValues;
 export type FormValues = {
   // Settings that saved to the backend
-  settings: LooseObject;
-  // Settings that saved to the frontend
-  // storages: LooseObject;
+  settings: Record<string, unknown>;
 
   // submit hooks
   hooks: StrictObject<HookType>;

--- a/frontend/src/pages/Settings/utilities/hooks.ts
+++ b/frontend/src/pages/Settings/utilities/hooks.ts
@@ -93,9 +93,9 @@ export function useUpdateArray<T>(
   const compareRef = useRef(compare);
   compareRef.current = compare;
 
-  const staged: T[] = useMemo(() => {
+  const staged: Readonly<T[]> = useMemo(() => {
     if (key in stagedValue) {
-      return stagedValue[key];
+      return stagedValue[key] as T[];
     } else {
       return current;
     }

--- a/frontend/src/types/utilities.d.ts
+++ b/frontend/src/types/utilities.d.ts
@@ -20,11 +20,6 @@ type CamelCaseKeys<T> =
         ? { [K in keyof T as CamelCase<K & string>]: CamelCaseKeys<T[K]> }
         : T;
 
-type LooseObject = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
-};
-
 type StrictObject<T> = {
   [key: string]: T;
 };

--- a/frontend/src/utilities/case.ts
+++ b/frontend/src/utilities/case.ts
@@ -31,7 +31,11 @@ export const camelCaseKeys = <T>(value: T): CamelCaseKeys<T> => {
   return value as CamelCaseKeys<T>;
 };
 
-export const snakeCaseKeys = <T>(value: T): LooseObject => {
+export function snakeCaseKeys<T>(value: T[]): Record<string, unknown>[];
+export function snakeCaseKeys<T>(value: T): Record<string, unknown>;
+export function snakeCaseKeys<T>(
+  value: T | T[],
+): Record<string, unknown> | Record<string, unknown>[] {
   if (Array.isArray(value)) {
     return value.map(snakeCaseKeys);
   }
@@ -46,5 +50,5 @@ export const snakeCaseKeys = <T>(value: T): LooseObject => {
     return result;
   }
 
-  return value as LooseObject;
-};
+  return value as Record<string, unknown>;
+}

--- a/frontend/src/utilities/storage.ts
+++ b/frontend/src/utilities/storage.ts
@@ -1,16 +1,6 @@
-import { useCallback } from "react";
 import { useSystemSettings } from "@/apis/hooks";
 
 export const uiPageSizeKey = "settings-general-page_size";
-
-export function useUpdateLocalStorage() {
-  return useCallback((newVals: LooseObject) => {
-    for (const key in newVals) {
-      const value = newVals[key];
-      localStorage.setItem(key, value);
-    }
-  }, []);
-}
 
 export function usePageSize() {
   const settings = useSystemSettings();


### PR DESCRIPTION
This PR removes the `LooseObject` type alias from `src/types/utilities.d.ts` and migrates all of its usages to `Record<string, unknown>` or `unknown`. This eliminates the last `// eslint-disable-next-line @typescript-eslint/no-explicit-any` comment in `src`.

`LooseObject` was effectively `Record<string, any>`, which turned off type checking for dynamic object values. Replacing it with `unknown`/`Record<string, unknown>` forces explicit handling of those values.