### PR TITLE
Fixed subdl provider not detecting hearing-impaired markers in release names

### DIFF
--- a/custom_libs/subliminal_patch/providers/subdl.py
+++ b/custom_libs/subliminal_patch/providers/subdl.py
@@ -544,7 +544,7 @@ class SubdlProvider(Provider):
             return True
 
         # Comments or release names include some specific strings
-        hi_keys = [item.get('comment', '').lower(), [x.lower() for x in item.get('releases', [])]]
+        hi_keys = [item.get('comment', '').lower()] + [x.lower() for x in item.get('releases', [])]
         hi_tag = ['_hi_', ' hi ', '.hi.', 'hi ', ' hi', 'sdh', '𝓢𝓓𝓗']
         for key in hi_keys:
             if any(x in key for x in hi_tag):

--- a/tests/subliminal_patch/test_subdl.py
+++ b/tests/subliminal_patch/test_subdl.py
@@ -299,6 +299,39 @@ def test_download_ai_translation_job_failure(requests_mock, mocker):
     assert sub.content is None
 
 
+def test_is_hi_marker_in_comment():
+    # An HI/SDH marker in the uploader comment flags the subtitle as hearing impaired.
+    item = {
+        "comment": "SDH version",
+        "name": "dune-en.zip",
+        "releases": [MATCHING_RELEASE],
+    }
+    assert SubdlProvider._is_hi(item) is True
+
+
+def test_is_hi_marker_in_release_name():
+    # An HI/SDH marker present only in a release name must be detected too. This
+    # used to be a dead branch: the release names were nested as a list inside
+    # hi_keys, so `x in key` did exact list membership instead of the intended
+    # substring scan and never matched a real release name.
+    item = {
+        "comment": "",
+        "name": "dune-en.zip",
+        "releases": ["Dune.2021.1080p.WEBRip.DD5.1.x264.SDH-SHITBOX"],
+    }
+    assert SubdlProvider._is_hi(item) is True
+
+
+def test_is_hi_negative():
+    # No HI markers anywhere: not hearing impaired.
+    item = {
+        "comment": "great subtitle",
+        "name": "dune-en.zip",
+        "releases": [MATCHING_RELEASE, OTHER_RELEASE],
+    }
+    assert SubdlProvider._is_hi(item) is False
+
+
 def test_list_subtitles_movie(provider, movies, languages):
     for sub in provider.list_subtitles(movies["dune"], {languages["en"]}):
         assert sub.language == languages["en"]


### PR DESCRIPTION
`SubdlProvider._is_hi()` was meant to scan both the uploader comment and the release names for HI/SDH markers (per its own comment: "Comments or release names include some specific strings"). However, the release names were nested as a list inside `hi_keys`, so `x in key` performed exact list membership instead of a substring scan - the release-name branch could never match a real release name. Subtitles whose only HI marker is in the release name (e.g. `Movie.2021.1080p.WEB.SDH-GROUP`) were misclassified as non-HI, giving wrong results for users who prefer or exclude hearing-impaired subtitles.

Fix: flatten `hi_keys` so the comment string and each release-name string are all substring-scanned, matching the sibling subsource provider's tag scan. Added pure (no-network) regression tests covering an HI marker in the comment, an HI marker only in a release name (the previously dead branch), and a non-HI case; the release-name test fails on `development` and passes with this change.

Disclosure: this fix was developed with the assistance of an AI tool (Claude), and I have reviewed and understand every line of the change.
