### PR TITLE
Added animetosho xyz provider

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -330,9 +330,6 @@ validators = [
     Validator('animetosho.anidb_api_client', must_exist=True, default='', is_type_of=str, cast=str),
     Validator('animetosho.anidb_api_client_ver', must_exist=True, default=1, is_type_of=int, gte=1, lte=9),
 
-    # animetosho_xyz section
-    Validator('animetosho_xyz.api_key', must_exist=True, default='', is_type_of=str, cast=str),
-
     # avistaz section
     Validator('avistaz.cookies', must_exist=True, default='', is_type_of=str),
     Validator('avistaz.user_agent', must_exist=True, default='', is_type_of=str),

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -330,6 +330,9 @@ validators = [
     Validator('animetosho.anidb_api_client', must_exist=True, default='', is_type_of=str, cast=str),
     Validator('animetosho.anidb_api_client_ver', must_exist=True, default=1, is_type_of=int, gte=1, lte=9),
 
+    # animetosho_xyz section
+    Validator('animetosho_xyz.api_key', must_exist=True, default='', is_type_of=str, cast=str),
+
     # avistaz section
     Validator('avistaz.cookies', must_exist=True, default='', is_type_of=str),
     Validator('avistaz.user_agent', must_exist=True, default='', is_type_of=str),

--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -343,6 +343,9 @@ def get_providers_auth():
         "animetosho": {
             'search_threshold': settings.animetosho.search_threshold,
         },
+        "animetosho_xyz": {
+            'api_key': settings.animetosho_xyz.api_key,
+        },
         "subdl": {
             'api_key': settings.subdl.api_key,
             'ai_translate': settings.subdl.ai_translate,

--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -343,9 +343,7 @@ def get_providers_auth():
         "animetosho": {
             'search_threshold': settings.animetosho.search_threshold,
         },
-        "animetosho_xyz": {
-            'api_key': settings.animetosho_xyz.api_key,
-        },
+        "animetosho_xyz": {},
         "subdl": {
             'api_key': settings.subdl.api_key,
             'ai_translate': settings.subdl.ai_translate,

--- a/bazarr/subtitles/refiners/anidb.py
+++ b/bazarr/subtitles/refiners/anidb.py
@@ -20,8 +20,8 @@ except ImportError:
     except ImportError:
         import xml.etree.ElementTree as etree
 
-refined_providers = {'animetosho', 'jimaku'}
-providers_requiring_anidb_api = {'animetosho'}
+refined_providers = {'animetosho', 'animetosho_xyz', 'jimaku'}
+providers_requiring_anidb_api = {'animetosho', 'animetosho_xyz'}
 
 logger = logging.getLogger(__name__)
 

--- a/custom_libs/subliminal_patch/providers/animetosho_xyz.py
+++ b/custom_libs/subliminal_patch/providers/animetosho_xyz.py
@@ -70,15 +70,12 @@ class AnimeToshoXYZProvider(Provider, ProviderSubtitleArchiveMixin):
     languages = {Language('por', 'BR')} | {Language(sl) for sl in supported_languages}
     video_types = Episode
 
-    def __init__(self, api_key=None):
+    def __init__(self):
         self.session = None
-        self.api_key = api_key
 
     def initialize(self):
         self.session = Session()
         self.session.headers.update({'User-Agent': os.environ.get("SZ_USER_AGENT", "Bazarr")})
-        if self.api_key:
-            self.session.headers.update({'X-Api-Key': self.api_key})
 
     def terminate(self):
         self.session.close()

--- a/custom_libs/subliminal_patch/providers/animetosho_xyz.py
+++ b/custom_libs/subliminal_patch/providers/animetosho_xyz.py
@@ -1,0 +1,201 @@
+# -*- coding: utf-8 -*-
+import logging
+import lzma
+import os
+from typing import Callable
+
+from guessit import guessit
+from requests import Session, Response
+from subzero.language import Language
+
+from subliminal.exceptions import ProviderError
+from subliminal_patch.providers import Provider
+from subliminal_patch.providers.mixins import ProviderSubtitleArchiveMixin
+from subliminal_patch.subtitle import Subtitle, guess_matches
+from subliminal.video import Episode
+
+logger = logging.getLogger(__name__)
+
+supported_languages = [
+    "ara",
+    "eng",
+    "fin",
+    "fra",
+    "deu",
+    "heb",
+    "ind",
+    "ita",
+    "jpn",
+    "por",
+    "pol",
+    "rus",
+    "spa",
+    "swe",
+    "tha",
+    "tur",
+    "vie",
+]
+
+
+class AnimeToshoXYZSubtitle(Subtitle):
+    provider_name = 'animetosho_xyz'
+
+    def __init__(self, language, download_link, meta, release_info):
+        super(AnimeToshoXYZSubtitle, self).__init__(
+            language,
+            page_link=download_link,
+        )
+        self.meta = meta
+        self.download_link = download_link
+        self.release_info = release_info
+        self.matches = set()
+
+    @property
+    def id(self):
+        return self.download_link
+
+    def get_matches(self, video):
+        self.matches |= guess_matches(video, guessit(self.meta.get('torrent_name', '')))
+
+        # Add these data are explicit extracted from the API and they always have to match otherwise they wouldn't
+        # arrive at this point and would stop on list_subtitles.
+        self.matches.update(['series', 'season', 'episode'])
+
+        return self.matches
+
+
+class AnimeToshoXYZProvider(Provider, ProviderSubtitleArchiveMixin):
+    provider_name = 'animetosho_xyz'
+    subtitle_class = AnimeToshoXYZSubtitle
+    languages = {Language('por', 'BR')} | {Language(sl) for sl in supported_languages}
+    video_types = Episode
+
+    def __init__(self, api_key=None):
+        self.session = None
+        self.api_key = api_key
+
+    def initialize(self):
+        self.session = Session()
+        self.session.headers.update({'User-Agent': os.environ.get("SZ_USER_AGENT", "Bazarr")})
+        if self.api_key:
+            self.session.headers.update({'X-Api-Key': self.api_key})
+
+    def terminate(self):
+        self.session.close()
+
+    def checked(self, fn: Callable) -> Response:
+        """
+        Executes the provided function and performs error handling and response validation for API calls.
+
+        :param fn: The callable function that makes the HTTP request.
+        :type fn: Callable
+        :return: The HTTP response object returned by the provided function if the status code is valid.
+        :rtype: Response
+        :raises ProviderError: If an unhandled exception occurs or the endpoint is not found.
+        """
+        response = None
+        try:
+            response = fn()
+        except Exception:
+            logger.exception('Unhandled exception raised.')
+            raise ProviderError('Unhandled exception raised. Check log.')
+        else:
+            status_code = response.status_code
+            if status_code == 404:
+                logger.error(f"Endpoint not found: {response.url}")
+                raise ProviderError("Endpoint not found")
+            elif status_code != 200:
+                logger.error(f"HTTP error {status_code} for {response.url}")
+                raise ProviderError(f"HTTP error {status_code}")
+
+            return response
+
+    def list_subtitles(self, video, languages):
+        if not video.series_anidb_episode_id:
+            logger.debug('Skipping video %r. It is not an anime or the anidb_episode_id could not be identified', video)
+            return []
+
+        episode_id = video.series_anidb_episode_id
+        if isinstance(episode_id, (list, tuple)):
+            episode_id = episode_id[-1] if episode_id else None
+
+        if not episode_id:
+            return []
+
+        return [s for s in self._get_series(episode_id) if s.language in languages]
+
+    def download_subtitle(self, subtitle):
+        logger.info('Downloading subtitle %r', subtitle)
+
+        r = self.checked(lambda: self.session.get(subtitle.page_link, timeout=10))
+
+        if not self._is_xz_file(r.content):
+            raise ProviderError('Unidentified archive type')
+
+        subtitle.content = lzma.decompress(r.content)
+        return subtitle
+
+    @staticmethod
+    def _is_xz_file(content):
+        return content.startswith(b'\xFD\x37\x7A\x58\x5A\x00')
+
+    def _get_series(self, episode_id):
+        detail_api_url = 'https://feed.animetosho.xyz/json'
+
+        subtitles = []
+        entries = self._get_series_entries(episode_id)
+
+        for entry in entries:
+            r = self.checked(
+                lambda: self.session.get(
+                    detail_api_url,
+                    params={
+                        'show': 'torrent',
+                        'id': entry['id'],
+                    },
+                    timeout=10
+                )
+            )
+
+            torrent_data = r.json()
+            attachments = torrent_data.get('attachments', [])
+
+            subtitle_files = list(filter(lambda a: a.get('type') == 'subtitle', attachments))
+
+            for subtitle_file in subtitle_files:
+                info = subtitle_file.get('info', {})
+                lang_code = info.get('language_code', 'eng')
+                lang = Language.fromalpha3b(lang_code)
+
+                if lang.alpha3 == 'por' and 'brazil' in info.get('language', '').lower():
+                    lang = Language('por', 'BR')
+
+                subtitle = self.subtitle_class(
+                    lang,
+                    subtitle_file['url'],
+                    meta=torrent_data,
+                    release_info=entry.get('title'),
+                )
+
+                logger.debug('Found subtitle %r', subtitle)
+                subtitles.append(subtitle)
+
+        return subtitles
+
+    def _get_series_entries(self, episode_id):
+        api_url = 'https://feed.animetosho.xyz/feed/json'
+
+        r = self.checked(
+            lambda: self.session.get(
+                api_url,
+                params={
+                    'eid': episode_id,
+                },
+                timeout=10
+            )
+        )
+
+        j = r.json()
+        entries = list(filter(lambda t: t['status'] == 'complete', j))
+        entries.sort(key=lambda t: t['timestamp'], reverse=True)
+        return entries

--- a/frontend/src/pages/Settings/Providers/list.ts
+++ b/frontend/src/pages/Settings/Providers/list.ts
@@ -89,6 +89,20 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
     message: "Requires AniDB Integration.",
   },
   {
+    key: "animetosho_xyz",
+    name: "AnimeTosho.xyz",
+    description:
+      "AnimeTosho.xyz is a free, completely automated service which mirrors most torrents posted on TokyoTosho's anime category, Nyaa.si's English translated anime category and AniDex's anime category.",
+    inputs: [
+      {
+        type: "password",
+        key: "api_key",
+        name: "API Key (optional, for higher rate limits)",
+      },
+    ],
+    message: "Requires AniDB Integration.",
+  },
+  {
     key: "animesubinfo",
     name: "AnimeSub.info",
     description: "Polish Anime Subtitles Provider",

--- a/frontend/src/pages/Settings/Providers/list.ts
+++ b/frontend/src/pages/Settings/Providers/list.ts
@@ -93,13 +93,6 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
     name: "AnimeTosho.xyz",
     description:
       "AnimeTosho.xyz is a free, completely automated service which mirrors most torrents posted on TokyoTosho's anime category, Nyaa.si's English translated anime category and AniDex's anime category.",
-    inputs: [
-      {
-        type: "password",
-        key: "api_key",
-        name: "API Key (optional, for higher rate limits)",
-      },
-    ],
     message: "Requires AniDB Integration.",
   },
   {

--- a/tests/subliminal_patch/data/animetosho_xyz_episode_response.json
+++ b/tests/subliminal_patch/data/animetosho_xyz_episode_response.json
@@ -1,0 +1,32 @@
+[
+    {
+        "id": 622245,
+        "title": "[Erai-raws] Crowned in a Hundred Days - 08 (CA) [1080p CR WEB-DL AVC AAC][MultiSub][81FBD56D]",
+        "link": "https://animetosho.xyz/view/622245",
+        "timestamp": 1784290258,
+        "status": "complete",
+        "info_hash": "a4c15054401b20791299b0ca1321796967905a96",
+        "magnet_uri": "magnet:?xt=urn:btih:a4c15054401b20791299b0ca1321796967905a96",
+        "seeders": 1,
+        "leechers": 0,
+        "total_size": 659900000,
+        "num_files": 1,
+        "anidb_aid": 20151,
+        "anidb_eid": 313249
+    },
+    {
+        "id": 622243,
+        "title": "[Erai-raws] Crowned in a Hundred Days - 08 (CA) [720p CR WEB-DL AVC AAC][MultiSub][41121A85]",
+        "link": "https://animetosho.xyz/view/622243",
+        "timestamp": 1784290200,
+        "status": "complete",
+        "info_hash": "a08e8fea17b15fd4608516a06f0f7c40a5062db5",
+        "magnet_uri": "magnet:?xt=urn:btih:a08e8fea17b15fd4608516a06f0f7c40a5062db5",
+        "seeders": 0,
+        "leechers": 0,
+        "total_size": 350000000,
+        "num_files": 1,
+        "anidb_aid": 20151,
+        "anidb_eid": 313249
+    }
+]

--- a/tests/subliminal_patch/data/animetosho_xyz_series_response.json
+++ b/tests/subliminal_patch/data/animetosho_xyz_series_response.json
@@ -1,0 +1,68 @@
+{
+    "id": 622245,
+    "title": "[Erai-raws] Crowned in a Hundred Days - 08 (CA) [1080p CR WEB-DL AVC AAC][MultiSub][81FBD56D]",
+    "link": "https://animetosho.xyz/view/622245",
+    "timestamp": 1784290258,
+    "status": "complete",
+    "info_hash": "a4c15054401b20791299b0ca1321796967905a96",
+    "magnet_uri": "magnet:?xt=urn:btih:a4c15054401b20791299b0ca1321796967905a96",
+    "seeders": 1,
+    "leechers": 0,
+    "total_size": 659900000,
+    "num_files": 1,
+    "anidb_aid": 20151,
+    "anidb_eid": 313249,
+    "primary_file_id": 29120,
+    "files": [
+        {
+            "id": 29120,
+            "is_archive": false,
+            "filename": "[Erai-raws] Crowned in a Hundred Days - 08 (CA) [1080p CR WEB-DL AVC AAC][MultiSub][81FBD56D].mkv",
+            "size": 659900000,
+            "processed": true,
+            "crc32": "81fbd56d",
+            "md5": null,
+            "sha1": null,
+            "sha256": null,
+            "ed2k": null,
+            "attachments": []
+        }
+    ],
+    "attachments": [
+        {
+            "id": 127398,
+            "type": "other",
+            "size": 1024,
+            "url": "https://storage.animetosho.xyz/releases/622245/subtitles/archive.zip",
+            "info": {
+                "format": "ARCHIVE"
+            }
+        },
+        {
+            "id": 127399,
+            "type": "subtitle",
+            "size": 25988,
+            "url": "https://storage.animetosho.xyz/releases/622245/subtitles/eng.ass",
+            "info": {
+                "format": "ASS",
+                "language": "English",
+                "language_code": "eng",
+                "default": true,
+                "forced": false
+            }
+        },
+        {
+            "id": 127400,
+            "type": "subtitle",
+            "size": 27100,
+            "url": "https://storage.animetosho.xyz/releases/622245/subtitles/por.ass",
+            "info": {
+                "format": "ASS",
+                "language": "Portuguese[BR]",
+                "language_code": "por",
+                "default": false,
+                "forced": false
+            }
+        }
+    ]
+}

--- a/tests/subliminal_patch/test_animetosho_xyz.py
+++ b/tests/subliminal_patch/test_animetosho_xyz.py
@@ -104,36 +104,6 @@ def test_list_subtitles_no_anidb_episode_id():
         assert len(subtitles) == 0
 
 
-def test_provider_with_api_key(anime_episodes, requests_mock, data):
-    # Verify that the API key is correctly set in the session headers when provided.
-    # This is required for authenticated access to the AnimeTosho.xyz API.
-    language = Language("eng")
-    item = anime_episodes["crowned_s01e08"]
-
-    with open(os.path.join(data, 'animetosho_xyz_episode_response.json'), "rb") as f:
-        requests_mock.get(
-            'https://feed.animetosho.xyz/feed/json?eid=313249',
-            content=f.read()
-        )
-
-    with open(os.path.join(data, 'animetosho_xyz_series_response.json'), "rb") as f:
-        response = f.read()
-        requests_mock.get(
-            'https://feed.animetosho.xyz/json?show=torrent&id=622245',
-            content=response
-        )
-        requests_mock.get(
-            'https://feed.animetosho.xyz/json?show=torrent&id=622243',
-            content=response
-        )
-
-    with AnimeToshoXYZProvider(api_key="test_api_key_12345") as provider:
-        assert provider.api_key == "test_api_key_12345"
-        assert provider.session.headers.get('X-Api-Key') == "test_api_key_12345"
-        subtitles = provider.list_subtitles(item, languages={language})
-        assert len(subtitles) == 2
-
-
 def test_list_subtitles_with_episode_id_tuple(anime_episodes, requests_mock, data):
     # The AniDB refiner returns episode IDs as tuples (anime_id, episode_id), not lists.
     # This test ensures the provider correctly extracts the episode ID from a tuple,

--- a/tests/subliminal_patch/test_animetosho_xyz.py
+++ b/tests/subliminal_patch/test_animetosho_xyz.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+
+import os
+import pytest
+
+from subliminal_patch.core import Episode
+from subliminal_patch.providers.animetosho_xyz import AnimeToshoXYZProvider
+from subzero.language import Language
+
+
+@pytest.fixture(scope="session")
+def anime_episodes():
+    return {
+        "crowned_s01e08": Episode(
+            "[Erai-raws] Crowned in a Hundred Days - 08 (CA) [1080p CR WEB-DL AVC AAC][MultiSub][81FBD56D].mkv",
+            "Crowned in a Hundred Days",
+            1,
+            8,
+            source="Web",
+            series_anidb_id=20151,
+            series_anidb_episode_id=313249,
+            series_tvdb_id=447504,
+            series_imdb_id="tt32234060",
+            release_group="Erai-raws",
+            resolution="1080p",
+            video_codec="H.264",
+        ),
+    }
+
+
+def test_list_subtitles(anime_episodes, requests_mock, data):
+    # Basic functionality test: verify that the provider can fetch subtitles for an anime episode
+    # when given a valid AniDB episode ID. This is the happy path for the provider.
+    language = Language("eng")
+    item = anime_episodes["crowned_s01e08"]
+
+    with open(os.path.join(data, 'animetosho_xyz_episode_response.json'), "rb") as f:
+        requests_mock.get(
+            'https://feed.animetosho.xyz/feed/json?eid=313249',
+            content=f.read()
+        )
+
+    with open(os.path.join(data, 'animetosho_xyz_series_response.json'), "rb") as f:
+        response = f.read()
+        requests_mock.get(
+            'https://feed.animetosho.xyz/json?show=torrent&id=622245',
+            content=response
+        )
+        requests_mock.get(
+            'https://feed.animetosho.xyz/json?show=torrent&id=622243',
+            content=response
+        )
+
+    with AnimeToshoXYZProvider() as provider:
+        subtitles = provider.list_subtitles(item, languages={language})
+        assert len(subtitles) == 2
+        assert all(s.language == language for s in subtitles)
+
+
+def test_list_subtitles_with_portuguese_br(anime_episodes, requests_mock, data):
+    # Brazilian Portuguese must be correctly identified when the language name contains "brazil".
+    # This verifies the fix for the .find('brazil') bug that always returned truthy (-1).
+    language = Language("por", "BR")
+    item = anime_episodes["crowned_s01e08"]
+
+    with open(os.path.join(data, 'animetosho_xyz_episode_response.json'), "rb") as f:
+        requests_mock.get(
+            'https://feed.animetosho.xyz/feed/json?eid=313249',
+            content=f.read()
+        )
+
+    with open(os.path.join(data, 'animetosho_xyz_series_response.json'), "rb") as f:
+        response = f.read()
+        requests_mock.get(
+            'https://feed.animetosho.xyz/json?show=torrent&id=622245',
+            content=response
+        )
+        requests_mock.get(
+            'https://feed.animetosho.xyz/json?show=torrent&id=622243',
+            content=response
+        )
+
+    with AnimeToshoXYZProvider() as provider:
+        subtitles = provider.list_subtitles(item, languages={language})
+        assert len(subtitles) == 2
+        assert all(s.language == language for s in subtitles)
+
+
+def test_list_subtitles_no_anidb_episode_id():
+    # When no AniDB episode ID is available, the provider should return an empty list
+    # without making any API calls. This prevents unnecessary network requests.
+    item = Episode(
+        "Some.Show.S01E01.720p.WEB.x264.mkv",
+        "Some Show",
+        1,
+        1,
+        source="Web",
+        resolution="720p",
+        video_codec="H.264",
+    )
+
+    with AnimeToshoXYZProvider() as provider:
+        subtitles = provider.list_subtitles(item, languages={Language("eng")})
+        assert len(subtitles) == 0
+
+
+def test_provider_with_api_key(anime_episodes, requests_mock, data):
+    # Verify that the API key is correctly set in the session headers when provided.
+    # This is required for authenticated access to the AnimeTosho.xyz API.
+    language = Language("eng")
+    item = anime_episodes["crowned_s01e08"]
+
+    with open(os.path.join(data, 'animetosho_xyz_episode_response.json'), "rb") as f:
+        requests_mock.get(
+            'https://feed.animetosho.xyz/feed/json?eid=313249',
+            content=f.read()
+        )
+
+    with open(os.path.join(data, 'animetosho_xyz_series_response.json'), "rb") as f:
+        response = f.read()
+        requests_mock.get(
+            'https://feed.animetosho.xyz/json?show=torrent&id=622245',
+            content=response
+        )
+        requests_mock.get(
+            'https://feed.animetosho.xyz/json?show=torrent&id=622243',
+            content=response
+        )
+
+    with AnimeToshoXYZProvider(api_key="test_api_key_12345") as provider:
+        assert provider.api_key == "test_api_key_12345"
+        assert provider.session.headers.get('X-Api-Key') == "test_api_key_12345"
+        subtitles = provider.list_subtitles(item, languages={language})
+        assert len(subtitles) == 2
+
+
+def test_list_subtitles_with_episode_id_tuple(anime_episodes, requests_mock, data):
+    # The AniDB refiner returns episode IDs as tuples (anime_id, episode_id), not lists.
+    # This test ensures the provider correctly extracts the episode ID from a tuple,
+    # preventing the bug where both IDs were sent to the API, returning empty results.
+    language = Language("eng")
+    item = anime_episodes["crowned_s01e08"]
+    item.series_anidb_episode_id = (20151, 313249)
+
+    with open(os.path.join(data, 'animetosho_xyz_episode_response.json'), "rb") as f:
+        requests_mock.get(
+            'https://feed.animetosho.xyz/feed/json?eid=313249',
+            content=f.read()
+        )
+
+    with open(os.path.join(data, 'animetosho_xyz_series_response.json'), "rb") as f:
+        response = f.read()
+        requests_mock.get(
+            'https://feed.animetosho.xyz/json?show=torrent&id=622245',
+            content=response
+        )
+        requests_mock.get(
+            'https://feed.animetosho.xyz/json?show=torrent&id=622243',
+            content=response
+        )
+
+    with AnimeToshoXYZProvider() as provider:
+        subtitles = provider.list_subtitles(item, languages={language})
+        assert len(subtitles) == 2


### PR DESCRIPTION
## Summary

This PR adds a new subtitle provider for [AnimeTosho.xyz](https://animetosho.xyz), replacing the obsolete animetosho.org provider

## Motivation

The original AnimeTosho.org service is no longer operational. AnimeTosho.xyz is the replacement service with an updated API that provides better subtitle metadata and more reliable access.

The legacy provider still there because of the massive amount of data for old anime that still not migrated.

### New Provider Implementation

- Extracts episode IDs from AniDB refiner tuples
- Handles XZ-compressed subtitle archives

> I have contact with the admin, rurin1x, received the private API documentation and is aware of Bazarr consuming. User-Agent has been added to the requests so they can identify the request comes from Bazarr.

