### PR TITLE
Run backend unit tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,15 @@ jobs:
       - name: Install Python dependencies
         run: pip install -r requirements.txt
 
+      - name: Install test dependencies
+        run: pip install -r dev-requirements.txt
+
+      - name: Install media binaries
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg mediainfo
+
+      - name: Pytest
+        run: python -m pytest tests/bazarr
+
       - name: Unit Tests
         run: |
           bash '${{ env.SCRIPTS_DIRECTORY }}/build_test.sh'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,10 +1,9 @@
 sympy
 vcrpy>=1.6.1
 pytest
-pytest-pep8
 pytest-flakes
 pytest-cov
 pytest-vcr
 pytest-mock
 requests-mock
-setuptools
+setuptools<81

--- a/tests/bazarr/test_app_get_providers.py
+++ b/tests/bazarr/test_app_get_providers.py
@@ -34,7 +34,7 @@ def test_get_providers_auth_embeddedsubtitles():
     assert isinstance(item["cache_dir"], str)
     assert isinstance(item["ffprobe_path"], str)
     assert isinstance(item["ffmpeg_path"], str)
-    assert isinstance(item["timeout"], str)
+    assert isinstance(item["timeout"], int)
     assert isinstance(item["unknown_as_fallback"], bool)
     assert isinstance(item["fallback_lang"], str)
 
@@ -47,19 +47,27 @@ def test_get_providers_auth_karagarga():
     assert item["f_password"] is not None
 
 
+@pytest.fixture(autouse=True)
+def _restore_language_equals():
+    """Tests below mutate the process-wide settings object; restore it afterwards."""
+    original = get_providers.settings.general.language_equals
+    yield
+    get_providers.settings.set("general.language_equals", original)
+
+
 def test_get_language_equals_default_settings():
     assert isinstance(get_providers.get_language_equals(), list)
 
 
 def test_get_language_equals_injected_settings_invalid():
     config = get_providers.settings
-    config.set("general", "language_equals", '["invalid"]')
+    config.set("general.language_equals", ["invalid"])
     assert not get_providers.get_language_equals(config)
 
 
 def test_get_language_equals_injected_settings_valid():
     config = get_providers.settings
-    config.set("general", "language_equals", '["spa:spa-MX"]')
+    config.set("general.language_equals", ["spa:spa-MX"])
 
     result = get_providers.get_language_equals(config)
     assert result == [(Language("spa"), Language("spa", "MX"))]
@@ -68,9 +76,9 @@ def test_get_language_equals_injected_settings_valid():
 @pytest.mark.parametrize(
     "config_value,expected",
     [
-        ('["spa:spl"]', (Language("spa"), Language("spa", "MX"))),
-        ('["por:pob"]', (Language("por"), Language("por", "BR"))),
-        ('["zho:zht"]', (Language("zho"), Language("zho", "TW"))),
+        (["spa:spl"], (Language("spa"), Language("spa", "MX"))),
+        (["por:pob"], (Language("por"), Language("por", "BR"))),
+        (["zho:zht"], (Language("zho"), Language("zho", "TW"))),
     ],
 )
 def test_get_language_equals_injected_settings_custom_lang_alpha3(
@@ -78,7 +86,7 @@ def test_get_language_equals_injected_settings_custom_lang_alpha3(
 ):
     config = get_providers.settings
 
-    config.set("general", "language_equals", config_value)
+    config.set("general.language_equals", config_value)
 
     result = get_providers.get_language_equals(config)
     assert result == [expected]
@@ -87,11 +95,8 @@ def test_get_language_equals_injected_settings_custom_lang_alpha3(
 def test_get_language_equals_injected_settings_multiple():
     config = get_providers.settings
 
-    config.set(
-        "general",
-        "language_equals",
-        "['eng@hi:eng', 'spa:spl', 'spa@hi:spl', 'spl@hi:spl']",
-    )
+    config.set("general.language_equals",
+               ['eng@hi:eng', 'spa:spl', 'spa@hi:spl', 'spl@hi:spl'])
 
     result = get_providers.get_language_equals(config)
     assert len(result) == 4
@@ -99,7 +104,7 @@ def test_get_language_equals_injected_settings_multiple():
 
 def test_get_language_equals_injected_settings_valid_multiple():
     config = get_providers.settings
-    config.set("general", "language_equals", '["spa:spa-MX", "spa-MX:spa"]')
+    config.set("general.language_equals", ["spa:spa-MX", "spa-MX:spa"])
 
     result = get_providers.get_language_equals(config)
     assert result == [
@@ -110,7 +115,7 @@ def test_get_language_equals_injected_settings_valid_multiple():
 
 def test_get_language_equals_injected_settings_hi():
     config = get_providers.settings
-    config.set("general", "language_equals", '["eng@hi:eng"]')
+    config.set("general.language_equals", ["eng@hi:eng"])
 
     result = get_providers.get_language_equals(config)
     assert result == [(Language("eng", hi=True), Language("eng"))]

--- a/tests/bazarr/test_config.py
+++ b/tests/bazarr/test_config.py
@@ -3,8 +3,3 @@ from bazarr.app import config
 
 def test_get_settings():
     assert isinstance(config.get_settings(), dict)
-
-
-def test_get_scores():
-    assert isinstance(config.get_scores()["movie"], dict)
-    assert isinstance(config.get_scores()["episode"], dict)

--- a/tests/bazarr/test_jellyfin_operations.py
+++ b/tests/bazarr/test_jellyfin_operations.py
@@ -3,16 +3,9 @@
 All test data is validated against Jellyfin's OpenAPI spec via the fake client.
 """
 
-import sys
 from unittest.mock import patch, MagicMock
 
 import pytest
-
-# Mock app.config before importing operations
-mock_config = MagicMock()
-sys.modules.setdefault("app", MagicMock())
-sys.modules.setdefault("app.config", mock_config)
-mock_config.settings = MagicMock()
 
 from bazarr.jellyfin.operations import (
     jellyfin_test_connection,
@@ -22,6 +15,19 @@ from bazarr.jellyfin.operations import (
 )
 from fake_jellyfin import FakeJellyfinClient, make_movie, make_series, make_episode
 
+
+mock_settings = MagicMock()
+
+
+@pytest.fixture(autouse=True)
+def _mock_operations_settings(monkeypatch):
+    """Give the operations module a fake settings object, scoped to each test.
+
+    operations.py does `from app.config import settings`, which binds a `settings` name inside
+    that module; patching that name (instead of app.config itself) keeps the real configuration
+    intact for every other test in the session. monkeypatch undoes it automatically.
+    """
+    monkeypatch.setattr("bazarr.jellyfin.operations.settings", mock_settings)
 
 
 @pytest.fixture
@@ -34,7 +40,7 @@ def fake():
 
 @pytest.fixture
 def settings():
-    return mock_config.settings
+    return mock_settings
 
 
 

--- a/tests/bazarr/test_utilities_video_analyzer.py
+++ b/tests/bazarr/test_utilities_video_analyzer.py
@@ -230,9 +230,10 @@ def test_embedded_subs_reader(mocker, mediainfo_data, video_file):
         "bazarr.utilities.video_analyzer.alpha3_from_alpha2", return_value=None
     )
     result = video_analyzer.embedded_subs_reader(1e6, video_file)
-    assert ["spl", False, False, "SubRip"] in result
-    assert ["pob", False, False, "SubRip"] in result
-    assert ["zht", False, False, "SubRip"] in result
+    tracks_without_id = [row[1:] for row in result]
+    assert ["spl", False, False, "SubRip"] in tracks_without_id
+    assert ["pob", False, False, "SubRip"] in tracks_without_id
+    assert ["zht", False, False, "SubRip"] in tracks_without_id
 
 
 def test_embedded_audio_reader(mocker, mediainfo_data, video_file):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,22 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../libs/"))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../bazarr/"))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../custom_libs/"))
 
+
+def pytest_configure(config):
+    """Tests import bazarr modules directly, skipping the startup code that normally creates the
+    database directory and schema. Do the minimum of it here so the suite also runs from a fresh
+    checkout (e.g. CI)."""
+    os.makedirs(os.path.join(os.path.dirname(__file__), "..", "data", "db"), exist_ok=True)
+
+    from app.database import engine, metadata
+
+    metadata.create_all(engine)
+
+    from languages.get_languages import load_language_in_db
+
+    load_language_in_db()
+
+
 def pytest_report_header(config):
     conflicting_packages = _get_conflicting("libs")
     if conflicting_packages:


### PR DESCRIPTION
Add a Pytest step to the Backend job, ahead of the existing execution smoke test, and install ffmpeg/mediainfo explicitly (config validation hangs at startup when ffprobe is missing, and the video analyzer tests need mediainfo).

Make the suite runnable from a fresh checkout and in one process:
- create the database directory and schema in tests/conftest.py, as app startup would
- drop pytest-pep8 from dev-requirements.txt (abandoned since 2014; installing it makes modern pytest fail to start) and pin setuptools<81 for the pkg_resources import in conftest
- stop test_jellyfin_operations.py from replacing app.config in sys.modules process-wide; patch the operations module's settings name per test instead
- fix test_app_get_providers.py language_equals tests: settings.set() was called with the section and key as separate arguments, which overwrote the whole general section for the rest of the run; also restore the mutated value after each test and align the embeddedsubtitles timeout assertion with the int validator
- update test_embedded_subs_reader for the track id column in embedded_subs_reader results
- remove test_get_scores, which calls a function removed with the custom scoring system