### PR TITLE
Fixed subf2m provider not finding subtitles for seasons 13, 14, 18 and 20 due to misspelled season names

### DIFF
--- a/custom_libs/subliminal_patch/providers/subf2m.py
+++ b/custom_libs/subliminal_patch/providers/subf2m.py
@@ -68,14 +68,14 @@ _SEASONS = (
     "Tenth",
     "Eleventh",
     "Twelfth",
-    "Thirdteenth",
-    "Fourthteenth",
+    "Thirteenth",
+    "Fourteenth",
     "Fifteenth",
     "Sixteenth",
     "Seventeenth",
-    "Eightheenth",
+    "Eighteenth",
     "Nineteenth",
-    "Tweentieth",
+    "Twentieth",
 )
 
 _LANGUAGE_MAP = {

--- a/tests/subliminal_patch/test_subf2m.py
+++ b/tests/subliminal_patch/test_subf2m.py
@@ -1,4 +1,5 @@
 import pytest
+from bs4 import BeautifulSoup
 from subliminal_patch.core import Episode
 from subliminal_patch.core import Movie
 from subliminal_patch.providers import subf2m
@@ -71,6 +72,40 @@ def test_init_empty_user_agent_raises_configurationerror():
 def test_search_tv_show_season(provider, series_title, season, year, expected_url):
     result = provider._search_tv_show_season(series_title, season, year)
     assert expected_url in result
+
+
+@pytest.mark.parametrize(
+    "season,season_word",
+    [
+        (12, "Twelfth"),
+        (13, "Thirteenth"),
+        (14, "Fourteenth"),
+        (15, "Fifteenth"),
+        (18, "Eighteenth"),
+        (20, "Twentieth"),
+    ],
+)
+def test_search_tv_show_season_ordinal_spelling(
+    provider, monkeypatch, season, season_word
+):
+    # Offline regression test: subf2m titles season pages with ordinal words
+    # (e.g. "Grey's Anatomy - Fourteenth Season  (2017)" at
+    # /subtitles/greys-anatomy-fourteenth-season). Seasons 13, 14, 18 and 20
+    # were unmatchable because _SEASONS misspelled them ("Thirdteenth",
+    # "Fourthteenth", "Eightheenth", "Tweentieth").
+    href = f"/subtitles/greys-anatomy-{season_word.lower()}-season"
+    html = (
+        "<li><div class='title'>"
+        f"<a href=\"{href}\">Grey&#39;s Anatomy - {season_word} Season  (2017)</a>"
+        "</div></li>"
+    )
+    tags = BeautifulSoup(html, "html.parser").select("li div[class='title'] a")
+    assert tags
+    monkeypatch.setattr(provider, "_gen_results", lambda query: iter(tags))
+
+    result = provider._search_tv_show_season("grey's anatomy", season)
+
+    assert result == {href}
 
 
 @pytest.mark.parametrize("language", [Language.fromalpha2("en"), Language("por", "BR")])


### PR DESCRIPTION
subf2m.co titles its season pages with ordinal words (e.g. "Grey's Anatomy - Fourteenth Season" at `/subtitles/greys-anatomy-fourteenth-season`), and `_search_tv_show_season` matches the parsed season word against the `_SEASONS` tuple. Four entries were misspelled - "Thirdteenth", "Fourthteenth", "Eightheenth" and "Tweentieth" - so the site's actual "thirteenth", "fourteenth", "eighteenth" and "twentieth" listings never matched and the provider returned no results for seasons 13, 14, 18 and 20 of any series (the numeric `str(season)` fallback only matches "Season N"-style entries, which subf2m uses for seasons 21+).

Verified against the live site: `/subtitles/greys-anatomy-eighteenth-season` returns 200 while the misspelled slug returns 404, and search results render "Thirteenth/Fourteenth/Twentieth Season" word forms (e.g. Supernatural, Grey's Anatomy, Heartland).

Added an offline regression test that feeds `_search_tv_show_season` search-result anchors mirroring the live markup for seasons 12-20; the four misspelled seasons fail before this fix and pass after (`PYTHONPATH=custom_libs:libs pytest tests/subliminal_patch/test_subf2m.py::test_search_tv_show_season_ordinal_spelling`).

Disclosure: this change was developed with AI assistance (Claude), human-directed and fully understood - the matching path is `_gen_results` -> `_tv_show_title_regex` group 2 -> membership test against `season_strs`, which is why the spelling of `_SEASONS` is load-bearing.
