### PR TITLE
fix(translate): non-empty Lingarr title for movie content translates

### DIFF
--- a/bazarr/subtitles/tools/translate/core/translator_utils.py
+++ b/bazarr/subtitles/tools/translate/core/translator_utils.py
@@ -117,7 +117,7 @@ def add_translator_info(dest_srt_file, info):
 
 def get_description(media_type, radarr_id, sonarr_series_id):
     try:
-        if media_type == 'movies':
+        if media_type in ('movies', 'movie'):
             movie = database.execute(
                 select(TableMovies.title, TableMovies.imdbId, TableMovies.year, TableMovies.overview)
                 .where(TableMovies.radarrId == radarr_id)
@@ -154,7 +154,7 @@ def get_title(
         sonarr_episode_id: Union[int, None] = None
 ) -> str:
     try:
-        if media_type == "movies":
+        if media_type in ("movies", "movie"):
             if radarr_id is None:
                 return ""
 

--- a/bazarr/subtitles/tools/translate/services/lingarr_translator.py
+++ b/bazarr/subtitles/tools/translate/services/lingarr_translator.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import logging
+import os
 import pysubs2
 import requests
 
@@ -130,6 +131,10 @@ class LingarrTranslatorService:
                 sonarr_series_id=self.sonarr_series_id,
                 sonarr_episode_id=self.sonarr_episode_id
             )
+            # Lingarr content API has no subtitle path field; put basename in title
+            # so the Translations UI is not blank when title lookup fails or is empty.
+            src_base = os.path.basename(self.source_srt_file or '') or 'subtitle.srt'
+            display_title = f'{title} · {src_base}' if (title or '').strip() else src_base
 
             if self.media_type == 'episode':
                 api_media_type = "Episode"
@@ -140,11 +145,14 @@ class LingarrTranslatorService:
 
             payload = {
                 "arrMediaId": arr_media_id,
-                "title": title,
+                "title": display_title,
                 "sourceLanguage": source_lang,
                 "targetLanguage": target_lang,
                 "mediaType": api_media_type,
-                "lines": lines_payload
+                "lines": lines_payload,
+                # Optional; ignored by older Lingarr, used when content API accepts paths
+                "sourceSubtitlePath": self.source_srt_file,
+                "translatedSubtitlePath": self.dest_srt_file,
             }
 
             logger.debug(f'BAZARR is sending {len(lines_payload)} lines to Lingarr with full media context')


### PR DESCRIPTION
## Summary

Fixes empty `title` on Lingarr content-translate jobs for movies.

`get_title()` / `get_description()` only matched `media_type == "movies"`, while the translate path passes `"movie"`. Lingarr’s Translations list then showed blank names even when line translation succeeded.

Also:
- Include source SRT **basename** in the Lingarr `title` payload for a stable UI label
- Send optional `sourceSubtitlePath` / `translatedSubtitlePath` for newer Lingarr builds (ignored if unknown)

## Test plan

- [ ] Set `translator_type=lingarr` with a reachable Lingarr instance
- [ ] Translate a **movie** external EN → target language via Subtitles → Translate
- [ ] Confirm Lingarr `POST /api/translate/content` body has non-empty `title`
- [ ] Confirm Lingarr Translations row shows media name and/or `.en.srt` basename
- [ ] Episode translate still gets series/SxxExx title
- [ ] Translated file still written next to the video as before

Closes #3454
