### PR TITLE
Fixed stale job manager

### DIFF
--- a/frontend/src/apis/hooks/system.ts
+++ b/frontend/src/apis/hooks/system.ts
@@ -53,7 +53,12 @@ export function useSystemJobs() {
   return useQuery({
     queryKey: [QueryKeys.System, QueryKeys.Jobs],
     queryFn: () => api.system.jobs(),
-    staleTime: Infinity,
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+    refetchInterval: (query) => {
+      const hasRunning = query.state.data?.some((j) => j.status === "running");
+      return hasRunning ? 10_000 : false;
+    },
   });
 }
 


### PR DESCRIPTION
## Problem

The Jobs Manager could get stuck showing a job as "running" long after the job had actually completed. This was most noticeable with Whisper transcription tasks, where the user would see a 15 minute runtime and spinning status, but after refreshing the browser the same job would show as completed in around 10 minutes.

## Root Cause

The useSystemJobs() query relied entirely on Socket.IO push events to update its state. It used:

- staleTime: Infinity
- refetchOnWindowFocus: false

During long-running tasks that produce no intermediate progress updates (such as Whisper), the browser tab could be throttled or the Socket.IO long-polling connection could miss the completion event. With no polling or focus-refetch fallback, the React Query cache stayed stale indefinitely until a manual page refresh.