### PR TITLE
Fix embedded subtitles never being cleared when a rescan finds zero tracks

### DIFF
--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -84,6 +84,9 @@ def store_subtitles_movie(radarr_id, use_cache=True):
                     .where(TableMoviesSubtitles.path.is_(None))
                     .where(TableMoviesSubtitles.embedded_track_id.is_(None))
                 )
+
+                embedded_subtitles_id_list = []
+
                 if len(embedded_subtitles):
                     # Insert new embedded subtitles or update existing ones
                     embedded_stmt = insert(TableMoviesSubtitles).values(embedded_subtitles)
@@ -99,16 +102,15 @@ def store_subtitles_movie(radarr_id, use_cache=True):
                         index_where=TableMoviesSubtitles.path.is_(None)
                     )
                     database.execute(embedded_stmt)
-
-                    # Delete prior indexed embedded subtitles that don't exist anymore
                     embedded_subtitles_id_list = [x['embedded_track_id'] for x in embedded_subtitles]
-                    if len(embedded_subtitles_id_list):
-                        database.execute(
-                            delete(TableMoviesSubtitles)
-                            .where(TableMoviesSubtitles.radarrId == radarr_id)
-                            .where(TableMoviesSubtitles.path.is_(None))
-                            .where(TableMoviesSubtitles.embedded_track_id.not_in(embedded_subtitles_id_list))
-                        )
+
+                # Delete prior indexed embedded subtitles that don't exist anymore
+                database.execute(
+                    delete(TableMoviesSubtitles)
+                    .where(TableMoviesSubtitles.radarrId == radarr_id)
+                    .where(TableMoviesSubtitles.path.is_(None))
+                    .where(TableMoviesSubtitles.embedded_track_id.not_in(embedded_subtitles_id_list))
+                )
             except Exception:
                 logging.exception(
                     f"BAZARR error when trying to analyze this {os.path.splitext(mapped_path)[1]} file: "

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -85,6 +85,9 @@ def store_subtitles(sonarr_episode_id, use_cache=True):
                     .where(TableEpisodesSubtitles.path.is_(None))
                     .where(TableEpisodesSubtitles.embedded_track_id.is_(None))
                 )
+
+                embedded_subtitles_id_list = []
+
                 if len(embedded_subtitles):
                     # Insert new embedded subtitles or update existing ones
                     embedded_stmt = insert(TableEpisodesSubtitles).values(embedded_subtitles)
@@ -101,16 +104,15 @@ def store_subtitles(sonarr_episode_id, use_cache=True):
                         index_where=TableEpisodesSubtitles.path.is_(None)
                     )
                     database.execute(embedded_stmt)
-
-                    # Delete prior indexed embedded subtitles that don't exist anymore
                     embedded_subtitles_id_list = [x['embedded_track_id'] for x in embedded_subtitles]
-                    if len(embedded_subtitles_id_list):
-                        database.execute(
-                            delete(TableEpisodesSubtitles)
-                            .where(TableEpisodesSubtitles.sonarrEpisodeId == sonarr_episode_id)
-                            .where(TableEpisodesSubtitles.path.is_(None))
-                            .where(TableEpisodesSubtitles.embedded_track_id.not_in(embedded_subtitles_id_list))
-                        )
+
+                # Delete prior indexed embedded subtitles that don't exist anymore
+                database.execute(
+                    delete(TableEpisodesSubtitles)
+                    .where(TableEpisodesSubtitles.sonarrEpisodeId == sonarr_episode_id)
+                    .where(TableEpisodesSubtitles.path.is_(None))
+                    .where(TableEpisodesSubtitles.embedded_track_id.not_in(embedded_subtitles_id_list))
+                )
             except Exception:
                 logging.exception(f"BAZARR error when trying to analyze this {os.path.splitext(mapped_path)[1]} file: "
                                   f"{mapped_path}")


### PR DESCRIPTION
When a video file's embedded subtitle tracks go from some to none, Bazarr never clears the previously indexed tracks, causing "Video File Subtitle Track" entries to persist through future scans. The proposed fix is to always run the delete query, defaulting to an empty list of IDs to match the `not_in` against if no embedded tracks were found.

Disclosure: I used AI to track down the bug but the fix is written by me.