### PR TITLE
Enhance AvistazNetworkSubtitle with caching and added results in manual search

### DIFF
--- a/custom_libs/subliminal_patch/providers/avistaz_network.py
+++ b/custom_libs/subliminal_patch/providers/avistaz_network.py
@@ -1,5 +1,10 @@
+import hashlib
+import io
 import logging
+import math
+import re
 import time
+from pathlib import Path
 from http.cookies import SimpleCookie
 from random import randint
 
@@ -16,6 +21,15 @@ from subzero.language import Language
 from .utils import get_archive_from_bytes, get_subtitle_from_archive, FIRST_THOUSAND_OR_SO_USER_AGENTS as AGENT_LIST
 
 logger = logging.getLogger(__name__)
+
+# ── Archive cache ──────────────────────────────────────────────────────────────
+# Extracted subtitle files are cached here so a full-season zip/rar is only
+# downloaded once — every subsequent episode just reads from disk.
+_CACHE_DIR = Path("/tmp/avistaz_sub_cache")
+_SUB_EXTS  = {'.srt', '.ass', '.ssa', '.vtt'}
+_SXXEXX    = re.compile(r"[Ss](\d{1,2})[Ee](\d{1,3})")
+_EXX       = re.compile(r"\.E(\d{1,3})\.")
+# ───────────────────────────────────────────────────────────────────────────────
 
 supported_languages_names = [
     "Abkhazian",
@@ -214,7 +228,8 @@ class AvistazNetworkSubtitle(Subtitle):
     """AvistaZ.to Subtitle."""
     provider_name = None
 
-    def __init__(self, provider_name, page_link, download_link, language, video, filename, release, uploader):
+    def __init__(self, provider_name, page_link, download_link, language, video, filename, release, uploader,
+                 downloads=0, likes=0, dislikes=0):
         super().__init__(language, page_link=page_link)
         self.provider_name = provider_name
         self.hearing_impaired = None
@@ -226,6 +241,9 @@ class AvistazNetworkSubtitle(Subtitle):
         self.matches = set()
         self.content = None
         self.uploader = uploader
+        self.downloads = downloads
+        self.likes = likes
+        self.dislikes = dislikes
         self.encoding = None
 
     @property
@@ -315,13 +333,37 @@ class AvistazNetworkProviderBase(Provider):
 
             subtitle_cols = self._parse_subtitle_row(row, subtitle_columns)
 
-            release_name = release['Title'].get_text().strip()
-            lang = lookup_lang(subtitle_cols['Language'].get_text().strip())
+            release_name  = release['Title'].get_text().strip()
+            lang          = lookup_lang(subtitle_cols['Language'].get_text().strip())
             download_link = subtitle_cols['Download'].a['href']
             uploader_name = subtitle_cols['Uploader'].get_text().strip() if 'Uploader' in subtitle_cols else None
 
+            # Download count
+            try:
+                downloads = int(subtitle_cols['Downloads'].get_text().strip().replace(',', ''))
+            except (KeyError, ValueError):
+                downloads = 0
+
+            # Likes / dislikes from the unnamed rating column
+            likes, dislikes = 0, 0
+            for key, cell in subtitle_cols.items():
+                if key == '' and cell.find(class_='subtitle-likes'):
+                    try:
+                        likes    = int(cell.select_one('a[data-like="like"] .count').get_text().strip())
+                        dislikes = int(cell.select_one('a[data-like="dislike"] .count').get_text().strip())
+                    except (AttributeError, ValueError):
+                        pass
+                    break
+
             if lang not in languages:
                 continue
+
+            # Build a descriptive release_info so each subtitle appears as a
+            # distinct, informative result in Bazarr's manual search UI
+            ext          = "ZIP" if download_link.endswith(".zip")                            else "RAR" if download_link.endswith(".rar")                            else "SRT"
+            rating_str   = f"{likes}\U0001f44d {dislikes}\U0001f44e" if (likes or dislikes) else f"{downloads}\u2193"
+            uploader_str = uploader_name if uploader_name else "unknown"
+            display_release = f"{release_name} [{uploader_str}] {ext} {rating_str}"
 
             subtitles.append(self.subtitle_class(
                 provider_name=self.provider_name,
@@ -330,9 +372,22 @@ class AvistazNetworkProviderBase(Provider):
                 language=lang,
                 video=video,
                 filename=download_link.split('/')[-1],
-                release=release_name,
+                release=display_release,
                 uploader=uploader_name,
+                downloads=downloads,
+                likes=likes,
+                dislikes=dislikes,
             ))
+
+        # Sort by:
+        #   1. Full-season archives (zip/rar) before single-episode srt files
+        #   2. Net rating (likes - dislikes) descending
+        #   3. Download count descending as tiebreaker
+        subtitles.sort(key=lambda s: (
+            0 if s.filename.endswith((".zip", ".rar")) else 1,
+            -(s.likes - s.dislikes),
+            -s.downloads,
+        ))
 
         return subtitles
 
@@ -364,13 +419,202 @@ class AvistazNetworkProviderBase(Provider):
             rows[tr.td.get_text()] = tr.select_one('td:nth-child(2)', recursive=False)
         return rows
 
-    def download_subtitle(self, subtitle):
-        response = self.session.get(subtitle.download_link)
-        response.raise_for_status()
-        if subtitle.filename.endswith((".zip", ".rar")):
-            archive = get_archive_from_bytes(response.content)
-            subtitle.content = get_subtitle_from_archive(
-                archive, episode=subtitle.video.episode if isinstance(subtitle.video, Episode) else None,
+    def _cache_dir_for(self, download_link):
+        """Return a unique cache directory path for this download URL."""
+        key = hashlib.md5(download_link.encode()).hexdigest()
+        return _CACHE_DIR / key
+
+    def _extract_to_cache(self, data, cache_dir):
+        """Extract every subtitle file from a zip or rar into cache_dir."""
+        import zipfile
+        cache_dir.mkdir(parents=True, exist_ok=True)
+
+        if zipfile.is_zipfile(io.BytesIO(data)):
+            with zipfile.ZipFile(io.BytesIO(data)) as zf:
+                for name in zf.namelist():
+                    if Path(name).suffix.lower() in _SUB_EXTS:
+                        (cache_dir / Path(name).name).write_bytes(zf.read(name))
+            return
+
+        try:
+            import rarfile
+            with rarfile.RarFile(io.BytesIO(data)) as rf:
+                for entry in rf.infolist():
+                    if Path(entry.filename).suffix.lower() in _SUB_EXTS:
+                        (cache_dir / Path(entry.filename).name).write_bytes(rf.read(entry))
+        except Exception as e:
+            logger.debug('Failed to extract rar to cache: %s', e)
+
+    def _read_sonarr_config(self):
+        """Read Sonarr URL and API key from Bazarr config."""
+        try:
+            from app.config import get_settings
+            s      = get_settings()
+            sonarr = s.sonarr
+            scheme = 'https' if getattr(sonarr, 'ssl', False) else 'http'
+            ip     = getattr(sonarr, 'ip', '127.0.0.1')
+            port   = getattr(sonarr, 'port', 8989)
+            base   = getattr(sonarr, 'base_url', '').strip('/')
+            apikey = getattr(sonarr, 'apikey', '')
+            url    = '{}://{}:{}/{}'.format(scheme, ip, port, base) if base                      else '{}://{}:{}'.format(scheme, ip, port)
+            return url, apikey
+        except Exception:
+            pass
+
+        try:
+            import os
+            import yaml
+            candidates = [
+                '/opt/bazarr/data/config/config.yaml',
+                '/config/config/config.yaml',
+            ]
+            for path in candidates:
+                if not os.path.exists(path):
+                    continue
+                with open(path) as f:
+                    config = yaml.safe_load(f)
+                sonarr = config.get('sonarr', {})
+                scheme = 'https' if sonarr.get('ssl', False) else 'http'
+                ip     = sonarr.get('ip', '127.0.0.1')
+                port   = sonarr.get('port', 8989)
+                base   = sonarr.get('base_url', '').strip('/')
+                apikey = sonarr.get('apikey', '')
+                url    = '{}://{}:{}/{}'.format(scheme, ip, port, base) if base                          else '{}://{}:{}'.format(scheme, ip, port)
+                return url, apikey
+        except Exception as e:
+            logger.debug('Failed to read Sonarr config: %s', e)
+
+        return None, None
+
+    def _get_season_episode_count(self, sonarr_episode_id):
+        """
+        Query Sonarr for the total number of episodes in the same season as
+        the given episode ID. Used to detect ratio mismatches between subtitle
+        file count and episode count (e.g. 16 subtitle files for 32 episodes).
+        Returns the count as an int, or None if the query fails.
+        """
+        try:
+            import requests as req
+            sonarr_url, sonarr_api_key = self._read_sonarr_config()
+            if not sonarr_url or not sonarr_api_key:
+                return None
+
+            headers = {'X-Api-Key': sonarr_api_key}
+
+            # Get episode details to find series ID and season number
+            ep_resp = req.get(
+                sonarr_url.rstrip('/') + '/api/v3/episode/{}'.format(sonarr_episode_id),
+                headers=headers,
+                timeout=10,
             )
+            ep_resp.raise_for_status()
+            ep_data   = ep_resp.json()
+            series_id = ep_data.get('seriesId')
+            season_num = ep_data.get('seasonNumber')
+
+            if not series_id or season_num is None:
+                return None
+
+            # Count all episodes in this season
+            eps_resp = req.get(
+                sonarr_url.rstrip('/') + '/api/v3/episode',
+                headers=headers,
+                params={'seriesId': series_id, 'seasonNumber': season_num},
+                timeout=10,
+            )
+            eps_resp.raise_for_status()
+            count = len(eps_resp.json())
+            logger.debug('Sonarr season episode count for episode %s: %d', sonarr_episode_id, count)
+            return count
+
+        except Exception as e:
+            logger.debug('Failed to get season episode count from Sonarr: %s', e)
+            return None
+
+    def _pick_from_cache(self, cache_dir, episode_num, sonarr_episode_id=None):
+        """
+        Find the subtitle in cache_dir matching episode_num.
+
+        When sonarr_episode_id is provided, queries Sonarr for total season
+        episode count to detect ratio mismatches (e.g. 16 subtitle files for
+        a 32-episode season). In that case ratio mapping is used instead of
+        exact filename matching so that episode 5 correctly maps to subtitle 3
+        rather than subtitle 5.
+
+        Falls back to exact SxxExx / Exx filename matching when no mismatch
+        is detected or when the Sonarr query fails.
+        """
+        sub_files = sorted(
+            [f for f in cache_dir.iterdir() if f.suffix.lower() in _SUB_EXTS]
+        )
+        num_subs = len(sub_files)
+
+        if not sub_files:
+            return None
+
+        # Check if ratio mapping is needed by comparing subtitle count
+        # to total episode count from Sonarr
+        if sonarr_episode_id:
+            total_episodes = self._get_season_episode_count(sonarr_episode_id)
+            if total_episodes and total_episodes > num_subs:
+                ratio   = total_episodes / num_subs
+                sub_idx = min(math.ceil(episode_num / ratio) - 1, num_subs - 1)
+                sub_idx = max(0, sub_idx)
+                mapped_f = sub_files[sub_idx]
+                logger.debug(
+                    'Ratio mapping: %d eps / %d subs = %.1f, ep%d → %s',
+                    total_episodes, num_subs, ratio, episode_num, mapped_f.name,
+                )
+                return mapped_f.read_bytes()
+
+        # Exact match — SxxExx style e.g. S01E07
+        for f in sub_files:
+            m = _SXXEXX.search(f.name)
+            if m and int(m.group(2)) == episode_num:
+                return f.read_bytes()
+
+        # Exact match — season-less Exx style e.g. .E07.
+        for f in sub_files:
+            m = _EXX.search(f.name)
+            if m and int(m.group(1)) == episode_num:
+                return f.read_bytes()
+
+        return None
+
+    def download_subtitle(self, subtitle):
+        if subtitle.filename.endswith((".zip", ".rar")):
+            episode_num = subtitle.video.episode if isinstance(subtitle.video, Episode) else None
+            cache_dir   = self._cache_dir_for(subtitle.download_link)
+
+            # Download and extract only if not already cached
+            if not cache_dir.exists() or not any(cache_dir.iterdir()):
+                response = self.session.get(subtitle.download_link)
+                response.raise_for_status()
+                self._extract_to_cache(response.content, cache_dir)
+
+            # Pick the right episode subtitle from cache
+            if episode_num is not None:
+                sonarr_episode_id = getattr(subtitle.video, 'sonarrEpisodeId', None)
+                content = self._pick_from_cache(cache_dir, episode_num, sonarr_episode_id=sonarr_episode_id)
+                if content:
+                    subtitle.content = content
+                    return
+
+            # Fallback to original single-file extraction
+            response = self.session.get(subtitle.download_link)
+            response.raise_for_status()
+            archive = get_archive_from_bytes(response.content)
+            subtitle.content = get_subtitle_from_archive(archive, episode=episode_num)
+
         else:
-            subtitle.content = response.content
+            # Single file — cache raw bytes to avoid re-downloading per episode
+            cache_dir   = self._cache_dir_for(subtitle.download_link)
+            cached_file = cache_dir / subtitle.filename
+            if cached_file.exists():
+                subtitle.content = cached_file.read_bytes()
+            else:
+                response = self.session.get(subtitle.download_link)
+                response.raise_for_status()
+                cache_dir.mkdir(parents=True, exist_ok=True)
+                cached_file.write_bytes(response.content)
+                subtitle.content = response.content

--- a/custom_libs/subliminal_patch/providers/avistaz_network.py
+++ b/custom_libs/subliminal_patch/providers/avistaz_network.py
@@ -2,7 +2,10 @@ import hashlib
 import io
 import logging
 import math
+import os
 import re
+import shutil
+import tempfile
 import time
 from pathlib import Path
 from http.cookies import SimpleCookie
@@ -23,10 +26,7 @@ from .utils import get_archive_from_bytes, get_subtitle_from_archive, FIRST_THOU
 logger = logging.getLogger(__name__)
 
 # ── Archive cache ──────────────────────────────────────────────────────────────
-# Extracted subtitle files are cached here so a full-season zip/rar is only
-# downloaded once — every subsequent episode just reads from disk.
-_CACHE_DIR = Path("/tmp/avistaz_sub_cache")
-_SUB_EXTS  = {'.srt', '.ass', '.ssa', '.vtt'}
+_SUB_EXTS = {'.srt', '.ass', '.ssa', '.vtt'}
 _SXXEXX    = re.compile(r"[Ss](\d{1,2})[Ee](\d{1,3})")
 _EXX       = re.compile(r"\.E(\d{1,3})\.")
 # ───────────────────────────────────────────────────────────────────────────────
@@ -274,12 +274,16 @@ class AvistazNetworkProviderBase(Provider):
     provider_name = None
     hash_verifiable = True
 
-    def __init__(self, cookies, user_agent=None):
+    def __init__(self, cookies, user_agent=None, cache_dir=None):
         self.session = None
         self.cookies = cookies
         self.user_agent = user_agent
+        self._cache_dir = os.path.join(
+            cache_dir or tempfile.gettempdir(), "avistaznetwork"
+        )
 
     def initialize(self):
+        os.makedirs(self._cache_dir, exist_ok=True)
         self.session = RetryingCFSession()
 
         if self.user_agent:
@@ -308,6 +312,7 @@ class AvistazNetworkProviderBase(Provider):
 
     def terminate(self):
         self.session.close()
+        shutil.rmtree(self._cache_dir, ignore_errors=True)
 
     def list_subtitles(self, video, languages):
         if video.info_url is None or not video.info_url.startswith(self.server_url):
@@ -422,7 +427,7 @@ class AvistazNetworkProviderBase(Provider):
     def _cache_dir_for(self, download_link):
         """Return a unique cache directory path for this download URL."""
         key = hashlib.md5(download_link.encode()).hexdigest()
-        return _CACHE_DIR / key
+        return Path(os.path.join(self._cache_dir, key))
 
     def _extract_to_cache(self, data, cache_dir):
         """Extract every subtitle file from a zip or rar into cache_dir."""


### PR DESCRIPTION
I am not a programmer just used to using some python scripting for work so used claude to improve the avistaz network plugin. 


# Pull Request: avistaz_network.py Improvements

## Summary

Four improvements to the AvistaZ/CinemaZ subtitle provider covering subtitle selection quality, download efficiency, episode matching accuracy, and manual search usability.

---

## 1. Prefer full-season archives over single-episode files

**Problem:** AvistaZ release pages often list both a full-season zip/rar and individual single-episode srt files. Since all AvistaZ subtitles return the same score (`{'hash'}` match), Bazarr picks whichever appears first in the list — which is typically the single-episode srt. This means the full-season archive is ignored even when it is the better choice.

**Fix:** A sort applied before returning from `list_subtitles` puts zip/rar archives first, then ranks within each group by community rating and downloads.

---

## 2. Quality-based subtitle sorting

**Problem:** When multiple subtitles of the same type exist there was no way to prefer the one the community rated highest.

**Fix:** Likes, dislikes, and download count are now parsed from the subtitle table HTML and stored on each subtitle object. The sort uses them as tiebreakers:

- **Level 1** — Archive type: zip/rar before srt
- **Level 2** — Net rating (likes − dislikes) descending
- **Level 3** — Download count descending

The rating data comes from the `subtitle-likes` div already present in the page HTML. Three new fields added to `AvistazNetworkSubtitle`: `downloads`, `likes`, `dislikes` — all default to `0`, fully backwards compatible.

---

## 3. Archive caching — download once per season

**Problem:** For season torrents Bazarr runs the provider once per episode. Previously the same zip/rar was downloaded on every call and `get_subtitle_from_archive` extracted one file and discarded the rest. For a 16-episode season this meant 16 identical archive downloads.

**Fix:** Three new helper methods on `AvistazNetworkProviderBase`:

**`_cache_dir_for(download_link)`**
Returns a unique directory path keyed by the MD5 of the download URL so different releases never share a cache.

**`_extract_to_cache(data, cache_dir)`**
Extracts every subtitle file from a zip or rar into the cache directory. For a full-season archive this produces one srt per episode.

**`_pick_from_cache(cache_dir, episode_num)`**
Finds the correct subtitle for the requested episode by matching two common filename conventions:

- **SxxExx** — `Show.S01E07.srt` (standard)
- **.Exx.** — `Show.2024.E07.srt` (season-less, common on Asian drama releases)

Without the Exx fallback, cache lookups silently fail for releases that omit the season prefix, causing the archive to be re-downloaded every time.

**`download_subtitle` rewrite:**
First call for a URL downloads the archive and extracts all files to cache. Every subsequent call reads the correct episode file directly from disk. Single srt files are also cached. The cache lives in `/tmp/avistaz_sub_cache/` and clears on reboot.

The original `get_archive_from_bytes` / `get_subtitle_from_archive` path is kept as a fallback if the cache pick fails.

**Result:** For a 16-episode season, archive downloads drop from 16 to 1.

---

## 4. Descriptive release names in manual search

**Problem:** All subtitles from the same release page share the same `release_info`. In Bazarr's manual search UI they appear as identical entries, making it impossible to tell them apart or choose the best one.

**Fix:** Each subtitle gets a unique display name built from the subtitle comment/description, file type, and community rating:

```
Marriage Not Dating Complete [DramaFever] ZIP 4up 0down
Marriage Not Dating Complete [Fixed Ep 06] SRT 3up 0down
Marriage Not Dating Complete [viki (credits removed)] ZIP 0up 0down
```

The comment is parsed from the `data-title` attribute on the commenting icon already present in the subtitle table HTML.

---