### PR TITLE
Fixed `throttled_count` never decaying, leaving providers with no retries after their first throttle

### DIFF
--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -463,12 +463,17 @@ def throttled_count(name):
     else:
         throttle_count[name] = {"count": 1, "time": (datetime.datetime.now() + datetime.timedelta(seconds=120))}
 
-    if throttle_count[name]['count'] >= 5:
-        return True
+    # the window is evaluated first so that failures older than it cannot add up to a
+    # throttle: a provider that has been quiet since then starts counting again from one
     if throttle_count[name]['time'] <= datetime.datetime.now():
         throttle_count[name] = {"count": 1, "time": (datetime.datetime.now() + datetime.timedelta(seconds=120))}
-    logging.info("Provider %s throttle count %s of 5, waiting 5sec and trying again", name,
-                 throttle_count[name]['count'])
+    count = throttle_count[name]['count']
+    if count >= 5:
+        # spent on the throttle being applied, so the next one starts from a clean count.
+        # Searches run in parallel and can report the same provider, hence the tolerant pop
+        throttle_count.pop(name, None)
+        return True
+    logging.info("Provider %s throttle count %s of 5, waiting 5sec and trying again", name, count)
     time.sleep(5)
     return False
 
@@ -522,6 +527,8 @@ def reset_throttled_providers(only_auth_or_conf_error=False):
                                                                'PaymentRequired']:
             continue
         tp.pop(provider, None)
+        # the reset hands back a clean slate, including strikes not yet spent on a throttle
+        throttle_count.pop(provider, None)
     set_throttled_providers(str(tp))
     update_throttled_provider()
     if only_auth_or_conf_error:

--- a/tests/bazarr/test_app_get_providers.py
+++ b/tests/bazarr/test_app_get_providers.py
@@ -1,3 +1,4 @@
+import datetime
 import inspect
 
 import pytest
@@ -134,3 +135,66 @@ def test_get_traceback_info():
     if error_ is not None:
         msg = get_providers._get_traceback_info(error_)
         assert len(msg) == 100
+
+
+@pytest.fixture
+def _throttle_count(monkeypatch):
+    """`throttle_count` is process-wide state and `throttled_count` sleeps between retries."""
+    monkeypatch.setattr(get_providers.time, "sleep", lambda seconds: None)
+    get_providers.throttle_count.clear()
+    yield get_providers.throttle_count
+    get_providers.throttle_count.clear()
+
+
+def _strikes_until_throttled(name):
+    for strike in range(1, 10):
+        if get_providers.throttled_count(name):
+            return strike
+    return None
+
+
+def test_throttled_count_grants_new_retries_after_throttling(_throttle_count):
+    """A provider that reached the limit once must not be throttled on sight afterwards."""
+    assert _strikes_until_throttled("provider") == 5
+    assert _strikes_until_throttled("provider") == 5
+
+
+def test_throttled_count_ignores_failures_older_than_the_window(_throttle_count):
+    """Strikes the provider collected before it went quiet must not add up to a throttle."""
+    for _ in range(4):
+        get_providers.throttled_count("provider")
+
+    _throttle_count["provider"]["time"] = datetime.datetime.now() - datetime.timedelta(seconds=1)
+
+    assert get_providers.throttled_count("provider") is False
+    assert _throttle_count["provider"]["count"] == 1
+
+
+def test_throttled_count_tolerates_a_concurrent_removal(monkeypatch):
+    """Providers are searched in parallel, so another thread may drop the entry first."""
+
+    class _RacingCount(dict):
+        def __delitem__(self, key):
+            super().__delitem__(key)
+            raise KeyError(key)
+
+    racing = _RacingCount(
+        {"provider": {"count": 5, "time": datetime.datetime.now() + datetime.timedelta(seconds=120)}}
+    )
+    monkeypatch.setattr(get_providers, "throttle_count", racing)
+
+    assert get_providers.throttled_count("provider") is True
+    assert "provider" not in racing
+
+
+def test_reset_throttled_providers_also_resets_the_count(monkeypatch, _throttle_count):
+    """Strikes not yet spent on a throttle would otherwise survive the reset."""
+    monkeypatch.setattr(get_providers, "set_throttled_providers", lambda data: None)
+    monkeypatch.setattr(get_providers, "update_throttled_provider", lambda: None)
+    get_providers.tp["provider"] = ("TooManyRequests", datetime.datetime.now(), "1 hour")
+    _throttle_count["provider"] = {"count": 3,
+                                   "time": datetime.datetime.now() + datetime.timedelta(seconds=120)}
+
+    get_providers.reset_throttled_providers()
+
+    assert "provider" not in _throttle_count


### PR DESCRIPTION
### Problem

`throttled_count()` compares the failure count to its limit **before** evaluating the 120 second window:

```python
if throttle_count[name]['count'] >= 5:
    return True
if throttle_count[name]['time'] <= datetime.datetime.now():
    throttle_count[name] = {"count": 1, "time": ...}
```

The count is incremented at the top of the function, so the reset below only ever runs when the incremented count is 1 to 4. Two consequences:

1. A provider parked at count 4 can never decay. However much time has passed, the next failure takes it to 5 and returns before the window is consulted, so stale failures still add up to a throttle.
2. Once a provider reaches 5, the early return leaves the count untouched. It can only grow, so every countable failure (`TooManyRequests`, `ServiceUnavailable`, `APIThrottled`, the timeouts) throttles that provider on sight for the remaining lifetime of the process, with no retry.

`reset_throttled_providers()` compounds it by popping from `tp` but not from `throttle_count`, so the Reset button hands back a provider that still carries every strike it had collected.

### Evidence

From an instance running continuously for 4.5 days:

```
$ docker inspect bazarr --format '{{.State.StartedAt}} restarts={{.RestartCount}}'
2026-07-23T21:09:38Z restarts=0

$ grep -h 'throttle count' /config/log/bazarr.log*
2026-07-24 04:24:26 | Provider subsource throttle count 1 of 5, waiting 5sec and trying again
2026-07-24 04:24:32 | Provider subsource throttle count 2 of 5, waiting 5sec and trying again
2026-07-24 04:24:37 | Provider subsource throttle count 3 of 5, waiting 5sec and trying again
2026-07-24 04:24:42 | Provider subsource throttle count 4 of 5, waiting 5sec and trying again
2026-07-28 18:40:40 | Provider opensubtitlescom throttle count 1 of 5, waiting 5sec and trying again
```

Those five lines are every retry granted to any provider in 4.5 days. Over the same window subsource was throttled **36 times**, an hour each.

The first of those throttles shows consequence 1:

```
2026-07-24 04:23:46 | Using subsource again after 1 hour, (disabled because: TooManyRequests)
2026-07-24 04:24:26 | Provider subsource throttle count 1 of 5, waiting 5sec and trying again
2026-07-24 04:24:32 | Provider subsource throttle count 2 of 5
2026-07-24 04:24:37 | Provider subsource throttle count 3 of 5
2026-07-24 04:24:42 | Provider subsource throttle count 4 of 5
2026-07-24 04:25:24 | BAZARR Finished searching for missing Movies Subtitles
2026-07-24 04:34:47 | Throttling subsource for 1 hour, until 26/07/24 05:34, because of: TooManyRequests
2026-07-24 04:41:18 | BAZARR Finished searching for missing Series Subtitles
```

The count reached 4 during the Movies search and stopped there when that task ended. Its 120 second window expired at 04:26:42. The Series search reached the same provider at 04:34:47, **485 seconds after the window had expired**, and the stale count tripped the throttle. Replaying those exact timestamps through the function confirms it:

```
--- current ---                      --- with this change ---
04:24:42  count=4  throttled=False   04:24:42  count=4  throttled=False
04:34:47  count=5  throttled=True    04:34:47  count=1  throttled=False
```

Every one of the following 35 throttles shows consequence 2: no `throttle count` line precedes any of them, because the count was stuck at 5 or above from 04:24 onward.

So of 36 throttles in that window, none were the 5 strike mechanism behaving as intended. One was caused by a stale count, and 35 by a count that could no longer decay.

### Change

- Evaluate the window before the count, so failures older than it cannot add up to a throttle.
- Clear the count when it is spent on a throttle, so the next round starts clean. Removed with `pop` rather than `del`: providers are searched in parallel through `SZAsyncProviderPool`, so two threads can report the same provider and the second must not hit a `KeyError`. This mirrors the race already covered by `test_get_providers_expired_throttle_cleanup_is_idempotent`.
- Clear it in `reset_throttled_providers()` too, so a reset hands back a genuinely clean slate.

### Tests

Four tests added to `tests/bazarr/test_app_get_providers.py`. Each is the sole catcher of at least one mutation:

| Mutation | Caught by |
|---|---|
| count checked before window | `ignores_failures_older_than_the_window` |
| window reset removed entirely | `ignores_failures_older_than_the_window` |
| no count cleared on throttle | `grants_new_retries_after_throttling` |
| `del` instead of `pop` | `tolerates_a_concurrent_removal` |
| reset not clearing the count | `reset_throttled_providers_also_resets_the_count` |
| threshold changed from 5 | `grants_new_retries_after_throttling` |

`pytest tests/bazarr/` is green.

### Trade-off

This makes Bazarr more forgiving of every provider, not just the one in the logs above. A provider that is genuinely down now gets 5 attempts per throttle cycle rather than being benched instantly, and `throttled_count` sleeps 5 seconds between them, so roughly 20 extra seconds per cycle are spent against a dead provider. That is what the code appears designed to do, and a provider that fails once should not stay on a hair trigger for the life of the process, but it is a behaviour change worth naming.

### Disclosure

I used Claude to help investigate this and draft the change. I have reviewed all of it and can explain the reasoning behind each part. I'm a software developer, just not a python expert (still can write/understand it).
