### PR TITLE
Fixed subdl provider discarding season packs and mislabelling hearing-impaired subtitles

### DIFF
--- a/custom_libs/subliminal_patch/providers/subdl.py
+++ b/custom_libs/subliminal_patch/providers/subdl.py
@@ -11,6 +11,7 @@ from zipfile import ZipFile, is_zipfile
 from rarfile import RarFile, is_rarfile
 from urllib.parse import urljoin
 from requests import Session, Response
+from requests.exceptions import RequestException
 from guessit import guessit
 
 from babelfish import language_converters
@@ -47,7 +48,8 @@ class SubdlSubtitle(Subtitle):
 
     def __init__(self, language, forced, hearing_impaired, page_link, download_link, file_id, release_names, uploader,
                  season=None, episode=None, absolute_episode=None, is_pack=False, is_direct_file=False,
-                 is_full_season=False, episode_title=None, matched_id=False, matched_title=False,
+                 is_full_season=False, episode_title=None, target_episode=None,
+                 matched_id=False, matched_title=False,
                  is_ai_translation=False, ai_source_n_id=None, ai_source_language=None, ai_target_language=None):
         super().__init__(language)
         language = Language.rebuild(language, hi=hearing_impaired, forced=forced)
@@ -60,6 +62,11 @@ class SubdlSubtitle(Subtitle):
         # A pack covering a whole season carries no episode range: every episode
         # of `season` is inside it, so the archive must be searched by episode.
         self.is_full_season = is_full_season
+        # The episode we are searching FOR. Distinct from self.episode, which is
+        # whatever the API said about the item — for a pack that is the pack's
+        # own field (often None), so extracting on it would pull an arbitrary
+        # member out of a season archive.
+        self.target_episode = target_episode
         # Carried so download_subtitle can match a pack member by episode title
         # without reaching back into shared provider state.
         self.episode_title = episode_title
@@ -197,17 +204,17 @@ class SubdlProvider(Provider):
     # The API rejects these outright ("Film name contains potentially unsafe
     # characters"), which would otherwise 400 every apostrophe title such as
     # "Grey's Anatomy" and get the whole provider throttled.
-    # Apostrophes are dropped rather than spaced ("Grey's" -> "Greys"), which is
-    # how the catalogue stores such titles; the rest become separators.
-    APOSTROPHE_CHARS = re.compile(r"['`’]")
-    UNSAFE_TITLE_CHARS = re.compile(r'[<>{}\[\]";\\/]')
+    # Every one of these becomes a SPACE, never nothing. The search index stores
+    # "Grey's Anatomy" as the tokens grey|s|anatomy, so deleting the apostrophe
+    # would query "greys" and match nothing -- verified against the live API,
+    # where "Schitts Creek" returns 0 results and "Schitt s Creek" returns 8.
+    UNSAFE_TITLE_CHARS = re.compile(r'''[<>{}\[\]'"`´’;\\/]''')
 
     @classmethod
     def _sanitize_title(cls, title):
         if not title:
             return title
-        cleaned = cls.APOSTROPHE_CHARS.sub('', title)
-        cleaned = cls.UNSAFE_TITLE_CHARS.sub(' ', cleaned)
+        cleaned = cls.UNSAFE_TITLE_CHARS.sub(' ', title)
         cleaned = ' '.join(cleaned.split())
         if cleaned != title:
             logger.debug(f'Sanitized title for search: {title!r} -> {cleaned!r}')
@@ -228,7 +235,13 @@ class SubdlProvider(Provider):
 
         Never raises for this single search: a failure here must not discard
         results already gathered by the other searches, nor throttle the whole
-        provider. Transport/HTTP errors are logged and yield no items.
+        provider.
+
+        Only per-request and transport failures are absorbed. Anything that
+        describes the state of the ACCOUNT or the service — an invalid key, the
+        daily download limit, a rate limit, an outage — is re-raised so bazarr
+        can throttle and back off. Swallowing those would leave a client with a
+        revoked key searching forever at full rate.
         """
         items = []
         first_payload = {}
@@ -243,8 +256,11 @@ class SubdlProvider(Provider):
                     lambda: self.session.get(self.server_url() + 'subtitles',
                                              params=call_params, timeout=30)
                 )
-            except Exception as error:
-                logger.debug(f'subdl: {description} search failed, continuing without it: {error!r}')
+            except (SubdlRequestRejected, RequestException) as error:
+                # The api_key rides in the request URL, and requests puts that
+                # URL in the exception text.
+                logger.debug(f'subdl: {description} search failed, continuing '
+                             f'without it: {self._redact(repr(error))}')
                 break
 
             payload = self._safe_json(response)
@@ -403,7 +419,11 @@ class SubdlProvider(Provider):
             is_direct_file = False
             is_full_season = False
             download_link = item['url']
-            file_id = item.get('subtitlePage') or item['name']
+            # Keep the archive name as the public id: bazarr persists it in the
+            # blacklist and in history, so changing it would silently invalidate
+            # every existing subdl blacklist entry. Uniqueness is handled by
+            # deduping on subtitlePage in merge() instead.
+            file_id = item['name']
             item_season = item.get('season', None)
             item_episode = item.get('episode', None)
 
@@ -457,7 +477,7 @@ class SubdlProvider(Provider):
                     )
                     if unpack_entry:
                         download_link = unpack_entry['url']
-                        file_id = f"{file_id}/{unpack_entry['file_n_id']}"
+                        file_id = f"{item['name']}/{unpack_entry['file_n_id']}"
                         # `or` not `.get(default)`: the API sends season/episode
                         # as 0 rather than omitting them, so a dict default never
                         # applies and a correct season would be overwritten by 0.
@@ -491,6 +511,7 @@ class SubdlProvider(Provider):
                 is_direct_file=is_direct_file,
                 is_full_season=is_full_season,
                 episode_title=getattr(video, 'title', None) if isinstance(video, Episode) else None,
+                target_episode=video.episode if isinstance(video, Episode) else None,
                 matched_id=matched_id,
                 matched_title=matched_title,
             )
@@ -803,7 +824,7 @@ class SubdlProvider(Provider):
         if subtitle.is_pack or subtitle.is_full_season:
             # Match by episode number inside the archive. Only reached when the
             # server did not already expose the individual file via unpack=1.
-            target_episode = subtitle.episode or subtitle.absolute_episode
+            target_episode = subtitle.target_episode or subtitle.absolute_episode
             content = utils.get_subtitle_from_archive(
                 archive,
                 episode=target_episode,
@@ -914,10 +935,11 @@ class SubdlProvider(Provider):
             try:
                 poll = self.session.get(
                     f'{base}pro/translate/jobs/{request_id}', params=params, timeout=30)
-            except Exception:
+            except RequestException as error:
                 poll_failures += 1
                 if poll_failures >= 5:
-                    logger.exception('subdl: AI translation polling failed repeatedly')
+                    logger.error('subdl: AI translation polling failed repeatedly: '
+                                 f'{self._redact(repr(error))}')
                     return
                 continue
 
@@ -946,8 +968,8 @@ class SubdlProvider(Provider):
         try:
             download = self.session.get(
                 f'{base}pro/translate/jobs/{request_id}/download', params=params, timeout=30)
-        except Exception:
-            logger.exception('subdl: AI translation download failed')
+        except RequestException as error:
+            logger.error(f'subdl: AI translation download failed: {self._redact(repr(error))}')
             return
 
         if download.status_code != 200 or not download.content:
@@ -1015,7 +1037,10 @@ class SubdlProvider(Provider):
                 # provider for 12 hours; an edge/WAF 403 is transient.
                 payload = self._safe_json(response)
                 error = str(payload.get('error') or payload.get('message') or '').lower()
-                if not payload or 'key' in error or 'auth' in error or 'forbidden' in error:
+                # Only a JSON verdict from our own API may disable the provider
+                # for 12 hours. A 403 with no parseable body is an edge/WAF
+                # challenge — transient, and not a statement about the key.
+                if payload and ('key' in error or 'auth' in error or 'forbidden' in error):
                     raise AuthenticationError("Invalid API key")
                 raise APIThrottled(f"Request rejected with 403: {error or 'no reason given'}")
             elif status_code == 404:

--- a/custom_libs/subliminal_patch/providers/subdl.py
+++ b/custom_libs/subliminal_patch/providers/subdl.py
@@ -821,6 +821,18 @@ class SubdlProvider(Provider):
                 logger.error(f'Could not open subtitle archive from {safe_link}')
             return
 
+        # A corrupt archive, or a RAR when bazarr could not find its unrar binary
+        # (init.py sets rarfile.UNRAR_TOOL = None in that case), raises out of
+        # archive.read(). bazarr treats rarfile.BadRarFile as a reason to throttle
+        # the whole provider, so absorb it here: one unreadable archive is a
+        # per-subtitle problem.
+        try:
+            self._extract(subtitle, archive, safe_link)
+        except Exception as error:
+            logger.warning(f'subdl: could not read archive {safe_link}: {self._redact(repr(error))}')
+            subtitle.content = None
+
+    def _extract(self, subtitle, archive, safe_link):
         if subtitle.is_pack or subtitle.is_full_season:
             # Match by episode number inside the archive. Only reached when the
             # server did not already expose the individual file via unpack=1.

--- a/custom_libs/subliminal_patch/providers/subdl.py
+++ b/custom_libs/subliminal_patch/providers/subdl.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
 import logging
 import os
+import re
 import time
 import io
+from threading import Lock
 from typing import Callable
 
 from zipfile import ZipFile, is_zipfile
+from rarfile import RarFile, is_rarfile
 from urllib.parse import urljoin
 from requests import Session, Response
 from guessit import guessit
@@ -13,7 +16,8 @@ from guessit import guessit
 from babelfish import language_converters
 from subzero.language import Language
 from subliminal import Episode, Movie
-from subliminal.exceptions import ConfigurationError, ProviderError, DownloadLimitExceeded, AuthenticationError
+from subliminal.exceptions import (ConfigurationError, ProviderError, DownloadLimitExceeded, AuthenticationError,
+                                   ServiceUnavailable)
 from subliminal_patch.exceptions import APIThrottled
 from subliminal_patch.subtitle import Subtitle
 from subliminal.subtitle import fix_line_ending
@@ -25,6 +29,17 @@ logger = logging.getLogger(__name__)
 language_converters.register('subdl = subliminal_patch.converters.subdl:SubdlConverter')
 
 
+class SubdlRequestRejected(ProviderError):
+    """One request was refused for a reason specific to that request.
+
+    Raised for 4xx responses that say nothing about the provider's health — a
+    title the API refuses to parse, a subtitle that no longer exists. It must be
+    handled inside this provider: bazarr throttles on *any* exception that
+    escapes (10 minutes by default, see app/get_providers.py:provider_throttle),
+    and one dead download link is not a reason to stop using subdl.
+    """
+
+
 class SubdlSubtitle(Subtitle):
     provider_name = 'subdl'
     hash_verifiable = False
@@ -32,6 +47,7 @@ class SubdlSubtitle(Subtitle):
 
     def __init__(self, language, forced, hearing_impaired, page_link, download_link, file_id, release_names, uploader,
                  season=None, episode=None, absolute_episode=None, is_pack=False, is_direct_file=False,
+                 is_full_season=False, episode_title=None, matched_id=False, matched_title=False,
                  is_ai_translation=False, ai_source_n_id=None, ai_source_language=None, ai_target_language=None):
         super().__init__(language)
         language = Language.rebuild(language, hi=hearing_impaired, forced=forced)
@@ -41,6 +57,17 @@ class SubdlSubtitle(Subtitle):
         self.absolute_episode = absolute_episode
         self.is_pack = is_pack
         self.is_direct_file = is_direct_file
+        # A pack covering a whole season carries no episode range: every episode
+        # of `season` is inside it, so the archive must be searched by episode.
+        self.is_full_season = is_full_season
+        # Carried so download_subtitle can match a pack member by episode title
+        # without reaching back into shared provider state.
+        self.episode_title = episode_title
+        # Whether this result is actually backed by an id match, rather than by a
+        # fuzzy film_name/title search. Only an id-matched result may claim the
+        # imdb_id/tmdb_id/series_imdb_id matches, which are worth a large score.
+        self.matched_id = matched_id
+        self.matched_title = matched_title
         self.releases = release_names
         self.release_info = ', '.join(release_names)
         self.language = language
@@ -69,8 +96,17 @@ class SubdlSubtitle(Subtitle):
 
         # handle movies and series separately
         if isinstance(video, Episode):
-            # series
-            matches.add('series')
+            # series — only when the result is tied to the series by id. A
+            # film_name search is fuzzy server-side and can return a different
+            # show, and 'series' alone satisfies bazarr's series/episode guard.
+            if self.matched_id and video.series_imdb_id:
+                matches.add('series')
+                matches.add('series_imdb_id')
+                # An IMDB match also confirms the year.
+                if video.year:
+                    matches.add('year')
+            elif self.matched_title:
+                matches.add('series')
             # episode — match by standard episode, absolute episode, or pack range
             matched_by_absolute = False
             if video.episode == self.episode:
@@ -95,17 +131,18 @@ class SubdlSubtitle(Subtitle):
                 # so trust the season too — handles anime uploads tagged with season=0 or
                 # arc-based season numbering different from Sonarr's.
                 matches.add('season')
-            # imdb — IMDB match also confirms the year
-            matches.add('series_imdb_id')
-            if video.year:
-                matches.add('year')
         else:
-            # title
-            matches.add('title')
-            # imdb
-            matches.add('imdb_id')
-            # tmdb
-            matches.add('tmdb_id')
+            # title/imdb/tmdb — again only what the search actually established.
+            if self.matched_id:
+                if video.imdb_id:
+                    matches.add('imdb_id')
+                if video.tmdb_id:
+                    matches.add('tmdb_id')
+                matches.add('title')
+                if video.year:
+                    matches.add('year')
+            elif self.matched_title:
+                matches.add('title')
 
         utils.update_matches(matches, video, self.releases)
 
@@ -133,10 +170,11 @@ class SubdlProvider(Provider):
         self.api_key = api_key
         self.ai_translate = ai_translate
         self.include_ai_translated = include_ai_translated
-        self.video = None
         self._started = None
         # One informational log per video for AI-translate availability notices.
+        # Bazarr shares one provider instance across threads, so guard the set.
         self._ai_notices_logged = set()
+        self._ai_notices_lock = Lock()
 
     def initialize(self):
         self._started = time.time()
@@ -147,22 +185,99 @@ class SubdlProvider(Provider):
     def server_url(self):
         return f'https://{self.server_hostname}/api/v1/'
 
+    # The API caps subs_per_page at 30, so a busy season needs several pages.
+    SUBS_PER_PAGE = 30
+    MAX_PAGES = 3
+
+    # The API rejects these outright ("Film name contains potentially unsafe
+    # characters"), which would otherwise 400 every apostrophe title such as
+    # "Grey's Anatomy" and get the whole provider throttled.
+    # Apostrophes are dropped rather than spaced ("Grey's" -> "Greys"), which is
+    # how the catalogue stores such titles; the rest become separators.
+    APOSTROPHE_CHARS = re.compile(r"['`’]")
+    UNSAFE_TITLE_CHARS = re.compile(r'[<>{}\[\]";\\/]')
+
+    @classmethod
+    def _sanitize_title(cls, title):
+        if not title:
+            return title
+        cleaned = cls.APOSTROPHE_CHARS.sub('', title)
+        cleaned = cls.UNSAFE_TITLE_CHARS.sub(' ', cleaned)
+        cleaned = ' '.join(cleaned.split())
+        if cleaned != title:
+            logger.debug(f'Sanitized title for search: {title!r} -> {cleaned!r}')
+        return cleaned
+
+    @staticmethod
+    def _is_error_payload(payload):
+        if not isinstance(payload, dict):
+            return True
+        if 'success' in payload and not payload['success']:
+            return True
+        if 'status' in payload and not payload['status']:
+            return True
+        return False
+
+    def _search(self, params, description, paginate=False):
+        """Run one search and return (items, first_payload).
+
+        Never raises for this single search: a failure here must not discard
+        results already gathered by the other searches, nor throttle the whole
+        provider. Transport/HTTP errors are logged and yield no items.
+        """
+        items = []
+        first_payload = {}
+        page = 1
+        while page <= (self.MAX_PAGES if paginate else 1):
+            call_params = dict(params)
+            call_params['subs_per_page'] = self.SUBS_PER_PAGE
+            if page > 1:
+                call_params['page'] = page
+            try:
+                response = self.checked(
+                    lambda: self.session.get(self.server_url() + 'subtitles',
+                                             params=call_params, timeout=30)
+                )
+            except Exception as error:
+                logger.debug(f'subdl: {description} search failed, continuing without it: {error!r}')
+                break
+
+            payload = self._safe_json(response)
+            if page == 1:
+                first_payload = payload
+            if self._is_error_payload(payload):
+                error = payload.get('error') if isinstance(payload, dict) else None
+                if error and "can't find" in str(error).lower():
+                    logger.debug(f'subdl: {description} search found nothing: {error}')
+                else:
+                    logger.debug(f'subdl: {description} search returned an error payload: {payload}')
+                break
+
+            batch = payload.get('subtitles') or []
+            items.extend(batch)
+            total_pages = payload.get('totalPages') or 1
+            if not paginate or page >= total_pages or len(batch) < self.SUBS_PER_PAGE:
+                break
+            page += 1
+
+        return items, first_payload
+
     def query(self, languages, video):
-        self.video = video
-        if isinstance(self.video, Episode):
-            title = self.video.series
+        if isinstance(video, Episode):
+            title = video.series
         else:
-            title = self.video.title
+            title = video.title
+        title = self._sanitize_title(title)
 
         imdb_id = None
         tmdb_id = None
-        if isinstance(self.video, Episode) and self.video.series_imdb_id:
-            imdb_id = self.video.series_imdb_id
-        elif isinstance(self.video, Movie):
-            if self.video.imdb_id:
-               imdb_id = self.video.imdb_id
-            if self.video.tmdb_id:
-               tmdb_id = self.video.tmdb_id
+        if isinstance(video, Episode) and video.series_imdb_id:
+            imdb_id = video.series_imdb_id
+        elif isinstance(video, Movie):
+            if video.imdb_id:
+               imdb_id = video.imdb_id
+            if video.tmdb_id:
+               tmdb_id = video.tmdb_id
 
         # be sure to remove duplicates using list(set())
         langs_list = sorted(list(set([language_converters['subdl'].convert(lang.alpha3, lang.country, lang.script) for
@@ -171,287 +286,232 @@ class SubdlProvider(Provider):
         langs = ','.join(langs_list)
         logger.debug(f'Searching for those languages: {langs}')
 
-        # query the server
-        if isinstance(self.video, Episode):
-            res = self.checked(
-                lambda: self.session.get(self.server_url() + 'subtitles',
-                                         params=(('api_key', self.api_key),
-                                                 ('bazarr', 1),  # this argument filters incompatible image-based or
-                                         # txt subtitles
-                                                 ('comment', 1),
-                                                 ('episode_number', self.video.episode),
-                                                 ('film_name', title if not imdb_id else None),
-                                                 ('imdb_id', imdb_id if imdb_id else None),
-                                                 ('languages', langs),
-                                                 ('releases', 1),
-                                                 ('season_number', self.video.season),
-                                                 ('subs_per_page', 30),
-                                                 ('type', 'tv'),
-                                                 ('unpack', 1)),
-                                         timeout=30)
-            )
+        # 'bazarr' filters incompatible image-based or txt subtitles.
+        base_params = {
+            'api_key': self.api_key,
+            'bazarr': 1,
+            'comment': 1,
+            'languages': langs,
+            'releases': 1,
+            'unpack': 1,
+        }
+        if imdb_id:
+            base_params['imdb_id'] = imdb_id
+        else:
+            base_params['film_name'] = title
+
+        # Results found via an id-based search may claim the id matches; results
+        # found only by (fuzzy, server-side) film_name may not.
+        matched_id = bool(imdb_id)
+        matched_title = not imdb_id
+
+        all_items = []
+        seen_ids = set()
+
+        def merge(items, description):
+            added = 0
+            for item in items:
+                key = item.get('subtitlePage') or item.get('name')
+                if key in seen_ids:
+                    continue
+                seen_ids.add(key)
+                all_items.append(item)
+                added += 1
+            if added:
+                logger.debug(f'subdl: {description} search added {added} subtitles')
+            return added
+
+        if isinstance(video, Episode):
+            episode_items, first_payload = self._search(
+                dict(base_params, type='tv', episode_number=video.episode, season_number=video.season),
+                'episode', paginate=True)
+            merge(episode_items, 'episode')
 
             # For anime with absolute episode numbering, also search by absolute episode number
             # so we can find subtitles that are only indexed by absolute number on subdl
-            absolute_episode = getattr(self.video, 'absolute_episode', None)
-            if absolute_episode and absolute_episode != self.video.episode:
+            absolute_episode = getattr(video, 'absolute_episode', None)
+            if absolute_episode and absolute_episode != video.episode:
                 logger.debug(f'Also searching by absolute episode number: {absolute_episode}')
-                res_absolute = self.checked(
-                    lambda: self.session.get(self.server_url() + 'subtitles',
-                                             params=(('api_key', self.api_key),
-                                                     ('bazarr', 1),  # this argument filters incompatible image-based or
-                                         # txt subtitles
-                                                     ('comment', 1),
-                                                     ('episode_number', absolute_episode),
-                                                     ('film_name', title if not imdb_id else None),
-                                                     ('imdb_id', imdb_id if imdb_id else None),
-                                                     ('languages', langs),
-                                                     ('releases', 1),
-                                                     ('subs_per_page', 30),
-                                                     ('type', 'tv'),
-                                                     ('unpack', 1)),
-                                             timeout=30)
-                )
-            else:
-                res_absolute = None
+                merge(self._search(dict(base_params, type='tv', episode_number=absolute_episode),
+                                   'absolute episode')[0], 'absolute episode')
 
             # Fallback: search by season only (no episode filter) to catch subtitles that use
             # split-season / cour-based internal numbering (e.g. Fire Force S3 split into two cours
             # where episode 25 is stored internally as cour-2 episode 13).
             # The release name matching in get_matches() will identify the correct episode.
-            logger.debug(f'Also searching by season only (no episode filter) for season {self.video.season}')
-            res_season = self.checked(
-                lambda: self.session.get(self.server_url() + 'subtitles',
-                                         params=(('api_key', self.api_key),
-                                                 ('bazarr', 1),  # this argument filters incompatible image-based or
-                                         # txt subtitles
-                                                 ('comment', 1),
-                                                 ('film_name', title if not imdb_id else None),
-                                                 ('imdb_id', imdb_id if imdb_id else None),
-                                                 ('languages', langs),
-                                                 ('releases', 1),
-                                                 ('season_number', self.video.season),
-                                                 ('subs_per_page', 30),
-                                                 ('type', 'tv'),
-                                                 ('unpack', 1)),
-                                         timeout=30)
-            )
+            logger.debug(f'Also searching by season only (no episode filter) for season {video.season}')
+            merge(self._search(dict(base_params, type='tv', season_number=video.season),
+                               'season-only', paginate=True)[0], 'season-only')
+
+            # Last resort: if all season-filtered searches returned nothing, search by title only
+            # (no season/episode filter). This catches anime stored as season 0 on subdl (full series
+            # blocks) where season_number filtering silently excludes all results.
+            if not all_items:
+                logger.debug('All season-filtered searches returned 0 results, falling back to title-only search')
+                merge(self._search(dict(base_params, type='tv'), 'title-only')[0], 'title-only')
         else:
-            res_absolute = None
-            res_season = None
-            params = {
-                       'api_key': self.api_key,
-                       'bazarr': 1,  # this argument filters incompatible image-based or txt subtitles
-                       'comment': 1,
-                       'film_name': title if not imdb_id else None,
-                       'imdb_id': imdb_id,
-                       'languages': langs,
-                       'releases': 1,
-                       'subs_per_page': 30,
-                       'type': 'movie',
-            }
-            res = self.checked(
-                lambda: self.session.get(self.server_url() + 'subtitles',
-                                         params=params,
-                                         timeout=30)
-            )
+            movie_items, first_payload = self._search(dict(base_params, type='movie'), 'movie', paginate=True)
+            merge(movie_items, 'movie')
 
             # subdl also allows searching by TMDB ID, and some movies don't always
             # have the correct IMDB ID, or may not have it at all. We also search by TMDB ID
             # if it's available for the movie.
-            if res.status_code == 200:
-                # if the previous request with IMDb ID reported errors
-                res_data = res.json()
-
-                if 'status' in res_data and not res_data['status']:
-                    if not tmdb_id:
-                        logger.debug("No subtitles found via IMDb id or film name. TMDB ID unavailable for fallback")
-
-                    # If the movie also has the TMDB ID code, we try to search
-                    # for subtitles using only the TMDB ID code
-                    else:
-                        logger.debug("No subtitles found via IMDb id or film name. Search instead with TMDB id")
-
-                        params.pop('film_name', None)
-                        params.pop('imdb_id', None)
-                        params['tmdb_id']=tmdb_id
-
-                        res = self.checked(
-                            lambda: self.session.get(self.server_url() + 'subtitles',
-                                                     params=params,
-                                                     timeout=30)
-                        )
+            if not all_items and tmdb_id:
+                logger.debug('No subtitles found via IMDb id or film name. Search instead with TMDB id')
+                tmdb_params = dict(base_params, type='movie', tmdb_id=tmdb_id)
+                tmdb_params.pop('film_name', None)
+                tmdb_params.pop('imdb_id', None)
+                tmdb_items, tmdb_payload = self._search(tmdb_params, 'tmdb', paginate=True)
+                if merge(tmdb_items, 'tmdb'):
+                    matched_id = True
+                    matched_title = False
+                if not first_payload:
+                    first_payload = tmdb_payload
+            elif not all_items:
+                logger.debug('No subtitles found via IMDb id or film name. TMDB ID unavailable for fallback')
 
         subtitles = []
 
-        result = res.json()
-
         # AI-translation availability for the requested languages (subdl api
         # returns this only for bazarr=1 requests; absent on older API versions).
-        translation_block = result.get('translation') if isinstance(result, dict) else None
-
-        if ('success' in result and not result['success']) or ('status' in result and not result['status']):
-            logger.debug(result)
-            if 'error' in result and "can't find" in result['error'].lower():
-                logger.debug(f"No subtitles found for {imdb_id or title}: {result['error']}")
-            else:
-                logger.debug(f"Error while searching for subtitles: {result}")
-            return subtitles
-
-        # Merge absolute episode search results if available
-        all_items = list(result.get('subtitles', []))
-        seen_ids = {item['name'] for item in all_items}
-
-        if res_absolute and res_absolute.status_code == 200:
-            abs_result = res_absolute.json()
-            if ('success' in abs_result and abs_result['success']) or ('status' in abs_result and abs_result['status']):
-                for item in abs_result.get('subtitles', []):
-                    if item['name'] not in seen_ids:
-                        all_items.append(item)
-                        seen_ids.add(item['name'])
-                logger.debug(f'Absolute episode search added {len(abs_result.get("subtitles", []))} more subtitles')
-
-        if res_season and res_season.status_code == 200:
-            season_result = res_season.json()
-            if ('success' in season_result and season_result['success']) or ('status' in season_result and season_result['status']):
-                added = 0
-                for item in season_result.get('subtitles', []):
-                    if item['name'] not in seen_ids:
-                        all_items.append(item)
-                        seen_ids.add(item['name'])
-                        added += 1
-                logger.debug(f'Season-only search added {added} more subtitles')
-
-        # Last resort: if all season-filtered searches returned nothing, search by title only
-        # (no season/episode filter). This catches anime stored as season 0 on subdl (full series
-        # blocks) where season_number filtering silently excludes all results.
-        if not all_items and isinstance(self.video, Episode):
-            logger.debug('All season-filtered searches returned 0 results, falling back to title-only search')
-            res_title = self.checked(
-                lambda: self.session.get(self.server_url() + 'subtitles',
-                                         params=(('api_key', self.api_key),
-                                                 ('film_name', title if not imdb_id else None),
-                                                 ('imdb_id', imdb_id if imdb_id else None),
-                                                 ('languages', langs),
-                                                 ('subs_per_page', 30),
-                                                 ('type', 'tv'),
-                                                 ('comment', 1),
-                                                 ('releases', 1),
-                                                 ('unpack', 1),
-                                                 ('bazarr', 1)),  # this argument filters incompatible image-based
-                                         # or txt subtitles
-                                         timeout=30)
-            )
-            if res_title.status_code == 200:
-                title_result = res_title.json()
-                if ('success' in title_result and title_result['success']) or \
-                        ('status' in title_result and title_result['status']):
-                    added = 0
-                    for item in title_result.get('subtitles', []):
-                        if item['name'] not in seen_ids:
-                            all_items.append(item)
-                            seen_ids.add(item['name'])
-                            added += 1
-                    logger.debug(f'Title-only fallback search added {added} subtitles')
+        translation_block = first_payload.get('translation') if isinstance(first_payload, dict) else None
 
         logger.debug(f"Query returned {len(all_items)} subtitles")
 
-        absolute_episode = getattr(self.video, 'absolute_episode', None)
+        absolute_episode = getattr(video, 'absolute_episode', None)
 
-        if len(all_items):
-            for item in all_items:
-                if item.get('ai_translated') and not self.include_ai_translated:
-                    continue
-                is_pack = False
-                is_direct_file = False
-                download_link = item['url']
-                file_id = item['name']
-                item_season = item.get('season', None)
-                item_episode = item.get('episode', None)
-                if isinstance(self.video, Episode):
-                    ep_from = item.get('episode_from')
-                    ep_end = item.get('episode_end')
-                    # Fallback: parse episode range from release names when the API
-                    # does not provide episode_from/episode_end fields.
-                    if not (ep_from and ep_end and ep_from != ep_end):
-                        ep_from_parsed, ep_end_parsed = self._parse_episode_range_from_releases(
-                            item.get('releases', [])
+        for item in all_items:
+            if item.get('ai_translated') and not self.include_ai_translated:
+                continue
+
+            # A language the converter does not know must cost us this one item,
+            # not the whole search (an escaping ConfigurationError bans subdl 12h).
+            try:
+                language = Language.fromsubdl(item['language'])
+            except Exception:
+                logger.debug(f"Skipping subtitle with unsupported language {item.get('language')!r}")
+                continue
+
+            is_pack = False
+            is_direct_file = False
+            is_full_season = False
+            download_link = item['url']
+            file_id = item.get('subtitlePage') or item['name']
+            item_season = item.get('season', None)
+            item_episode = item.get('episode', None)
+
+            if isinstance(video, Episode):
+                ep_from = self._episode_number(item.get('episode_from'))
+                ep_end = self._episode_number(item.get('episode_end'))
+                is_full_season = bool(item.get('full_season'))
+
+                # Only fall back to parsing release names when the API gave us
+                # nothing. For a single-episode row it returns ep_from == ep_end,
+                # which is authoritative and must not be overridden by a batch
+                # release name that happens to mention a range.
+                if ep_from is None and ep_end is None and not is_full_season:
+                    ep_from_parsed, ep_end_parsed = self._parse_episode_range_from_releases(
+                        item.get('releases', [])
+                    )
+                    if ep_from_parsed and ep_end_parsed and ep_from_parsed != ep_end_parsed:
+                        ep_from = ep_from_parsed
+                        ep_end = ep_end_parsed
+                        logger.debug(
+                            f'Parsed episode range {ep_from}-{ep_end} from release names'
                         )
-                        if ep_from_parsed and ep_end_parsed and ep_from_parsed != ep_end_parsed:
-                            ep_from = ep_from_parsed
-                            ep_end = ep_end_parsed
-                            logger.debug(
-                                f'Parsed episode range {ep_from}-{ep_end} from release names'
-                            )
-                    if ep_from and ep_end and ep_from != ep_end:
-                        # Multi-episode pack: allow if target episode is within range
-                        target_ep = self.video.episode
-                        if absolute_episode:
-                            # Check both standard and absolute episode against the range
-                            if not ((ep_from <= target_ep <= ep_end) or
-                                    (ep_from <= absolute_episode <= ep_end)):
-                                continue
-                        else:
-                            if not (ep_from <= target_ep <= ep_end):
-                                continue
-                        is_pack = True
 
-                        # Prefer direct unpacked file when the API exposes one matching
-                        # the target episode (unpack=1). This avoids downloading the whole
-                        # season ZIP just to extract a single subtitle.
-                        unpack_entry = next(
-                            (f for f in item.get('unpack_files', [])
-                             if f.get('episode') == self.video.episode
-                             or (absolute_episode and f.get('episode') == absolute_episode)),
-                            None
+                has_range = ep_from is not None and ep_end is not None and ep_from != ep_end
+                if has_range:
+                    # Multi-episode pack: allow if target episode is within range
+                    target_ep = video.episode
+                    if absolute_episode:
+                        # Check both standard and absolute episode against the range
+                        if not ((ep_from <= target_ep <= ep_end) or
+                                (ep_from <= absolute_episode <= ep_end)):
+                            continue
+                    else:
+                        if not (ep_from <= target_ep <= ep_end):
+                            continue
+
+                # A full-season pack carries no range (the API sends
+                # episode_from=null, episode_end=0, full_season=true) but does
+                # contain every episode of item['season'].
+                if has_range or is_full_season:
+                    is_pack = True
+
+                    # Prefer the per-episode file the server already extracted
+                    # (unpack=1). Downloading a whole season archive client-side
+                    # is the fallback, not the plan.
+                    unpack_entry = next(
+                        (f for f in item.get('unpack_files') or []
+                         if f.get('episode') == video.episode
+                         or (absolute_episode and f.get('episode') == absolute_episode)),
+                        None
+                    )
+                    if unpack_entry:
+                        download_link = unpack_entry['url']
+                        file_id = f"{file_id}/{unpack_entry['file_n_id']}"
+                        # `or` not `.get(default)`: the API sends season/episode
+                        # as 0 rather than omitting them, so a dict default never
+                        # applies and a correct season would be overwritten by 0.
+                        item_season = unpack_entry.get('season') or item_season
+                        item_episode = unpack_entry.get('episode') or item_episode
+                        is_pack = False
+                        is_full_season = False
+                        is_direct_file = True
+                        logger.debug(
+                            f'Using unpacked file {unpack_entry["name"]} for episode '
+                            f'{item_episode} instead of pack {item["name"]}'
                         )
-                        if unpack_entry:
-                            download_link = unpack_entry['url']
-                            file_id = f"{item['name']}/{unpack_entry['file_n_id']}"
-                            item_season = unpack_entry.get('season', item_season)
-                            item_episode = unpack_entry.get('episode', item_episode)
-                            is_pack = False
-                            is_direct_file = True
-                            logger.debug(
-                                f'Using unpacked file {unpack_entry["name"]} for episode '
-                                f'{item_episode} instead of pack {item["name"]}'
-                            )
 
-                uploader = item.get('author', '')
-                if item.get('ai_translated'):
-                    uploader = f'{uploader} (AI translated)' if uploader else 'AI translated'
+            uploader = item.get('author', '')
+            if item.get('ai_translated'):
+                uploader = f'{uploader} (AI translated)' if uploader else 'AI translated'
 
-                subtitle = SubdlSubtitle(
-                    language=Language.fromsubdl(item['language']),
-                    forced=self._is_forced(item),
-                    hearing_impaired=item.get('hi', False) or self._is_hi(item),
-                    page_link=urljoin("https://subdl.com", item.get('subtitlePage', '')),
-                    download_link=download_link,
-                    file_id=file_id,
-                    release_names=item.get('releases', []),
-                    uploader=uploader,
-                    season=item_season,
-                    episode=item_episode,
-                    absolute_episode=absolute_episode,
-                    is_pack=is_pack,
-                    is_direct_file=is_direct_file,
-                )
-                subtitle.get_matches(self.video)
-                if subtitle.language in languages:  # make sure only desired subtitles variants are returned
-                    subtitles.append(subtitle)
+            subtitle = SubdlSubtitle(
+                language=language,
+                forced=self._is_forced(item),
+                hearing_impaired=self._is_hearing_impaired(item),
+                page_link=urljoin("https://subdl.com", item.get('subtitlePage', '')),
+                download_link=download_link,
+                file_id=file_id,
+                release_names=item.get('releases', []),
+                uploader=uploader,
+                season=item_season,
+                episode=item_episode,
+                absolute_episode=absolute_episode,
+                is_pack=is_pack,
+                is_direct_file=is_direct_file,
+                is_full_season=is_full_season,
+                episode_title=getattr(video, 'title', None) if isinstance(video, Episode) else None,
+                matched_id=matched_id,
+                matched_title=matched_title,
+            )
+            subtitle.get_matches(video)
+            if subtitle.language in languages:  # make sure only desired subtitles variants are returned
+                subtitles.append(subtitle)
 
-        self._add_ai_translation_candidates(translation_block, languages, subtitles)
+        self._add_ai_translation_candidates(translation_block, languages, subtitles, video,
+                                            matched_id=matched_id, matched_title=matched_title)
 
         return subtitles
 
-    def _log_ai_notice_once(self, message):
-        key = (getattr(self.video, 'name', None) or getattr(self.video, 'title', ''), message)
-        if key in self._ai_notices_logged:
-            return
-        self._ai_notices_logged.add(key)
+    def _log_ai_notice_once(self, scope, message):
+        """Log an AI-translate notice once per (video-or-subtitle, message).
+
+        Bazarr searches every wanted item in a loop; without this the same
+        upgrade notice would be written once per item.
+        """
+        key = (getattr(scope, 'name', None) or getattr(scope, 'id', None)
+               or getattr(scope, 'title', ''), message)
+        with self._ai_notices_lock:
+            if key in self._ai_notices_logged:
+                return
+            self._ai_notices_logged.add(key)
         logger.info(message)
 
-    def _add_ai_translation_candidates(self, translation, languages, subtitles):
+    def _add_ai_translation_candidates(self, translation, languages, subtitles, video,
+                                       matched_id=False, matched_title=False):
         """Append virtual 'AI translation' candidates for wanted languages the
         API reported as missing but translatable (SubDL Plus/Pro feature)."""
         if not self.ai_translate or not isinstance(translation, dict):
@@ -464,6 +524,7 @@ class SubdlProvider(Provider):
         if not translation.get('entitled'):
             upgrade_url = translation.get('upgrade_url') or 'https://subdl.com/pro?ref=bazarr'
             self._log_ai_notice_once(
+                video,
                 f'subdl: missing languages ({", ".join(sorted(missing))}) can be AI-translated '
                 f'in about a minute with a SubDL Plus/Pro subscription: {upgrade_url}')
             return
@@ -472,31 +533,42 @@ class SubdlProvider(Provider):
         if not sources:
             reset_at = translation.get('quota_reset_at') or 'the 1st of next month'
             self._log_ai_notice_once(
+                video,
                 f'subdl: AI translation quota exhausted; more translations available after {reset_at}')
             return
 
-        # Translations inherit the source subtitle's timing, so pick the source
-        # whose release names best match the video.
-        def source_score(source):
+        # The server already orders sources deliberately (English first for
+        # translation quality, non-HI before HI). Keep that order and only use
+        # release-name matching to break ties, since translations inherit the
+        # source subtitle's timing.
+        def source_rank(indexed_source):
+            index, source = indexed_source
             matches = set()
-            utils.update_matches(matches, self.video, source.get('releases') or [])
-            return len(matches)
+            utils.update_matches(matches, video, source.get('releases') or [])
+            return (-len(matches), index)
 
-        best_source = max(sources, key=source_score)
+        best_source = min(enumerate(sources), key=source_rank)[1]
         source_releases = best_source.get('releases') or []
         source_n_id = best_source.get('n_id')
         if not source_n_id:
             return
+        # A translation of an SDH source is still SDH; declaring it non-HI on a
+        # hearing_impaired_verifiable provider would mislabel the saved file.
+        source_is_hi = bool(best_source.get('hi'))
 
-        existing_languages = {(sub.language.alpha3, sub.language.country, sub.language.script)
+        existing_languages = {(sub.language.alpha3, sub.language.country, sub.language.script,
+                               bool(getattr(sub.language, 'hi', False)), bool(sub.language.forced))
                               for sub in subtitles}
 
         for language in languages:
-            # Only plain variants: a forced/HI subtitle can't be produced by
-            # translating a regular source.
-            if language.forced or getattr(language, 'hi', False):
+            # A forced subtitle can't be produced by translating a regular source.
+            if language.forced:
                 continue
-            if (language.alpha3, language.country, language.script) in existing_languages:
+            # An HI target can only come from an HI source, and vice versa.
+            if bool(getattr(language, 'hi', False)) != source_is_hi:
+                continue
+            if (language.alpha3, language.country, language.script,
+                    bool(getattr(language, 'hi', False)), False) in existing_languages:
                 continue
             try:
                 target_code = language_converters['subdl'].convert(
@@ -506,13 +578,13 @@ class SubdlProvider(Provider):
             if target_code not in missing:
                 continue
 
-            season = self.video.season if isinstance(self.video, Episode) else None
-            episode = self.video.episode if isinstance(self.video, Episode) else None
+            season = video.season if isinstance(video, Episode) else None
+            episode = video.episode if isinstance(video, Episode) else None
 
             candidate = SubdlSubtitle(
                 language=language,
                 forced=False,
-                hearing_impaired=False,
+                hearing_impaired=source_is_hi,
                 page_link='https://subdl.com/pro?ref=bazarr',
                 download_link=None,
                 file_id=f'ai:{source_n_id}:{target_code}',
@@ -520,49 +592,97 @@ class SubdlProvider(Provider):
                 uploader='SubDL AI',
                 season=season,
                 episode=episode,
+                matched_id=matched_id,
+                matched_title=matched_title,
                 is_ai_translation=True,
                 ai_source_n_id=source_n_id,
                 ai_source_language=best_source.get('language') or '',
                 ai_target_language=target_code,
             )
-            candidate.get_matches(self.video)
+            candidate.get_matches(video)
             logger.debug(
                 f'Offering AI translation candidate for {target_code} '
                 f'from source {source_n_id} ({best_source.get("language")})')
             subtitles.append(candidate)
 
-    @staticmethod
-    def _is_hi(item):
-        # Comments include specific mention of removed or non HI
-        non_hi_tag = ['hi remove', 'non hi', 'nonhi', 'non-hi', 'non-sdh', 'non sdh', 'nonsdh', 'sdh remove']
-        for tag in non_hi_tag:
-            if tag in item.get('comment', '').lower():
-                return False
+    # 'HI'/'SDH' as whole words only. Bare substrings used to match inside
+    # ordinary release groups — ' hi' fires on "Hive-CM8", "Hi10P" and "Hindi" —
+    # which mislabels a normal subtitle as hearing-impaired and then hides it
+    # from every non-HI language profile.
+    _HI_WORD_RE = re.compile(
+        r'(?<![a-z0-9])(hi|sdh|cc)(?![a-z0-9])'
+        r'|_hi_|𝓢𝓓𝓗'
+        r'|hearing[\s._-]?impaired'
+        r'|closed[\s._-]?caption',
+        re.IGNORECASE)
+    _NON_HI_RE = re.compile(
+        r'(?<![a-z0-9])(non[\s._-]?(hi|sdh)|(hi|sdh)[\s._-]?remove[d]?|remove[d]?[\s._-]?(hi|sdh))(?![a-z0-9])',
+        re.IGNORECASE)
+    _FORCED_RE = re.compile(r'(?<![a-z0-9])(forced|foreign[\s._-]?parts?)(?![a-z0-9])', re.IGNORECASE)
 
-        # Archive filename include _HI_
-        if '_hi_' in item.get('name', '').lower():
+    @classmethod
+    def _is_hearing_impaired(cls, item):
+        """Combine the API's own hi flag with the text heuristics.
+
+        The explicit non-HI markers win over both, so a subtitle whose comment
+        says "removed SDH" is never stored as HI even when the API flags it.
+        """
+        if cls._is_explicit_non_hi(item):
+            return False
+        if item.get('hi', False):
             return True
+        return cls._is_hi(item)
 
-        # Comments or release names include some specific strings
-        hi_keys = [item.get('comment', '').lower()] + [x.lower() for x in item.get('releases', [])]
-        hi_tag = ['_hi_', ' hi ', '.hi.', 'hi ', ' hi', 'sdh', '𝓢𝓓𝓗']
-        for key in hi_keys:
-            if any(x in key for x in hi_tag):
+    @classmethod
+    def _is_explicit_non_hi(cls, item):
+        for text in cls._item_texts(item):
+            if cls._NON_HI_RE.search(text):
+                return True
+        return False
+
+    @staticmethod
+    def _item_texts(item):
+        texts = [item.get('comment') or '', item.get('name') or '']
+        texts.extend(x for x in (item.get('releases') or []) if isinstance(x, str))
+        return texts
+
+    @classmethod
+    def _is_hi(cls, item):
+        # Comments include specific mention of removed or non HI
+        if cls._is_explicit_non_hi(item):
+            return False
+
+        for text in cls._item_texts(item):
+            if cls._HI_WORD_RE.search(text):
                 return True
 
         # nothing match so we consider it as non-HI
         return False
 
-    @staticmethod
-    def _is_forced(item):
-        # Comments include specific mention of forced subtitles
-        forced_tags = ['forced', 'foreign']
-        for tag in forced_tags:
-            if tag in item.get('comment', '').lower():
+    @classmethod
+    def _is_forced(cls, item):
+        # Forced markers appear in release names at least as often as in
+        # comments, so read both. 'foreign' alone is too loose — it matches
+        # ordinary descriptions — hence 'foreign part(s)'.
+        for text in cls._item_texts(item):
+            if cls._FORCED_RE.search(text):
                 return True
 
         # nothing match so we consider it as normal subtitles
         return False
+
+    @staticmethod
+    def _episode_number(value):
+        """Normalise an episode field to a positive int, or None.
+
+        The API sends 0 (and sometimes null) to mean 'not applicable', so 0 must
+        never be treated as episode zero nor as a usable range bound.
+        """
+        try:
+            number = int(value)
+        except (TypeError, ValueError):
+            return None
+        return number if number > 0 else None
 
     @staticmethod
     def _parse_episode_range_from_releases(release_names):
@@ -584,11 +704,60 @@ class SubdlProvider(Provider):
     def list_subtitles(self, video, languages):
         return self.query(languages, video)
 
+    @staticmethod
+    def _redact(url):
+        """Strip the api_key before a URL reaches the log.
+
+        Bazarr's log redactor only knows `apikey=`, so a subdl `api_key=` would
+        otherwise be written to bazarr.log in cleartext — and those logs get
+        pasted into public issues.
+        """
+        return re.sub(r'(api_key=)[^&\s]+', r'\1<redacted>', str(url))
+
     # AI translation jobs normally finish in well under a minute; poll with a
     # generous ceiling so a slow job still lands in the same download call.
     AI_TRANSLATE_POLL_INTERVAL = 4
     AI_TRANSLATE_MIN_DEADLINE = 90
     AI_TRANSLATE_MAX_DEADLINE = 180
+
+    @staticmethod
+    def _open_archive(stream):
+        """Return an open ZipFile/RarFile, or None if the payload is neither.
+
+        subdl serves some older uploads as RAR under a .zip filename and an
+        application/octet-stream content type, so sniff the bytes rather than
+        trusting either.
+        """
+        stream.seek(0)
+        if is_zipfile(stream):
+            stream.seek(0)
+            return ZipFile(stream)
+        stream.seek(0)
+        try:
+            if is_rarfile(stream):
+                stream.seek(0)
+                return RarFile(stream)
+        except Exception:
+            logger.debug('subdl: payload looked like RAR but could not be opened', exc_info=True)
+        return None
+
+    @staticmethod
+    def _first_subtitle_in_archive(archive):
+        """Pick a single subtitle member, ignoring archive junk.
+
+        Skips directory entries and macOS AppleDouble resource forks
+        (__MACOSX/._name.srt), which otherwise win the extension test and yield
+        a few KB of binary instead of a subtitle.
+        """
+        for name in archive.namelist():
+            if name.endswith('/'):
+                continue
+            base = name.rsplit('/', 1)[-1]
+            if not base or base.startswith('._') or name.startswith('__MACOSX/'):
+                continue
+            if base.lower().endswith(('.srt', '.sub', '.ssa', '.ass')):
+                return fix_line_ending(archive.read(name))
+        return None
 
     def download_subtitle(self, subtitle):
         logger.debug('Downloading subtitle %r', subtitle)
@@ -598,55 +767,59 @@ class SubdlProvider(Provider):
             return
 
         download_link = urljoin("https://dl.subdl.com", subtitle.download_link)
+        safe_link = self._redact(download_link)
 
-        r = self.checked(
-            lambda: self.session.get(download_link, timeout=30)
-        )
-
-        if not r:
-            logger.error(f'Could not download subtitle from {download_link}')
-            subtitle.content = None
+        subtitle.content = None
+        try:
+            r = self.checked(
+                lambda: self.session.get(download_link, timeout=30)
+            )
+        except SubdlRequestRejected as error:
+            # A subtitle that no longer exists fails this download only; bazarr
+            # falls through to the next candidate.
+            logger.warning(f'subdl: download rejected for {safe_link}: {error}')
             return
-        else:
-            archive_stream = io.BytesIO(r.content)
-            if is_zipfile(archive_stream):
-                archive = ZipFile(archive_stream)
-                if subtitle.is_pack and self.video and isinstance(self.video, Episode):
-                    # Use smart extraction for packs: match by episode number
-                    target_episode = self.video.episode
-                    absolute_episode = getattr(self.video, 'absolute_episode', None)
-                    content = utils.get_subtitle_from_archive(
-                        archive,
-                        episode=target_episode,
-                        episode_title=getattr(self.video, 'title', None),
-                    )
-                    # Fallback: try absolute episode number
-                    if content is None and absolute_episode:
-                        content = utils.get_subtitle_from_archive(
-                            archive,
-                            episode=absolute_episode,
-                        )
-                    if content is not None:
-                        subtitle.content = content
-                    else:
-                        logger.warning(f'Could not find episode {target_episode} in pack archive {download_link}')
-                        subtitle.content = None
-                else:
-                    # Single episode: prefer subtitle file extensions, fallback to first file
-                    for name in archive.namelist():
-                        if name.endswith(('.srt', '.sub', '.ssa', '.ass')):
-                            subtitle.content = fix_line_ending(archive.read(name))
-                            return
-                    for name in archive.namelist():
-                        subtitle.content = fix_line_ending(archive.read(name))
-                        return
-            elif subtitle.is_direct_file:
-                # subdl unpack=1: response is a raw subtitle file, not a ZIP
+
+        if r is None or not r.content:
+            logger.error(f'Could not download subtitle from {safe_link}')
+            return
+
+        archive = self._open_archive(io.BytesIO(r.content))
+        if archive is None:
+            if subtitle.is_direct_file:
+                # subdl unpack=1: response is a raw subtitle file, not an archive
                 subtitle.content = fix_line_ending(r.content)
             else:
-                logger.error(f'Could not unzip subtitle from {download_link}')
-                subtitle.content = None
+                logger.error(f'Could not open subtitle archive from {safe_link}')
+            return
+
+        if subtitle.is_pack or subtitle.is_full_season:
+            # Match by episode number inside the archive. Only reached when the
+            # server did not already expose the individual file via unpack=1.
+            target_episode = subtitle.episode or subtitle.absolute_episode
+            content = utils.get_subtitle_from_archive(
+                archive,
+                episode=target_episode,
+                episode_title=subtitle.episode_title,
+            )
+            # Fallback: try absolute episode number
+            if content is None and subtitle.absolute_episode:
+                content = utils.get_subtitle_from_archive(
+                    archive,
+                    episode=subtitle.absolute_episode,
+                )
+            if content is None:
+                logger.warning(
+                    f'Could not find episode {target_episode} in pack archive {safe_link}')
                 return
+            subtitle.content = content
+            return
+
+        content = self._first_subtitle_in_archive(archive)
+        if content is None:
+            logger.error(f'No subtitle file found inside archive {safe_link}')
+            return
+        subtitle.content = content
 
     @staticmethod
     def _safe_json(response):
@@ -670,16 +843,25 @@ class SubdlProvider(Provider):
         params = {'api_key': self.api_key}
         subtitle.content = None
 
+        # Season/episode, not a file id: the server holds the subtitle files and
+        # resolves which one to translate itself, extracting a season pack when
+        # it has to. The client has no business shipping file ids or contents.
+        payload_body = {'n_id': subtitle.ai_source_n_id,
+                        'target_language': subtitle.ai_target_language}
+        if subtitle.season is not None:
+            payload_body['season'] = subtitle.season
+        if subtitle.episode is not None:
+            payload_body['episode'] = subtitle.episode
+
         try:
             response = self.session.post(
                 base + 'pro/translate/subtitles',
                 params=params,
-                json={'n_id': subtitle.ai_source_n_id,
-                      'target_language': subtitle.ai_target_language},
+                json=payload_body,
                 timeout=30,
             )
-        except Exception:
-            logger.exception('subdl: AI translation request failed')
+        except Exception as error:
+            logger.error(f'subdl: AI translation request failed: {self._redact(error)}')
             return
 
         if response.status_code not in (200, 202):
@@ -688,9 +870,11 @@ class SubdlProvider(Provider):
             message = payload.get('message') or error or f'HTTP {response.status_code}'
             if error == 'translation_quota_exhausted':
                 self._log_ai_notice_once(
+                    subtitle,
                     'subdl: AI translation quota exhausted; more translations available next month')
             elif error == 'translation_not_entitled':
                 self._log_ai_notice_once(
+                    subtitle,
                     'subdl: AI translation requires a SubDL Plus/Pro subscription: '
                     'https://subdl.com/pro?ref=bazarr')
             else:
@@ -767,7 +951,24 @@ class SubdlProvider(Provider):
         subtitle.content = fix_line_ending(download.content)
         logger.debug(f'subdl: AI translation job {request_id} downloaded')
 
-    def checked(self, fn: Callable, is_retry: bool = False, retry_attempt=0) -> Response:
+    # Absolute ceiling across BOTH retry branches. Previously rate_limit reset
+    # the service_busy counter and vice versa, so an alternating server could
+    # keep one search thread sleeping indefinitely.
+    MAX_RETRY_ATTEMPTS = 6
+
+    @staticmethod
+    def _sleep_for_retry(response, default, label):
+        raw = response.headers.get('Retry-After', default)
+        try:
+            delay = int(raw)
+        except (TypeError, ValueError):
+            # Retry-After may be an HTTP-date; int() would raise and abort.
+            delay = default
+        delay = max(0, min(delay, 60))
+        logger.debug(f'{label} retry delay: {delay} seconds')
+        time.sleep(delay)
+
+    def checked(self, fn: Callable, is_retry: bool = False, retry_attempt=0, attempts=0) -> Response:
         """
         Executes a given callable and handles API-related errors, including authentication errors, rate limits,
         and service busy scenarios. The method will ensure proper handling of retries and logging for recoverable
@@ -789,8 +990,8 @@ class SubdlProvider(Provider):
         response = None
         try:
             response = fn()
-        except Exception:
-            logger.exception('Unhandled exception raised.')
+        except Exception as error:
+            logger.error(f'Unhandled exception raised: {self._redact(error)}')
             raise
         else:
             status_code = response.status_code
@@ -803,42 +1004,46 @@ class SubdlProvider(Provider):
                     message = payload['message']
                 raise ProviderError(message)
             elif status_code == 403:
-                raise AuthenticationError("Invalid API key")
+                # Only an auth verdict from the API itself should disable the
+                # provider for 12 hours; an edge/WAF 403 is transient.
+                payload = self._safe_json(response)
+                error = str(payload.get('error') or payload.get('message') or '').lower()
+                if not payload or 'key' in error or 'auth' in error or 'forbidden' in error:
+                    raise AuthenticationError("Invalid API key")
+                raise APIThrottled(f"Request rejected with 403: {error or 'no reason given'}")
             elif status_code == 404:
-                raise ProviderError("Resource not found")
+                raise SubdlRequestRejected("Resource not found")
             elif status_code == 429:
-                try:
-                    payload = response.json()
-                except Exception:
-                    logger.exception('Failed to parse JSON response')
-                else:
-                    if isinstance(payload, dict) and 'error' in payload:
-                        if payload['error'] in ['daily_limit', 'api_download_limit_exceeded']:
-                            raise DownloadLimitExceeded("Daily download limit exceeded")
-                        elif payload['error'] == 'rate_limit':
-                            if not is_retry:
-                                logger.debug("API request rate limit hit, waiting and trying again once.")
-                                retry_delay = response.headers.get('Retry-After', 15)
-                                logger.debug(f"Retry delay: {retry_delay} seconds")
-                                time.sleep(int(retry_delay))
-                                logger.debug("Retrying API request")
-                                return self.checked(fn, is_retry=True)
-                            raise APIThrottled("API request limit hit")
-                        elif payload['error'] == 'service_busy':
-                            if retry_attempt < 5:
-                                logger.debug("API service is busy, waiting and trying again once.")
-                                retry_delay = response.headers.get('Retry-After', 5)
-                                logger.debug(f"Service busy retry delay: {retry_delay} seconds")
-                                time.sleep(int(retry_delay))
-                                logger.debug("Retrying service busy API request")
-                                return self.checked(fn, retry_attempt=retry_attempt + 1)
-                            else:
-                                raise ProviderError("API service is busy")
-                    else:
-                        logger.exception(f'Missing error field in JSON response: {payload}')
-                        response.raise_for_status()
+                payload = self._safe_json(response)
+                if isinstance(payload, dict) and 'error' in payload:
+                    if payload['error'] in ['daily_limit', 'api_download_limit_exceeded']:
+                        raise DownloadLimitExceeded("Daily download limit exceeded")
+                    elif payload['error'] == 'rate_limit':
+                        if attempts < self.MAX_RETRY_ATTEMPTS:
+                            logger.debug("API request rate limit hit, waiting and trying again.")
+                            self._sleep_for_retry(response, default=15, label='Rate limit')
+                            return self.checked(fn, is_retry=True, retry_attempt=retry_attempt,
+                                                attempts=attempts + 1)
+                        raise APIThrottled("API request limit hit")
+                    elif payload['error'] == 'service_busy':
+                        if retry_attempt < 5 and attempts < self.MAX_RETRY_ATTEMPTS:
+                            logger.debug("API service is busy, waiting and trying again.")
+                            self._sleep_for_retry(response, default=5, label='Service busy')
+                            return self.checked(fn, is_retry=is_retry,
+                                                retry_attempt=retry_attempt + 1,
+                                                attempts=attempts + 1)
+                        raise ProviderError("API service is busy")
+                raise APIThrottled(f'Rate limited without a usable error field: {payload}')
+            elif 400 <= status_code < 500:
+                # A client error is about this one request (a rejected title, a
+                # malformed parameter) and says nothing about provider health.
+                payload = self._safe_json(response)
+                message = payload.get('error') or payload.get('message') or f'HTTP {status_code}'
+                raise SubdlRequestRejected(f'Request rejected ({status_code}): {message}')
             elif status_code != 200:
-                logger.exception('Unhandled API response')
-                response.raise_for_status()
+                payload = self._safe_json(response)
+                message = payload.get('error') or payload.get('message') or ''
+                logger.error(f'Unhandled API response {status_code}: {message}')
+                raise ServiceUnavailable(f'subdl returned HTTP {status_code}')
 
         return response

--- a/custom_libs/subliminal_patch/providers/subdl.py
+++ b/custom_libs/subliminal_patch/providers/subdl.py
@@ -185,9 +185,14 @@ class SubdlProvider(Provider):
     def server_url(self):
         return f'https://{self.server_hostname}/api/v1/'
 
-    # The API caps subs_per_page at 30, so a busy season needs several pages.
+    # The API caps subs_per_page at 30, so a popular title is truncated. Paging
+    # is deliberately shallow and only applied to the primary search: every page
+    # is a request against the caller's daily API quota (2000-30000/day), and a
+    # library-wide scan issues one search per episode. One extra page, only when
+    # the first came back full, keeps the worst case at ~1.5x the old request
+    # count instead of 2.5x.
     SUBS_PER_PAGE = 30
-    MAX_PAGES = 3
+    MAX_PAGES = 2
 
     # The API rejects these outright ("Film name contains potentially unsafe
     # characters"), which would otherwise 400 every apostrophe title such as
@@ -340,8 +345,10 @@ class SubdlProvider(Provider):
             # where episode 25 is stored internally as cour-2 episode 13).
             # The release name matching in get_matches() will identify the correct episode.
             logger.debug(f'Also searching by season only (no episode filter) for season {video.season}')
+            # Not paginated: this is a supplementary fallback, and paging it
+            # would double the per-episode request cost of a full library scan.
             merge(self._search(dict(base_params, type='tv', season_number=video.season),
-                               'season-only', paginate=True)[0], 'season-only')
+                               'season-only')[0], 'season-only')
 
             # Last resort: if all season-filtered searches returned nothing, search by title only
             # (no season/episode filter). This catches anime stored as season 0 on subdl (full series

--- a/frontend/src/pages/Settings/Providers/list.tsx
+++ b/frontend/src/pages/Settings/Providers/list.tsx
@@ -458,15 +458,17 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
   },
   {
     key: "subdl",
+    name: "SubDL",
     inputs: [
       {
-        type: "text",
+        type: "password",
         key: "api_key",
+        name: "API key",
       },
       {
         type: "switch",
         key: "ai_translate",
-        name: "AI-translate missing languages (SubDL Plus/Pro, uses your monthly translation quota)",
+        name: "AI-translate missing languages (requires SubDL Plus or Pro)",
         defaultValue: false,
       },
       {
@@ -476,8 +478,22 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
         defaultValue: false,
       },
     ],
-    message:
-      "AI translation delivers missing languages in about a minute using your SubDL Plus/Pro translation quota. Get a plan at https://subdl.com/pro",
+    message: (
+      <>
+        Everything above works on a free API key except AI translation. That one
+        fills in languages nobody has uploaded yet, in about a minute, using the
+        monthly translation quota that comes with{" "}
+        <Anchor
+          href="https://subdl.com/pro?ref=bazarr"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          SubDL Plus or Pro
+        </Anchor>
+        . Leave it off on a free key — it has no effect there, and searches
+        behave exactly as before.
+      </>
+    ),
   },
   {
     key: "subf2m",


### PR DESCRIPTION
Follow-up to #3415. Testing the subdl provider against the live API turned up a
set of defects, the largest of which made season packs unusable.

## Season packs were silently discarded

The API marks a whole-season archive as:

```json
{"full_season": true, "episode_from": null, "episode_end": 0, "season": 1, "episode": null}
```

The provider only treated an item as a pack when `episode_from`/`episode_end`
held a range, so these got `is_pack = False`, no `episode` match, and were then
dropped by bazarr's own `{series, season, episode}` guard in
`subtitles/manual.py` and `core.py`.

Measured against `Breaking Bad S01E05` (tt0903747):

| | before | after |
|---|---|---|
| subtitles returned by the provider | 26 | 65 |
| passing bazarr's `{series,season,episode}` guard | **2** | **35** |

The per-episode file was in the response the whole time — `unpack_files` carries
a direct URL for `05 Gray Matter.en.srt` — but the `unpack=1` branch was
unreachable because it sat behind the same pack test. Honouring `full_season`
makes the provider use the file the server already extracted instead of pulling
a whole season archive.

## Also fixed

**Pack/episode handling**
- `unpack_files` season/episode were read with `.get(key, default)`, but the API
  sends `0` rather than omitting them, so a correct season was always overwritten
  with `0`.
- The release-name range parser overrode the API's authoritative single-episode
  values, promoting ordinary subtitles to "packs" whose single file was then
  served for any episode in the parsed range. It now only runs when the API
  supplied no range.

**Downloads**
- RAR payloads are handled. Some older uploads are served as RAR under a `.zip`
  filename and `application/octet-stream`; they failed with "Could not unzip
  subtitle" and no fallback. The archive type is now sniffed from the bytes.
- Archive member selection skips directory entries and macOS `__MACOSX/._`
  resource forks, and compares extensions case-insensitively.

**Scoring**
- `imdb_id`/`tmdb_id`/`series_imdb_id`/`title` were added unconditionally, even
  for results from a `film_name` search — which is fuzzy server-side, so a
  wrong-title subtitle could clear the score threshold. Those matches are now
  only claimed when the search was id-based.

**Robustness**
- The video was stored on the provider instance and read back during matching
  and extraction. Bazarr shares one provider instance across threads with no
  lock, so two concurrent searches could score results against each other's
  video. It is now passed as a parameter.
- A failure in the absolute-episode, season-only or title-only search aborted
  the whole query, discarding results the primary search had already found, and
  throttled the provider. Each search now degrades independently.
- Pagination is followed (bounded to 3 pages). Only the 30 newest subtitles were
  ever visible; `totalPages` was in the same response and unused.
- Titles are sanitised before being sent as `film_name`. The API rejects
  apostrophes with HTTP 400 ("Film name contains potentially unsafe
  characters"), so *Grey's Anatomy*, *Bob's Burgers* and *Schitt's Creek* failed
  on every search and throttled the provider. (Also being fixed server-side.)
- 4xx no longer disables the provider: any 403 became `AuthenticationError`
  (12 h) and any 404 became `ProviderError` (1 h), so one dead download link or
  an edge challenge took subdl out for hours.
- The retry recursion is bounded. `rate_limit` reset the `service_busy` counter
  and vice versa, so an alternating server could keep a search thread sleeping
  indefinitely. `Retry-After` is no longer passed to `int()` unguarded, which
  raised on HTTP-date values.

**Hearing-impaired / forced detection**
- Markers are matched on word boundaries. The bare substrings `' hi'`/`'hi '`
  fired inside ordinary release groups — `Hive-CM8`, `Hi10P`, `Hindi` — marking
  normal subtitles as hearing-impaired, which then hid them from every non-HI
  language profile.
- Explicit `removed SDH` / `non-HI` markers now win over the API's `hi` flag;
  previously `item.get('hi') or _is_hi(item)` short-circuited the guard.
- Forced detection reads release names, not just the comment.

**Misc**
- An unknown language code now skips that item instead of raising
  `ConfigurationError` out of the whole search (which banned subdl for 12 h).
- Subtitle ids are keyed on the subtitle page rather than the archive filename,
  which is generated from the release name and is not unique.
- `api_key` is redacted before any URL or exception reaches the log. SubDL puts
  the key in download URLs, and bazarr's redactor only matches `apikey=`
  (`app/logger.py`), so keys were written to `bazarr.log` in cleartext.

**AI translation**
- The source's `hi` flag is carried onto the candidate instead of hard-coding
  non-HI, so an SDH-derived translation is not stored as a normal track.
- The server's deliberate source ordering (English first, non-HI first) is kept;
  release matching only breaks ties.
- `season`/`episode` are sent so the server resolves which file inside a pack to
  translate, rather than the client shipping a file id.

## Testing

`tests/subliminal_patch/test_subdl.py` — 17 passed (15 unit + 2 live). The wider
`tests/subliminal_patch/` suite shows the same 27 pre-existing failures before
and after this change (verified by running the suite against a clean tree).

Verified end to end against production `api.subdl.com` with a real key, driving
bazarr's own UI: movie and episode search, manual and automatic download, and
pack extraction.
