### PR TITLE
Fixed Google translator baking errors into subtitles and swallowing per-line failures

### DIFF
--- a/bazarr/subtitles/tools/translate/services/google_translator.py
+++ b/bazarr/subtitles/tools/translate/services/google_translator.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import logging
+import re
 import pysubs2
 
 from retry.api import retry
@@ -73,11 +74,27 @@ class GoogleTranslatorService:
                 future = pool.submit(translate_line, i, line)
                 futures.append(future)
             pool.shutdown(wait=True)
+
+            # Surface per-line failures instead of silently swallowing them. Previously, a line
+            # that exhausted its retries (429/5xx/network error) was dropped, leaving its original
+            # text in place and the subtitle was saved as if translation had succeeded. We now
+            # collect those failures and abort so no partially-translated file is written.
+            line_errors = []
             for future in futures:
                 try:
                     future.result()
                 except Exception as e:
                     logger.error(f"Error in translation task: {e}")
+                    line_errors.append(e)
+
+            if line_errors:
+                first_error = line_errors[0]
+                message = (f'Google translation failed for {len(line_errors)}/{lines_list_len} line(s) '
+                           f'({first_error.__class__.__name__}: {first_error}). '
+                           f'Subtitle was not saved to avoid leaving partially-translated content.')
+                logger.error(message)
+                jobs_queue.update_job_progress(job_id=job_id, progress_message=message)
+                raise RequestError(message)
 
             for i, line in enumerate(translated_lines):
                 lines_list[line['id']] = line['line']
@@ -126,10 +143,20 @@ class GoogleTranslatorService:
     @retry(exceptions=(TooManyRequests, RequestError), tries=6, delay=1, backoff=2, jitter=(0, 1))
     def _translate_text(self, text, job_id):
         try:
-            return GoogleTranslator(
+            translated_text = GoogleTranslator(
                 source='auto',
                 target=self.language_code_convert_dict.get(self.lang_obj.alpha2, self.lang_obj.alpha2)
             ).translate(text=text)
+
+            # The free Google endpoint occasionally answers 200 OK with an error/captcha HTML page
+            # instead of a real translation. deep_translator then returns that error text (e.g.
+            # "Error 500", "Too Many Requests", raw HTML) as the translation, which used to get
+            # written straight into the subtitle. Detect and reject those so they are retried and,
+            # if they persist, surfaced as a failure instead of being baked into the output.
+            if translated_text is None or self._looks_like_error_response(translated_text):
+                raise RequestError(f'Google Translate returned an invalid response: {translated_text!r}')
+
+            return translated_text
         except (TooManyRequests, RequestError) as e:
             logger.error(f'Google Translate API error after retries: {str(e)}')
             jobs_queue.update_job_progress(job_id=job_id,
@@ -140,3 +167,24 @@ class GoogleTranslatorService:
             jobs_queue.update_job_progress(job_id=job_id,
                                            progress_message=f'Translation error: {str(e)}')
             raise
+
+    @staticmethod
+    def _looks_like_error_response(text: str) -> bool:
+        """Heuristic guard against Google serving an error/captcha page as a translation."""
+        if not text:
+            return False
+        # Raw HTML leaking through (error pages, captcha interstitials).
+        if re.search(r'<\s*(html|body|div|br|p|DOCTYPE)[^>]*>', text, re.IGNORECASE):
+            return True
+        lowered = text.lower()
+        error_markers = (
+            'too many requests', 'server error', 'internal server error',
+            'service unavailable', 'bad gateway', 'temporarily unavailable',
+            'captcha', 'unusual traffic', 'rate limit',
+        )
+        if any(marker in lowered for marker in error_markers):
+            return True
+        # "Error 500", "HTTP 429", standalone "500"/"429" style leftovers.
+        if re.search(r'\b(error|http)[ _-]?\d{3}\b', lowered):
+            return True
+        return False

--- a/tests/bazarr/test_google_translator.py
+++ b/tests/bazarr/test_google_translator.py
@@ -1,0 +1,106 @@
+import pytest
+
+from bazarr.subtitles.tools.translate.services import google_translator
+from deep_translator.exceptions import RequestError
+
+
+def _build_service(tmp_path):
+    return google_translator.GoogleTranslatorService(
+        source_srt_file=str(tmp_path / "input.srt"),
+        dest_srt_file=str(tmp_path / "output.srt"),
+        lang_obj=type("L", (), {"alpha2": "fr"})(),
+        to_lang="fra",
+        from_lang="en",
+        media_type="movie",
+        video_path="/tmp/video.mkv",
+        orig_to_lang="fr",
+        forced=False,
+        hi=False,
+        sonarr_series_id=1,
+        sonarr_episode_id=1,
+        radarr_id=1,
+    )
+
+
+def test_looks_like_error_response_detects_html_and_error_text():
+    assert google_translator.GoogleTranslatorService._looks_like_error_response(
+        "<html><body>Error 500</body></html>")
+    assert google_translator.GoogleTranslatorService._looks_like_error_response(
+        "Too Many Requests")
+    assert google_translator.GoogleTranslatorService._looks_like_error_response(
+        "Error 500: Internal Server Error")
+    assert google_translator.GoogleTranslatorService._looks_like_error_response(
+        "<div class='captcha'>unusual traffic</div>")
+
+
+def test_looks_like_error_response_leaves_real_translations_alone():
+    assert not google_translator.GoogleTranslatorService._looks_like_error_response("Bonjour le monde")
+    assert not google_translator.GoogleTranslatorService._looks_like_error_response("¿Qué hora es?")
+    # An unrelated "500" inside normal text must not be flagged as an error.
+    assert not google_translator.GoogleTranslatorService._looks_like_error_response(
+        "The reward is 500 dollars.")
+
+
+def test_translate_text_raises_on_error_response_baked_into_result(mocker, tmp_path):
+    """
+    Regression: the free Google endpoint can answer 200 OK with an error/captcha page, and
+    deep_translator returns that error text as the translation. The translator must reject it
+    (raising RequestError so @retry can retry) instead of baking "Error 500" into the subtitle.
+    """
+    service = _build_service(tmp_path)
+    mocker.patch.object(google_translator, "GoogleTranslator")
+
+    # Force the inner retry to give up quickly so the test stays fast.
+    mocker.patch.object(
+        google_translator,
+        "retry",
+        lambda *a, **kw: (lambda f: f),
+    )
+
+    google_translator.GoogleTranslator.return_value.translate.return_value = "Error 500: Server Error"
+    mocker.patch.object(google_translator.jobs_queue, "update_job_progress")
+
+    with pytest.raises(RequestError):
+        service._translate_text("Hello world", job_id="job-1")
+
+
+def test_translate_aborts_when_lines_fail_instead_of_writing_partial_file(mocker, tmp_path):
+    """
+    Regression: per-line failures used to be swallowed by the futures loop, the subtitle was
+    saved with untranslated lines, and the job reported success. We now collect failures and
+    raise so no partially-translated subtitle is written.
+    """
+    input_file = tmp_path / "input.srt"
+    output_file = tmp_path / "output.srt"
+    input_file.write_text("1\n00:00:00,000 --> 00:00:02,000\nHello world\n\n", encoding="utf-8")
+
+    service = _build_service(tmp_path)
+
+    # Make every line fail to translate.
+    mocker.patch.object(service, "_translate_text", side_effect=RequestError("boom"))
+    mocker.patch.object(google_translator.jobs_queue, "update_job_progress")
+    # Guard: saving must never happen when translation failed.
+    save_mock = mocker.patch("pysubs2.SSAFile.save", autospec=True)
+
+    with pytest.raises(RequestError, match="1/1 line"):
+        service.translate(job_id="job-1")
+
+    save_mock.assert_not_called()
+
+
+def test_translate_succeeds_when_all_lines_translate(mocker, tmp_path):
+    """Happy path: when translation succeeds the output file is written and the path returned."""
+    input_file = tmp_path / "input.srt"
+    output_file = tmp_path / "output.srt"
+    input_file.write_text("1\n00:00:00,000 --> 00:00:02,000\nHello world\n\n", encoding="utf-8")
+
+    service = _build_service(tmp_path)
+    mocker.patch.object(service, "_translate_text", return_value="Bonjour le monde")
+    mocker.patch.object(google_translator.jobs_queue, "update_job_progress")
+    mocker.patch.object(google_translator, "history_log")
+    mocker.patch.object(google_translator, "history_log_movie")
+
+    result = service.translate(job_id="job-1")
+
+    assert result == str(output_file)
+    assert output_file.exists()


### PR DESCRIPTION
## Summary

The free Google Translate path (`google_translate`) can silently produce a bad subtitle: a mix of translated, untranslated, and error-text lines, while the job reports success. This fixes two root causes.

### 1. Per-line failures were silently swallowed

In `GoogleTranslatorService.translate`, lines are translated in a `ThreadPoolExecutor`. Only `TranslationNotFound` is caught inside `translate_line`; any other error (a `429`/`5xx` that exhausted its `@retry` budget, a network error) propagates into the future, and the futures loop just logged and dropped it:

```python
for future in futures:
    try: future.result()
    except Exception as e: logger.error(f"Error in translation task: {e}")   # swallowed
```

Dropped lines were never written back, so they kept their **original** text and the subtitle was saved as if translation had succeeded. This now collects those failures and raises a `RequestError` *before* saving, so no partially-translated file is written and the failure is surfaced to the job queue/history instead of being hidden.

### 2. Error text was returned as a translation ("500" baked into the subtitle)

`deep_translator`'s free Google client raises on non-2xx, but when the endpoint answers **200 OK with an error/captcha HTML page** (common under IP rate-limiting) `request_failed(200)` is `False`, BeautifulSoup scrapes the **error text as the translation**, and it gets written straight into the subtitle. `@retry` only catches exceptions, so a bogus string sailed through.

This adds `_looks_like_error_response()` to reject obvious garbage (raw HTML, `Too Many Requests`, `Error 500`/`HTTP 5xx`, captcha markers) and raise `RequestError`, so it is retried and — if it persists — counted as a failure by fix #1 rather than baked into the output.

## Why focused on the Google path

`translator_type` defaults to `google_translate` (`config.py`), so this is the path most users hit. The Gemini path already has its own retry/key-rotation logic; a separate follow-up can harden it.

## Testing

- Added `tests/bazarr/test_google_translator.py` (5 tests): error-response detection (positive + negative, incl. a legit `500 dollars` line that must **not** be flagged), rejection of a baked-in `Error 500` result, the no-partial-file-on-failure regression, and a happy-path save.
- Full suite locally: `5 passed` for the new file; the only failing tests (`test_utilities_video_analyzer`) also fail on a clean `development` checkout because they require the `ffmpeg`/`mediainfo` binaries that CI installs.

## Notes

- I followed `CONTRIBUTING.md`: branched from `development`, single meaningful commit message, scope kept tight.
- Disclosure: this change was developed with AI assistance (Claude Code); I wrote and understand every line and validated it against a live translation path. Happy to discuss on Discord before merge if you'd prefer changes.