### PR TITLE
Fixed Persian subtitles being detected as hearing-impaired, and api key redaction missing api_key=

### DIFF
--- a/bazarr/app/logger.py
+++ b/bazarr/app/logger.py
@@ -18,7 +18,12 @@ logger = logging.getLogger()
 
 class FileHandlerFormatter(logging.Formatter):
     """Formatter that removes apikey from logs."""
-    APIKEY_RE = re.compile(r'apikey(?:=|%3D)([a-zA-Z0-9]+)')
+    # Matches `apikey=`, `api_key=` and `apiKey=`, url-encoded or not, and keys
+    # containing '-', '_' or '.'. The old pattern required the literal `apikey`
+    # and value chars [a-zA-Z0-9], so a provider using `api_key=` — or a key
+    # like `subdl_Cq…-5IU…` — was written to the log verbatim. These logs are
+    # routinely pasted into public issue reports.
+    APIKEY_RE = re.compile(r'api[-_]?key(?:=|%3D)([\w.\-]+)', re.IGNORECASE)
     IPv4_RE = re.compile(r'\b(?<!Failed\sauthentication\sfrom\s)(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.)'
                          r'{3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\b')
     PLEX_URL_RE = re.compile(r'(?:https?://)?[0-9\-]+\.[a-f0-9]+\.plex\.direct(?::\d+)?')
@@ -31,7 +36,9 @@ class FileHandlerFormatter(logging.Formatter):
         return repr(result)  # or format into one line however you want to
 
     def formatApikey(self, s):
-        return re.sub(self.APIKEY_RE, 'apikey=(removed)', s)
+        # Keep the parameter name the caller used so the log still reads
+        # naturally; only the value is removed.
+        return re.sub(self.APIKEY_RE, lambda m: f'{m.group(0)[:m.start(1) - m.start(0)]}(removed)', s)
 
     def formatIPv4(self, s):
         return re.sub(self.IPv4_RE, '***.***.***.***', s)

--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -52,7 +52,10 @@ _POOL_LIFETIME = datetime.timedelta(hours=12)
 HI_REGEX_WITHOUT_PARENTHESIS = re.compile(r'[*¶♫♪].{3,}[*¶♫♪]|[\[\{].{3,}[\]\}](?<!{\\an\d})')
 HI_REGEX_WITH_PARENTHESIS = re.compile(r'[*¶♫♪].{3,}[*¶♫♪]|[\[\(\{].{3,}[\]\)\}](?<!{\\an\d})')
 
-HI_REGEX_PARENTHESIS_EXCLUDED_LANGUAGES = ['ara']
+# Languages whose subtitles conventionally use parentheses for translator notes
+# rather than for sound cues, so the parenthesis arm of the HI heuristic would
+# mislabel ordinary subtitles as hearing-impaired.
+HI_REGEX_PARENTHESIS_EXCLUDED_LANGUAGES = ['ara', 'fas']
 
 
 def parse_for_hi_regex(subtitle_text, alpha3_language):


### PR DESCRIPTION
Two independent defects found while testing a provider against a live service.
Neither is provider-specific — both are in core — so they are separate from
#3488.

## Persian subtitles are saved as hearing-impaired

`parse_for_hi_regex` treats any parenthesised run of 3+ characters as a sound
cue:

```python
HI_REGEX_WITH_PARENTHESIS = re.compile(r'[*¶♫♪].{3,}[*¶♫♪]|[\[\(\{].{3,}[\]\)\}](?<!{\\an\d})')
HI_REGEX_PARENTHESIS_EXCLUDED_LANGUAGES = ['ara']
```

Persian subtitles conventionally use parentheses for **translator notes** —
glosses explaining a term to the reader — not for sound cues. So an ordinary
Persian subtitle is detected as hearing-impaired at `core.py:1231`, written as
`.fa.hi.srt`, and displayed as "PERSIAN HI".

Reproduced end to end on a real download. The text that matched:

```
00:03:55,445 --> 00:03:57,536
"من نگاه کردم، بهش میگن "پولترگایست
(یه نوع روح که کارهایی مثل بهم زدن اشیاء و ایجاد صدا می کنه)
```

— a parenthetical explaining the word "poltergeist". Arabic is already exempt
from the parenthesis arm for exactly this reason; this adds Persian beside it.

Verified against that same file after the change:

| | before | after |
|---|---|---|
| `parse_for_hi_regex(text, 'fas')` | `True` | `False` |
| `parse_for_hi_regex('[door slams]', 'fas')` | `True` | `True` |
| `parse_for_hi_regex('♪ music ♪', 'fas')` | `True` | `True` |
| `parse_for_hi_regex(text, 'eng')` | `True` | `True` |

Bracketed and musical cues still detect normally, so genuine HI subtitles are
unaffected, and no other language changes behaviour.

## The api key redaction misses `api_key=`

`FileHandlerFormatter.APIKEY_RE` was:

```python
APIKEY_RE = re.compile(r'apikey(?:=|%3D)([a-zA-Z0-9]+)')
```

That requires the literal `apikey` and a value of `[a-zA-Z0-9]`. A provider
whose API names the parameter `api_key`, or whose keys contain `-`, `_` or `.`,
had its credential written to `bazarr.log` verbatim — for example every
download URL of a provider that carries the key in the query string.

IP addresses in the same formatter *are* redacted, so the intent is clearly
that secrets do not reach the file, and these logs are routinely pasted into
public issue reports.

The pattern now covers `apikey` / `api_key` / `apiKey`, url-encoded or not, and
the usual key characters. The parameter name is preserved so the line still
reads naturally:

```
GET /subtitle/1-2.zip?api_key=(removed) HTTP/1.1
https://sonarr/api?apikey=(removed)
https://x/y?apiKey=(removed)
url?api_key%3D(removed)&x=1
```

## Testing

`pytest tests/` shows the same 29 pre-existing failures and 358 passes before
and after (verified by reverting both files against `origin/development` and
re-running).
