### PR TITLE
Fixed animetosho Brazilian Portuguese detection

### DIFF
--- a/custom_libs/subliminal_patch/providers/animetosho.py
+++ b/custom_libs/subliminal_patch/providers/animetosho.py
@@ -151,7 +151,7 @@ class AnimeToshoProvider(Provider, ProviderSubtitleArchiveMixin):
                     # For Portuguese and Portuguese Brazilian they both share the same code, the name is the only
                     # identifier AnimeTosho provides. Also, some subtitles does not have name, in this case it could
                     # be a false negative but there is nothing we can use to guarantee it is PT-BR, we rather skip it.
-                    if lang.alpha3 == 'por' and subtitle_file['info'].get('name', '').lower().find('brazil'):
+                    if lang.alpha3 == 'por' and 'brazil' in subtitle_file['info'].get('name', '').lower():
                         lang = Language('por', 'BR')
 
                     subtitle = self.subtitle_class(

--- a/tests/subliminal_patch/test_animetosho.py
+++ b/tests/subliminal_patch/test_animetosho.py
@@ -57,3 +57,50 @@ def test_list_subtitles(anime_episodes, requests_mock, data):
         subtitles = provider.list_subtitles(item, languages={language})
 
         assert len(subtitles) == 2
+
+
+def _torrent_response(sub_info):
+    return {
+        "files": [
+            {
+                "filename": "[EMBER] Ore dake Level Up na Ken S01E12 [1080p] [HEVC WEBRip].mkv",
+                "attachments": [
+                    {"id": 1, "filename": "subs.ass", "type": "subtitle", "info": sub_info},
+                ],
+            }
+        ]
+    }
+
+
+@pytest.mark.parametrize(
+    "info,expected",
+    [
+        # AnimeTosho reports both Portuguese variants as "por"; the attachment name is the only
+        # hint. The name is frequently absent altogether (the recorded API payload in
+        # data/animetosho_series_response.json carries no "name" key), and an unnamed track must
+        # stay plain Portuguese rather than be promoted to pt-BR.
+        ({"lang": "por"}, Language("por")),
+        ({"lang": "por", "name": "Portugues"}, Language("por")),
+        # A name that starts with "brazil" is still Brazilian Portuguese.
+        ({"lang": "por", "name": "Brazilian Portuguese"}, Language("por", "BR")),
+        ({"lang": "por", "name": "Portuguese (Brazil)"}, Language("por", "BR")),
+    ],
+)
+def test_portuguese_brazilian_detection(anime_episodes, requests_mock, info, expected):
+    item = anime_episodes["solo_leveling_s01e10"]
+
+    requests_mock.get(
+        'https://feed.animetosho.org/json?eid=277518',
+        json=[{"id": 608526, "timestamp": 1711853493, "status": "complete", "title": "Solo Leveling - 12"}],
+    )
+    requests_mock.get(
+        'https://feed.animetosho.org/json?show=torrent&id=608526',
+        json=_torrent_response(info),
+    )
+
+    with AnimeToshoProvider(1) as provider:
+        # Ask for both variants so nothing is filtered out and the resolved language is asserted.
+        subtitles = provider.list_subtitles(item, languages={Language("por"), Language("por", "BR")})
+
+        assert len(subtitles) == 1
+        assert subtitles[0].language == expected


### PR DESCRIPTION
### What

`animetosho` decides between Portuguese and Brazilian Portuguese with `subtitle_file['info'].get('name', '').lower().find('brazil')` used directly as a boolean. `str.find()` returns `-1` when the substring is absent — which is truthy — and `0` when it matches at index 0 — which is falsy. The condition is inverted for the two cases that actually occur:

| `info["name"]` | `find` | result | correct |
|---|---|---|---|
| absent → `""` | `-1` | pt-BR | no |
| `"Portugues"` | `-1` | pt-BR | no |
| `"Brazilian Portuguese"` | `0` | pt | no |
| `"Portuguese (Brazil)"` | `12` | pt-BR | yes |

The missing-name case is the common one: the recorded API payload already in this repo (`tests/subliminal_patch/data/animetosho_series_response.json`) has no `name` key on its subtitle attachment at all. The comment directly above the line says an unnamed track should stay plain Portuguese ("we rather skip it") — the code does the opposite and promotes every unnamed `por` track to pt-BR.

### Why this is the intended behaviour

The sibling provider added in #3445 already does it the right way — `animetosho_xyz.py` uses `'brazil' in info.get('language', '').lower()`, and its test even documents this exact bug:

```python
# This verifies the fix for the .find('brazil') bug that always returned truthy (-1).
```

The fix was just never backported to the original provider. This change makes `animetosho` match it.

### Testing

Added a parametrized offline regression test to `tests/subliminal_patch/test_animetosho.py` covering all four name shapes, using `requests_mock` with payloads shaped after the recorded fixture (same convention as the existing provider tests).

- Before the fix: 3 failed, 2 passed
- After the fix: 5 passed

Unrelated heads-up while I was in here: `tests/subliminal_patch/test_animetosho_xyz.py::test_list_subtitles_with_portuguese_br` fails on a pristine `development` checkout — its fixture uses `"language": "Portuguese[BR]"` and `'brazil' in 'portuguese[br]'` is `False`. It goes unnoticed because CI runs `tests/bazarr/` only. Happy to send that as a separate PR if useful — I've left it out of this one to keep the change single-purpose.

### AI disclosure

Per CONTRIBUTING's "Working with AI": written with AI assistance (Claude). The `str.find()` semantics were confirmed against the actual recorded API payload rather than assumed, the intent traced through `git blame` to the sibling provider's fix in #3445, and fail-before/pass-after verified before opening.
