### PR TITLE
Added translation of embedded subtitles and original-format preservation

### DIFF
--- a/bazarr/api/subtitles/subtitles.py
+++ b/bazarr/api/subtitles/subtitles.py
@@ -10,6 +10,7 @@ from languages.get_languages import alpha3_from_alpha2
 from utilities.path_mappings import path_mappings
 from utilities.video_analyzer import subtitles_sync_references
 from subtitles.tools.translate.main import translate_subtitles_file
+from subtitles.tools.translate.core.translator_utils import resolve_translation_source
 from subtitles.tools.mods import subtitles_apply_mods
 from subtitles.indexer.series import store_subtitles
 from subtitles.indexer.movies import store_subtitles_movie
@@ -126,10 +127,19 @@ class Subtitles(Resource):
         forced = True if args.get('forced') == 'True' else False
         hi = True if args.get('hi') == 'True' else False
 
-        if action != 'extract':
+        subtitles_id = args.get('subtitles_id')
+
+        if action not in ('extract', 'translate'):
             if subtitles_path and not os.path.exists(subtitles_path):
                 return 'Subtitles file not found. Path mapping issue?', 500
             if not subtitles_path:
+                return f'Path not provided and is required with this action: {action}', 501
+        elif action == 'translate':
+            # translate can target either an external file (path) or an embedded track
+            # identified by its subtitles database id (which is extracted first).
+            if subtitles_path and not os.path.exists(subtitles_path):
+                return 'Subtitles file not found. Path mapping issue?', 500
+            if not subtitles_path and not subtitles_id:
                 return f'Path not provided and is required with this action: {action}', 501
 
         if media_type == 'episode':
@@ -177,33 +187,39 @@ class Subtitles(Resource):
                 return 'Unable to edit subtitles file. Check logs.', 409
         elif action == 'translate':
             dest_language = language
-            from_language = None
 
             subtitles = get_subtitles(sonarr_episode_id=id if media_type == "episode" else None,
                                       radarr_id=id if media_type == "movie" else None)
 
-            if subtitles:
-                for external_subtitles in subtitles:
-                    if external_subtitles['path'] == subtitles_path:
-                        from_language = external_subtitles['code2']
-                        break
+            try:
+                from_language, embedded_subtitle_id = resolve_translation_source(
+                    subtitles, subtitles_path, subtitles_id)
+            except ValueError as e:
+                return str(e), 400
 
-                if not from_language or not alpha3_from_alpha2(from_language):
-                    return 'Invalid source language code', 400
-
+            # Translating an embedded track requires extracting it to an external file first.
+            # extract_embedded_subtitle returns the path of the newly created external file.
+            if embedded_subtitle_id is not None:
                 try:
-                    translate_subtitles_file(video_path=video_path, source_srt_file=subtitles_path,
-                                             from_lang=from_language, to_lang=dest_language, forced=forced, hi=hi,
-                                             media_type=media_type,
-                                             sonarr_series_id=metadata.sonarrSeriesId if media_type == "episode" else None,
-                                             sonarr_episode_id=id,
-                                             radarr_id=id,
-                                             metadata=metadata)
+                    subtitles_path = extract_embedded_subtitle(
+                        subtitles_id=embedded_subtitle_id, media_type=media_type)
+                except BitmapSubtitlesNotSupportedError:
+                    return 'Image based embedded subtitles cannot be extracted', 415
+                except (EmbeddedSubtitlesExtractionError, OSError):
+                    return 'Unable to take action on subtitles file. Check logs.', 409
 
-                except OSError:
-                    return 'Unable to edit subtitles file. Check logs.', 409
+            try:
+                translate_subtitles_file(video_path=video_path, source_srt_file=subtitles_path,
+                                         from_lang=from_language, to_lang=dest_language, forced=forced, hi=hi,
+                                         media_type=media_type,
+                                         sonarr_series_id=metadata.sonarrSeriesId if media_type == "episode" else None,
+                                         sonarr_episode_id=id,
+                                         radarr_id=id,
+                                         metadata=metadata)
+
+            except OSError:
+                return 'Unable to edit subtitles file. Check logs.', 409
         elif action == 'extract':
-            subtitles_id = args.get('subtitles_id')
             if not subtitles_id:
                 return 'Subtitles ID is required for extraction', 400
             try:

--- a/bazarr/api/subtitles/subtitles.py
+++ b/bazarr/api/subtitles/subtitles.py
@@ -212,6 +212,7 @@ class Subtitles(Resource):
                 translate_subtitles_file(video_path=video_path, source_srt_file=subtitles_path,
                                          from_lang=from_language, to_lang=dest_language, forced=forced, hi=hi,
                                          media_type=media_type,
+                                         original_format=args.get('original_format') == 'True',
                                          sonarr_series_id=metadata.sonarrSeriesId if media_type == "episode" else None,
                                          sonarr_episode_id=id,
                                          radarr_id=id,

--- a/bazarr/subtitles/tools/translate/core/translator_utils.py
+++ b/bazarr/subtitles/tools/translate/core/translator_utils.py
@@ -31,6 +31,42 @@ def validate_translation_params(video_path, source_srt_file, from_lang, to_lang)
     return True
 
 
+def resolve_translation_source(subtitles, subtitles_path, subtitles_id, language_validator=alpha3_from_alpha2):
+    """
+    Resolve the source language for a translate request from the subtitles list returned by
+    `get_subtitles(...)`.
+
+    A translate target is either an external file (identified by its `path`) or an embedded track
+    (identified by its subtitles database `id`). For the embedded case the matched track id is
+    returned so the caller can extract it to an external file before translating.
+
+    :param language_validator: callable used to validate the resolved language code2. Defaults to
+        `alpha3_from_alpha2`; injected mainly for unit testing.
+    :return: tuple ``(from_language, embedded_subtitle_id)`` where ``embedded_subtitle_id`` is
+        ``None`` for an external subtitle.
+    :raises ValueError: with an API-friendly message if the source cannot be identified, is not a
+        valid language, or the supplied id does not point to an embedded track.
+    """
+    if subtitles_path:
+        for external_subtitles in subtitles:
+            if external_subtitles['path'] == subtitles_path:
+                from_language = external_subtitles['code2']
+                if from_language and language_validator(from_language):
+                    return from_language, None
+                break
+    elif subtitles_id is not None:
+        for embedded_subtitles in subtitles:
+            if embedded_subtitles['id'] == subtitles_id:
+                if embedded_subtitles.get('embedded_track_id') is None:
+                    raise ValueError('Selected subtitle is not an embedded track')
+                from_language = embedded_subtitles['code2']
+                if from_language and language_validator(from_language):
+                    return from_language, subtitles_id
+                break
+
+    raise ValueError('Invalid source language code')
+
+
 def convert_language_codes(to_lang, forced=False, hi=False):
     """Convert and validate language codes."""
     orig_to_lang = to_lang

--- a/bazarr/subtitles/tools/translate/core/translator_utils.py
+++ b/bazarr/subtitles/tools/translate/core/translator_utils.py
@@ -67,6 +67,36 @@ def resolve_translation_source(subtitles, subtitles_path, subtitles_id, language
     raise ValueError('Invalid source language code')
 
 
+# Subtitle extensions that Bazarr can produce a translated file in. The Google and Lingarr
+# translators go through pysubs2, which honours the destination path extension; the Gemini
+# translator only handles SRT (see get_translation_extension below).
+SUPPORTED_TRANSLATION_EXTENSIONS = ('.srt', '.ass', '.ssa', '.vtt')
+
+
+def get_translation_extension(source_srt_file, original_format, translator_type):
+    """
+    Return the extension to use for the translated subtitle file.
+
+    When ``original_format`` is true and the source has a supported text-based extension, that
+    extension is preserved so a ``.ass``/``.vtt`` source is translated into a ``.ass``/``.vtt``
+    file instead of always being converted to ``.srt``. The Gemini translator reads and writes
+    SRT only, so for any non-SRT source it falls back to ``.srt``.
+    """
+    if not original_format:
+        return '.srt'
+
+    src_ext = os.path.splitext(source_srt_file)[1].lower()
+    if src_ext not in SUPPORTED_TRANSLATION_EXTENSIONS:
+        return '.srt'
+
+    if translator_type == 'gemini' and src_ext != '.srt':
+        logger.info(f'Gemini translator cannot preserve the {src_ext} format; falling back to .srt '
+                    f'for {source_srt_file}')
+        return '.srt'
+
+    return src_ext
+
+
 def convert_language_codes(to_lang, forced=False, hi=False):
     """Convert and validate language codes."""
     orig_to_lang = to_lang
@@ -113,6 +143,12 @@ def create_process_result(message, video_path, orig_to_lang, forced, hi, dest_sr
 
 def add_translator_info(dest_srt_file, info):
     if settings.translator.translator_info:
+        # The info cue is injected via the SRT library, so it only applies to .srt outputs.
+        # For other formats (.ass/.vtt) we skip it rather than risk corrupting the file.
+        if os.path.splitext(dest_srt_file)[1].lower() != '.srt':
+            logger.debug(f'Skipping translator info cue for non-SRT file: {dest_srt_file}')
+            return
+
         # Load the SRT content
         with open(dest_srt_file, "r", encoding="utf-8") as f:
             srt_content = f.read()

--- a/bazarr/subtitles/tools/translate/main.py
+++ b/bazarr/subtitles/tools/translate/main.py
@@ -7,7 +7,7 @@ import os
 from subliminal_patch.core import get_subtitle_path
 from subzero.language import Language
 
-from .core.translator_utils import validate_translation_params, convert_language_codes
+from .core.translator_utils import validate_translation_params, convert_language_codes, get_translation_extension
 from .services.translator_factory import TranslatorFactory
 from languages.get_languages import alpha3_from_alpha2
 from app.config import settings
@@ -16,7 +16,8 @@ from utilities.helper import get_target_folder
 
 
 def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, forced, hi,
-                             media_type, sonarr_series_id, sonarr_episode_id, radarr_id, metadata, job_id=None):
+                             media_type, sonarr_series_id, sonarr_episode_id, radarr_id, metadata,
+                             original_format=False, job_id=None):
     if not job_id:
         jobs_queue.add_job_from_function(f'Translating from {from_lang.upper()} to {to_lang.upper()} using '
                                          f'{settings.translator.translator_type.replace("_", " ").title()}',
@@ -31,11 +32,19 @@ def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, fo
 
         logging.debug(f'BAZARR is translating in {lang_obj} this subtitles {source_srt_file}')
 
+        translator_type = settings.translator.translator_type or 'google'
+
+        # Preserve the source subtitle format (.ass/.vtt) when requested instead of always
+        # writing .srt. Gemini only supports SRT and is handled by get_translation_extension.
+        dest_extension = get_translation_extension(source_srt_file, original_format, translator_type)
+        logging.debug(f'Translation destination extension: {dest_extension} '
+                      f'(original_format={original_format}, translator={translator_type})')
+
         # get the destination path if the subtitles are alongside the video
         dest_srt_file_if_alongside_video = get_subtitle_path(
             video_path,
             language=lang_obj if isinstance(lang_obj, Language) else lang_obj.subzero_language(),
-            extension='.srt',
+            extension=dest_extension,
             forced_tag=forced,
             hi_tag=hi
         )
@@ -51,7 +60,6 @@ def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, fo
             # otherwise, we just use the destination path as it is
             dest_srt_file = dest_srt_file_if_alongside_video
 
-        translator_type = settings.translator.translator_type or 'google'
         logging.debug(f'Using translator type: {translator_type}')
 
         translator = TranslatorFactory.create_translator(

--- a/frontend/src/components/SubtitleToolsMenu.tsx
+++ b/frontend/src/components/SubtitleToolsMenu.tsx
@@ -165,12 +165,16 @@ const SubtitleToolsMenu: FunctionComponent<Props> = ({
     [selections],
   );
 
-  // Embedded subtitles only support extraction, so show a stripped-down menu
+  // Embedded subtitles only support a few actions, so show a stripped-down menu
   // that omits (rather than disables) the unsupported tools and actions. This
   // avoids confusion such as "why can't I delete my embedded subtitles?".
+  // Translating an embedded track extracts it first (server-side) and is only
+  // offered for a single selection, mirroring the Extract action.
+  const translationTool = tools.find((t) => t.key === "translation");
   const showTools = isExternalOnly;
   const showSearch = selections.length === 0;
   const showExtract = isSingleEmbedded;
+  const showEmbeddedTranslate = isSingleEmbedded;
   const showDelete = isExternalOnly;
 
   return (
@@ -200,7 +204,25 @@ const SubtitleToolsMenu: FunctionComponent<Props> = ({
             <Divider></Divider>
           </>
         )}
-        <Menu.Label>Actions</Menu.Label>
+        {showEmbeddedTranslate && translationTool?.modal && (
+          <>
+            <Menu.Label>Tools</Menu.Label>
+            <Menu.Item
+              leftSection={
+                <FontAwesomeIcon icon={translationTool.icon}></FontAwesomeIcon>
+              }
+              onClick={() => {
+                modals.openContextModal(translationTool.modal!, { selections });
+              }}
+            >
+              {translationTool.name}
+            </Menu.Item>
+            <Divider></Divider>
+          </>
+        )}
+        {(showSearch || showExtract || showDelete) && (
+          <Menu.Label>Actions</Menu.Label>
+        )}
         {showSearch && (
           <Menu.Item
             disabled={onAction === undefined}

--- a/frontend/src/components/forms/TranslationForm.tsx
+++ b/frontend/src/components/forms/TranslationForm.tsx
@@ -1,5 +1,12 @@
 import { FunctionComponent, useMemo } from "react";
-import { Alert, Button, Divider, LoadingOverlay, Stack } from "@mantine/core";
+import {
+  Alert,
+  Button,
+  Divider,
+  LoadingOverlay,
+  Stack,
+  Switch,
+} from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { showNotification } from "@mantine/notifications";
 import { isObject } from "lodash";
@@ -7,7 +14,7 @@ import { useSubtitleAction, useSystemSettings } from "@/apis/hooks";
 import { Selector } from "@/components/inputs";
 import { useModals, withModal } from "@/modules/modals";
 import { notification } from "@/modules/task";
-import { useSelectorOptions } from "@/utilities";
+import { toPython, useSelectorOptions } from "@/utilities";
 import FormUtils from "@/utilities/form";
 import { useEnabledLanguages } from "@/utilities/languages";
 
@@ -143,6 +150,7 @@ const TranslationForm: FunctionComponent<Props> = ({
   const form = useForm({
     initialValues: {
       language: null as Language.Info | null,
+      originalFormat: true,
     },
     validate: {
       language: FormUtils.validation(isObject, "Please select a language"),
@@ -200,14 +208,18 @@ const TranslationForm: FunctionComponent<Props> = ({
 
   return (
     <form
-      onSubmit={form.onSubmit(async ({ language }) => {
+      onSubmit={form.onSubmit(async ({ language, originalFormat }) => {
         if (language) {
           try {
             await Promise.all(
               selections.map((s) =>
                 mutateAsync({
                   action: "translate",
-                  form: { ...s, language: language.code2 },
+                  form: {
+                    ...s,
+                    language: language.code2,
+                    originalFormat: toPython(originalFormat),
+                  },
                 }),
               ),
             );
@@ -248,6 +260,11 @@ const TranslationForm: FunctionComponent<Props> = ({
           </Alert>
         )}
         <Selector {...options} {...form.getInputProps("language")}></Selector>
+        <Switch
+          label="Preserve original format"
+          description="Keep the source subtitle format (e.g. .ass, .vtt) instead of converting to .srt."
+          {...form.getInputProps("originalFormat", { type: "checkbox" })}
+        ></Switch>
         <Divider></Divider>
         <Button type="submit" loading={isPending}>
           Start

--- a/tests/bazarr/test_api_subtitles_translate.py
+++ b/tests/bazarr/test_api_subtitles_translate.py
@@ -1,0 +1,67 @@
+import pytest
+
+
+def _resolve(subtitles, subtitles_path, subtitles_id, validator=None):
+    # The language validator is injected to keep these tests off the database.
+    from bazarr.subtitles.tools.translate.core.translator_utils import resolve_translation_source
+
+    if validator is None:
+        # Treat any non-empty code as valid, except the explicit invalid sentinel "zzz".
+        validator = lambda code: None if code == "zzz" else (code or None)
+
+    return resolve_translation_source(
+        subtitles, subtitles_path, subtitles_id, language_validator=validator
+    )
+
+
+def _external(path="/movies/Foo (2020)/Foo.en.srt", code2="eng", sub_id=1):
+    return {"path": path, "code2": code2, "id": sub_id, "embedded_track_id": None}
+
+
+def _embedded(code2="eng", sub_id=2, track_id=4):
+    return {"path": None, "code2": code2, "id": sub_id, "embedded_track_id": track_id}
+
+
+def test_resolve_external_by_path():
+    subs = [_external(), _embedded()]
+    from_language, embedded_id = _resolve(subs, "/movies/Foo (2020)/Foo.en.srt", None)
+    assert from_language == "eng"
+    assert embedded_id is None
+
+
+def test_resolve_embedded_by_id_returns_track_id_for_extraction():
+    subs = [_external(), _embedded(code2="eng", sub_id=2, track_id=4)]
+    from_language, embedded_id = _resolve(subs, None, 2)
+    assert from_language == "eng"
+    # The embedded track id is returned so the caller can extract it before translating.
+    assert embedded_id == 2
+
+
+def test_resolve_rejects_external_id_passed_as_embedded():
+    # id 1 points to an external file (no embedded_track_id), not an embedded track.
+    subs = [_external(sub_id=1), _embedded(sub_id=2)]
+    with pytest.raises(ValueError, match="not an embedded track"):
+        _resolve(subs, None, 1)
+
+
+def test_resolve_unknown_path_raises():
+    subs = [_external()]
+    with pytest.raises(ValueError, match="Invalid source language code"):
+        _resolve(subs, "/nope.srt", None)
+
+
+def test_resolve_unknown_id_raises():
+    subs = [_embedded(sub_id=2)]
+    with pytest.raises(ValueError, match="Invalid source language code"):
+        _resolve(subs, None, 999)
+
+
+def test_resolve_invalid_language_raises():
+    subs = [{"path": "/x.srt", "code2": "zzz", "id": 1, "embedded_track_id": None}]
+    with pytest.raises(ValueError, match="Invalid source language code"):
+        _resolve(subs, "/x.srt", None)
+
+
+def test_resolve_neither_path_nor_id_raises():
+    with pytest.raises(ValueError, match="Invalid source language code"):
+        _resolve([_external()], None, None)

--- a/tests/bazarr/test_translation_format.py
+++ b/tests/bazarr/test_translation_format.py
@@ -1,0 +1,34 @@
+from bazarr.subtitles.tools.translate.core.translator_utils import get_translation_extension
+
+
+def test_defaults_to_srt_when_not_preserving():
+    assert get_translation_extension("/m/Foo.en.ass", False, "google_translate") == ".srt"
+
+
+def test_preserves_supported_source_format_for_pysubs2_translators():
+    assert get_translation_extension("/m/Foo.en.ass", True, "google_translate") == ".ass"
+    assert get_translation_extension("/m/Foo.en.vtt", True, "lingarr") == ".vtt"
+    assert get_translation_extension("/m/Foo.en.ssa", True, "google_translate") == ".ssa"
+
+
+def test_srt_source_stays_srt():
+    assert get_translation_extension("/m/Foo.en.srt", True, "google_translate") == ".srt"
+
+
+def test_gemini_cannot_preserve_non_srt():
+    # Gemini only reads/writes SRT, so a .ass source falls back to .srt even when preserving.
+    assert get_translation_extension("/m/Foo.en.ass", True, "gemini") == ".srt"
+    assert get_translation_extension("/m/Foo.en.vtt", True, "gemini") == ".srt"
+
+
+def test_gemini_srt_is_preserved():
+    assert get_translation_extension("/m/Foo.en.srt", True, "gemini") == ".srt"
+
+
+def test_unsupported_extension_falls_back_to_srt():
+    assert get_translation_extension("/m/Foo.en.sub", True, "google_translate") == ".srt"
+    assert get_translation_extension("/m/Foo.en", True, "google_translate") == ".srt"
+
+
+def test_extension_lookup_is_case_insensitive():
+    assert get_translation_extension("/m/Foo.EN.ASS", True, "google_translate") == ".ass"


### PR DESCRIPTION
Two related translate improvements, bundled per the maintainer's request on this thread (format preservation follow-up).

## 1. Translate embedded subtitles (extract-then-translate)

Today **Translate…** only appears on subtitles that exist as an external file. Embedded/internal tracks (`path === null`) get no Translate option, so a user whose only subtitle for a title is an embedded track can't translate it from the UI. This adds **Translate…** for a single embedded subtitle by reusing the existing extraction capability.

- **Frontend** (`SubtitleToolsMenu.tsx`): a single embedded selection now shows **Translate…** (opening the existing `TranslationModal`), the same way it shows **Extract**. Single-track only, mirroring Extract; other tools stay hidden for embedded rows.
- **Backend** (`api/subtitles/subtitles.py`, `translate` branch): the `path` requirement is relaxed so a request can identify the target by `subtitles_id`. When the matched row is an embedded track (`embedded_track_id` set, no path), `extract_embedded_subtitle(...)` runs first to produce an external file, and that path is handed to `translate_subtitles_file(...)`. The external-file path is unchanged.
- The source-language resolution (match by path **or** by subtitles id, validate language, distinguish embedded vs external) is extracted into a pure helper `resolve_translation_source(...)` so it's unit-testable without spinning up the API/Flask stack.
- Image/bitmap tracks (PGS etc.) surface the existing `415 Image based embedded subtitles cannot be extracted`.

## 2. Preserve original subtitle format

Follow-up to the format note below: translation always wrote `.srt`, so translating a `.ass`/`.vtt` subtitle converted it to `.srt` (and historically crashed on `.ass`, see #3046). This adds an opt-in **"Preserve original format"** so a `.ass`/`.vtt`/`.ssa` source keeps its format, reusing the existing `original_format` convention from mods.

- **`translate/main.py`**: `translate_subtitles_file` gains an `original_format` parameter; the destination extension is derived from the source via a small helper instead of being hardcoded to `.srt`.
- **`translator_utils.py`**: `get_translation_extension(source, original_format, translator_type)` returns the extension (`.srt/.ass/.ssa/.vtt`; anything else → `.srt`). Google and Lingarr go through `pysubs2`, which already honours the destination path extension — **no translator changes needed**.
- **Gemini** reads/writes SRT only, so for non-SRT sources it falls back to `.srt` (logged). Porting Gemini to `pysubs2` is a larger change, intentionally left out of scope.
- **`add_translator_info`** is skipped for non-`.srt` outputs (it's SRT-only) so it can't corrupt a `.ass`/`.vtt` file.
- **API**: forwards `original_format=args.get('original_format') == 'True'` (absent → `False`, current behavior).
- **Frontend** (`TranslationForm.tsx`): a **"Preserve original format"** switch, default ON, wired to the existing `ModifySubtitle.originalFormat` field.

For `.srt` sources (the common case) the output is identical to today whether the option is on or off.

## Notes

- Extracted original-language files are kept alongside the translation, consistent with a manual Extract → Translate. Happy to change that or take the design to Discord per `CONTRIBUTING.md`.
- Per `CONTRIBUTING.md` I know features are ideally discussed on Discord first; I went ahead since both changes are small and build entirely on already-shipped plumbing (the `extract` action and the `original_format` convention).

## Testing

- New `tests/bazarr/test_api_subtitles_translate.py` (7 tests) for `resolve_translation_source` (external-by-path, embedded-by-id, rejecting an external id, unknown path/id, invalid language, neither-path-nor-id; language validation injected to stay off the DB).
- New `tests/bazarr/test_translation_format.py` (7 tests) for `get_translation_extension` (default-to-srt, preserve `.ass`/`.vtt`/`.ssa`, Gemini non-SRT fallback, unsupported-extension fallback, case-insensitivity).
- Backend suite: `161 passed` (the only failing tests, `test_utilities_video_analyzer`, also fail on a clean `development` checkout — they need the `ffmpeg`/`mediainfo` binaries CI installs).
- Frontend: `check:ts`, `check:fmt`, `check:style` clean; `npm test` green (86 files / 457 tests). Existing `TranslationForm.test.tsx` still passes.

## Disclosure

Developed with AI assistance (Claude Code); I wrote and understand every line. Followed `CONTRIBUTING.md` (branched from `development`, focused commits).