### PR TITLE
Added sort and filter

### DIFF
--- a/bazarr/api/movies/__init__.py
+++ b/bazarr/api/movies/__init__.py
@@ -5,6 +5,7 @@ from .movies_subtitles import api_ns_movies_subtitles
 from .history import api_ns_movies_history
 from .wanted import api_ns_movies_wanted
 from .blacklist import api_ns_movies_blacklist
+from .tags import api_ns_movies_tags
 
 
 api_ns_list_movies = [
@@ -12,5 +13,6 @@ api_ns_list_movies = [
     api_ns_movies_blacklist,
     api_ns_movies_history,
     api_ns_movies_subtitles,
+    api_ns_movies_tags,
     api_ns_movies_wanted,
 ]

--- a/bazarr/api/movies/movies.py
+++ b/bazarr/api/movies/movies.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from flask_restx import Resource, Namespace, reqparse, fields, marshal
+from sqlalchemy import or_
 
 from app.database import TableMovies, database, update, select, func
 from radarr.sync.movies import update_one_movie
@@ -10,7 +11,8 @@ from subtitles.wanted import wanted_search_missing_subtitles_movies
 from subtitles.mass_download import movies_download_subtitles
 from api.swaggerui import subtitles_model, subtitles_language_model, audio_language_model
 
-from api.utils import authenticate, None_Keys, postprocess
+from api.utils import authenticate, None_Keys, postprocess, add_list_query_args, profile_filter_clause, \
+    tags_filter_clause, audio_language_filter_clause, apply_sort
 
 api_ns_movies = Namespace('Movies', description='List movies metadata, update movie languages profile or run actions '
                                                 'for specific movies.')
@@ -22,7 +24,8 @@ class Movies(Resource):
     get_request_parser.add_argument('start', type=int, required=False, default=0, help='Paging start integer')
     get_request_parser.add_argument('length', type=int, required=False, default=-1, help='Paging length integer')
     get_request_parser.add_argument('radarrid[]', type=int, action='append', required=False, default=[],
-                                    help='Movies IDs to get metadata for')
+                                     help='Movies IDs to get metadata for')
+    add_list_query_args(get_request_parser)
 
     get_subtitles_model = api_ns_movies.model('subtitles_model', subtitles_model)
     get_subtitles_language_model = api_ns_movies.model('subtitles_language_model', subtitles_language_model)
@@ -31,6 +34,7 @@ class Movies(Resource):
     data_model = api_ns_movies.model('movies_data_model', {
         'alternativeTitles': fields.List(fields.String),
         'audio_language': fields.Nested(get_audio_language_model),
+        'created_at_timestamp': fields.String(),
         'fanart': fields.String(),
         'imdbId': fields.String(),
         'missing_subtitles': fields.Nested(get_subtitles_language_model),
@@ -62,9 +66,17 @@ class Movies(Resource):
         start = args.get('start')
         length = args.get('length')
         radarrId = args.get('radarrid[]')
+        sort_by = args.get('sort_by')
+        sort_order = args.get('sort_order')
+        monitored = args.get('monitored')
+        profile_id = args.get('profileid')
+        missing = args.get('missing')
+        audio_language = args.get('audio_language')
+        tags = args.get('tags[]')
 
         stmt = select(TableMovies.alternativeTitles,
                       TableMovies.audio_language,
+                      TableMovies.created_at_timestamp,
                       TableMovies.fanart,
                       TableMovies.imdbId,
                       TableMovies.missing_subtitles,
@@ -78,11 +90,39 @@ class Movies(Resource):
                       TableMovies.tags,
                       TableMovies.title,
                       TableMovies.year,
-                      )\
-            .order_by(TableMovies.sortTitle)
+                      )
+
+        where_clauses = []
 
         if len(radarrId) != 0:
-            stmt = stmt.where(TableMovies.radarrId.in_(radarrId))
+            where_clauses.append(TableMovies.radarrId.in_(radarrId))
+        if monitored is not None:
+            where_clauses.append(TableMovies.monitored.is_(monitored == 'true'))
+        if profile_id is not None:
+            where_clauses.append(profile_filter_clause(TableMovies.profileId, profile_id))
+        if missing is not None:
+            if missing == 'true':
+                where_clauses.append(TableMovies.missing_subtitles.is_not(None))
+                where_clauses.append(TableMovies.missing_subtitles != '[]')
+            else:
+                where_clauses.append(or_(TableMovies.missing_subtitles.is_(None),
+                                         TableMovies.missing_subtitles == '[]'))
+        if audio_language is not None:
+            where_clauses.append(audio_language_filter_clause(TableMovies.audio_language, audio_language))
+        if tags:
+            where_clauses.append(tags_filter_clause(TableMovies.tags, tags))
+
+        if where_clauses:
+            stmt = stmt.where(*where_clauses)
+
+        stmt = apply_sort(stmt, {
+            'title': TableMovies.sortTitle,
+            'year': TableMovies.year,
+            'profileId': TableMovies.profileId,
+            'audio_language': TableMovies.audio_language,
+            'audioLanguage': TableMovies.audio_language,
+            'createdAtTimestamp': TableMovies.created_at_timestamp,
+        }, TableMovies.sortTitle, sort_by, sort_order)
 
         if length > 0:
             stmt = stmt.limit(length).offset(start)
@@ -90,6 +130,7 @@ class Movies(Resource):
         results = [postprocess({
             'alternativeTitles': x.alternativeTitles,
             'audio_language': x.audio_language,
+            'created_at_timestamp': x.created_at_timestamp,
             'fanart': x.fanart,
             'imdbId': x.imdbId,
             'missing_subtitles': x.missing_subtitles,
@@ -105,10 +146,11 @@ class Movies(Resource):
             'year': x.year,
         }) for x in database.execute(stmt).all()]
 
-        count = database.execute(
-            select(func.count())
-            .select_from(TableMovies)) \
-            .scalar()
+        count_stmt = select(func.count()).select_from(TableMovies)
+        if where_clauses:
+            count_stmt = count_stmt.where(*where_clauses)
+
+        count = database.execute(count_stmt).scalar()
 
         return marshal({'data': results, 'total': count}, self.get_response_model)
 

--- a/bazarr/api/movies/movies.py
+++ b/bazarr/api/movies/movies.py
@@ -12,7 +12,7 @@ from subtitles.mass_download import movies_download_subtitles
 from api.swaggerui import subtitles_model, subtitles_language_model, audio_language_model
 
 from api.utils import authenticate, None_Keys, postprocess, add_list_query_args, profile_filter_clause, \
-    tags_filter_clause, audio_language_filter_clause, apply_sort
+    monitored_filter_clause, tags_filter_clause, audio_language_filter_clause, apply_sort
 
 api_ns_movies = Namespace('Movies', description='List movies metadata, update movie languages profile or run actions '
                                                 'for specific movies.')
@@ -97,7 +97,7 @@ class Movies(Resource):
         if len(radarrId) != 0:
             where_clauses.append(TableMovies.radarrId.in_(radarrId))
         if monitored is not None:
-            where_clauses.append(TableMovies.monitored.is_(monitored == 'true'))
+            where_clauses.append(monitored_filter_clause(TableMovies.monitored, monitored))
         if profile_id is not None:
             where_clauses.append(profile_filter_clause(TableMovies.profileId, profile_id))
         if missing is not None:

--- a/bazarr/api/movies/tags.py
+++ b/bazarr/api/movies/tags.py
@@ -1,0 +1,27 @@
+# coding=utf-8
+
+import ast
+
+from flask_restx import Resource, Namespace
+
+from app.database import TableMovies, database, select
+
+from ..utils import authenticate
+
+api_ns_movies_tags = Namespace('Movies Tags', description='List tags assigned to movies')
+
+
+@api_ns_movies_tags.route('movies/tags')
+class MoviesTags(Resource):
+    @authenticate
+    @api_ns_movies_tags.response(200, 'Success')
+    @api_ns_movies_tags.response(401, 'Not Authenticated')
+    def get(self):
+        """List all distinct tags assigned to any movie"""
+        rows = database.execute(
+            select(TableMovies.tags).where(TableMovies.tags.is_not(None))).all()
+        tags = set()
+        for row in rows:
+            if row.tags:
+                tags.update(ast.literal_eval(row.tags))
+        return sorted(tags)

--- a/bazarr/api/movies/tags.py
+++ b/bazarr/api/movies/tags.py
@@ -2,7 +2,7 @@
 
 import ast
 
-from flask_restx import Resource, Namespace
+from flask_restx import Resource, Namespace, fields, marshal
 
 from app.database import TableMovies, database, select
 
@@ -13,6 +13,10 @@ api_ns_movies_tags = Namespace('Movies Tags', description='List tags assigned to
 
 @api_ns_movies_tags.route('movies/tags')
 class MoviesTags(Resource):
+    get_response_model = api_ns_movies_tags.model('MoviesTagsGetResponse', {
+        'tag': fields.String(),
+    })
+
     @authenticate
     @api_ns_movies_tags.response(200, 'Success')
     @api_ns_movies_tags.response(401, 'Not Authenticated')
@@ -24,4 +28,4 @@ class MoviesTags(Resource):
         for row in rows:
             if row.tags:
                 tags.update(ast.literal_eval(row.tags))
-        return sorted(tags)
+        return marshal([{'tag': tag} for tag in sorted(tags)], self.get_response_model, envelope='data')

--- a/bazarr/api/series/__init__.py
+++ b/bazarr/api/series/__init__.py
@@ -1,8 +1,10 @@
 # coding=utf-8
 
 from .series import api_ns_series
+from .tags import api_ns_series_tags
 
 
 api_ns_list_series = [
     api_ns_series,
+    api_ns_series_tags,
 ]

--- a/bazarr/api/series/series.py
+++ b/bazarr/api/series/series.py
@@ -13,7 +13,8 @@ from subtitles.wanted import wanted_search_missing_subtitles_series
 from app.event_handler import event_stream
 from api.swaggerui import subtitles_model, subtitles_language_model, audio_language_model
 
-from api.utils import authenticate, None_Keys, postprocess
+from api.utils import authenticate, None_Keys, postprocess, add_list_query_args, profile_filter_clause, \
+    tags_filter_clause, audio_language_filter_clause, apply_sort
 
 api_ns_series = Namespace('Series', description='List series metadata, update series languages profile or run actions '
                                                 'for specific series.')
@@ -26,6 +27,7 @@ class Series(Resource):
     get_request_parser.add_argument('length', type=int, required=False, default=-1, help='Paging length integer')
     get_request_parser.add_argument('seriesid[]', type=int, action='append', required=False, default=[],
                                     help='Series IDs to get metadata for')
+    add_list_query_args(get_request_parser)
 
     get_subtitles_model = api_ns_series.model('subtitles_model', subtitles_model)
     get_subtitles_language_model = api_ns_series.model('subtitles_language_model', subtitles_language_model)
@@ -34,6 +36,7 @@ class Series(Resource):
     data_model = api_ns_series.model('series_data_model', {
         'alternativeTitles': fields.List(fields.String),
         'audio_language': fields.Nested(get_audio_language_model),
+        'created_at_timestamp': fields.String(),
         'episodeFileCount': fields.Integer(default=0),
         'ended': fields.Boolean(),
         'episodeMissingCount': fields.Integer(default=0),
@@ -68,6 +71,13 @@ class Series(Resource):
         start = args.get('start')
         length = args.get('length')
         seriesId = args.get('seriesid[]')
+        sort_by = args.get('sort_by')
+        sort_order = args.get('sort_order')
+        monitored = args.get('monitored')
+        profile_id = args.get('profileid')
+        missing = args.get('missing')
+        audio_language = args.get('audio_language')
+        tags = args.get('tags[]')
 
         episodeFileCount = select(TableShows.sonarrSeriesId,
                                   func.count(TableEpisodes.sonarrSeriesId).label('episodeFileCount')) \
@@ -91,6 +101,7 @@ class Series(Resource):
         stmt = select(TableShows.tvdbId,
                       TableShows.alternativeTitles,
                       TableShows.audio_language,
+                      TableShows.created_at_timestamp,
                       TableShows.fanart,
                       TableShows.imdbId,
                       TableShows.monitored,
@@ -109,18 +120,46 @@ class Series(Resource):
                       episodeMissingCount.c.episodeMissingCount) \
             .select_from(TableShows) \
             .join(episodeFileCount, TableShows.sonarrSeriesId == episodeFileCount.c.sonarrSeriesId, isouter=True) \
-            .join(episodeMissingCount, TableShows.sonarrSeriesId == episodeMissingCount.c.sonarrSeriesId, isouter=True)\
-            .order_by(TableShows.sortTitle)
+            .join(episodeMissingCount, TableShows.sonarrSeriesId == episodeMissingCount.c.sonarrSeriesId, isouter=True)
+
+        where_clauses = []
 
         if len(seriesId) != 0:
-            stmt = stmt.where(TableShows.sonarrSeriesId.in_(seriesId))
-        elif length > 0:
+            where_clauses.append(TableShows.sonarrSeriesId.in_(seriesId))
+        if monitored is not None:
+            where_clauses.append(TableShows.monitored.is_(monitored == 'true'))
+        if profile_id is not None:
+            where_clauses.append(profile_filter_clause(TableShows.profileId, profile_id))
+        if missing is not None:
+            missing_clause = func.coalesce(episodeMissingCount.c.episodeMissingCount, 0) > 0
+            if missing != 'true':
+                missing_clause = func.coalesce(episodeMissingCount.c.episodeMissingCount, 0) == 0
+            where_clauses.append(missing_clause)
+        if audio_language is not None:
+            where_clauses.append(audio_language_filter_clause(TableShows.audio_language, audio_language))
+        if tags:
+            where_clauses.append(tags_filter_clause(TableShows.tags, tags))
+
+        if where_clauses:
+            stmt = stmt.where(reduce(operator.and_, where_clauses))
+
+        stmt = apply_sort(stmt, {
+            'title': TableShows.sortTitle,
+            'year': TableShows.year,
+            'episodeFileCount': episodeFileCount.c.episodeFileCount,
+            'episodeMissingCount': episodeMissingCount.c.episodeMissingCount,
+            'profileId': TableShows.profileId,
+            'createdAtTimestamp': TableShows.created_at_timestamp,
+        }, TableShows.sortTitle, sort_by, sort_order)
+
+        if length > 0:
             stmt = stmt.limit(length).offset(start)
 
         results = [postprocess({
             'tvdbId': x.tvdbId,
             'alternativeTitles': x.alternativeTitles,
             'audio_language': x.audio_language,
+            'created_at_timestamp': x.created_at_timestamp,
             'fanart': x.fanart,
             'imdbId': x.imdbId,
             'monitored': x.monitored,
@@ -139,10 +178,14 @@ class Series(Resource):
             'episodeMissingCount': x.episodeMissingCount,
         }) for x in database.execute(stmt).all()]
 
-        count = database.execute(
-            select(func.count())
-            .select_from(TableShows)) \
-            .scalar()
+        count_stmt = select(func.count()) \
+            .select_from(TableShows) \
+            .join(episodeFileCount, TableShows.sonarrSeriesId == episodeFileCount.c.sonarrSeriesId, isouter=True) \
+            .join(episodeMissingCount, TableShows.sonarrSeriesId == episodeMissingCount.c.sonarrSeriesId, isouter=True)
+        if where_clauses:
+            count_stmt = count_stmt.where(reduce(operator.and_, where_clauses))
+
+        count = database.execute(count_stmt).scalar()
 
         return marshal({'data': results, 'total': count}, self.get_response_model)
 

--- a/bazarr/api/series/series.py
+++ b/bazarr/api/series/series.py
@@ -14,7 +14,7 @@ from app.event_handler import event_stream
 from api.swaggerui import subtitles_model, subtitles_language_model, audio_language_model
 
 from api.utils import authenticate, None_Keys, postprocess, add_list_query_args, profile_filter_clause, \
-    monitored_filter_clause, tags_filter_clause, audio_language_filter_clause, apply_sort
+    monitored_filter_clause, tags_filter_clause, series_audio_language_filter_clause, apply_sort
 
 api_ns_series = Namespace('Series', description='List series metadata, update series languages profile or run actions '
                                                 'for specific series.')
@@ -136,7 +136,7 @@ class Series(Resource):
                 missing_clause = func.coalesce(episodeMissingCount.c.episodeMissingCount, 0) == 0
             where_clauses.append(missing_clause)
         if audio_language is not None:
-            where_clauses.append(audio_language_filter_clause(TableShows.audio_language, audio_language))
+            where_clauses.append(series_audio_language_filter_clause(audio_language))
         if tags:
             where_clauses.append(tags_filter_clause(TableShows.tags, tags))
 

--- a/bazarr/api/series/series.py
+++ b/bazarr/api/series/series.py
@@ -14,7 +14,7 @@ from app.event_handler import event_stream
 from api.swaggerui import subtitles_model, subtitles_language_model, audio_language_model
 
 from api.utils import authenticate, None_Keys, postprocess, add_list_query_args, profile_filter_clause, \
-    tags_filter_clause, audio_language_filter_clause, apply_sort
+    monitored_filter_clause, tags_filter_clause, audio_language_filter_clause, apply_sort
 
 api_ns_series = Namespace('Series', description='List series metadata, update series languages profile or run actions '
                                                 'for specific series.')
@@ -127,7 +127,7 @@ class Series(Resource):
         if len(seriesId) != 0:
             where_clauses.append(TableShows.sonarrSeriesId.in_(seriesId))
         if monitored is not None:
-            where_clauses.append(TableShows.monitored.is_(monitored == 'true'))
+            where_clauses.append(monitored_filter_clause(TableShows.monitored, monitored))
         if profile_id is not None:
             where_clauses.append(profile_filter_clause(TableShows.profileId, profile_id))
         if missing is not None:

--- a/bazarr/api/series/tags.py
+++ b/bazarr/api/series/tags.py
@@ -1,0 +1,27 @@
+# coding=utf-8
+
+import ast
+
+from flask_restx import Resource, Namespace
+
+from app.database import TableShows, database, select
+
+from ..utils import authenticate
+
+api_ns_series_tags = Namespace('Series Tags', description='List tags assigned to series')
+
+
+@api_ns_series_tags.route('series/tags')
+class SeriesTags(Resource):
+    @authenticate
+    @api_ns_series_tags.response(200, 'Success')
+    @api_ns_series_tags.response(401, 'Not Authenticated')
+    def get(self):
+        """List all distinct tags assigned to any series"""
+        rows = database.execute(
+            select(TableShows.tags).where(TableShows.tags.is_not(None))).all()
+        tags = set()
+        for row in rows:
+            if row.tags:
+                tags.update(ast.literal_eval(row.tags))
+        return sorted(tags)

--- a/bazarr/api/series/tags.py
+++ b/bazarr/api/series/tags.py
@@ -2,7 +2,7 @@
 
 import ast
 
-from flask_restx import Resource, Namespace
+from flask_restx import Resource, Namespace, fields, marshal
 
 from app.database import TableShows, database, select
 
@@ -13,6 +13,10 @@ api_ns_series_tags = Namespace('Series Tags', description='List tags assigned to
 
 @api_ns_series_tags.route('series/tags')
 class SeriesTags(Resource):
+    get_response_model = api_ns_series_tags.model('SeriesTagsGetResponse', {
+        'tag': fields.String(),
+    })
+
     @authenticate
     @api_ns_series_tags.response(200, 'Success')
     @api_ns_series_tags.response(401, 'Not Authenticated')
@@ -24,4 +28,4 @@ class SeriesTags(Resource):
         for row in rows:
             if row.tags:
                 tags.update(ast.literal_eval(row.tags))
-        return sorted(tags)
+        return marshal([{'tag': tag} for tag in sorted(tags)], self.get_response_model, envelope='data')

--- a/bazarr/api/utils.py
+++ b/bazarr/api/utils.py
@@ -28,7 +28,6 @@ def profile_id_type(value):
 
 
 def add_list_query_args(parser):
-    # Shared filter/sort args for the series and movies list endpoints.
     parser.add_argument('sort_by', type=str, required=False, default='title',
                         help='Column to sort by')
     parser.add_argument('sort_order', type=str, required=False, default='asc', choices=('asc', 'desc'),

--- a/bazarr/api/utils.py
+++ b/bazarr/api/utils.py
@@ -6,12 +6,12 @@ from functools import wraps
 from flask import request, abort
 from operator import itemgetter
 
-from sqlalchemy import or_
+from sqlalchemy import or_, and_
 
 from app.config import settings, base_url
 from languages.get_languages import language_from_alpha2, alpha3_from_alpha2
 from app.database import (get_audio_profile_languages, get_desired_languages, get_subtitles, database, TableEpisodes,
-                          select)
+                          TableShows, select)
 from utilities.helper import bool_map
 from utilities.path_mappings import path_mappings
 
@@ -66,6 +66,24 @@ def audio_language_filter_clause(column, language):
     # Audio languages are stored as a stringified list of language names
     # (e.g. "['English', 'French']").
     return column.contains(f"'{language}'")
+
+
+def series_audio_language_filter_clause(language):
+    # Series with an empty audio_language display the audio languages
+    # aggregated from their episodes (see postprocess), so the filter must
+    # match both the series value and the episodes values to stay consistent
+    # with what the table shows.
+    pattern = f"'{language}'"
+    return or_(
+        TableShows.audio_language.contains(pattern),
+        and_(
+            or_(TableShows.audio_language == '[]', TableShows.audio_language.is_(None)),
+            TableShows.sonarrSeriesId.in_(
+                select(TableEpisodes.sonarrSeriesId)
+                .where(TableEpisodes.audio_language.contains(pattern))
+            ),
+        ),
+    )
 
 
 def apply_sort(stmt, sort_columns, default_column, sort_by, sort_order):

--- a/bazarr/api/utils.py
+++ b/bazarr/api/utils.py
@@ -11,6 +11,7 @@ from sqlalchemy import or_
 from app.config import settings, base_url
 from languages.get_languages import language_from_alpha2, alpha3_from_alpha2
 from app.database import get_audio_profile_languages, get_desired_languages, get_subtitles
+from utilities.helper import bool_map
 from utilities.path_mappings import path_mappings
 
 None_Keys = ['null', 'undefined', '', None]
@@ -52,7 +53,7 @@ def profile_filter_clause(column, value):
 
 def monitored_filter_clause(column, value):
     # monitored is stored as the string 'True'/'False', not a boolean
-    return column == ('True' if value == 'true' else 'False')
+    return column == str(bool_map[value])
 
 
 def tags_filter_clause(column, tags):

--- a/bazarr/api/utils.py
+++ b/bazarr/api/utils.py
@@ -50,6 +50,11 @@ def profile_filter_clause(column, value):
     return column == value
 
 
+def monitored_filter_clause(column, value):
+    # monitored is stored as the string 'True'/'False', not a boolean
+    return column == ('True' if value == 'true' else 'False')
+
+
 def tags_filter_clause(column, tags):
     # Tags are stored as a stringified list (e.g. "['tag1', 'tag2']"), match
     # any of the requested tags using the same pattern as get_exclusion_clause.

--- a/bazarr/api/utils.py
+++ b/bazarr/api/utils.py
@@ -6,6 +6,8 @@ from functools import wraps
 from flask import request, abort
 from operator import itemgetter
 
+from sqlalchemy import or_
+
 from app.config import settings, base_url
 from languages.get_languages import language_from_alpha2, alpha3_from_alpha2
 from app.database import get_audio_profile_languages, get_desired_languages, get_subtitles
@@ -14,6 +16,57 @@ from utilities.path_mappings import path_mappings
 None_Keys = ['null', 'undefined', '', None]
 
 False_Keys = ['False', 'false', '0']
+
+
+def profile_id_type(value):
+    # reqparse type for the profileid filter: a profile ID or "none" to list
+    # items without a languages profile. Raises ValueError (400) otherwise.
+    if value == 'none':
+        return value
+    return int(value)
+
+
+def add_list_query_args(parser):
+    # Shared filter/sort args for the series and movies list endpoints.
+    parser.add_argument('sort_by', type=str, required=False, default='title',
+                        help='Column to sort by')
+    parser.add_argument('sort_order', type=str, required=False, default='asc', choices=('asc', 'desc'),
+                        help='Sort direction')
+    parser.add_argument('monitored', type=str, required=False, choices=('true', 'false'),
+                        help='Filter by monitored status')
+    parser.add_argument('profileid', type=profile_id_type, required=False,
+                        help='Filter by languages profile ID or "none"')
+    parser.add_argument('missing', type=str, required=False, choices=('true', 'false'),
+                        help='Filter by missing subtitles')
+    parser.add_argument('audio_language', type=str, required=False,
+                        help='Filter by audio language name')
+    parser.add_argument('tags[]', type=str, action='append', required=False, default=[],
+                        help='Tags to filter by')
+
+
+def profile_filter_clause(column, value):
+    if value == 'none':
+        return column.is_(None)
+    return column == value
+
+
+def tags_filter_clause(column, tags):
+    # Tags are stored as a stringified list (e.g. "['tag1', 'tag2']"), match
+    # any of the requested tags using the same pattern as get_exclusion_clause.
+    return or_(*[column.contains(f"'{tag}'") for tag in tags])
+
+
+def audio_language_filter_clause(column, language):
+    # Audio languages are stored as a stringified list of language names
+    # (e.g. "['English', 'French']").
+    return column.contains(f"'{language}'")
+
+
+def apply_sort(stmt, sort_columns, default_column, sort_by, sort_order):
+    # sort_columns is a whitelist of allowed sort columns; unknown sort_by
+    # values fall back to the default column.
+    sort_column = sort_columns.get(sort_by, default_column)
+    return stmt.order_by(sort_column.asc() if sort_order == 'asc' else sort_column.desc())
 
 
 def authenticate(actual_method):

--- a/bazarr/radarr/sync/movies.py
+++ b/bazarr/radarr/sync/movies.py
@@ -16,15 +16,13 @@ from constants import MINIMUM_VIDEO_SIZE
 from radarr.rootfolder import check_radarr_rootfolder
 from subtitles.indexer.movies import store_subtitles_movie
 from subtitles.mass_download import movies_download_subtitles
+from utilities.helper import bool_map
 from utilities.path_mappings import path_mappings
 from subtitles.adaptive_searching import is_search_active
 
 from sqlalchemy.exc import IntegrityError
 from .parser import movieParser
 from .utils import get_profile_list, get_tags, get_movies_from_radarr_api
-
-# map between booleans and strings in DB
-bool_map = {"True": True, "False": False}
 
 FEATURE_PREFIX = "SYNC_MOVIES "
 

--- a/bazarr/sonarr/sync/episodes.py
+++ b/bazarr/sonarr/sync/episodes.py
@@ -12,6 +12,7 @@ from functools import reduce
 from constants import MINIMUM_VIDEO_SIZE
 from app.database import database, TableShows, TableEpisodes, delete, update, insert, select, get_exclusion_clause
 from app.config import settings
+from utilities.helper import bool_map
 from utilities.path_mappings import path_mappings
 from subtitles.indexer.series import store_subtitles, series_full_scan_subtitles
 from subtitles.mass_download import episode_download_subtitles
@@ -23,9 +24,6 @@ from subtitles.adaptive_searching import is_search_active
 
 from .parser import episodeParser
 from .utils import get_episodes_from_sonarr_api, get_episodesFiles_from_sonarr_api
-
-# map between booleans and strings in DB
-bool_map = {"True": True, "False": False}
 
 FEATURE_PREFIX = "SYNC_EPISODES "
 

--- a/bazarr/sonarr/sync/series.py
+++ b/bazarr/sonarr/sync/series.py
@@ -10,6 +10,7 @@ from app.config import settings
 from subtitles.indexer.series import list_missing_subtitles
 from sonarr.rootfolder import check_sonarr_rootfolder
 from app.database import TableShows, TableLanguagesProfiles, database, insert, update, delete, select
+from utilities.helper import bool_map
 from utilities.path_mappings import path_mappings
 from app.event_handler import event_stream
 from app.jobs_queue import jobs_queue
@@ -17,9 +18,6 @@ from app.jobs_queue import jobs_queue
 from .episodes import sync_episodes
 from .parser import seriesParser
 from .utils import get_profile_list, get_tags, get_series_from_sonarr_api
-
-# map between booleans and strings in DB
-bool_map = {"True": True, "False": False}
 
 FEATURE_PREFIX = "SYNC_SERIES "
 

--- a/bazarr/utilities/helper.py
+++ b/bazarr/utilities/helper.py
@@ -11,7 +11,6 @@ from bs4 import UnicodeDammit
 from app.config import settings
 
 
-# map between booleans and their string representation in DB and query params
 bool_map = {"True": True, "False": False, "true": True, "false": False}
 
 

--- a/bazarr/utilities/helper.py
+++ b/bazarr/utilities/helper.py
@@ -11,6 +11,10 @@ from bs4 import UnicodeDammit
 from app.config import settings
 
 
+# map between booleans and their string representation in DB and query params
+bool_map = {"True": True, "False": False, "true": True, "false": False}
+
+
 def check_credentials(user, pw, request, log_success=True):
     forwarded_for_ip_addr = request.environ.get('HTTP_X_FORWARDED_FOR')
     real_ip_addr = request.environ.get('HTTP_X_REAL_IP')

--- a/frontend/config/chunks.ts
+++ b/frontend/config/chunks.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-restricted-imports
-import { dependencies } from "../package.json";
+import { dependencies } from "../package.json" with { type: "json" };
 
 const groups: Record<string, string[]> = {
   vendors: ["react", "react-router", "react-dom"],

--- a/frontend/config/configReader.ts
+++ b/frontend/config/configReader.ts
@@ -2,8 +2,10 @@
 /// <reference types="node" />
 
 import { readFileSync } from "fs";
-import { get } from "lodash";
+import lodash from "lodash";
 import { parse } from "yaml";
+
+const { get } = lodash;
 
 class ConfigReader {
   config: object;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "url": "https://github.com/morpheus65535/bazarr/issues"
   },
   "private": true,
+  "type": "module",
   "dependencies": {
     "@mantine/core": "^9.5.1",
     "@mantine/dropzone": "^9.5.1",
@@ -102,14 +103,14 @@
     "check:fmt": "prettier -c .",
     "check:style": "stylelint \"src/**/*.{css,scss}\" --max-warnings 0",
     "check:style:fix": "stylelint \"src/**/*.{css,scss}\" --fix",
-    "coverage": "vitest run --coverage",
+    "coverage": "NODE_OPTIONS='--disable-warning=ExperimentalWarning' vitest run --coverage",
     "format": "prettier -w .",
     "pwa-assets:generate": "pwa-assets-generator --preset minimal-2023 public/images/logo128.png",
     "prepare": "cd .. && husky frontend/.husky",
     "preview": "vite preview",
     "start": "vite",
-    "test": "vitest",
-    "test:ui": "vitest --ui"
+    "test": "NODE_OPTIONS='--disable-warning=ExperimentalWarning' vitest",
+    "test:ui": "NODE_OPTIONS='--disable-warning=ExperimentalWarning' vitest --ui"
   },
   "browserslist": {
     "production": [

--- a/frontend/src/apis/hooks/movies.ts
+++ b/frontend/src/apis/hooks/movies.ts
@@ -29,20 +29,15 @@ export const useMovieById = (id: number) => {
 export const useMovies = (state: Parameter.ListState = {}) => {
   const client = useQueryClient();
 
-  const hasState = state.filters !== undefined || state.sortBy !== undefined;
-
   const query = useQuery({
     queryKey: [QueryKeys.Movies, QueryKeys.All, state],
     queryFn: async () => {
-      if (hasState) {
-        const response = await api.movies.moviesBy({
-          start: 0,
-          length: -1,
-          ...state,
-        });
-        return response.data;
-      }
-      return api.movies.movies();
+      const response = await api.movies.moviesBy({
+        start: 0,
+        length: -1,
+        ...state,
+      });
+      return response.data;
     },
   });
 

--- a/frontend/src/apis/hooks/movies.ts
+++ b/frontend/src/apis/hooks/movies.ts
@@ -26,12 +26,26 @@ export const useMovieById = (id: number) => {
   });
 };
 
-export const useMovies = () => {
+export const useMovies = (state: Parameter.ListState = {}) => {
   const client = useQueryClient();
 
+  // With an active filter/sort state (mass editor carrying over the list
+  // filters), use the filtered list endpoint; otherwise the plain full list.
+  const hasState = state.filters !== undefined || state.sortBy !== undefined;
+
   const query = useQuery({
-    queryKey: [QueryKeys.Movies, QueryKeys.All],
-    queryFn: () => api.movies.movies(),
+    queryKey: [QueryKeys.Movies, QueryKeys.All, state],
+    queryFn: async () => {
+      if (hasState) {
+        const response = await api.movies.moviesBy({
+          start: 0,
+          length: -1,
+          ...state,
+        });
+        return response.data;
+      }
+      return api.movies.movies();
+    },
   });
 
   useEffect(() => {

--- a/frontend/src/apis/hooks/movies.ts
+++ b/frontend/src/apis/hooks/movies.ts
@@ -50,6 +50,13 @@ export const useMovies = (state: Parameter.ListState = {}) => {
   return query;
 };
 
+export const useMovieTags = () =>
+  useQuery({
+    queryKey: [QueryKeys.Movies, QueryKeys.Tags],
+    queryFn: () => api.movies.tags(),
+    staleTime: Infinity,
+  });
+
 export const moviesPaginationKey = [QueryKeys.Movies];
 
 export const moviesPaginationQuery: RangeQuery<Item.Movie> = (param) =>

--- a/frontend/src/apis/hooks/movies.ts
+++ b/frontend/src/apis/hooks/movies.ts
@@ -29,8 +29,6 @@ export const useMovieById = (id: number) => {
 export const useMovies = (state: Parameter.ListState = {}) => {
   const client = useQueryClient();
 
-  // With an active filter/sort state (mass editor carrying over the list
-  // filters), use the filtered list endpoint; otherwise the plain full list.
   const hasState = state.filters !== undefined || state.sortBy !== undefined;
 
   const query = useQuery({

--- a/frontend/src/apis/hooks/series.ts
+++ b/frontend/src/apis/hooks/series.ts
@@ -42,12 +42,26 @@ export const useSeriesById = (id: number) => {
   });
 };
 
-export const useSeries = () => {
+export const useSeries = (state: Parameter.ListState = {}) => {
   const client = useQueryClient();
 
+  // With an active filter/sort state (mass editor carrying over the list
+  // filters), use the filtered list endpoint; otherwise the plain full list.
+  const hasState = state.filters !== undefined || state.sortBy !== undefined;
+
   const query = useQuery({
-    queryKey: [QueryKeys.Series, QueryKeys.All],
-    queryFn: () => api.series.series(),
+    queryKey: [QueryKeys.Series, QueryKeys.All, state],
+    queryFn: async () => {
+      if (hasState) {
+        const response = await api.series.seriesBy({
+          start: 0,
+          length: -1,
+          ...state,
+        });
+        return response.data;
+      }
+      return api.series.series();
+    },
   });
 
   useEffect(() => {

--- a/frontend/src/apis/hooks/series.ts
+++ b/frontend/src/apis/hooks/series.ts
@@ -66,6 +66,13 @@ export const useSeries = (state: Parameter.ListState = {}) => {
   return query;
 };
 
+export const useSeriesTags = () =>
+  useQuery({
+    queryKey: [QueryKeys.Series, QueryKeys.Tags],
+    queryFn: () => api.series.tags(),
+    staleTime: Infinity,
+  });
+
 export const seriesPaginationKey = [QueryKeys.Series];
 
 export const seriesPaginationQuery: RangeQuery<Item.Series> = (param) =>

--- a/frontend/src/apis/hooks/series.ts
+++ b/frontend/src/apis/hooks/series.ts
@@ -45,8 +45,6 @@ export const useSeriesById = (id: number) => {
 export const useSeries = (state: Parameter.ListState = {}) => {
   const client = useQueryClient();
 
-  // With an active filter/sort state (mass editor carrying over the list
-  // filters), use the filtered list endpoint; otherwise the plain full list.
   const hasState = state.filters !== undefined || state.sortBy !== undefined;
 
   const query = useQuery({

--- a/frontend/src/apis/hooks/series.ts
+++ b/frontend/src/apis/hooks/series.ts
@@ -45,20 +45,15 @@ export const useSeriesById = (id: number) => {
 export const useSeries = (state: Parameter.ListState = {}) => {
   const client = useQueryClient();
 
-  const hasState = state.filters !== undefined || state.sortBy !== undefined;
-
   const query = useQuery({
     queryKey: [QueryKeys.Series, QueryKeys.All, state],
     queryFn: async () => {
-      if (hasState) {
-        const response = await api.series.seriesBy({
-          start: 0,
-          length: -1,
-          ...state,
-        });
-        return response.data;
-      }
-      return api.series.series();
+      const response = await api.series.seriesBy({
+        start: 0,
+        length: -1,
+        ...state,
+      });
+      return response.data;
     },
   });
 

--- a/frontend/src/apis/queries/hooks.ts
+++ b/frontend/src/apis/queries/hooks.ts
@@ -118,9 +118,9 @@ export const usePaginationQuery = <
   useEffect(() => {
     if (hasResetOnQueryChange.current) {
       setIndex(0);
-    } else {
-      hasResetOnQueryChange.current = true;
+      return;
     }
+    hasResetOnQueryChange.current = true;
   }, [queryKeySuffix]);
 
   // Reset page index if we out of bound
@@ -129,7 +129,9 @@ export const usePaginationQuery = <
 
     if (page >= pageCount) {
       setIndex(pageCount - 1);
-    } else if (page < 0) {
+      return;
+    }
+    if (page < 0) {
       setIndex(0);
     }
   }, [page, pageCount]);

--- a/frontend/src/apis/queries/hooks.ts
+++ b/frontend/src/apis/queries/hooks.ts
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router";
 import {
   InfiniteData,
+  keepPreviousData,
   QueryKey,
   useInfiniteQuery,
   UseInfiniteQueryResult,
@@ -9,7 +10,7 @@ import {
   useQueryClient,
   UseQueryResult,
 } from "@tanstack/react-query";
-import { GetItemId, useOnValueChange } from "@/utilities";
+import { GetItemId } from "@/utilities";
 import { usePageSize } from "@/utilities/storage";
 import { QueryKeys } from "./keys";
 
@@ -45,7 +46,15 @@ export const usePaginationQuery = <
     searchParams.get("page") ? Number(searchParams.get("page")) - 1 : 0,
   );
 
-  const queryKeySuffix = useMemo(() => JSON.stringify(query), [query]);
+  // Reset to the first page when the filter/sort query changes. Adjusting
+  // state during render skips the mount, so a ?page= URL param is still
+  // honored on first load.
+  const queryKeySuffix = JSON.stringify(query);
+  const [prevQueryKeySuffix, setPrevQueryKeySuffix] = useState(queryKeySuffix);
+  if (prevQueryKeySuffix !== queryKeySuffix) {
+    setPrevQueryKeySuffix(queryKeySuffix);
+    setIndex(0);
+  }
 
   const pageSize = usePageSize();
 
@@ -62,6 +71,8 @@ export const usePaginationQuery = <
       };
       return queryFn(param);
     },
+
+    placeholderData: keepPreviousData,
   });
 
   const { data } = results;
@@ -97,32 +108,6 @@ export const usePaginationQuery = <
     [pageCount],
   );
 
-  const [isPageLoading, setIsPageLoading] = useState(false);
-
-  useOnValueChange(page, () => {
-    if (results.isFetching) {
-      setIsPageLoading(true);
-    }
-  });
-
-  useEffect(() => {
-    if (!results.isFetching) {
-      setIsPageLoading(false);
-    }
-  }, [results.isFetching]);
-
-  // Reset to the first page when the filter/sort query changes. The ref skips
-  // the effect on mount so a ?page= URL param is still honored on first load
-  // (useOnValueChange cannot be used here, it fires on mount).
-  const hasResetOnQueryChange = useRef(false);
-  useEffect(() => {
-    if (hasResetOnQueryChange.current) {
-      setIndex(0);
-      return;
-    }
-    hasResetOnQueryChange.current = true;
-  }, [queryKeySuffix]);
-
   // Reset page index if we out of bound
   useEffect(() => {
     if (pageCount === 0) return;
@@ -139,7 +124,7 @@ export const usePaginationQuery = <
   return {
     ...results,
     paginationStatus: {
-      isPageLoading,
+      isPageLoading: results.isPlaceholderData,
       totalCount,
       pageCount,
       pageSize,

--- a/frontend/src/apis/queries/hooks.ts
+++ b/frontend/src/apis/queries/hooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
 import {
   InfiniteData,
@@ -35,6 +35,7 @@ export const usePaginationQuery = <
   queryKey: TQueryKey,
   queryFn: RangeQuery<TObject>,
   cacheIndividual = true,
+  query: Parameter.ListState = {},
 ): UsePaginationQueryResult<TObject> => {
   const client = useQueryClient();
 
@@ -44,17 +45,20 @@ export const usePaginationQuery = <
     searchParams.get("page") ? Number(searchParams.get("page")) - 1 : 0,
   );
 
+  const queryKeySuffix = useMemo(() => JSON.stringify(query), [query]);
+
   const pageSize = usePageSize();
 
   const start = page * pageSize;
 
   const results = useQuery({
-    queryKey: [...queryKey, QueryKeys.Range, { start, size: pageSize }],
+    queryKey: [...queryKey, QueryKeys.Range, { start, size: pageSize, query }],
 
     queryFn: () => {
-      const param: Parameter.Range = {
+      const param: Parameter.ListQuery = {
         start,
         length: pageSize,
+        ...query,
       };
       return queryFn(param);
     },
@@ -78,6 +82,7 @@ export const usePaginationQuery = <
     cacheIndividual,
     queryKey,
     page,
+    query,
   ]);
 
   const totalCount = data?.total ?? 0;
@@ -105,6 +110,18 @@ export const usePaginationQuery = <
       setIsPageLoading(false);
     }
   }, [results.isFetching]);
+
+  // Reset to the first page when the filter/sort query changes. The ref skips
+  // the effect on mount so a ?page= URL param is still honored on first load
+  // (useOnValueChange cannot be used here, it fires on mount).
+  const hasResetOnQueryChange = useRef(false);
+  useEffect(() => {
+    if (hasResetOnQueryChange.current) {
+      setIndex(0);
+    } else {
+      hasResetOnQueryChange.current = true;
+    }
+  }, [queryKeySuffix]);
 
   // Reset page index if we out of bound
   useEffect(() => {
@@ -159,6 +176,7 @@ export const useInfinitePaginationQuery = <
   queryKey: TQueryKey,
   queryFn: RangeQuery<TObject>,
   cacheIndividual = true,
+  query: Parameter.ListState = {},
 ): UseInfinitePaginationQueryResult<TObject> => {
   const client = useQueryClient();
 
@@ -171,12 +189,13 @@ export const useInfinitePaginationQuery = <
     QueryKey,
     number
   >({
-    queryKey: [...queryKey, QueryKeys.Range, { size: pageSize }],
+    queryKey: [...queryKey, QueryKeys.Range, { size: pageSize, query }],
 
     queryFn: ({ pageParam }) => {
-      const param: Parameter.Range = {
+      const param: Parameter.ListQuery = {
         start: pageParam,
         length: pageSize,
+        ...query,
       };
       return queryFn(param);
     },
@@ -202,7 +221,7 @@ export const useInfinitePaginationQuery = <
         });
       });
     }
-  }, [results.isSuccess, data, client, cacheIndividual, queryKey]);
+  }, [results.isSuccess, data, client, cacheIndividual, queryKey, query]);
 
   const { fetchNextPage: fetchNext, ...rest } = results;
   const { hasNextPage, isFetchingNextPage } = results;

--- a/frontend/src/apis/queries/keys.ts
+++ b/frontend/src/apis/queries/keys.ts
@@ -10,6 +10,7 @@ export enum QueryKeys {
   Providers = "providers",
   Languages = "languages",
   LanguagesProfiles = "languages-profiles",
+  Tags = "tags",
   Blacklist = "blacklist",
   Search = "search",
   Actions = "actions",

--- a/frontend/src/apis/raw/movies.ts
+++ b/frontend/src/apis/raw/movies.ts
@@ -44,7 +44,8 @@ class MovieApi extends BaseApi {
   }
 
   async tags() {
-    return this.get<string[]>("/tags");
+    const response = await this.get<DataWrapper<{ tag: string }[]>>("/tags");
+    return response.data.map(({ tag }) => tag);
   }
 
   async wanted(params: Parameter.Range) {

--- a/frontend/src/apis/raw/movies.ts
+++ b/frontend/src/apis/raw/movies.ts
@@ -1,5 +1,6 @@
 import { camelCaseKeys, snakeCaseKeys } from "@/utilities/case";
 import BaseApi from "./base";
+import { buildListParams } from "./utils";
 
 class MovieApi extends BaseApi {
   constructor() {
@@ -27,10 +28,10 @@ class MovieApi extends BaseApi {
     return response.data.map(camelCaseKeys);
   }
 
-  async moviesBy(params: Parameter.Range) {
+  async moviesBy(params: Parameter.ListQuery) {
     const response = await this.get<DataWrapperWithTotal<Item.RawMovie>>(
       "",
-      params,
+      buildListParams(params),
     );
     return {
       ...response,

--- a/frontend/src/apis/raw/movies.ts
+++ b/frontend/src/apis/raw/movies.ts
@@ -43,6 +43,10 @@ class MovieApi extends BaseApi {
     await this.post("", { radarrid: form.id, profileid: form.profileId });
   }
 
+  async tags() {
+    return this.get<string[]>("/tags");
+  }
+
   async wanted(params: Parameter.Range) {
     const response = await this.get<DataWrapperWithTotal<Wanted.RawMovie>>(
       "/wanted",

--- a/frontend/src/apis/raw/series.ts
+++ b/frontend/src/apis/raw/series.ts
@@ -29,6 +29,10 @@ class SeriesApi extends BaseApi {
     await this.post("", { seriesid: form.id, profileid: form.profileId });
   }
 
+  async tags() {
+    return this.get<string[]>("/tags");
+  }
+
   async action(form: FormType.SeriesAction) {
     const payload: Record<string, unknown> = { action: form.action };
 

--- a/frontend/src/apis/raw/series.ts
+++ b/frontend/src/apis/raw/series.ts
@@ -1,5 +1,6 @@
 import { camelCaseKeys } from "@/utilities/case";
 import BaseApi from "./base";
+import { buildListParams } from "./utils";
 
 class SeriesApi extends BaseApi {
   constructor() {
@@ -13,10 +14,10 @@ class SeriesApi extends BaseApi {
     return response.data.map(camelCaseKeys);
   }
 
-  async seriesBy(params: Parameter.Range) {
+  async seriesBy(params: Parameter.ListQuery) {
     const response = await this.get<DataWrapperWithTotal<Item.RawSeries>>(
       "",
-      params,
+      buildListParams(params),
     );
     return {
       ...response,

--- a/frontend/src/apis/raw/series.ts
+++ b/frontend/src/apis/raw/series.ts
@@ -30,7 +30,8 @@ class SeriesApi extends BaseApi {
   }
 
   async tags() {
-    return this.get<string[]>("/tags");
+    const response = await this.get<DataWrapper<{ tag: string }[]>>("/tags");
+    return response.data.map(({ tag }) => tag);
   }
 
   async action(form: FormType.SeriesAction) {

--- a/frontend/src/apis/raw/utils.test.ts
+++ b/frontend/src/apis/raw/utils.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { buildListParams } from "./utils";
+
+describe("buildListParams", () => {
+  it("keeps the paging fields", () => {
+    expect(buildListParams({ start: 10, length: 25 })).toEqual({
+      start: 10,
+      length: 25,
+    });
+  });
+
+  it("maps sort and filters to backend params", () => {
+    expect(
+      buildListParams({
+        start: 0,
+        length: 25,
+        sortBy: "title",
+        sortOrder: "desc",
+        filters: {
+          monitored: true,
+          missing: false,
+          profileId: 3,
+          audioLanguage: "English",
+          tags: ["a", "b"],
+        },
+      }),
+    ).toEqual({
+      start: 0,
+      length: 25,
+      sort_by: "title",
+      sort_order: "desc",
+      monitored: "true",
+      missing: "false",
+      profileid: 3,
+      audio_language: "English",
+      tags: ["a", "b"],
+    });
+  });
+
+  it("maps profileId 0 to none", () => {
+    expect(
+      buildListParams({ start: 0, length: 25, filters: { profileId: 0 } })
+        .profileid,
+    ).toBe("none");
+  });
+
+  it("drops undefined values and empty tags", () => {
+    expect(
+      buildListParams({
+        start: 0,
+        length: 25,
+        filters: { tags: [] },
+      }),
+    ).toEqual({ start: 0, length: 25 });
+  });
+});

--- a/frontend/src/apis/raw/utils.ts
+++ b/frontend/src/apis/raw/utils.ts
@@ -49,9 +49,6 @@ class RequestUtils {
 const requestUtils = new RequestUtils();
 export default requestUtils;
 
-// Maps the frontend list query state to the snake_case params expected by the
-// backend list endpoints (/series, /movies). Undefined values are dropped by
-// axios when building the query string.
 export const buildListParams = (
   params: Parameter.ListQuery,
 ): Record<string, unknown> => {

--- a/frontend/src/apis/raw/utils.ts
+++ b/frontend/src/apis/raw/utils.ts
@@ -49,3 +49,40 @@ class RequestUtils {
 
 const requestUtils = new RequestUtils();
 export default requestUtils;
+
+// Maps the frontend list query state to the snake_case params expected by the
+// backend list endpoints (/series, /movies). Undefined values are dropped by
+// axios when building the query string.
+export const buildListParams = (
+  params: Parameter.ListQuery,
+): Record<string, unknown> => {
+  const { start, length, sortBy, sortOrder, filters } = params;
+  const result: Record<string, unknown> = { start, length };
+
+  if (sortBy) {
+    result.sort_by = sortBy;
+  }
+  if (sortOrder) {
+    result.sort_order = sortOrder;
+  }
+  if (filters) {
+    if (filters.monitored !== undefined) {
+      result.monitored = filters.monitored ? "true" : "false";
+    }
+    if (filters.missing !== undefined) {
+      result.missing = filters.missing ? "true" : "false";
+    }
+    if (filters.profileId !== undefined) {
+      // 0 means "items without a languages profile"
+      result.profileid = filters.profileId === 0 ? "none" : filters.profileId;
+    }
+    if (filters.audioLanguage !== undefined) {
+      result.audio_language = filters.audioLanguage;
+    }
+    if (filters.tags && filters.tags.length > 0) {
+      result.tags = filters.tags;
+    }
+  }
+
+  return result;
+};

--- a/frontend/src/apis/raw/utils.ts
+++ b/frontend/src/apis/raw/utils.ts
@@ -22,9 +22,8 @@ class RequestUtils {
       const { data } = result;
       if (data.status && data.version) {
         return data;
-      } else {
-        throw new Error("Cannot get response, fallback to v3 api");
       }
+      throw new Error("Cannot get response, fallback to v3 api");
     } catch {
       const result = await client.axios.get<UrlTestResponse>(
         `../test/${protocol}/${url}api/v3/system/status`,

--- a/frontend/src/components/grids/QueryPosterGrid.test.tsx
+++ b/frontend/src/components/grids/QueryPosterGrid.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vitest } from "vitest";
 import { UseInfinitePaginationQueryResult } from "@/apis/queries/hooks";
-import { customRender, screen, waitFor } from "@/tests";
+import { act, customRender, screen, waitFor } from "@/tests";
 import QueryPosterGrid from "./QueryPosterGrid";
 
 const item = { title: "My Movie", radarrId: 1 } as Item.Movie;
@@ -51,7 +51,11 @@ const buildQuery = (
 };
 
 const renderPoster = (item: Item.Movie) => {
-  return <div data-testid="poster-card">{item.title}</div>;
+  return (
+    <div key={item.radarrId} data-testid="poster-card">
+      {item.title}
+    </div>
+  );
 };
 
 describe("QueryPosterGrid", () => {
@@ -81,7 +85,7 @@ describe("QueryPosterGrid", () => {
 
     customRender(<QueryPosterGrid query={query} renderPoster={renderPoster} />);
 
-    intersect(true);
+    act(() => intersect(true));
 
     await waitFor(() =>
       expect(query.controls.fetchNextPage).toHaveBeenCalledTimes(1),
@@ -93,7 +97,7 @@ describe("QueryPosterGrid", () => {
 
     customRender(<QueryPosterGrid query={query} renderPoster={renderPoster} />);
 
-    intersect(false);
+    act(() => intersect(false));
 
     await screen.findByTestId("poster-card");
     expect(query.controls.fetchNextPage).not.toHaveBeenCalled();

--- a/frontend/src/components/inputs/Selector.tsx
+++ b/frontend/src/components/inputs/Selector.tsx
@@ -149,6 +149,7 @@ export const MultiSelector = <T,>({
   onChange,
   getkey = DefaultKeyBuilder,
   buildOption,
+  hidePickedOptions = true,
   ...select
 }: MultiSelectorProps<T>) => {
   const labelRef = useRef(getkey);
@@ -196,7 +197,7 @@ export const MultiSelector = <T,>({
   return (
     <MultiSelect
       {...select}
-      hidePickedOptions
+      hidePickedOptions={hidePickedOptions}
       value={wrappedValue}
       defaultValue={wrappedDefaultValue}
       onChange={wrappedOnChange}

--- a/frontend/src/components/tables/QueryPageTable.tsx
+++ b/frontend/src/components/tables/QueryPageTable.tsx
@@ -26,8 +26,6 @@ const QueryPageTable = <T extends RowData>(props: Props<T>) => {
     ScrollToTop();
   }, [page]);
 
-  // isPending covers the first load and filter/sort changes (new query key
-  // with no cached data yet); isPageLoading covers page navigation.
   return (
     <LoadingProvider value={isPageLoading || query.isPending}>
       <SimpleTable {...remain} data={data.data}></SimpleTable>

--- a/frontend/src/components/tables/QueryPageTable.tsx
+++ b/frontend/src/components/tables/QueryPageTable.tsx
@@ -26,8 +26,10 @@ const QueryPageTable = <T extends RowData>(props: Props<T>) => {
     ScrollToTop();
   }, [page]);
 
+  // isPending covers the first load and filter/sort changes (new query key
+  // with no cached data yet); isPageLoading covers page navigation.
   return (
-    <LoadingProvider value={isPageLoading}>
+    <LoadingProvider value={isPageLoading || query.isPending}>
       <SimpleTable {...remain} data={data.data}></SimpleTable>
       <PageControl
         count={pageCount}

--- a/frontend/src/pages/Movies/Editor.tsx
+++ b/frontend/src/pages/Movies/Editor.tsx
@@ -8,9 +8,13 @@ import { AudioList } from "@/components/bazarr";
 import LanguageProfileName from "@/components/bazarr/LanguageProfile";
 import { AppColumnDef as ColumnDef } from "@/components/tables/features";
 import MassEditor from "@/pages/views/MassEditor";
+import { useListQueryState } from "@/utilities";
 
 const MovieMassEditor: FunctionComponent = () => {
-  const query = useMovies();
+  // Carry over the filters from the list page (preserved in the URL by the
+  // Mass Edit button) so the editor shows the same subset.
+  const { query: listState } = useListQueryState("movies");
+  const query = useMovies(listState);
   const mutation = useMovieModification();
 
   useDocumentTitle(`Movies - ${useInstanceName()} (Mass Editor)`);

--- a/frontend/src/pages/Movies/index.tsx
+++ b/frontend/src/pages/Movies/index.tsx
@@ -10,6 +10,7 @@ import {
   moviesPaginationKey,
   moviesPaginationQuery,
   useMovieModification,
+  useMovieTags,
 } from "@/apis/hooks";
 import { useInstanceName } from "@/apis/hooks/site";
 import { Action } from "@/components";
@@ -199,6 +200,7 @@ const MovieView: FunctionComponent = () => {
         viewModeKey={moviesViewModeKey}
         renderPoster={renderPoster}
         filterConfig={moviesFilterConfig}
+        useTags={useMovieTags}
         statePrefix="movies"
       ></ItemView>
     </Container>

--- a/frontend/src/pages/Movies/index.tsx
+++ b/frontend/src/pages/Movies/index.tsx
@@ -24,6 +24,22 @@ import { BuildKey } from "@/utilities";
 import { moviesViewModeKey } from "@/utilities/viewMode";
 import MoviePosterCard from "./PosterCard";
 
+const moviesFilterConfig = {
+  sortFields: [
+    { value: "title", label: "Name" },
+    { value: "profileId", label: "Profile" },
+    { value: "audioLanguage", label: "Audio" },
+    { value: "createdAtTimestamp", label: "Added" },
+  ],
+  filters: {
+    monitored: true,
+    missing: true,
+    profile: true,
+    audio: true,
+    tags: true,
+  },
+};
+
 const MovieView: FunctionComponent = () => {
   const modifyMovie = useMovieModification();
 
@@ -112,6 +128,17 @@ const MovieView: FunctionComponent = () => {
         },
       },
       {
+        header: "Added",
+        accessorKey: "createdAtTimestamp",
+        cell: ({ row: { original } }) => (
+          <>
+            {original.createdAtTimestamp
+              ? new Date(original.createdAtTimestamp).toLocaleDateString()
+              : ""}
+          </>
+        ),
+      },
+      {
         id: "radarrId",
         cell: ({ row }) => {
           return (
@@ -171,6 +198,8 @@ const MovieView: FunctionComponent = () => {
         columns={columns}
         viewModeKey={moviesViewModeKey}
         renderPoster={renderPoster}
+        filterConfig={moviesFilterConfig}
+        statePrefix="movies"
       ></ItemView>
     </Container>
   );

--- a/frontend/src/pages/Series/Editor.tsx
+++ b/frontend/src/pages/Series/Editor.tsx
@@ -8,9 +8,13 @@ import { AudioList } from "@/components/bazarr";
 import LanguageProfileName from "@/components/bazarr/LanguageProfile";
 import { AppColumnDef as ColumnDef } from "@/components/tables/features";
 import MassEditor from "@/pages/views/MassEditor";
+import { useListQueryState } from "@/utilities";
 
 const SeriesMassEditor: FunctionComponent = () => {
-  const query = useSeries();
+  // Carry over the filters from the list page (preserved in the URL by the
+  // Mass Edit button) so the editor shows the same subset.
+  const { query: listState } = useListQueryState("series");
+  const query = useSeries(listState);
   const mutation = useSeriesModification();
 
   const columns = useMemo<ColumnDef<Item.Series>[]>(

--- a/frontend/src/pages/Series/index.tsx
+++ b/frontend/src/pages/Series/index.tsx
@@ -14,6 +14,7 @@ import {
   seriesPaginationKey,
   seriesPaginationQuery,
   useSeriesModification,
+  useSeriesTags,
 } from "@/apis/hooks";
 import { useInstanceName } from "@/apis/hooks/site";
 import { Action } from "@/components";
@@ -199,6 +200,7 @@ const SeriesView: FunctionComponent = () => {
         viewModeKey={seriesViewModeKey}
         renderPoster={renderPoster}
         filterConfig={seriesFilterConfig}
+        useTags={useSeriesTags}
         statePrefix="series"
       ></ItemView>
     </Container>

--- a/frontend/src/pages/Series/index.tsx
+++ b/frontend/src/pages/Series/index.tsx
@@ -25,6 +25,23 @@ import ItemView from "@/pages/views/ItemView";
 import { seriesViewModeKey } from "@/utilities/viewMode";
 import SeriesPosterCard from "./PosterCard";
 
+const seriesFilterConfig = {
+  sortFields: [
+    { value: "title", label: "Name" },
+    { value: "episodeFileCount", label: "Episodes" },
+    { value: "episodeMissingCount", label: "Missing" },
+    { value: "profileId", label: "Profile" },
+    { value: "createdAtTimestamp", label: "Added" },
+  ],
+  filters: {
+    monitored: true,
+    missing: true,
+    profile: true,
+    audio: true,
+    tags: true,
+  },
+};
+
 const SeriesView: FunctionComponent = () => {
   const mutation = useSeriesModification();
 
@@ -111,6 +128,17 @@ const SeriesView: FunctionComponent = () => {
         },
       },
       {
+        header: "Added",
+        accessorKey: "createdAtTimestamp",
+        cell: ({ row: { original } }) => (
+          <>
+            {original.createdAtTimestamp
+              ? new Date(original.createdAtTimestamp).toLocaleDateString()
+              : ""}
+          </>
+        ),
+      },
+      {
         id: "sonarrSeriesId",
         cell: ({ row: { original } }) => {
           return (
@@ -170,6 +198,8 @@ const SeriesView: FunctionComponent = () => {
         columns={columns}
         viewModeKey={seriesViewModeKey}
         renderPoster={renderPoster}
+        filterConfig={seriesFilterConfig}
+        statePrefix="series"
       ></ItemView>
     </Container>
   );

--- a/frontend/src/pages/views/ItemView.test.tsx
+++ b/frontend/src/pages/views/ItemView.test.tsx
@@ -1,14 +1,33 @@
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vitest } from "vitest";
+import { beforeEach, describe, expect, it, vi, vitest } from "vitest";
 import { AppColumnDef as ColumnDef } from "@/components/tables/features";
 import { customRender, screen } from "@/tests";
 import ItemView from "./ItemView";
 
-const item = { title: "My Show", sonarrSeriesId: 1 } as Item.Series;
+vi.mock("@/apis/hooks", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/apis/hooks")>()),
+  useLanguageProfiles: () => ({ data: [] }),
+}));
+
+const item = {
+  title: "My Show",
+  sonarrSeriesId: 1,
+  tags: [],
+} as unknown as Item.Series;
 
 const columns: ColumnDef<Item.Series>[] = [
   { header: "Name", accessorKey: "title" },
 ];
+
+const filterConfig = {
+  sortFields: [{ value: "title", label: "Name" }],
+  filters: {
+    monitored: true,
+    missing: true,
+    profile: true,
+    tags: true,
+  },
+};
 
 const queryKey = ["test-item-view"];
 
@@ -23,6 +42,7 @@ const renderPoster = (item: Item.Series) => {
 describe("ItemView", () => {
   beforeEach(() => {
     window.localStorage.clear();
+    window.history.pushState({}, "", "/");
   });
 
   it("renders the table view by default", async () => {
@@ -33,6 +53,7 @@ describe("ItemView", () => {
         columns={columns}
         viewModeKey="test-view-mode"
         renderPoster={renderPoster}
+        filterConfig={filterConfig}
       ></ItemView>,
     );
 
@@ -50,9 +71,13 @@ describe("ItemView", () => {
         columns={columns}
         viewModeKey="test-view-mode"
         renderPoster={renderPoster}
+        filterConfig={filterConfig}
       ></ItemView>,
     );
 
+    await userEvent.click(
+      await screen.findByRole("button", { name: "View: table" }),
+    );
     await userEvent.click(await screen.findByText("Poster view"));
 
     expect(await screen.findByTestId("poster-card")).toBeInTheDocument();
@@ -72,6 +97,7 @@ describe("ItemView", () => {
         columns={columns}
         viewModeKey="test-view-mode"
         renderPoster={renderPoster}
+        filterConfig={filterConfig}
       ></ItemView>,
     );
 
@@ -88,9 +114,13 @@ describe("ItemView", () => {
         columns={columns}
         viewModeKey="test-view-mode"
         renderPoster={renderPoster}
+        filterConfig={filterConfig}
       ></ItemView>,
     );
 
+    await userEvent.click(
+      await screen.findByRole("button", { name: "View: poster" }),
+    );
     await userEvent.click(await screen.findByText("Table view"));
 
     expect(
@@ -99,12 +129,56 @@ describe("ItemView", () => {
     expect(screen.queryByTestId("poster-card")).not.toBeInTheDocument();
   });
 
+  it("sorts by clicking the column header", async () => {
+    customRender(
+      <ItemView
+        queryKey={queryKey}
+        queryFn={buildQueryFn()}
+        columns={columns}
+        viewModeKey="test-view-mode"
+        renderPoster={renderPoster}
+        filterConfig={filterConfig}
+      ></ItemView>,
+    );
+
+    const header = await screen.findByRole("columnheader", { name: "Name" });
+
+    await userEvent.click(header);
+    expect(window.location.search).toContain("sort_by=title");
+    expect(window.location.search).toContain("sort_order=asc");
+
+    await userEvent.click(header);
+    expect(window.location.search).toContain("sort_order=desc");
+  });
+
+  it("resets the page param when a filter changes", async () => {
+    window.history.pushState({}, "", "/?page=2");
+
+    customRender(
+      <ItemView
+        queryKey={queryKey}
+        queryFn={buildQueryFn()}
+        columns={columns}
+        viewModeKey="test-view-mode"
+        renderPoster={renderPoster}
+        filterConfig={filterConfig}
+      ></ItemView>,
+    );
+
+    await screen.findByRole("columnheader", { name: "Name" });
+    await userEvent.click(screen.getByText("Monitored"));
+
+    expect(window.location.search).toContain("monitored=true");
+    expect(window.location.search).not.toContain("page=");
+  });
+
   it("does not show the toggle without poster support", async () => {
     customRender(
       <ItemView
         queryKey={queryKey}
         queryFn={buildQueryFn()}
         columns={columns}
+        filterConfig={filterConfig}
       ></ItemView>,
     );
 

--- a/frontend/src/pages/views/ItemView.test.tsx
+++ b/frontend/src/pages/views/ItemView.test.tsx
@@ -247,17 +247,13 @@ describe("ItemView", () => {
   });
 
   it("commits the tags filter only when the dropdown closes", async () => {
-    const taggedItem = { ...item, tags: ["anime"] };
-    const queryFn: RangeQuery<Item.Series> = vitest.fn(() =>
-      Promise.resolve({ data: [taggedItem], total: 1 }),
-    );
-
     customRender(
       <ItemView
         queryKey={["test-item-view-tags"]}
-        queryFn={queryFn}
+        queryFn={buildQueryFn()}
         columns={columns}
         filterConfig={filterConfig}
+        useTags={() => ({ data: ["anime"] })}
       ></ItemView>,
     );
 

--- a/frontend/src/pages/views/ItemView.test.tsx
+++ b/frontend/src/pages/views/ItemView.test.tsx
@@ -1,7 +1,7 @@
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi, vitest } from "vitest";
 import { AppColumnDef as ColumnDef } from "@/components/tables/features";
-import { customRender, screen } from "@/tests";
+import { customRender, screen, within } from "@/tests";
 import ItemView from "./ItemView";
 
 vi.mock("@/apis/hooks", async (importOriginal) => ({
@@ -156,6 +156,55 @@ describe("ItemView", () => {
     expect(window.location.search).toContain("sort_order=desc");
   });
 
+  it("sorts from the poster view dropdown, flipping the default field", async () => {
+    window.localStorage.setItem("test-view-mode", JSON.stringify("poster"));
+
+    customRender(
+      <ItemView
+        queryKey={queryKey}
+        queryFn={buildQueryFn()}
+        columns={columns}
+        viewModeKey="test-view-mode"
+        renderPoster={renderPoster}
+        filterConfig={filterConfig}
+      ></ItemView>,
+    );
+
+    await screen.findByTestId("poster-card");
+
+    // "Name" is the default sort field, so the first click flips its direction
+    await userEvent.click(screen.getByRole("button", { name: /Sort/ }));
+    await userEvent.click(
+      await screen.findByRole("menuitem", { name: "Name" }),
+    );
+    expect(window.location.search).toContain("sort_by=title");
+    expect(window.location.search).toContain("sort_order=desc");
+  });
+
+  it("flips the sort direction of the active field", async () => {
+    window.localStorage.setItem("test-view-mode", JSON.stringify("poster"));
+    window.history.pushState({}, "", "/?sort_by=title&sort_order=desc");
+
+    customRender(
+      <ItemView
+        queryKey={queryKey}
+        queryFn={buildQueryFn()}
+        columns={columns}
+        viewModeKey="test-view-mode"
+        renderPoster={renderPoster}
+        filterConfig={filterConfig}
+      ></ItemView>,
+    );
+
+    await screen.findByTestId("poster-card");
+
+    await userEvent.click(screen.getByRole("button", { name: /Sort/ }));
+    await userEvent.click(
+      await screen.findByRole("menuitem", { name: "Name" }),
+    );
+    expect(window.location.search).toContain("sort_order=asc");
+  });
+
   it("resets the page param when a filter changes", async () => {
     window.history.pushState({}, "", "/?page=2");
 
@@ -175,6 +224,56 @@ describe("ItemView", () => {
 
     expect(window.location.search).toContain("monitored=true");
     expect(window.location.search).not.toContain("page=");
+  });
+
+  it("clears a filter when All is selected", async () => {
+    window.history.pushState({}, "", "/?monitored=true");
+
+    customRender(
+      <ItemView
+        queryKey={queryKey}
+        queryFn={buildQueryFn()}
+        columns={columns}
+        filterConfig={filterConfig}
+      ></ItemView>,
+    );
+
+    await screen.findByRole("columnheader", { name: "Name" });
+
+    const monitored = screen.getByRole("radiogroup", { name: "Monitored" });
+    await userEvent.click(within(monitored).getByText("All"));
+
+    expect(window.location.search).not.toContain("monitored");
+  });
+
+  it("commits the tags filter only when the dropdown closes", async () => {
+    const taggedItem = { ...item, tags: ["anime"] };
+    const queryFn: RangeQuery<Item.Series> = vitest.fn(() =>
+      Promise.resolve({ data: [taggedItem], total: 1 }),
+    );
+
+    customRender(
+      <ItemView
+        queryKey={["test-item-view-tags"]}
+        queryFn={queryFn}
+        columns={columns}
+        filterConfig={filterConfig}
+      ></ItemView>,
+    );
+
+    await screen.findByRole("columnheader", { name: "Name" });
+
+    const tagsInput = screen.getByPlaceholderText("Tags");
+    await userEvent.click(tagsInput);
+    await userEvent.click(
+      await screen.findByRole("option", { hidden: true, name: "anime" }),
+    );
+
+    // picking an option must not push a URL change (it closes the dropdown)
+    expect(window.location.search).not.toContain("tags");
+
+    await userEvent.keyboard("{Escape}");
+    expect(window.location.search).toContain("tags=anime");
   });
 
   it("does not show the toggle without poster support", async () => {

--- a/frontend/src/pages/views/ItemView.test.tsx
+++ b/frontend/src/pages/views/ItemView.test.tsx
@@ -7,6 +7,7 @@ import ItemView from "./ItemView";
 vi.mock("@/apis/hooks", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/apis/hooks")>()),
   useLanguageProfiles: () => ({ data: [] }),
+  useLanguages: () => ({ data: [] }),
 }));
 
 const item = {
@@ -36,7 +37,11 @@ const buildQueryFn = (total = 1): RangeQuery<Item.Series> => {
 };
 
 const renderPoster = (item: Item.Series) => {
-  return <div data-testid="poster-card">{item.title}</div>;
+  return (
+    <div key={item.sonarrSeriesId} data-testid="poster-card">
+      {item.title}
+    </div>
+  );
 };
 
 describe("ItemView", () => {

--- a/frontend/src/pages/views/ItemView.tsx
+++ b/frontend/src/pages/views/ItemView.tsx
@@ -224,9 +224,9 @@ const ItemViewSortControl = ({
   const handleSort = (field: string) => {
     if (field === sortBy) {
       setSort(sortBy, sortOrder === "asc" ? "desc" : "asc");
-    } else {
-      setSort(field, "asc");
+      return;
     }
+    setSort(field, "asc");
   };
 
   return (
@@ -398,10 +398,9 @@ const ItemViewToolbox = <T extends Item.Base>({
       if (!collapsed && groupEl.scrollWidth > groupEl.clientWidth + epsilon) {
         controlsWidth.current = groupEl.scrollWidth;
         setCollapsed(true);
-      } else if (
-        collapsed &&
-        groupEl.clientWidth >= controlsWidth.current + epsilon
-      ) {
+        return;
+      }
+      if (collapsed && groupEl.clientWidth >= controlsWidth.current + epsilon) {
         setCollapsed(false);
       }
     };

--- a/frontend/src/pages/views/ItemView.tsx
+++ b/frontend/src/pages/views/ItemView.tsx
@@ -55,6 +55,8 @@ import {
 import { useListQueryState } from "@/utilities";
 import { useViewMode, ViewMode } from "@/utilities/viewMode";
 
+const EMPTY_TAGS: string[] = [];
+
 const ToolboxIconButton = ({
   icon,
   children,
@@ -335,7 +337,7 @@ const ItemViewFilterControls = ({
 
       {filterConfig.filters?.tags && (
         <TagsFilterSelector
-          value={query.filters?.tags ?? []}
+          value={query.filters?.tags ?? EMPTY_TAGS}
           options={tagOptions}
           onChange={(value) => setFilter("tags", value)}
         />

--- a/frontend/src/pages/views/ItemView.tsx
+++ b/frontend/src/pages/views/ItemView.tsx
@@ -53,8 +53,6 @@ import {
 import { useListQueryState } from "@/utilities";
 import { useViewMode, ViewMode } from "@/utilities/viewMode";
 
-// Toolbox button with the icon stacked above the label, shared by all toolbox
-// controls so Mass Edit, sort, view and filters look the same.
 const ToolboxIconButton = ({
   icon,
   children,
@@ -178,8 +176,6 @@ interface TriStateFilterProps {
   onChange: (value: boolean | undefined) => void;
 }
 
-// Three-state (all/yes/no) filter as a segmented control: one click instead
-// of the two a dropdown would need, with an explicit neutral state.
 const TriStateFilter = ({
   ariaLabel,
   trueLabel,
@@ -206,9 +202,6 @@ interface SortControlProps {
   setSort: (by: string, order: "asc" | "desc") => void;
 }
 
-// Poster view sort: icon button opening a dropdown with one item per field.
-// Click a field to sort ascending, click the active field again to flip the
-// direction. Table view sorts via column header clicks instead.
 const ItemViewSortControl = ({
   query,
   filterConfig,
@@ -452,7 +445,6 @@ const ItemViewToolbox = <T extends Item.Base>({
           Mass Edit
         </ToolboxIconButton>
 
-        {/* Inline when they fit, filter popover button when they do not */}
         {!collapsed && (
           <Group
             gap="sm"

--- a/frontend/src/pages/views/ItemView.tsx
+++ b/frontend/src/pages/views/ItemView.tsx
@@ -3,6 +3,7 @@ import {
   ReactNode,
   useCallback,
   useEffect,
+  useEffectEvent,
   useMemo,
   useRef,
   useState,
@@ -19,6 +20,7 @@ import {
   Stack,
   Table,
 } from "@mantine/core";
+import { useMergedRef, useResizeObserver } from "@mantine/hooks";
 import { IconDefinition } from "@fortawesome/fontawesome-common-types";
 import {
   faCaretDown,
@@ -129,26 +131,21 @@ interface TagsFilterProps {
 const TagsFilterSelector = ({ value, options, onChange }: TagsFilterProps) => {
   const [localValue, setLocalValue] = useState<string[]>(value);
   const dirty = useRef(false);
-  const localValueRef = useRef(localValue);
-  localValueRef.current = localValue;
-  const onChangeRef = useRef(onChange);
-  onChangeRef.current = onChange;
 
   useEffect(() => {
     setLocalValue(value);
-    localValueRef.current = value;
     dirty.current = false;
   }, [value]);
 
-  const commit = useCallback(() => {
+  const commit = (tags: string[]) => {
     if (dirty.current) {
       dirty.current = false;
-      const current = localValueRef.current;
-      onChangeRef.current(current.length === 0 ? undefined : current);
+      onChange(tags.length === 0 ? undefined : tags);
     }
-  }, []);
+  };
 
-  useEffect(() => commit, [commit]);
+  const commitOnUnmount = useEffectEvent(() => commit(localValue));
+  useEffect(() => commitOnUnmount, []);
 
   return (
     <MultiSelector<string>
@@ -163,7 +160,7 @@ const TagsFilterSelector = ({ value, options, onChange }: TagsFilterProps) => {
         dirty.current = true;
         setLocalValue(tags);
       }}
-      onDropdownClose={commit}
+      onDropdownClose={() => commit(localValue)}
     />
   );
 };
@@ -378,6 +375,8 @@ const ItemViewToolbox = <T extends Item.Base>({
   // longer fit next to the Mass Edit button. Records the width at which the
   // controls overflowed so they only expand again when there is room.
   const [groupEl, setGroupEl] = useState<HTMLDivElement | null>(null);
+  const [resizeRef, groupRect] = useResizeObserver();
+  const groupRef = useMergedRef(setGroupEl, resizeRef);
   const controlsWidth = useRef(0);
   const [collapsed, setCollapsed] = useState(false);
 
@@ -387,22 +386,15 @@ const ItemViewToolbox = <T extends Item.Base>({
     }
 
     const epsilon = 8;
-    const check = () => {
-      if (!collapsed && groupEl.scrollWidth > groupEl.clientWidth + epsilon) {
-        controlsWidth.current = groupEl.scrollWidth;
-        setCollapsed(true);
-        return;
-      }
-      if (collapsed && groupEl.clientWidth >= controlsWidth.current + epsilon) {
-        setCollapsed(false);
-      }
-    };
-
-    check();
-    const observer = new ResizeObserver(check);
-    observer.observe(groupEl);
-    return () => observer.disconnect();
-  }, [groupEl, collapsed]);
+    if (!collapsed && groupEl.scrollWidth > groupEl.clientWidth + epsilon) {
+      controlsWidth.current = groupEl.scrollWidth;
+      setCollapsed(true);
+      return;
+    }
+    if (collapsed && groupEl.clientWidth >= controlsWidth.current + epsilon) {
+      setCollapsed(false);
+    }
+  }, [groupEl, groupRect, collapsed]);
 
   const activeFilterCount = Object.keys(query.filters ?? {}).length;
 
@@ -426,7 +418,7 @@ const ItemViewToolbox = <T extends Item.Base>({
   return (
     <Toolbox>
       <Group
-        ref={setGroupEl}
+        ref={groupRef}
         gap="sm"
         wrap="nowrap"
         align="center"

--- a/frontend/src/pages/views/ItemView.tsx
+++ b/frontend/src/pages/views/ItemView.tsx
@@ -15,6 +15,7 @@ import {
   Group,
   Indicator,
   Menu,
+  Pill,
   Popover,
   SegmentedControl,
   Stack,
@@ -33,7 +34,7 @@ import {
   faTableList,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { QueryKey } from "@tanstack/react-query";
+import { QueryKey, UseQueryResult } from "@tanstack/react-query";
 import { flexRender } from "@tanstack/react-table";
 import { useLanguageProfiles, useLanguages } from "@/apis/hooks";
 import {
@@ -56,6 +57,7 @@ import { useListQueryState } from "@/utilities";
 import { useViewMode, ViewMode } from "@/utilities/viewMode";
 
 const EMPTY_TAGS: string[] = [];
+const MAX_VISIBLE_TAGS = 2;
 
 const ToolboxIconButton = ({
   icon,
@@ -109,6 +111,9 @@ interface Props<T extends Item.Base = Item.Base> {
   viewModeKey?: string;
   renderPoster?: (item: T) => ReactNode;
   filterConfig: FilterConfig;
+  // Required when filterConfig.filters.tags is set: fetches the full list of
+  // tags in use, independent of the currently loaded/filtered items.
+  useTags?: () => Pick<UseQueryResult<string[]>, "data">;
   // Scopes the filter/sort URL params (e.g. "series_sort_by") so state does
   // not bleed between pages sharing this view.
   statePrefix?: string;
@@ -152,8 +157,10 @@ const TagsFilterSelector = ({ value, options, onChange }: TagsFilterProps) => {
   return (
     <MultiSelector<string>
       size="sm"
-      w={180}
+      w={220}
       searchable
+      hidePickedOptions={false}
+      styles={{ pillsList: { flexWrap: "nowrap", overflow: "hidden" } }}
       placeholder={localValue.length === 0 ? "Tags" : undefined}
       value={localValue}
       options={options}
@@ -163,6 +170,21 @@ const TagsFilterSelector = ({ value, options, onChange }: TagsFilterProps) => {
         setLocalValue(tags);
       }}
       onDropdownClose={() => commit(localValue)}
+      renderPill={({ option, value: tag, onRemove }) => {
+        const label = option?.label ?? tag ?? option?.value ?? "";
+        const index = localValue.indexOf(String(tag ?? option?.value));
+        if (index === MAX_VISIBLE_TAGS) {
+          return <Pill>+{localValue.length - MAX_VISIBLE_TAGS}</Pill>;
+        }
+        if (index > MAX_VISIBLE_TAGS) {
+          return null;
+        }
+        return (
+          <Pill withRemoveButton onRemove={onRemove}>
+            {label}
+          </Pill>
+        );
+      }}
     />
   );
 };
@@ -346,29 +368,29 @@ const ItemViewFilterControls = ({
   );
 };
 
-interface ToolboxProps<T extends Item.Base> {
+interface ToolboxProps {
   totalCount: number;
-  items: T[];
   viewMode: ViewMode;
   canShowPoster: boolean;
   onViewModeChange: (mode: ViewMode) => void;
   query: Parameter.ListState;
   filterConfig: FilterConfig;
+  useTags?: () => Pick<UseQueryResult<string[]>, "data">;
   setSort: (by: string, order: "asc" | "desc") => void;
   setFilter: SetFilter;
 }
 
-const ItemViewToolbox = <T extends Item.Base>({
+const ItemViewToolbox = ({
   totalCount,
-  items,
   viewMode,
   canShowPoster,
   onViewModeChange,
   query,
   filterConfig,
+  useTags = () => ({ data: undefined }),
   setSort,
   setFilter,
-}: ToolboxProps<T>) => {
+}: ToolboxProps) => {
   const navigate = useNavigate();
   const location = useLocation();
   const [filtersOpened, setFiltersOpened] = useState(false);
@@ -400,13 +422,16 @@ const ItemViewToolbox = <T extends Item.Base>({
 
   const activeFilterCount = Object.keys(query.filters ?? {}).length;
 
+  const { data: allTags } = useTags();
+
   const tagOptions = useMemo(() => {
-    const tags = new Set<string>();
-    items.forEach((item) => item.tags?.forEach((tag) => tags.add(tag)));
+    const tags = new Set<string>(allTags ?? []);
+    // allTags may lag behind a just-picked tag; keep active filters visible.
+    query.filters?.tags?.forEach((tag) => tags.add(tag));
     return Array.from(tags)
       .sort()
       .map((tag) => ({ value: tag, label: tag }));
-  }, [items]);
+  }, [allTags, query.filters?.tags]);
 
   const controls = (
     <ItemViewFilterControls
@@ -541,7 +566,7 @@ interface ViewProps<T extends Item.Base> {
   queryKey: QueryKey;
   queryFn: RangeQuery<T>;
   query: Parameter.ListState;
-  toolbox: Omit<ToolboxProps<T>, "totalCount" | "items">;
+  toolbox: Omit<ToolboxProps, "totalCount">;
 }
 
 const ItemTableView = <T extends Item.Base>({
@@ -606,7 +631,6 @@ const ItemTableView = <T extends Item.Base>({
       <ItemViewToolbox
         {...toolbox}
         totalCount={tableQuery.paginationStatus.totalCount}
-        items={tableQuery.data?.data ?? []}
       ></ItemViewToolbox>
       <QueryPageTable
         columns={columns}
@@ -636,7 +660,6 @@ const ItemPosterView = <T extends Item.Base>({
       <ItemViewToolbox
         {...toolbox}
         totalCount={posterQuery.paginationStatus.totalCount}
-        items={posterQuery.items}
       ></ItemViewToolbox>
       <QueryPosterGrid
         query={posterQuery}
@@ -654,6 +677,7 @@ const ItemView = <T extends Item.Base>({
   viewModeKey,
   renderPoster,
   filterConfig,
+  useTags,
   statePrefix,
 }: Props<T>) => {
   const [viewMode, setViewMode] = useViewMode(viewModeKey ?? "item-view-mode");
@@ -662,12 +686,13 @@ const ItemView = <T extends Item.Base>({
   const canShowPoster = viewModeKey !== undefined && renderPoster !== undefined;
   const showPoster = canShowPoster && viewMode === "poster";
 
-  const toolbox: Omit<ToolboxProps<T>, "totalCount" | "items"> = {
+  const toolbox: Omit<ToolboxProps, "totalCount"> = {
     viewMode,
     canShowPoster,
     onViewModeChange: setViewMode,
     query,
     filterConfig,
+    useTags,
     setSort,
     setFilter,
   };

--- a/frontend/src/pages/views/ItemView.tsx
+++ b/frontend/src/pages/views/ItemView.tsx
@@ -135,11 +135,23 @@ interface TagsFilterProps {
 // Keeps the selected tags in local state so picking an option does not push a
 // URL change (which closes the dropdown). The URL is updated once the dropdown
 // closes or the control unmounts (e.g. the mobile popover closes).
+const sameTags = (a: string[], b: string[]) =>
+  a.length === b.length && a.every((tag, i) => tag === b[i]);
+
 const TagsFilterSelector = ({ value, options, onChange }: TagsFilterProps) => {
   const [localValue, setLocalValue] = useState<string[]>(value);
   const dirty = useRef(false);
+  const syncedValue = useRef(value);
 
   useEffect(() => {
+    // A caller may pass a fresh-but-equal array on every render (e.g. a new
+    // `[]` literal, or a derived array from URL params); only resync when the
+    // committed value actually changed, so that doesn't clobber a pending
+    // (not-yet-committed) local selection.
+    if (sameTags(value, syncedValue.current)) {
+      return;
+    }
+    syncedValue.current = value;
     setLocalValue(value);
     dirty.current = false;
   }, [value]);
@@ -160,7 +172,10 @@ const TagsFilterSelector = ({ value, options, onChange }: TagsFilterProps) => {
       w={220}
       searchable
       hidePickedOptions={false}
-      styles={{ pillsList: { flexWrap: "nowrap", overflow: "hidden" } }}
+      styles={{
+        pillsList: { flexWrap: "nowrap" },
+        inputField: { minWidth: 0 },
+      }}
       placeholder={localValue.length === 0 ? "Tags" : undefined}
       value={localValue}
       options={options}
@@ -171,8 +186,8 @@ const TagsFilterSelector = ({ value, options, onChange }: TagsFilterProps) => {
       }}
       onDropdownClose={() => commit(localValue)}
       renderPill={({ option, value: tag, onRemove }) => {
-        const label = option?.label ?? tag ?? option?.value ?? "";
-        const index = localValue.indexOf(String(tag ?? option?.value));
+        const label = option?.label ?? tag ?? "";
+        const index = localValue.indexOf(tag ?? "");
         if (index === MAX_VISIBLE_TAGS) {
           return <Pill>+{localValue.length - MAX_VISIBLE_TAGS}</Pill>;
         }
@@ -425,9 +440,8 @@ const ItemViewToolbox = ({
   const { data: allTags } = useTags();
 
   const tagOptions = useMemo(() => {
-    const tags = new Set<string>(allTags ?? []);
     // allTags may lag behind a just-picked tag; keep active filters visible.
-    query.filters?.tags?.forEach((tag) => tags.add(tag));
+    const tags = new Set([...(allTags ?? []), ...(query.filters?.tags ?? [])]);
     return Array.from(tags)
       .sort()
       .map((tag) => ({ value: tag, label: tag }));

--- a/frontend/src/pages/views/ItemView.tsx
+++ b/frontend/src/pages/views/ItemView.tsx
@@ -1,25 +1,102 @@
-import { ReactNode } from "react";
-import { useNavigate } from "react-router";
 import {
-  Center,
+  ComponentProps,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useLocation, useNavigate } from "react-router";
+import {
+  Button,
+  ButtonProps,
+  Group,
+  Indicator,
+  Menu,
+  Popover,
   SegmentedControl,
-  Tooltip,
-  VisuallyHidden,
+  Stack,
+  Table,
 } from "@mantine/core";
+import { IconDefinition } from "@fortawesome/fontawesome-common-types";
 import {
+  faCaretDown,
+  faCaretUp,
+  faCheck,
+  faFilter,
   faList,
+  faSort,
   faTableCellsLarge,
   faTableList,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { QueryKey } from "@tanstack/react-query";
+import { flexRender } from "@tanstack/react-table";
+import { useLanguageProfiles, useLanguages } from "@/apis/hooks";
 import {
   useInfinitePaginationQuery,
   usePaginationQuery,
 } from "@/apis/queries/hooks";
-import { QueryPageTable, QueryPosterGrid, Toolbox } from "@/components";
-import { AppColumnDef as ColumnDef } from "@/components/tables/features";
+import {
+  MultiSelector,
+  QueryPageTable,
+  QueryPosterGrid,
+  Selector,
+  SelectorOption,
+  Toolbox,
+} from "@/components";
+import {
+  AppColumnDef as ColumnDef,
+  AppHeader as Header,
+} from "@/components/tables/features";
+import { useListQueryState } from "@/utilities";
 import { useViewMode, ViewMode } from "@/utilities/viewMode";
+
+// Toolbox button with the icon stacked above the label, shared by all toolbox
+// controls so Mass Edit, sort, view and filters look the same.
+const ToolboxIconButton = ({
+  icon,
+  children,
+  ...props
+}: { icon: IconDefinition } & ButtonProps &
+  Omit<ComponentProps<"button">, "ref">) => (
+  <Button
+    variant="subtle"
+    color="gray"
+    size="xs"
+    leftSection={<FontAwesomeIcon icon={icon} size="lg" />}
+    styles={{
+      root: { height: "auto", padding: "6px 12px" },
+      inner: { flexDirection: "column", gap: 6 },
+      section: { marginInlineEnd: 0 },
+    }}
+    {...props}
+  >
+    {children}
+  </Button>
+);
+
+interface SortField {
+  value: string;
+  label: string;
+}
+
+interface FilterConfig {
+  sortFields: SortField[];
+  filters?: {
+    monitored?: boolean;
+    missing?: boolean;
+    profile?: boolean;
+    audio?: boolean;
+    tags?: boolean;
+  };
+}
+
+type SetFilter = <K extends keyof Parameter.ListFilters>(
+  key: K,
+  value: Parameter.ListFilters[K] | undefined,
+) => void;
 
 interface Props<T extends Item.Base = Item.Base> {
   queryKey: QueryKey;
@@ -29,63 +106,448 @@ interface Props<T extends Item.Base = Item.Base> {
   // to persist the selection in the browser.
   viewModeKey?: string;
   renderPoster?: (item: T) => ReactNode;
+  filterConfig: FilterConfig;
+  // Scopes the filter/sort URL params (e.g. "series_sort_by") so state does
+  // not bleed between pages sharing this view.
+  statePrefix?: string;
 }
 
-interface ToolboxProps {
+interface FilterControlsProps {
+  query: Parameter.ListState;
+  filterConfig: FilterConfig;
+  tagOptions: SelectorOption<string>[];
+  setFilter: SetFilter;
+}
+
+interface TagsFilterProps {
+  value: string[];
+  options: SelectorOption<string>[];
+  onChange: (value: string[] | undefined) => void;
+}
+
+// Keeps the selected tags in local state so picking an option does not push a
+// URL change (which closes the dropdown). The URL is updated once the dropdown
+// closes or the control unmounts (e.g. the mobile popover closes).
+const TagsFilterSelector = ({ value, options, onChange }: TagsFilterProps) => {
+  const [localValue, setLocalValue] = useState<string[]>(value);
+  const dirty = useRef(false);
+  const localValueRef = useRef(localValue);
+  localValueRef.current = localValue;
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  useEffect(() => {
+    setLocalValue(value);
+    localValueRef.current = value;
+    dirty.current = false;
+  }, [value]);
+
+  const commit = useCallback(() => {
+    if (dirty.current) {
+      dirty.current = false;
+      const current = localValueRef.current;
+      onChangeRef.current(current.length === 0 ? undefined : current);
+    }
+  }, []);
+
+  useEffect(() => commit, [commit]);
+
+  return (
+    <MultiSelector<string>
+      size="sm"
+      w={180}
+      searchable
+      placeholder={localValue.length === 0 ? "Tags" : undefined}
+      value={localValue}
+      options={options}
+      buildOption={(tag) => tag}
+      onChange={(tags) => {
+        dirty.current = true;
+        setLocalValue(tags);
+      }}
+      onDropdownClose={commit}
+    />
+  );
+};
+
+interface TriStateFilterProps {
+  ariaLabel: string;
+  trueLabel: string;
+  falseLabel: string;
+  value: boolean | undefined;
+  onChange: (value: boolean | undefined) => void;
+}
+
+// Three-state (all/yes/no) filter as a segmented control: one click instead
+// of the two a dropdown would need, with an explicit neutral state.
+const TriStateFilter = ({
+  ariaLabel,
+  trueLabel,
+  falseLabel,
+  value,
+  onChange,
+}: TriStateFilterProps) => (
+  <SegmentedControl
+    size="sm"
+    aria-label={ariaLabel}
+    value={value === undefined ? "all" : value ? "true" : "false"}
+    onChange={(v) => onChange(v === "all" ? undefined : v === "true")}
+    data={[
+      { value: "all", label: "All" },
+      { value: "true", label: trueLabel },
+      { value: "false", label: falseLabel },
+    ]}
+  ></SegmentedControl>
+);
+
+interface SortControlProps {
+  query: Parameter.ListState;
+  filterConfig: FilterConfig;
+  setSort: (by: string, order: "asc" | "desc") => void;
+}
+
+// Poster view sort: icon button opening a dropdown with one item per field.
+// Click a field to sort ascending, click the active field again to flip the
+// direction. Table view sorts via column header clicks instead.
+const ItemViewSortControl = ({
+  query,
+  filterConfig,
+  setSort,
+}: SortControlProps) => {
+  const sortBy = query.sortBy ?? filterConfig.sortFields[0]?.value ?? "title";
+  const sortOrder = query.sortOrder ?? "asc";
+
+  const sortLabel =
+    filterConfig.sortFields.find((field) => field.value === sortBy)?.label ??
+    sortBy;
+
+  const handleSort = (field: string) => {
+    if (field === sortBy) {
+      setSort(sortBy, sortOrder === "asc" ? "desc" : "asc");
+    } else {
+      setSort(field, "asc");
+    }
+  };
+
+  return (
+    <Menu position="bottom-end" shadow="md" withinPortal>
+      <Menu.Target>
+        <ToolboxIconButton
+          icon={faSort}
+          aria-label={`Sort: ${sortLabel}, ${sortOrder === "asc" ? "ascending" : "descending"}`}
+        >
+          Sort
+        </ToolboxIconButton>
+      </Menu.Target>
+      <Menu.Dropdown>
+        {filterConfig.sortFields.map((field) => (
+          <Menu.Item
+            key={field.value}
+            onClick={() => handleSort(field.value)}
+            rightSection={
+              field.value === sortBy ? (
+                <FontAwesomeIcon
+                  icon={sortOrder === "asc" ? faCaretUp : faCaretDown}
+                ></FontAwesomeIcon>
+              ) : undefined
+            }
+          >
+            {field.label}
+          </Menu.Item>
+        ))}
+      </Menu.Dropdown>
+    </Menu>
+  );
+};
+
+// Filter and sort controls. Rendered as a fragment so the parent can lay them
+// out inline (desktop) or stacked inside a popover (mobile).
+const ItemViewFilterControls = ({
+  query,
+  filterConfig,
+  tagOptions,
+  setFilter,
+}: FilterControlsProps) => {
+  const { data: profiles } = useLanguageProfiles();
+  const { data: languages } = useLanguages();
+
+  const profileOptions = useMemo(
+    () => [
+      // 0 means "items without a languages profile" (sent as "none")
+      { value: 0, label: "No profile" },
+      ...(profiles ?? []).map((profile) => ({
+        value: profile.profileId,
+        label: profile.name,
+      })),
+    ],
+    [profiles],
+  );
+
+  const audioOptions = useMemo(
+    () =>
+      (languages ?? []).map((language) => ({
+        value: language.name,
+        label: language.name,
+      })),
+    [languages],
+  );
+
+  return (
+    <>
+      {filterConfig.filters?.monitored && (
+        <TriStateFilter
+          ariaLabel="Monitored"
+          trueLabel="Monitored"
+          falseLabel="Unmonitored"
+          value={query.filters?.monitored}
+          onChange={(value) => setFilter("monitored", value)}
+        />
+      )}
+
+      {filterConfig.filters?.missing && (
+        <TriStateFilter
+          ariaLabel="Missing subtitles"
+          trueLabel="Missing"
+          falseLabel="Complete"
+          value={query.filters?.missing}
+          onChange={(value) => setFilter("missing", value)}
+        />
+      )}
+
+      {filterConfig.filters?.profile && (
+        <Selector<number | null>
+          size="sm"
+          w={150}
+          placeholder="Profile"
+          clearable
+          value={query.filters?.profileId ?? null}
+          options={profileOptions}
+          onChange={(value) =>
+            setFilter("profileId", value === null ? undefined : value)
+          }
+        />
+      )}
+
+      {filterConfig.filters?.audio && (
+        <Selector<string | null>
+          size="sm"
+          w={150}
+          placeholder="Audio"
+          clearable
+          searchable
+          value={query.filters?.audioLanguage ?? null}
+          options={audioOptions}
+          onChange={(value) =>
+            setFilter("audioLanguage", value === null ? undefined : value)
+          }
+        />
+      )}
+
+      {filterConfig.filters?.tags && (
+        <TagsFilterSelector
+          value={query.filters?.tags ?? []}
+          options={tagOptions}
+          onChange={(value) => setFilter("tags", value)}
+        />
+      )}
+    </>
+  );
+};
+
+interface ToolboxProps<T extends Item.Base> {
   totalCount: number;
+  items: T[];
   viewMode: ViewMode;
   canShowPoster: boolean;
   onViewModeChange: (mode: ViewMode) => void;
+  query: Parameter.ListState;
+  filterConfig: FilterConfig;
+  setSort: (by: string, order: "asc" | "desc") => void;
+  setFilter: SetFilter;
 }
 
-const ItemViewToolbox = ({
+const ItemViewToolbox = <T extends Item.Base>({
   totalCount,
+  items,
   viewMode,
   canShowPoster,
   onViewModeChange,
-}: ToolboxProps) => {
+  query,
+  filterConfig,
+  setSort,
+  setFilter,
+}: ToolboxProps<T>) => {
   const navigate = useNavigate();
+  const location = useLocation();
+  const [filtersOpened, setFiltersOpened] = useState(false);
+
+  // Collapse the inline filter controls into a popover button when they no
+  // longer fit next to the Mass Edit button. Records the width at which the
+  // controls overflowed so they only expand again when there is room.
+  const [groupEl, setGroupEl] = useState<HTMLDivElement | null>(null);
+  const controlsWidth = useRef(0);
+  const [collapsed, setCollapsed] = useState(false);
+
+  useEffect(() => {
+    if (!groupEl) {
+      return;
+    }
+
+    const epsilon = 8;
+    const check = () => {
+      if (!collapsed && groupEl.scrollWidth > groupEl.clientWidth + epsilon) {
+        controlsWidth.current = groupEl.scrollWidth;
+        setCollapsed(true);
+      } else if (
+        collapsed &&
+        groupEl.clientWidth >= controlsWidth.current + epsilon
+      ) {
+        setCollapsed(false);
+      }
+    };
+
+    check();
+    const observer = new ResizeObserver(check);
+    observer.observe(groupEl);
+    return () => observer.disconnect();
+  }, [groupEl, collapsed]);
+
+  const activeFilterCount = Object.keys(query.filters ?? {}).length;
+
+  const tagOptions = useMemo(() => {
+    const tags = new Set<string>();
+    items.forEach((item) => item.tags?.forEach((tag) => tags.add(tag)));
+    return Array.from(tags)
+      .sort()
+      .map((tag) => ({ value: tag, label: tag }));
+  }, [items]);
+
+  const controls = (
+    <ItemViewFilterControls
+      query={query}
+      filterConfig={filterConfig}
+      tagOptions={tagOptions}
+      setFilter={setFilter}
+    ></ItemViewFilterControls>
+  );
 
   return (
     <Toolbox>
-      <Toolbox.Button
-        disabled={totalCount === 0}
-        icon={faList}
-        onClick={() => navigate("edit")}
+      <Group
+        ref={setGroupEl}
+        gap="sm"
+        wrap="nowrap"
+        align="center"
+        flex={1}
+        miw={0}
+        preventGrowOverflow={false}
       >
-        Mass Edit
-      </Toolbox.Button>
-      {canShowPoster && (
-        <SegmentedControl
-          size="xs"
-          value={viewMode}
-          onChange={(value) => onViewModeChange(value as ViewMode)}
-          data={[
-            {
-              value: "table",
-              label: (
-                <Tooltip label="Table view" openDelay={500}>
-                  <Center component="span" style={{ display: "inline-flex" }}>
-                    <FontAwesomeIcon icon={faTableList}></FontAwesomeIcon>
-                    <VisuallyHidden>Table view</VisuallyHidden>
-                  </Center>
-                </Tooltip>
-              ),
-            },
-            {
-              value: "poster",
-              label: (
-                <Tooltip label="Poster view" openDelay={500}>
-                  <Center component="span" style={{ display: "inline-flex" }}>
-                    <FontAwesomeIcon icon={faTableCellsLarge}></FontAwesomeIcon>
-                    <VisuallyHidden>Poster view</VisuallyHidden>
-                  </Center>
-                </Tooltip>
-              ),
-            },
-          ]}
-        ></SegmentedControl>
-      )}
+        <ToolboxIconButton
+          disabled={totalCount === 0}
+          icon={faList}
+          style={{ flexShrink: 0 }}
+          onClick={() =>
+            navigate({ pathname: "edit", search: location.search })
+          }
+        >
+          Mass Edit
+        </ToolboxIconButton>
+
+        {/* Inline when they fit, filter popover button when they do not */}
+        {!collapsed && (
+          <Group
+            gap="sm"
+            wrap="nowrap"
+            align="center"
+            style={{ flexShrink: 0 }}
+          >
+            {controls}
+          </Group>
+        )}
+      </Group>
+
+      <Group gap="sm" wrap="nowrap" align="center">
+        {viewMode === "poster" && (
+          <ItemViewSortControl
+            query={query}
+            filterConfig={filterConfig}
+            setSort={setSort}
+          ></ItemViewSortControl>
+        )}
+
+        {canShowPoster && (
+          <Menu position="bottom-end" shadow="md" withinPortal>
+            <Menu.Target>
+              <ToolboxIconButton
+                icon={viewMode === "table" ? faTableList : faTableCellsLarge}
+                aria-label={`View: ${viewMode}`}
+              >
+                View
+              </ToolboxIconButton>
+            </Menu.Target>
+            <Menu.Dropdown>
+              <Menu.Item
+                leftSection={
+                  <FontAwesomeIcon icon={faTableList}></FontAwesomeIcon>
+                }
+                rightSection={
+                  viewMode === "table" ? (
+                    <FontAwesomeIcon icon={faCheck}></FontAwesomeIcon>
+                  ) : undefined
+                }
+                onClick={() => onViewModeChange("table")}
+              >
+                Table view
+              </Menu.Item>
+              <Menu.Item
+                leftSection={
+                  <FontAwesomeIcon icon={faTableCellsLarge}></FontAwesomeIcon>
+                }
+                rightSection={
+                  viewMode === "poster" ? (
+                    <FontAwesomeIcon icon={faCheck}></FontAwesomeIcon>
+                  ) : undefined
+                }
+                onClick={() => onViewModeChange("poster")}
+              >
+                Poster view
+              </Menu.Item>
+            </Menu.Dropdown>
+          </Menu>
+        )}
+
+        {collapsed && (
+          <Popover
+            opened={filtersOpened}
+            onChange={setFiltersOpened}
+            position="bottom-end"
+            withArrow
+            shadow="md"
+            withinPortal
+          >
+            <Popover.Target>
+              <Indicator
+                disabled={activeFilterCount === 0}
+                label={activeFilterCount}
+                size={16}
+              >
+                <ToolboxIconButton
+                  icon={faFilter}
+                  aria-label="Filters"
+                  onClick={() => setFiltersOpened((opened) => !opened)}
+                >
+                  Filters
+                </ToolboxIconButton>
+              </Indicator>
+            </Popover.Target>
+            <Popover.Dropdown>
+              <Stack gap="xs" w={260}>
+                {controls}
+              </Stack>
+            </Popover.Dropdown>
+          </Popover>
+        )}
+      </Group>
     </Toolbox>
   );
 };
@@ -93,27 +555,78 @@ const ItemViewToolbox = ({
 interface ViewProps<T extends Item.Base> {
   queryKey: QueryKey;
   queryFn: RangeQuery<T>;
-  toolbox: Omit<ToolboxProps, "totalCount">;
+  query: Parameter.ListState;
+  toolbox: Omit<ToolboxProps<T>, "totalCount" | "items">;
 }
 
 const ItemTableView = <T extends Item.Base>({
   queryKey,
   queryFn,
+  query,
   columns,
   toolbox,
 }: ViewProps<T> & { columns: ColumnDef<T>[] }) => {
-  const query = usePaginationQuery(queryKey, queryFn);
+  const tableQuery = usePaginationQuery(queryKey, queryFn, true, query);
+  const { filterConfig, setSort } = toolbox;
+
+  const sortableIds = useMemo(
+    () => new Set(filterConfig.sortFields.map((field) => field.value)),
+    [filterConfig],
+  );
+
+  const headersRenderer = useCallback(
+    (headers: Header<T, unknown>[]) =>
+      headers.map((header) => {
+        const id = header.column.id;
+        const isSortable = sortableIds.has(id);
+        const isSorted = query.sortBy === id;
+        const order = query.sortOrder ?? "asc";
+
+        return (
+          <Table.Th
+            key={header.id}
+            style={{
+              whiteSpace: "nowrap",
+              cursor: isSortable ? "pointer" : undefined,
+            }}
+            onClick={() => {
+              if (!isSortable) {
+                return;
+              }
+              setSort(id, isSorted && order === "asc" ? "desc" : "asc");
+            }}
+          >
+            <Group gap="xs" wrap="nowrap" align="center">
+              {flexRender(header.column.columnDef.header, header.getContext())}
+              {isSortable && (
+                <FontAwesomeIcon
+                  icon={
+                    isSorted
+                      ? order === "asc"
+                        ? faCaretUp
+                        : faCaretDown
+                      : faSort
+                  }
+                ></FontAwesomeIcon>
+              )}
+            </Group>
+          </Table.Th>
+        );
+      }),
+    [sortableIds, query, setSort],
+  );
 
   return (
     <>
       <ItemViewToolbox
         {...toolbox}
-        totalCount={query.paginationStatus.totalCount}
+        totalCount={tableQuery.paginationStatus.totalCount}
+        items={tableQuery.data?.data ?? []}
       ></ItemViewToolbox>
       <QueryPageTable
         columns={columns}
-        query={query}
-        tableStyles={{ emptyText: "No items found" }}
+        query={tableQuery}
+        tableStyles={{ emptyText: "No items found", headersRenderer }}
       ></QueryPageTable>
     </>
   );
@@ -122,19 +635,26 @@ const ItemTableView = <T extends Item.Base>({
 const ItemPosterView = <T extends Item.Base>({
   queryKey,
   queryFn,
+  query,
   renderPoster,
   toolbox,
 }: ViewProps<T> & { renderPoster: (item: T) => ReactNode }) => {
-  const query = useInfinitePaginationQuery(queryKey, queryFn);
+  const posterQuery = useInfinitePaginationQuery(
+    queryKey,
+    queryFn,
+    true,
+    query,
+  );
 
   return (
     <>
       <ItemViewToolbox
         {...toolbox}
-        totalCount={query.paginationStatus.totalCount}
+        totalCount={posterQuery.paginationStatus.totalCount}
+        items={posterQuery.items}
       ></ItemViewToolbox>
       <QueryPosterGrid
-        query={query}
+        query={posterQuery}
         renderPoster={renderPoster}
         emptyText="No items found"
       ></QueryPosterGrid>
@@ -148,16 +668,23 @@ const ItemView = <T extends Item.Base>({
   columns,
   viewModeKey,
   renderPoster,
+  filterConfig,
+  statePrefix,
 }: Props<T>) => {
   const [viewMode, setViewMode] = useViewMode(viewModeKey ?? "item-view-mode");
+  const { query, setSort, setFilter } = useListQueryState(statePrefix);
 
   const canShowPoster = viewModeKey !== undefined && renderPoster !== undefined;
   const showPoster = canShowPoster && viewMode === "poster";
 
-  const toolbox: ViewProps<T>["toolbox"] = {
+  const toolbox: Omit<ToolboxProps<T>, "totalCount" | "items"> = {
     viewMode,
     canShowPoster,
     onViewModeChange: setViewMode,
+    query,
+    filterConfig,
+    setSort,
+    setFilter,
   };
 
   // Only one view is mounted at a time, keeping a single active query. Each
@@ -167,6 +694,7 @@ const ItemView = <T extends Item.Base>({
       <ItemPosterView
         queryKey={queryKey}
         queryFn={queryFn}
+        query={query}
         renderPoster={renderPoster}
         toolbox={toolbox}
       ></ItemPosterView>
@@ -177,6 +705,7 @@ const ItemView = <T extends Item.Base>({
     <ItemTableView
       queryKey={queryKey}
       queryFn={queryFn}
+      query={query}
       columns={columns}
       toolbox={toolbox}
     ></ItemTableView>

--- a/frontend/src/tests/setup.tsx
+++ b/frontend/src/tests/setup.tsx
@@ -98,6 +98,12 @@ beforeEach(() => {
         },
       });
     }),
+    http.get("/api/system/languages", () => {
+      return HttpResponse.json([]);
+    }),
+    http.get("/api/system/languages/profiles", () => {
+      return HttpResponse.json([]);
+    }),
   );
 });
 

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -157,6 +157,7 @@ declare namespace Item {
     TagType &
     MonitoredType &
     RawAudioLanguageType & {
+      created_at_timestamp?: string | null;
       profileId: number | null;
       fanart: string;
       overview: string;
@@ -303,6 +304,24 @@ declare namespace Parameter {
     start: number;
     length: number;
   }
+
+  interface ListFilters {
+    monitored?: boolean;
+    missing?: boolean;
+    profileId?: number;
+    audioLanguage?: string;
+    tags?: string[];
+  }
+
+  interface ListQuery extends Range {
+    sortBy?: string;
+    sortOrder?: "asc" | "desc";
+    filters?: ListFilters;
+  }
+
+  // ListQuery without the paging fields, as managed by the filter/sort UI
+  // state (URL params) and passed to the pagination hooks.
+  type ListState = Omit<ListQuery, "start" | "length">;
 }
 
 declare namespace Plex {

--- a/frontend/src/types/function.d.ts
+++ b/frontend/src/types/function.d.ts
@@ -1,3 +1,3 @@
 type RangeQuery<T> = (
-  param: Parameter.Range,
+  param: Parameter.ListQuery,
 ) => Promise<DataWrapperWithTotal<T>>;

--- a/frontend/src/utilities/index.ts
+++ b/frontend/src/utilities/index.ts
@@ -66,4 +66,5 @@ export const toPython = (value: boolean): PythonBoolean =>
 export * from "./env";
 export * from "./hooks";
 export * from "./case";
+export * from "./listQuery";
 export * from "./validate";

--- a/frontend/src/utilities/listQuery.test.ts
+++ b/frontend/src/utilities/listQuery.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { buildListSearchParams, parseListQuery } from "./listQuery";
+
+describe("parseListQuery", () => {
+  it("parses sort and filters", () => {
+    const params = new URLSearchParams(
+      "sort_by=title&sort_order=desc&monitored=true&missing=false&profileid=3&audio_language=English&tags=a&tags=b",
+    );
+    expect(parseListQuery(params)).toEqual({
+      sortBy: "title",
+      sortOrder: "desc",
+      filters: {
+        monitored: true,
+        missing: false,
+        profileId: 3,
+        audioLanguage: "English",
+        tags: ["a", "b"],
+      },
+    });
+  });
+
+  it("parses profileid none as 0", () => {
+    const params = new URLSearchParams("profileid=none");
+    expect(parseListQuery(params).filters?.profileId).toBe(0);
+  });
+
+  it("returns empty state when nothing is set", () => {
+    expect(parseListQuery(new URLSearchParams())).toEqual({
+      sortBy: undefined,
+      sortOrder: undefined,
+      filters: undefined,
+    });
+  });
+
+  it("uses prefixed keys when a prefix is given", () => {
+    const params = new URLSearchParams(
+      "series_sort_by=title&series_monitored=true&sort_by=other",
+    );
+    const result = parseListQuery(params, "series");
+    expect(result.sortBy).toBe("title");
+    expect(result.filters?.monitored).toBe(true);
+  });
+});
+
+describe("buildListSearchParams", () => {
+  it("serializes sort and filters", () => {
+    const next = buildListSearchParams(new URLSearchParams(), {
+      sortBy: "title",
+      sortOrder: "asc",
+      filters: {
+        monitored: true,
+        missing: false,
+        profileId: 0,
+        audioLanguage: "English",
+        tags: ["a", "b"],
+      },
+    });
+    expect(next.get("sort_by")).toBe("title");
+    expect(next.get("sort_order")).toBe("asc");
+    expect(next.get("monitored")).toBe("true");
+    expect(next.get("missing")).toBe("false");
+    expect(next.get("profileid")).toBe("none");
+    expect(next.get("audio_language")).toBe("English");
+    expect(next.getAll("tags")).toEqual(["a", "b"]);
+  });
+
+  it("removes keys when values are cleared", () => {
+    const prev = new URLSearchParams("sort_by=title&monitored=true&tags=a");
+    const next = buildListSearchParams(prev, {});
+    expect(next.get("sort_by")).toBeNull();
+    expect(next.get("monitored")).toBeNull();
+    expect(next.getAll("tags")).toEqual([]);
+  });
+
+  it("uses prefixed keys when a prefix is given", () => {
+    const next = buildListSearchParams(
+      new URLSearchParams(),
+      { sortBy: "title" },
+      "movies",
+    );
+    expect(next.get("movies_sort_by")).toBe("title");
+    expect(next.get("sort_by")).toBeNull();
+  });
+
+  it("keeps unrelated params untouched", () => {
+    const prev = new URLSearchParams("page=3&other=1");
+    const next = buildListSearchParams(prev, { sortBy: "title" });
+    expect(next.get("other")).toBe("1");
+    expect(next.get("page")).toBe("3");
+  });
+
+  it("roundtrips through parse", () => {
+    const state: Parameter.ListState = {
+      sortBy: "title",
+      sortOrder: "desc",
+      filters: { monitored: true, profileId: 0, tags: ["x"] },
+    };
+    expect(
+      parseListQuery(buildListSearchParams(new URLSearchParams(), state)),
+    ).toEqual(state);
+  });
+});

--- a/frontend/src/utilities/listQuery.ts
+++ b/frontend/src/utilities/listQuery.ts
@@ -1,0 +1,179 @@
+import { useCallback, useMemo } from "react";
+import { useSearchParams } from "react-router";
+
+interface ListQueryKeys {
+  sortBy: string;
+  sortOrder: string;
+  monitored: string;
+  missing: string;
+  profileId: string;
+  audioLanguage: string;
+  tags: string;
+}
+
+// URL params are optionally scoped with a page prefix (e.g. "series_sort_by")
+// so filter/sort state does not bleed between the series and movies pages.
+const keysFor = (prefix?: string): ListQueryKeys => {
+  const p = prefix ? `${prefix}_` : "";
+  return {
+    sortBy: `${p}sort_by`,
+    sortOrder: `${p}sort_order`,
+    monitored: `${p}monitored`,
+    missing: `${p}missing`,
+    profileId: `${p}profileid`,
+    audioLanguage: `${p}audio_language`,
+    tags: `${p}tags`,
+  };
+};
+
+// A profileId of 0 means "items without a languages profile", sent to the
+// backend as "none".
+const NO_PROFILE = "none";
+
+export const parseListQuery = (
+  searchParams: URLSearchParams,
+  prefix?: string,
+): Parameter.ListState => {
+  const keys = keysFor(prefix);
+
+  const sortBy = searchParams.get(keys.sortBy) ?? undefined;
+  const sortOrder =
+    (searchParams.get(keys.sortOrder) as "asc" | "desc" | null) ?? undefined;
+
+  const filters: Parameter.ListFilters = {};
+  const monitored = searchParams.get(keys.monitored);
+  const missing = searchParams.get(keys.missing);
+  const profileId = searchParams.get(keys.profileId);
+  const tags = searchParams.getAll(keys.tags);
+
+  if (monitored !== null) {
+    filters.monitored = monitored === "true";
+  }
+  if (missing !== null) {
+    filters.missing = missing === "true";
+  }
+  if (profileId !== null) {
+    filters.profileId = profileId === NO_PROFILE ? 0 : Number(profileId);
+  }
+  const audioLanguage = searchParams.get(keys.audioLanguage);
+  if (audioLanguage !== null) {
+    filters.audioLanguage = audioLanguage;
+  }
+  if (tags.length > 0) {
+    filters.tags = tags;
+  }
+
+  return {
+    sortBy,
+    sortOrder,
+    filters: Object.keys(filters).length > 0 ? filters : undefined,
+  };
+};
+
+export const buildListSearchParams = (
+  searchParams: URLSearchParams,
+  query: Parameter.ListState,
+  prefix?: string,
+): URLSearchParams => {
+  const keys = keysFor(prefix);
+  const next = new URLSearchParams(searchParams);
+
+  if (query.sortBy) {
+    next.set(keys.sortBy, query.sortBy);
+  } else {
+    next.delete(keys.sortBy);
+  }
+
+  if (query.sortOrder) {
+    next.set(keys.sortOrder, query.sortOrder);
+  } else {
+    next.delete(keys.sortOrder);
+  }
+
+  if (query.filters?.monitored !== undefined) {
+    next.set(keys.monitored, query.filters.monitored ? "true" : "false");
+  } else {
+    next.delete(keys.monitored);
+  }
+
+  if (query.filters?.missing !== undefined) {
+    next.set(keys.missing, query.filters.missing ? "true" : "false");
+  } else {
+    next.delete(keys.missing);
+  }
+
+  if (query.filters?.profileId !== undefined) {
+    next.set(
+      keys.profileId,
+      query.filters.profileId === 0
+        ? NO_PROFILE
+        : String(query.filters.profileId),
+    );
+  } else {
+    next.delete(keys.profileId);
+  }
+
+  if (query.filters?.audioLanguage !== undefined) {
+    next.set(keys.audioLanguage, query.filters.audioLanguage);
+  } else {
+    next.delete(keys.audioLanguage);
+  }
+
+  next.delete(keys.tags);
+  if (query.filters?.tags && query.filters.tags.length > 0) {
+    query.filters.tags.forEach((tag) => next.append(keys.tags, tag));
+  }
+
+  return next;
+};
+
+export const useListQueryState = (prefix?: string) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const query = useMemo(
+    () => parseListQuery(searchParams, prefix),
+    [searchParams, prefix],
+  );
+
+  const update = useCallback(
+    (nextQuery: Parameter.ListState) => {
+      const next = buildListSearchParams(searchParams, nextQuery, prefix);
+      next.delete("page");
+      setSearchParams(next, { replace: true });
+    },
+    [searchParams, setSearchParams, prefix],
+  );
+
+  const setSort = useCallback(
+    (sortBy: string, sortOrder: "asc" | "desc") => {
+      update({ ...query, sortBy, sortOrder });
+    },
+    [query, update],
+  );
+
+  const setFilter = useCallback(
+    <K extends keyof Parameter.ListFilters>(
+      key: K,
+      value: Parameter.ListFilters[K] | undefined,
+    ) => {
+      const filters: Parameter.ListFilters = { ...query.filters };
+
+      if (value === undefined || (Array.isArray(value) && value.length === 0)) {
+        delete filters[key];
+      } else {
+        filters[key] = value;
+      }
+
+      update({
+        ...query,
+        filters: Object.keys(filters).length > 0 ? filters : undefined,
+      });
+    },
+    [query, update],
+  );
+
+  const clearFilters = useCallback(() => {
+    update({ sortBy: query.sortBy, sortOrder: query.sortOrder });
+  }, [query, update]);
+
+  return { query, setSort, setFilter, clearFilters };
+};

--- a/frontend/src/utilities/listQuery.ts
+++ b/frontend/src/utilities/listQuery.ts
@@ -164,9 +164,5 @@ export const useListQueryState = (prefix?: string) => {
     [query, update],
   );
 
-  const clearFilters = useCallback(() => {
-    update({ sortBy: query.sortBy, sortOrder: query.sortOrder });
-  }, [query, update]);
-
-  return { query, setSort, setFilter, clearFilters };
+  return { query, setSort, setFilter };
 };

--- a/frontend/src/utilities/listQuery.ts
+++ b/frontend/src/utilities/listQuery.ts
@@ -70,7 +70,7 @@ export const parseListQuery = (
   };
 };
 
-const setOrDelete = (
+const setParam = (
   params: URLSearchParams,
   key: string,
   value: string | undefined,
@@ -93,11 +93,11 @@ export const buildListSearchParams = (
   const keys = keysFor(prefix);
   const next = new URLSearchParams(searchParams);
 
-  setOrDelete(next, keys.sortBy, query.sortBy);
-  setOrDelete(next, keys.sortOrder, query.sortOrder);
-  setOrDelete(next, keys.monitored, boolParam(query.filters?.monitored));
-  setOrDelete(next, keys.missing, boolParam(query.filters?.missing));
-  setOrDelete(
+  setParam(next, keys.sortBy, query.sortBy);
+  setParam(next, keys.sortOrder, query.sortOrder);
+  setParam(next, keys.monitored, boolParam(query.filters?.monitored));
+  setParam(next, keys.missing, boolParam(query.filters?.missing));
+  setParam(
     next,
     keys.profileId,
     query.filters?.profileId === undefined
@@ -106,7 +106,7 @@ export const buildListSearchParams = (
         ? NO_PROFILE
         : String(query.filters.profileId),
   );
-  setOrDelete(next, keys.audioLanguage, query.filters?.audioLanguage);
+  setParam(next, keys.audioLanguage, query.filters?.audioLanguage);
 
   next.delete(keys.tags);
   if (query.filters?.tags && query.filters.tags.length > 0) {

--- a/frontend/src/utilities/listQuery.ts
+++ b/frontend/src/utilities/listQuery.ts
@@ -70,6 +70,21 @@ export const parseListQuery = (
   };
 };
 
+const setOrDelete = (
+  params: URLSearchParams,
+  key: string,
+  value: string | undefined,
+) => {
+  if (value === undefined) {
+    params.delete(key);
+    return;
+  }
+  params.set(key, value);
+};
+
+const boolParam = (value: boolean | undefined) =>
+  value === undefined ? undefined : value ? "true" : "false";
+
 export const buildListSearchParams = (
   searchParams: URLSearchParams,
   query: Parameter.ListState,
@@ -78,46 +93,20 @@ export const buildListSearchParams = (
   const keys = keysFor(prefix);
   const next = new URLSearchParams(searchParams);
 
-  if (query.sortBy) {
-    next.set(keys.sortBy, query.sortBy);
-  } else {
-    next.delete(keys.sortBy);
-  }
-
-  if (query.sortOrder) {
-    next.set(keys.sortOrder, query.sortOrder);
-  } else {
-    next.delete(keys.sortOrder);
-  }
-
-  if (query.filters?.monitored !== undefined) {
-    next.set(keys.monitored, query.filters.monitored ? "true" : "false");
-  } else {
-    next.delete(keys.monitored);
-  }
-
-  if (query.filters?.missing !== undefined) {
-    next.set(keys.missing, query.filters.missing ? "true" : "false");
-  } else {
-    next.delete(keys.missing);
-  }
-
-  if (query.filters?.profileId !== undefined) {
-    next.set(
-      keys.profileId,
-      query.filters.profileId === 0
+  setOrDelete(next, keys.sortBy, query.sortBy);
+  setOrDelete(next, keys.sortOrder, query.sortOrder);
+  setOrDelete(next, keys.monitored, boolParam(query.filters?.monitored));
+  setOrDelete(next, keys.missing, boolParam(query.filters?.missing));
+  setOrDelete(
+    next,
+    keys.profileId,
+    query.filters?.profileId === undefined
+      ? undefined
+      : query.filters.profileId === 0
         ? NO_PROFILE
         : String(query.filters.profileId),
-    );
-  } else {
-    next.delete(keys.profileId);
-  }
-
-  if (query.filters?.audioLanguage !== undefined) {
-    next.set(keys.audioLanguage, query.filters.audioLanguage);
-  } else {
-    next.delete(keys.audioLanguage);
-  }
+  );
+  setOrDelete(next, keys.audioLanguage, query.filters?.audioLanguage);
 
   next.delete(keys.tags);
   if (query.filters?.tags && query.filters.tags.length > 0) {
@@ -157,9 +146,13 @@ export const useListQueryState = (prefix?: string) => {
     ) => {
       const filters: Parameter.ListFilters = { ...query.filters };
 
-      if (value === undefined || (Array.isArray(value) && value.length === 0)) {
+      const shouldRemove =
+        value === undefined || (Array.isArray(value) && value.length === 0);
+
+      if (shouldRemove) {
         delete filters[key];
-      } else {
+      }
+      if (!shouldRemove) {
         filters[key] = value;
       }
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,8 +7,8 @@ import path from "path";
 import { defineConfig, loadEnv } from "vite";
 import checker from "vite-plugin-checker";
 import { VitePWA } from "vite-plugin-pwa";
-import chunks from "./config/chunks";
-import overrideEnv from "./config/configReader";
+import chunks from "./config/chunks.ts";
+import overrideEnv from "./config/configReader.ts";
 
 export default defineConfig(({ mode, command }) => {
   const env = loadEnv(mode, process.cwd());
@@ -112,7 +112,7 @@ export default defineConfig(({ mode, command }) => {
     base: "./",
     resolve: {
       alias: {
-        "@": path.resolve(__dirname, "./src"),
+        "@": path.resolve(import.meta.dirname, "./src"),
       },
     },
     build: {


### PR DESCRIPTION
# Description

Add an initial implementation of filtering and sorting.

<img width="1525" height="80" alt="Screenshot 2026-08-08 at 20 53 41" src="https://github.com/user-attachments/assets/6b59882a-3ce8-481c-a7f2-6a63ceeda165" />

## Backend

- GET /series and GET /movies accept new optional query params: sort_by, sort_order, monitored, profileid ("none" = items without a languages profile), missing, audio_language, tags[]

- New created_at_timestamp field ("Added" column/sort)

> Creating index was considered but they mostly wont be used, i would rather wait for report of performance issues and analyze the case. Computed sort columns (episodeFileCount, episodeMissingCount) still need sort-after-join, so doesn't matter much, tags and audio filters use contains, so not indexable wildcard, monitored cardinality is low, 2 value column.

## Frontend
- New filter/sort toolbar on both pages: three-state Monitored/Missing segmented controls, Profile, Audio, and Tags selectors, and a sort dropdown (poster view) / sortable column headers (table view)

- State lives in the URL (scoped per page, e.g. series_sort_by), so filtered views are shareable and survive navigation; the Mass Editor carries over the active filters

- Toolbar collapses into a popover (with active-filter badge) when space runs out

- New useListQueryState/parseListQuery/buildListSearchParams utilities plus buildListParams for the API layer

- Pagination uses TanStack Query's keepPreviousData so the current page stays visible while navigating
