### PR TITLE
Fix Brazilian Portuguese detection on the animetosho_xyz provider

### DIFF
--- a/custom_libs/subliminal_patch/providers/animetosho_xyz.py
+++ b/custom_libs/subliminal_patch/providers/animetosho_xyz.py
@@ -2,6 +2,7 @@
 import logging
 import lzma
 import os
+import re
 from typing import Callable
 
 from guessit import guessit
@@ -35,6 +36,8 @@ supported_languages = [
     "tur",
     "vie",
 ]
+
+_BRAZILIAN_PORTUGUESE_RE = re.compile(r'brazil|\bbr\b', re.IGNORECASE)
 
 
 class AnimeToshoXYZSubtitle(Subtitle):
@@ -164,7 +167,10 @@ class AnimeToshoXYZProvider(Provider, ProviderSubtitleArchiveMixin):
                 lang_code = info.get('language_code', 'eng')
                 lang = Language.fromalpha3b(lang_code)
 
-                if lang.alpha3 == 'por' and 'brazil' in info.get('language', '').lower():
+                # Portuguese and Brazilian Portuguese share the same code, so the language name is
+                # the only thing telling them apart. The API labels it "Portuguese[BR]", but the
+                # spelled-out "Brazilian Portuguese" also shows up.
+                if lang.alpha3 == 'por' and _BRAZILIAN_PORTUGUESE_RE.search(info.get('language', '')):
                     lang = Language('por', 'BR')
 
                 subtitle = self.subtitle_class(


### PR DESCRIPTION
## Problem

`animetosho_xyz` separates Portuguese from Brazilian Portuguese with a substring check on the API's language name:

```python
if lang.alpha3 == 'por' and 'brazil' in info.get('language', '').lower():
    lang = Language('por', 'BR')
```

The API doesn't spell it out, it labels the track `Portuguese[BR]`. `'brazil' in 'portuguese[br]'` is False, so PT-BR subtitles are always handed back as plain Portuguese and users asking for pt-BR get nothing.

The repo's own test already covers this and is currently red on `development`:

```
FAILED tests/subliminal_patch/test_animetosho_xyz.py::test_list_subtitles_with_portuguese_br
assert 0 == 2
```

It goes unnoticed because CI only runs `tests/bazarr/`. The checked-in fixture `animetosho_xyz_series_response.json` has the real shape: `"language": "Portuguese[BR]", "language_code": "por"`.

## Fix

Match on a `BR` marker as well as the spelled-out name, still gated on `alpha3 == 'por'`:

```python
_BRAZILIAN_PORTUGUESE_RE = re.compile(r'brazil|\bbr\b', re.IGNORECASE)
```

Covers `Portuguese[BR]`, `Portuguese (BR)`, `pt-BR` and `Brazilian Portuguese`, while `Portuguese`, `Portuguese[PT]` and `European Portuguese` stay unmatched.

Note this is a different code path from the `animetosho` provider, which matches on the subtitle *file name* rather than a language label, so that one is left alone.

## Tests

No new tests needed, the existing `test_list_subtitles_with_portuguese_br` covers it. Locally (`NO_CLI=true pytest tests/subliminal_patch/test_animetosho_xyz.py tests/subliminal_patch/test_animetosho.py`): 1 failed / 3 passed before, 9 passed after. The rest of `tests/subliminal_patch/` is unchanged, its failures are the pre-existing ones that need network access or API keys.

## AI disclosure

Written with Claude (Claude Code). I verified the failing-before and passing-after states locally and checked the regex against the realistic label variants listed above.