### PR TITLE
Added option to preserve original subtitle format when translating

### DIFF
--- a/bazarr/api/subtitles/subtitles.py
+++ b/bazarr/api/subtitles/subtitles.py
@@ -195,6 +195,7 @@ class Subtitles(Resource):
                     translate_subtitles_file(video_path=video_path, source_srt_file=subtitles_path,
                                              from_lang=from_language, to_lang=dest_language, forced=forced, hi=hi,
                                              media_type=media_type,
+                                             original_format=args.get('original_format') == 'True',
                                              sonarr_series_id=metadata.sonarrSeriesId if media_type == "episode" else None,
                                              sonarr_episode_id=id,
                                              radarr_id=id,

--- a/bazarr/subtitles/tools/translate/core/translator_utils.py
+++ b/bazarr/subtitles/tools/translate/core/translator_utils.py
@@ -31,6 +31,36 @@ def validate_translation_params(video_path, source_srt_file, from_lang, to_lang)
     return True
 
 
+# Subtitle extensions that Bazarr can produce a translated file in. The Google and Lingarr
+# translators go through pysubs2, which honours the destination path extension; the Gemini
+# translator only handles SRT (see get_translation_extension below).
+SUPPORTED_TRANSLATION_EXTENSIONS = ('.srt', '.ass', '.ssa', '.vtt')
+
+
+def get_translation_extension(source_srt_file, original_format, translator_type):
+    """
+    Return the extension to use for the translated subtitle file.
+
+    When ``original_format`` is true and the source has a supported text-based extension, that
+    extension is preserved so a ``.ass``/``.vtt`` source is translated into a ``.ass``/``.vtt``
+    file instead of always being converted to ``.srt``. The Gemini translator reads and writes
+    SRT only, so for any non-SRT source it falls back to ``.srt``.
+    """
+    if not original_format:
+        return '.srt'
+
+    src_ext = os.path.splitext(source_srt_file)[1].lower()
+    if src_ext not in SUPPORTED_TRANSLATION_EXTENSIONS:
+        return '.srt'
+
+    if translator_type == 'gemini' and src_ext != '.srt':
+        logger.info(f'Gemini translator cannot preserve the {src_ext} format; falling back to .srt '
+                    f'for {source_srt_file}')
+        return '.srt'
+
+    return src_ext
+
+
 def convert_language_codes(to_lang, forced=False, hi=False):
     """Convert and validate language codes."""
     orig_to_lang = to_lang
@@ -77,6 +107,12 @@ def create_process_result(message, video_path, orig_to_lang, forced, hi, dest_sr
 
 def add_translator_info(dest_srt_file, info):
     if settings.translator.translator_info:
+        # The info cue is injected via the SRT library, so it only applies to .srt outputs.
+        # For other formats (.ass/.vtt) we skip it rather than risk corrupting the file.
+        if os.path.splitext(dest_srt_file)[1].lower() != '.srt':
+            logger.debug(f'Skipping translator info cue for non-SRT file: {dest_srt_file}')
+            return
+
         # Load the SRT content
         with open(dest_srt_file, "r", encoding="utf-8") as f:
             srt_content = f.read()

--- a/bazarr/subtitles/tools/translate/main.py
+++ b/bazarr/subtitles/tools/translate/main.py
@@ -7,7 +7,7 @@ import os
 from subliminal_patch.core import get_subtitle_path
 from subzero.language import Language
 
-from .core.translator_utils import validate_translation_params, convert_language_codes
+from .core.translator_utils import validate_translation_params, convert_language_codes, get_translation_extension
 from .services.translator_factory import TranslatorFactory
 from languages.get_languages import alpha3_from_alpha2
 from app.config import settings
@@ -16,7 +16,8 @@ from utilities.helper import get_target_folder
 
 
 def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, forced, hi,
-                             media_type, sonarr_series_id, sonarr_episode_id, radarr_id, metadata, job_id=None):
+                             media_type, sonarr_series_id, sonarr_episode_id, radarr_id, metadata,
+                             original_format=False, job_id=None):
     if not job_id:
         jobs_queue.add_job_from_function(f'Translating from {from_lang.upper()} to {to_lang.upper()} using '
                                          f'{settings.translator.translator_type.replace("_", " ").title()}',
@@ -31,11 +32,19 @@ def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, fo
 
         logging.debug(f'BAZARR is translating in {lang_obj} this subtitles {source_srt_file}')
 
+        translator_type = settings.translator.translator_type or 'google'
+
+        # Preserve the source subtitle format (.ass/.vtt) when requested instead of always
+        # writing .srt. Gemini only supports SRT and is handled by get_translation_extension.
+        dest_extension = get_translation_extension(source_srt_file, original_format, translator_type)
+        logging.debug(f'Translation destination extension: {dest_extension} '
+                      f'(original_format={original_format}, translator={translator_type})')
+
         # get the destination path if the subtitles are alongside the video
         dest_srt_file_if_alongside_video = get_subtitle_path(
             video_path,
             language=lang_obj if isinstance(lang_obj, Language) else lang_obj.subzero_language(),
-            extension='.srt',
+            extension=dest_extension,
             forced_tag=forced,
             hi_tag=hi
         )
@@ -51,7 +60,6 @@ def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, fo
             # otherwise, we just use the destination path as it is
             dest_srt_file = dest_srt_file_if_alongside_video
 
-        translator_type = settings.translator.translator_type or 'google'
         logging.debug(f'Using translator type: {translator_type}')
 
         translator = TranslatorFactory.create_translator(

--- a/frontend/src/components/forms/TranslationForm.tsx
+++ b/frontend/src/components/forms/TranslationForm.tsx
@@ -1,5 +1,12 @@
 import { FunctionComponent, useMemo } from "react";
-import { Alert, Button, Divider, LoadingOverlay, Stack } from "@mantine/core";
+import {
+  Alert,
+  Button,
+  Divider,
+  LoadingOverlay,
+  Stack,
+  Switch,
+} from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { showNotification } from "@mantine/notifications";
 import { isObject } from "lodash";
@@ -7,7 +14,7 @@ import { useSubtitleAction, useSystemSettings } from "@/apis/hooks";
 import { Selector } from "@/components/inputs";
 import { useModals, withModal } from "@/modules/modals";
 import { notification } from "@/modules/task";
-import { useSelectorOptions } from "@/utilities";
+import { toPython, useSelectorOptions } from "@/utilities";
 import FormUtils from "@/utilities/form";
 import { useEnabledLanguages } from "@/utilities/languages";
 
@@ -143,6 +150,7 @@ const TranslationForm: FunctionComponent<Props> = ({
   const form = useForm({
     initialValues: {
       language: null as Language.Info | null,
+      originalFormat: true,
     },
     validate: {
       language: FormUtils.validation(isObject, "Please select a language"),
@@ -200,14 +208,18 @@ const TranslationForm: FunctionComponent<Props> = ({
 
   return (
     <form
-      onSubmit={form.onSubmit(async ({ language }) => {
+      onSubmit={form.onSubmit(async ({ language, originalFormat }) => {
         if (language) {
           try {
             await Promise.all(
               selections.map((s) =>
                 mutateAsync({
                   action: "translate",
-                  form: { ...s, language: language.code2 },
+                  form: {
+                    ...s,
+                    language: language.code2,
+                    originalFormat: toPython(originalFormat),
+                  },
                 }),
               ),
             );
@@ -248,6 +260,11 @@ const TranslationForm: FunctionComponent<Props> = ({
           </Alert>
         )}
         <Selector {...options} {...form.getInputProps("language")}></Selector>
+        <Switch
+          label="Preserve original format"
+          description="Keep the source subtitle format (e.g. .ass, .vtt) instead of converting to .srt."
+          {...form.getInputProps("originalFormat", { type: "checkbox" })}
+        ></Switch>
         <Divider></Divider>
         <Button type="submit" loading={isPending}>
           Start

--- a/tests/bazarr/test_translation_format.py
+++ b/tests/bazarr/test_translation_format.py
@@ -1,0 +1,34 @@
+from bazarr.subtitles.tools.translate.core.translator_utils import get_translation_extension
+
+
+def test_defaults_to_srt_when_not_preserving():
+    assert get_translation_extension("/m/Foo.en.ass", False, "google_translate") == ".srt"
+
+
+def test_preserves_supported_source_format_for_pysubs2_translators():
+    assert get_translation_extension("/m/Foo.en.ass", True, "google_translate") == ".ass"
+    assert get_translation_extension("/m/Foo.en.vtt", True, "lingarr") == ".vtt"
+    assert get_translation_extension("/m/Foo.en.ssa", True, "google_translate") == ".ssa"
+
+
+def test_srt_source_stays_srt():
+    assert get_translation_extension("/m/Foo.en.srt", True, "google_translate") == ".srt"
+
+
+def test_gemini_cannot_preserve_non_srt():
+    # Gemini only reads/writes SRT, so a .ass source falls back to .srt even when preserving.
+    assert get_translation_extension("/m/Foo.en.ass", True, "gemini") == ".srt"
+    assert get_translation_extension("/m/Foo.en.vtt", True, "gemini") == ".srt"
+
+
+def test_gemini_srt_is_preserved():
+    assert get_translation_extension("/m/Foo.en.srt", True, "gemini") == ".srt"
+
+
+def test_unsupported_extension_falls_back_to_srt():
+    assert get_translation_extension("/m/Foo.en.sub", True, "google_translate") == ".srt"
+    assert get_translation_extension("/m/Foo.en", True, "google_translate") == ".srt"
+
+
+def test_extension_lookup_is_case_insensitive():
+    assert get_translation_extension("/m/Foo.EN.ASS", True, "google_translate") == ".ass"


### PR DESCRIPTION
Follow-up to the format note in #3497, as you suggested.

## What & why

Translation always wrote a `.srt` file, regardless of the source format — so translating a `.ass` or `.vtt` subtitle converted it to `.srt` (and historically crashed on `.ass`, see #3046). This adds an opt-in **"Preserve original format"** so a `.ass`/`.vtt`/`.ssa` source is translated into the same format. The existing `original_format` request arg (already used by mods) is reused as the precedent.

## How it works

- **`translate/main.py`**: `translate_subtitles_file` gains an `original_format` parameter. The destination extension is derived from the source file's extension via a small helper instead of being hardcoded to `.srt`.
- **`translator_utils.py`**: new `get_translation_extension(source, original_format, translator_type)` decides the extension. Supported formats: `.srt`, `.ass`, `.ssa`, `.vtt`; anything else falls back to `.srt`. The Google and Lingarr translators go through `pysubs2`, which already honours the destination path's extension — so **no translator code changes are needed** for them.
- **Gemini caveat:** the Gemini translator reads/writes SRT only (`srt.parse`/`srt.compose`), so for a non-SRT source it intentionally falls back to `.srt` (with a log line). Porting Gemini to `pysubs2` would remove that limitation but is a larger, riskier change I deliberately left out of scope.
- **`add_translator_info`**: the translator-info cue is injected via the SRT library, so it's now skipped for non-`.srt` outputs rather than risk corrupting a `.ass`/`.vtt` file.
- **API** (`api/subtitles/subtitles.py`): forwards `original_format=args.get('original_format') == 'True'` to `translate_subtitles_file`. Absent → `False`, preserving current behavior for any caller that doesn't opt in.
- **Frontend** (`TranslationForm.tsx`): a **"Preserve original format"** switch, default ON, wired to the existing `ModifySubtitle.originalFormat` field (auto-snake_cased to `original_format` by the API client).

For `.srt` sources (the common case) the output is identical to today whether the option is on or off.

## Testing

- New `tests/bazarr/test_translation_format.py` (7 tests): default-to-srt, preserve `.ass`/`.vtt`/`.ssa`, SRT stays SRT, Gemini non-SRT fallback, Gemini SRT preserved, unsupported-extension fallback, case-insensitivity.
- Backend suite: `154 passed` (the only failing tests, `test_utilities_video_analyzer`, also fail on a clean `development` checkout — they need the `ffmpeg`/`mediainfo` binaries CI installs).
- Frontend: `check:ts`, `check:fmt`, `check:style` clean; `npm test` green (457 passed). `TranslationForm.test.tsx` still passes.

## Disclosure

Developed with AI assistance (Claude Code); I wrote and understand every line. Followed `CONTRIBUTING.md` (branched from `development`, single focused commit).