### PR TITLE
Added database schema for Sportarr sports support

### DIFF
--- a/bazarr/app/database.py
+++ b/bazarr/app/database.py
@@ -11,8 +11,8 @@ from dogpile.cache import make_region
 from datetime import datetime
 from typing import List
 
-from sqlalchemy import create_engine, inspect, DateTime, ForeignKey, Integer, LargeBinary, Text, func, text, BigInteger, \
-    Boolean
+from sqlalchemy import create_engine, inspect, DateTime, ForeignKey, Index, Integer, LargeBinary, Text, func, text, \
+    BigInteger, Boolean
 # importing here to be indirectly imported in other modules later
 from sqlalchemy import update, delete, select, func, UniqueConstraint  # noqa W0611
 from sqlalchemy.orm import scoped_session, sessionmaker, mapped_column, close_all_sessions, declarative_base
@@ -457,6 +457,12 @@ class TableSportsEvents(Base):
     # deleted and rebuilt on every upgrade, losing its subtitle history.
     __table_args__ = (
         UniqueConstraint('sportarrEventId', 'partNumber', name='uc_sports_event_part'),
+        # Indexes live on the model, not only in the migration. init_db()
+        # runs create_all() before migrate_db(), so a missing table is
+        # always built from this definition and the migration's guarded
+        # create is skipped.
+        Index('ix_sports_events_sportarr_league_id', 'sportarrLeagueId'),
+        Index('ix_sports_events_path', 'path'),
     )
 
     def to_dict(self):
@@ -484,6 +490,15 @@ class TableSportsEventsSubtitles(Base):
                          name='uc_external_sports_events_subtitles'),
         UniqueConstraint('embedded_track_id', 'sportarrLeagueId', 'sportsEventId', 'language', 'forced', 'hi',
                          name='uc_embedded_sports_events_subtitles'),
+        # Same index set as table_episodes_subtitles and
+        # table_movies_subtitles got in revision 537e9b4d10e3, defined on
+        # the model as well so create_all() builds them on fresh installs.
+        Index('ix_sports_events_subtitles_sports_event_id', 'sportsEventId'),
+        Index('ix_sports_events_subtitles_sportarr_league_id', 'sportarrLeagueId'),
+        Index('ix_sports_events_subtitles_path', 'path'),
+        Index('ix_sports_events_subtitles_embedded_track_id', 'embedded_track_id'),
+        Index('ix_sports_events_subtitles_language_hi_forced', 'language', 'hi', 'forced'),
+        Index('ix_sports_events_subtitles_event_path_track', 'sportsEventId', 'path', 'embedded_track_id'),
     )
 
 

--- a/bazarr/app/database.py
+++ b/bazarr/app/database.py
@@ -431,20 +431,33 @@ class TableSportsEvents(Base):
     format = mapped_column(Text)
     missing_subtitles = mapped_column(Text)
     monitored = mapped_column(Text)
+    id = mapped_column(Integer, primary_key=True)
     # Prelims, Main Card, Qualifying. Null when the event has a single file.
     partName = mapped_column(Text)
+    # Orders the parts, and identifies the row with the event. 0 when the event
+    # has a single file.
+    partNumber = mapped_column(Integer, nullable=False, default=0)
     path = mapped_column(Text, nullable=False)
     resolution = mapped_column(Text)
     # Release name, and only when a real grab produced the file. Sportarr
     # renames files, so the name on disk never matches a release.
     sceneName = mapped_column(Text)
     season = mapped_column(Integer, nullable=False)
-    sportarrEventId = mapped_column(Integer, primary_key=True)
+    sportarrEventId = mapped_column(Integer, nullable=False)
     sportarrLeagueId = mapped_column(Integer, ForeignKey('table_sports_leagues.sportarrLeagueId',
                                                         ondelete='CASCADE'))
     title = mapped_column(Text, nullable=False)
     updated_at_timestamp = mapped_column(DateTime)
     video_codec = mapped_column(Text)
+
+    # The event and its part identify a row, not the Sportarr event id alone.
+    # A card ships prelims and a main card under ONE event id, so that id
+    # cannot be the key. The file id cannot either, because Sportarr issues a
+    # new one when a quality upgrade replaces the file, and the row would be
+    # deleted and rebuilt on every upgrade, losing its subtitle history.
+    __table_args__ = (
+        UniqueConstraint('sportarrEventId', 'partNumber', name='uc_sports_event_part'),
+    )
 
     def to_dict(self):
         return {column.name: getattr(self, column.name) for column in self.__table__.columns}
@@ -460,15 +473,16 @@ class TableSportsEventsSubtitles(Base):
     path = mapped_column(Text, nullable=True)
     size = mapped_column(BigInteger, nullable=True)
     embedded_track_id = mapped_column(Integer, nullable=True)
-    sportarrEventId = mapped_column(Integer, ForeignKey('table_sports_events.sportarrEventId', ondelete='CASCADE'),
-                                    nullable=False)
+    # Points at the event row, which is one part, not at the Sportarr event id.
+    sportsEventId = mapped_column(Integer, ForeignKey('table_sports_events.id', ondelete='CASCADE'),
+                                  nullable=False)
     sportarrLeagueId = mapped_column(Integer, ForeignKey('table_sports_leagues.sportarrLeagueId', ondelete='CASCADE'),
                                      nullable=False)
 
     __table_args__ = (
-        UniqueConstraint('path', 'sportarrLeagueId', 'sportarrEventId', 'language', 'forced', 'hi',
+        UniqueConstraint('path', 'sportarrLeagueId', 'sportsEventId', 'language', 'forced', 'hi',
                          name='uc_external_sports_events_subtitles'),
-        UniqueConstraint('embedded_track_id', 'sportarrLeagueId', 'sportarrEventId', 'language', 'forced', 'hi',
+        UniqueConstraint('embedded_track_id', 'sportarrLeagueId', 'sportsEventId', 'language', 'forced', 'hi',
                          name='uc_embedded_sports_events_subtitles'),
     )
 

--- a/bazarr/app/database.py
+++ b/bazarr/app/database.py
@@ -382,6 +382,106 @@ class TableShowsRootfolder(Base):
     path = mapped_column(Text)
 
 
+class TableSportsLeagues(Base):
+    # A league is the sports equivalent of a show. It groups events the way a
+    # show groups episodes.
+    __tablename__ = 'table_sports_leagues'
+
+    audio_language = mapped_column(Text)
+    created_at_timestamp = mapped_column(DateTime)
+    # Sportarr id that survives a remove and re-add, unlike sportarrLeagueId.
+    # Match on this to keep subtitle history across that.
+    externalId = mapped_column(Text)
+    fanart = mapped_column(Text)
+    monitored = mapped_column(Text)
+    overview = mapped_column(Text)
+    path = mapped_column(Text, nullable=False, unique=True)
+    poster = mapped_column(Text)
+    profileId = mapped_column(Integer, ForeignKey('table_languages_profiles.profileId', ondelete='SET NULL'))
+    sortTitle = mapped_column(Text)
+    # Soccer, Fighting, Motorsport. The closest thing sports has to seriesType.
+    sport = mapped_column(Text)
+    sportarrLeagueId = mapped_column(Integer, primary_key=True)
+    tags = mapped_column(Text)
+    title = mapped_column(Text, nullable=False)
+    updated_at_timestamp = mapped_column(DateTime)
+
+    def to_dict(self):
+        return {column.name: getattr(self, column.name) for column in self.__table__.columns}
+
+
+class TableSportsEvents(Base):
+    # One row per playable file, not per event. A fight card ships prelims and
+    # a main card separately, and each needs its own subtitles. An event with
+    # one file is simply an event with one part.
+    __tablename__ = 'table_sports_events'
+
+    audio_codec = mapped_column(Text)
+    audio_language = mapped_column(Text)
+    broadcastDate = mapped_column(Text)
+    created_at_timestamp = mapped_column(DateTime)
+    episode = mapped_column(Integer, nullable=False)
+    externalId = mapped_column(Text)
+    failedAttempts = mapped_column(Text)
+    ffprobe_cache = mapped_column(LargeBinary)
+    # Sportarr's id for the file itself. It changes when a file is replaced, so
+    # a change here means the media changed even when the path did not.
+    file_id = mapped_column(Integer)
+    file_size = mapped_column(BigInteger)
+    format = mapped_column(Text)
+    missing_subtitles = mapped_column(Text)
+    monitored = mapped_column(Text)
+    # Prelims, Main Card, Qualifying. Null when the event has a single file.
+    partName = mapped_column(Text)
+    path = mapped_column(Text, nullable=False)
+    resolution = mapped_column(Text)
+    # Release name, and only when a real grab produced the file. Sportarr
+    # renames files, so the name on disk never matches a release.
+    sceneName = mapped_column(Text)
+    season = mapped_column(Integer, nullable=False)
+    sportarrEventId = mapped_column(Integer, primary_key=True)
+    sportarrLeagueId = mapped_column(Integer, ForeignKey('table_sports_leagues.sportarrLeagueId',
+                                                        ondelete='CASCADE'))
+    title = mapped_column(Text, nullable=False)
+    updated_at_timestamp = mapped_column(DateTime)
+    video_codec = mapped_column(Text)
+
+    def to_dict(self):
+        return {column.name: getattr(self, column.name) for column in self.__table__.columns}
+
+
+class TableSportsEventsSubtitles(Base):
+    __tablename__ = 'table_sports_events_subtitles'
+
+    id = mapped_column(Integer, primary_key=True)
+    language = mapped_column(Text, nullable=False)
+    hi = mapped_column(Boolean, nullable=False)
+    forced = mapped_column(Boolean, nullable=False)
+    path = mapped_column(Text, nullable=True)
+    size = mapped_column(BigInteger, nullable=True)
+    embedded_track_id = mapped_column(Integer, nullable=True)
+    sportarrEventId = mapped_column(Integer, ForeignKey('table_sports_events.sportarrEventId', ondelete='CASCADE'),
+                                    nullable=False)
+    sportarrLeagueId = mapped_column(Integer, ForeignKey('table_sports_leagues.sportarrLeagueId', ondelete='CASCADE'),
+                                     nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint('path', 'sportarrLeagueId', 'sportarrEventId', 'language', 'forced', 'hi',
+                         name='uc_external_sports_events_subtitles'),
+        UniqueConstraint('embedded_track_id', 'sportarrLeagueId', 'sportarrEventId', 'language', 'forced', 'hi',
+                         name='uc_embedded_sports_events_subtitles'),
+    )
+
+
+class TableSportsLeaguesRootfolder(Base):
+    __tablename__ = 'table_sports_leagues_rootfolder'
+
+    accessible = mapped_column(Integer)
+    error = mapped_column(Text)
+    id = mapped_column(Integer, primary_key=True)
+    path = mapped_column(Text)
+
+
 def init_db():
     database.begin()
 

--- a/migrations/versions/a3f2c81b9d47_.py
+++ b/migrations/versions/a3f2c81b9d47_.py
@@ -1,7 +1,7 @@
 """empty message
 
 Revision ID: a3f2c81b9d47
-Revises: 0124f9e278fb
+Revises: 537e9b4d10e3
 Create Date: 2026-08-12 14:22:08.417293
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'a3f2c81b9d47'
-down_revision = '0124f9e278fb'
+down_revision = '537e9b4d10e3'
 branch_labels = None
 depends_on = None
 
@@ -79,6 +79,29 @@ def upgrade():
             sa.UniqueConstraint('sportarrEventId', 'partNumber', name='uc_sports_event_part'),
         )
 
+        # =====================================================================
+        # SPORTS EVENTS TABLE INDEXES
+        # =====================================================================
+        # Based on:
+        # - Foreign key column used in JOIN operations and league filtering
+        # - Filtering by path during events sync and disk indexing
+
+        # Index for league lookups (foreign key)
+        op.create_index(
+            'ix_sports_events_sportarr_league_id',
+            'table_sports_events',
+            ['sportarrLeagueId'],
+            unique=False
+        )
+
+        # Index for path-based lookups (event file path queries)
+        op.create_index(
+            'ix_sports_events_path',
+            'table_sports_events',
+            ['path'],
+            unique=False
+        )
+
     if 'table_sports_events_subtitles' not in tables:
         op.create_table(
             'table_sports_events_subtitles',
@@ -99,6 +122,64 @@ def upgrade():
                                 name='uc_external_sports_events_subtitles'),
             sa.UniqueConstraint('embedded_track_id', 'sportarrLeagueId', 'sportsEventId', 'language', 'forced', 'hi',
                                 name='uc_embedded_sports_events_subtitles'),
+        )
+
+        # =====================================================================
+        # SPORTS EVENTS SUBTITLES TABLE INDEXES
+        # =====================================================================
+        # Based on:
+        # - Foreign key columns used in JOIN operations
+        # - Filtering by path and embedded_track_id
+        # - Composite lookups combining multiple columns
+        # Mirrors the index set added for table_episodes_subtitles and
+        # table_movies_subtitles in revision 537e9b4d10e3.
+
+        # Index for event lookups (foreign key)
+        op.create_index(
+            'ix_sports_events_subtitles_sports_event_id',
+            'table_sports_events_subtitles',
+            ['sportsEventId'],
+            unique=False
+        )
+
+        # Index for league lookups (foreign key)
+        op.create_index(
+            'ix_sports_events_subtitles_sportarr_league_id',
+            'table_sports_events_subtitles',
+            ['sportarrLeagueId'],
+            unique=False
+        )
+
+        # Index for path-based lookups (subtitle file path queries)
+        op.create_index(
+            'ix_sports_events_subtitles_path',
+            'table_sports_events_subtitles',
+            ['path'],
+            unique=False
+        )
+
+        # Index for embedded track lookups
+        op.create_index(
+            'ix_sports_events_subtitles_embedded_track_id',
+            'table_sports_events_subtitles',
+            ['embedded_track_id'],
+            unique=False
+        )
+
+        # Composite index for language and format filtering
+        op.create_index(
+            'ix_sports_events_subtitles_language_hi_forced',
+            'table_sports_events_subtitles',
+            ['language', 'hi', 'forced'],
+            unique=False
+        )
+
+        # Composite index combining event ID, path, and track ID for complex lookups
+        op.create_index(
+            'ix_sports_events_subtitles_event_path_track',
+            'table_sports_events_subtitles',
+            ['sportsEventId', 'path', 'embedded_track_id'],
+            unique=False
         )
 
     if 'table_sports_leagues_rootfolder' not in tables:

--- a/migrations/versions/a3f2c81b9d47_.py
+++ b/migrations/versions/a3f2c81b9d47_.py
@@ -1,0 +1,113 @@
+"""empty message
+
+Revision ID: a3f2c81b9d47
+Revises: 0124f9e278fb
+Create Date: 2026-08-12 14:22:08.417293
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a3f2c81b9d47'
+down_revision = '0124f9e278fb'
+branch_labels = None
+depends_on = None
+
+
+bind = op.get_context().bind
+insp = sa.inspect(bind)
+tables = insp.get_table_names()
+
+
+def upgrade():
+    if 'table_sports_leagues' not in tables:
+        op.create_table(
+            'table_sports_leagues',
+            sa.Column('sportarrLeagueId', sa.Integer(), nullable=False),
+            sa.Column('audio_language', sa.Text(), nullable=True),
+            sa.Column('created_at_timestamp', sa.DateTime(), nullable=True),
+            sa.Column('externalId', sa.Text(), nullable=True),
+            sa.Column('fanart', sa.Text(), nullable=True),
+            sa.Column('monitored', sa.Text(), nullable=True),
+            sa.Column('overview', sa.Text(), nullable=True),
+            sa.Column('path', sa.Text(), nullable=False),
+            sa.Column('poster', sa.Text(), nullable=True),
+            sa.Column('profileId', sa.Integer(), nullable=True),
+            sa.Column('sortTitle', sa.Text(), nullable=True),
+            sa.Column('sport', sa.Text(), nullable=True),
+            sa.Column('tags', sa.Text(), nullable=True),
+            sa.Column('title', sa.Text(), nullable=False),
+            sa.Column('updated_at_timestamp', sa.DateTime(), nullable=True),
+            sa.ForeignKeyConstraint(['profileId'], ['table_languages_profiles.profileId'], ondelete='SET NULL'),
+            sa.PrimaryKeyConstraint('sportarrLeagueId'),
+            sa.UniqueConstraint('path'),
+        )
+
+    if 'table_sports_events' not in tables:
+        op.create_table(
+            'table_sports_events',
+            sa.Column('sportarrEventId', sa.Integer(), nullable=False),
+            sa.Column('audio_codec', sa.Text(), nullable=True),
+            sa.Column('audio_language', sa.Text(), nullable=True),
+            sa.Column('broadcastDate', sa.Text(), nullable=True),
+            sa.Column('created_at_timestamp', sa.DateTime(), nullable=True),
+            sa.Column('episode', sa.Integer(), nullable=False),
+            sa.Column('externalId', sa.Text(), nullable=True),
+            sa.Column('failedAttempts', sa.Text(), nullable=True),
+            sa.Column('ffprobe_cache', sa.LargeBinary(), nullable=True),
+            sa.Column('file_id', sa.Integer(), nullable=True),
+            sa.Column('file_size', sa.BigInteger(), nullable=True),
+            sa.Column('format', sa.Text(), nullable=True),
+            sa.Column('missing_subtitles', sa.Text(), nullable=True),
+            sa.Column('monitored', sa.Text(), nullable=True),
+            sa.Column('partName', sa.Text(), nullable=True),
+            sa.Column('path', sa.Text(), nullable=False),
+            sa.Column('resolution', sa.Text(), nullable=True),
+            sa.Column('sceneName', sa.Text(), nullable=True),
+            sa.Column('season', sa.Integer(), nullable=False),
+            sa.Column('sportarrLeagueId', sa.Integer(), nullable=True),
+            sa.Column('title', sa.Text(), nullable=False),
+            sa.Column('updated_at_timestamp', sa.DateTime(), nullable=True),
+            sa.Column('video_codec', sa.Text(), nullable=True),
+            sa.ForeignKeyConstraint(['sportarrLeagueId'], ['table_sports_leagues.sportarrLeagueId'],
+                                    ondelete='CASCADE'),
+            sa.PrimaryKeyConstraint('sportarrEventId'),
+        )
+
+    if 'table_sports_events_subtitles' not in tables:
+        op.create_table(
+            'table_sports_events_subtitles',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('language', sa.Text(), nullable=False),
+            sa.Column('hi', sa.Boolean(), nullable=False),
+            sa.Column('forced', sa.Boolean(), nullable=False),
+            sa.Column('path', sa.Text(), nullable=True),
+            sa.Column('size', sa.BigInteger(), nullable=True),
+            sa.Column('embedded_track_id', sa.Integer(), nullable=True),
+            sa.Column('sportarrEventId', sa.Integer(), nullable=False),
+            sa.Column('sportarrLeagueId', sa.Integer(), nullable=False),
+            sa.ForeignKeyConstraint(['sportarrEventId'], ['table_sports_events.sportarrEventId'], ondelete='CASCADE'),
+            sa.ForeignKeyConstraint(['sportarrLeagueId'], ['table_sports_leagues.sportarrLeagueId'],
+                                    ondelete='CASCADE'),
+            sa.PrimaryKeyConstraint('id'),
+            sa.UniqueConstraint('path', 'sportarrLeagueId', 'sportarrEventId', 'language', 'forced', 'hi',
+                                name='uc_external_sports_events_subtitles'),
+            sa.UniqueConstraint('embedded_track_id', 'sportarrLeagueId', 'sportarrEventId', 'language', 'forced', 'hi',
+                                name='uc_embedded_sports_events_subtitles'),
+        )
+
+    if 'table_sports_leagues_rootfolder' not in tables:
+        op.create_table(
+            'table_sports_leagues_rootfolder',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('accessible', sa.Integer(), nullable=True),
+            sa.Column('error', sa.Text(), nullable=True),
+            sa.Column('path', sa.Text(), nullable=True),
+            sa.PrimaryKeyConstraint('id'),
+        )
+
+
+def downgrade():
+    pass

--- a/migrations/versions/a3f2c81b9d47_.py
+++ b/migrations/versions/a3f2c81b9d47_.py
@@ -48,7 +48,7 @@ def upgrade():
     if 'table_sports_events' not in tables:
         op.create_table(
             'table_sports_events',
-            sa.Column('sportarrEventId', sa.Integer(), nullable=False),
+            sa.Column('id', sa.Integer(), nullable=False),
             sa.Column('audio_codec', sa.Text(), nullable=True),
             sa.Column('audio_language', sa.Text(), nullable=True),
             sa.Column('broadcastDate', sa.Text(), nullable=True),
@@ -63,17 +63,20 @@ def upgrade():
             sa.Column('missing_subtitles', sa.Text(), nullable=True),
             sa.Column('monitored', sa.Text(), nullable=True),
             sa.Column('partName', sa.Text(), nullable=True),
+            sa.Column('partNumber', sa.Integer(), nullable=False, server_default='0'),
             sa.Column('path', sa.Text(), nullable=False),
             sa.Column('resolution', sa.Text(), nullable=True),
             sa.Column('sceneName', sa.Text(), nullable=True),
             sa.Column('season', sa.Integer(), nullable=False),
+            sa.Column('sportarrEventId', sa.Integer(), nullable=False),
             sa.Column('sportarrLeagueId', sa.Integer(), nullable=True),
             sa.Column('title', sa.Text(), nullable=False),
             sa.Column('updated_at_timestamp', sa.DateTime(), nullable=True),
             sa.Column('video_codec', sa.Text(), nullable=True),
             sa.ForeignKeyConstraint(['sportarrLeagueId'], ['table_sports_leagues.sportarrLeagueId'],
                                     ondelete='CASCADE'),
-            sa.PrimaryKeyConstraint('sportarrEventId'),
+            sa.PrimaryKeyConstraint('id'),
+            sa.UniqueConstraint('sportarrEventId', 'partNumber', name='uc_sports_event_part'),
         )
 
     if 'table_sports_events_subtitles' not in tables:
@@ -86,15 +89,15 @@ def upgrade():
             sa.Column('path', sa.Text(), nullable=True),
             sa.Column('size', sa.BigInteger(), nullable=True),
             sa.Column('embedded_track_id', sa.Integer(), nullable=True),
-            sa.Column('sportarrEventId', sa.Integer(), nullable=False),
+            sa.Column('sportsEventId', sa.Integer(), nullable=False),
             sa.Column('sportarrLeagueId', sa.Integer(), nullable=False),
-            sa.ForeignKeyConstraint(['sportarrEventId'], ['table_sports_events.sportarrEventId'], ondelete='CASCADE'),
+            sa.ForeignKeyConstraint(['sportsEventId'], ['table_sports_events.id'], ondelete='CASCADE'),
             sa.ForeignKeyConstraint(['sportarrLeagueId'], ['table_sports_leagues.sportarrLeagueId'],
                                     ondelete='CASCADE'),
             sa.PrimaryKeyConstraint('id'),
-            sa.UniqueConstraint('path', 'sportarrLeagueId', 'sportarrEventId', 'language', 'forced', 'hi',
+            sa.UniqueConstraint('path', 'sportarrLeagueId', 'sportsEventId', 'language', 'forced', 'hi',
                                 name='uc_external_sports_events_subtitles'),
-            sa.UniqueConstraint('embedded_track_id', 'sportarrLeagueId', 'sportarrEventId', 'language', 'forced', 'hi',
+            sa.UniqueConstraint('embedded_track_id', 'sportarrLeagueId', 'sportsEventId', 'language', 'forced', 'hi',
                                 name='uc_embedded_sports_events_subtitles'),
         )
 


### PR DESCRIPTION
First PR of the Sportarr integration, kept to schema only so it is easy to review and easy to revert.

Adds four tables mirroring the existing series ones. Leagues take the place of shows and events take the place of episodes, so `table_sports_leagues` mirrors `table_shows`, `table_sports_events` mirrors `table_episodes`, and the subtitles and rootfolder tables follow the same pattern. Nothing existing is modified.

Three things differ from a straight copy, and each is deliberate.

Events are one row per playable file rather than one per event. I went through `sonarr/sync/episodes.py` first, and your episode row is really one file with one path, which fits sports well. A fight card ships prelims and a main card as separate files needing their own subtitles, so mapping a part onto your episode row means nothing here has to learn a new concept. An event with a single file is simply an event with one part.

Both tables carry an `externalId` alongside the numeric id. Sportarr's ids survive a remove and re-add while its internal id does not, so matching on it keeps subtitle history intact where keying on the integer alone would delete and re-add the rows.

`file_id` mirrors `episode_file_id`. Sportarr can replace a file at the same path during a quality upgrade, so the path alone will not tell you the media changed. This gives the same signal you already use to trigger reprocessing.

Verified on Python 3.13 with ffmpeg and mediainfo installed: your backend suite passes at 173 tests, the migration applies cleanly on boot, and all four tables are created. The `build_test.sh` UI check returns 500 in my container, but a clean checkout of this branch does the same because there is no built frontend in a bare dev checkout, so it is unrelated to this change.

I used an AI coding assistant while building this, modeled closely on your existing Sonarr integration. I directed the design, reviewed every line, and tested it against a live Bazarr instance with real data. I can explain any part of it.

One question while I am here. Your CI matrix runs Python 3.10 through 3.14, but CONTRIBUTING says anything 3.14 or greater is not allowed because it might break the libraries. I targeted 3.13 for this. Which one should I be treating as authoritative for the rest of the work?