### PR TITLE
fix(series sync): bail out when Sonarr API returns None

### DIFF
--- a/bazarr/sonarr/sync/series.py
+++ b/bazarr/sonarr/sync/series.py
@@ -56,6 +56,9 @@ def update_series(job_id=None, wait_for_completion=False):
         logging.exception(f"BAZARR Error trying to get series from Sonarr: {e}")
         return
     else:
+        if not isinstance(series, list):
+            return
+
         # Get current shows in DB
         current_shows_db = [x.sonarrSeriesId for x in
                             database.execute(

--- a/tests/bazarr/test_sync_performance_paths.py
+++ b/tests/bazarr/test_sync_performance_paths.py
@@ -117,6 +117,71 @@ def test_update_series_runs_one_explicit_episode_sync(monkeypatch):
     assert update_calls[0][1]["sync_episodes_after_update"] is False
 
 
+def test_update_series_returns_early_when_sonarr_api_returns_none(monkeypatch):
+    from sonarr.sync import series as series_sync
+
+    execute_calls = []
+    episode_sync_calls = []
+    update_one_series_calls = []
+    job_name_updates = []
+
+    class _Database:
+        def execute(self, statement):
+            execute_calls.append(statement)
+            return _Result(all_value=[])
+
+    monkeypatch.setattr(series_sync, "database", _Database())
+    monkeypatch.setattr(
+        series_sync,
+        "settings",
+        SimpleNamespace(
+            general=SimpleNamespace(debug=False),
+            sonarr=SimpleNamespace(
+                apikey="sonarr-key",
+                sync_only_monitored_series=False,
+            ),
+        ),
+    )
+    monkeypatch.setattr(series_sync, "check_sonarr_rootfolder", lambda: None)
+    # The API helper swallows ConnectionError/Timeout errors and returns None.
+    monkeypatch.setattr(
+        series_sync,
+        "get_series_from_sonarr_api",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(series_sync, "get_profile_list", lambda: [])
+    monkeypatch.setattr(series_sync, "get_tags", lambda: {})
+    monkeypatch.setattr(series_sync, "get_language_profiles", lambda: [])
+    monkeypatch.setattr(
+        series_sync,
+        "update_one_series",
+        lambda *args, **kwargs: update_one_series_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        series_sync,
+        "sync_episodes",
+        lambda series_id: episode_sync_calls.append(series_id),
+    )
+    monkeypatch.setattr(
+        series_sync,
+        "jobs_queue",
+        SimpleNamespace(
+            add_job_from_function=lambda *args, **kwargs: None,
+            update_job_progress=lambda *args, **kwargs: None,
+            update_job_name=lambda *args, **kwargs: job_name_updates.append(
+                (args, kwargs)
+            ),
+        ),
+    )
+
+    series_sync.update_series(job_id="job")
+
+    assert execute_calls == []
+    assert episode_sync_calls == []
+    assert update_one_series_calls == []
+    assert job_name_updates == []
+
+
 def test_unchanged_series_skips_update_but_manual_call_syncs_episodes(monkeypatch):
     from sonarr.sync import series as series_sync
 


### PR DESCRIPTION
## Summary

When Sonarr is unreachable, `get_series_from_sonarr_api()` catches the `requests` exception (`ConnectionError`/`Timeout`/`HTTPError`) and returns `None`. `update_series()` then unconditionally evaluates `series_count = len(series)` on that `None` result, raising `TypeError: object of type 'NoneType' has no len()`. This leaves the scheduled series sync job stuck in a failed state every time it runs while Sonarr is down.

This fix adds the same defensive guard in `update_series()` that already exists on the Radarr side: return early unless the fetched data is a `list`. An empty list is still treated as valid so the existing DB cleanup logic runs unchanged; only a non-list result (the `None` from the error path) short-circuits the sync.

## Equivalence with the existing Radarr guard

The Radarr path already guards against this exact failure in `update_movies()`:

```python
movies = get_movies_from_radarr_api(apikey_radarr=apikey_radarr)
if not isinstance(movies, list):
    return
```

Canonical source (pinned to `development` HEAD `011e0959`): https://github.com/morpheus65535/bazarr/blob/011e095915c310175c92411acdd3631ab85f3711/bazarr/radarr/sync/movies.py#L139-L140

This PR brings the Sonarr path (`bazarr/sonarr/sync/series.py`) to parity.

## Testing

- Added `test_update_series_returns_early_when_sonarr_api_returns_none` in `tests/bazarr/test_sync_performance_paths.py` (mocks `get_series_from_sonarr_api()` to return `None` and asserts the sync bails out without touching the DB).
- Affected test file: 7/7 pass.
- Full `tests/bazarr/` suite: 83 passed; 27 pre-existing failures identical on a pristine `development` checkout (missing system-level deps, unrelated to this change).
- Verified across supported Python versions 3.10, 3.12, and 3.13.
- Live validation: the identical guard was deployed and verified on a running instance; boot + UI smoke test (`build_test.sh` equivalent) passes with the change.

## Disclosure

This change was developed with the assistance of an AI coding tool, per the Bazarr Contributor Code of Conduct ("Working with AI"). The underlying bug was diagnosed, the fix designed, and the change reviewed by a human. I fully understand and can explain the logic of this submission.
