### PR TITLE
Fixed GreekSubs manual downloads with expired tokens

### DIFF
--- a/custom_libs/subliminal_patch/providers/greeksubs.py
+++ b/custom_libs/subliminal_patch/providers/greeksubs.py
@@ -10,7 +10,7 @@ from subliminal_patch.subtitle import guess_matches
 from .utils import FIRST_THOUSAND_OR_SO_USER_AGENTS as AGENT_LIST
 
 from subliminal.providers import ParserBeautifulSoup, Provider
-from subliminal.subtitle import SUBTITLE_EXTENSIONS, Subtitle, fix_line_ending
+from subliminal.subtitle import Subtitle, fix_line_ending
 from subliminal.video import Episode, Movie
 
 logger = logging.getLogger(__name__)
@@ -68,6 +68,23 @@ class GreekSubsProvider(Provider):
     def terminate(self):
         self.session.close()
 
+    def _parse_subtitle_row(self, subtitles_item, sec_code, referer):
+        try:
+            download_button = subtitles_item.find('button', {'onclick': re.compile(r'^downloadMe')})
+            subtitle_id = re.search(r"downloadMe\('([^']+)'\)", download_button.get('onclick')).group(1)
+            language_image = subtitles_item.find('img', {'src': re.compile(r'/resources/lang/')})
+            language = Language.fromalpha2(language_image.get('alt'))
+            download_cell = download_button.find_parent('td')
+            version_cell = download_cell.find_next_sibling('td').find_next_sibling('td')
+            version = version_cell.get_text(strip=True)
+            uploader = subtitles_item.find(class_='userNameBox').get_text(strip=True)
+        except Exception as e:
+            logging.debug(e)
+            return None
+
+        download_link = self.server_url + 'dll/' + subtitle_id + '/0/' + sec_code
+        return self.subtitle_class(language, download_link, version, uploader, referer, subtitle_id)
+
     def query(self, video, languages, imdb_id, season=None, episode=None):
         logger.debug('Searching subtitles for %r', imdb_id)
         subtitles = []
@@ -102,24 +119,10 @@ class GreekSubsProvider(Provider):
                             logging.debug(e)
                         else:
                             for subtitles_item in soup_subs.select('#elSub > tbody > tr'):
-                                try:
-                                    subtitle_id = re.search(r'downloadMe\(\'(.*)\'\)',
-                                                            subtitles_item.contents[2].contents[2].contents[0].attrs[
-                                                                'onclick']).group(1)
-                                    download_link = self.server_url + 'dll/' + subtitle_id + '/0/' + secCode
-                                    language = Language.fromalpha2(subtitles_item.parent.find('img')['alt'])
-                                    version = subtitles_item.contents[2].contents[4].text.strip()
-                                    uploader = (subtitles_item.contents[2].contents[5].contents[0].contents[1].text
-                                                .strip())
-                                except Exception as e:
-                                    logging.debug(e)
-                                else:
-                                    if language in languages:
-                                        subtitle = self.subtitle_class(language, download_link, version, uploader,
-                                                                       search_link, subtitle_id)
-
-                                        logger.debug('Found subtitle %r', subtitle)
-                                        subtitles.append(subtitle)
+                                subtitle = self._parse_subtitle_row(subtitles_item, secCode, episode_page)
+                                if subtitle is not None and subtitle.language in languages:
+                                    logger.debug('Found subtitle %r', subtitle)
+                                    subtitles.append(subtitle)
                     else:
                         pass
             except Exception as e:
@@ -133,23 +136,10 @@ class GreekSubsProvider(Provider):
                     logging.debug(e)
                 else:
                     for subtitles_item in soup_subs.select('#elSub > tbody > tr'):
-                        try:
-                            subtitle_id = re.search(r'downloadMe\(\'(.*)\'\)',
-                                                    subtitles_item.contents[2].contents[2].contents[0].attrs[
-                                                        'onclick']).group(1)
-                            download_link = self.server_url + 'dll/' + subtitle_id + '/0/' + secCode
-                            language = Language.fromalpha2(subtitles_item.parent.find('img')['alt'])
-                            version = subtitles_item.contents[2].contents[4].text.strip()
-                            uploader = subtitles_item.contents[2].contents[5].contents[0].contents[1].text.strip()
-                        except Exception as e:
-                            logging.debug(e)
-                        else:
-                            if language in languages:
-                                subtitle = self.subtitle_class(language, download_link, version, uploader, search_link,
-                                                               subtitle_id)
-
-                                logger.debug('Found subtitle %r', subtitle)
-                                subtitles.append(subtitle)
+                        subtitle = self._parse_subtitle_row(subtitles_item, secCode, search_link)
+                        if subtitle is not None and subtitle.language in languages:
+                            logger.debug('Found subtitle %r', subtitle)
+                            subtitles.append(subtitle)
             except Exception as e:
                 logging.debug(e)
 
@@ -184,11 +174,26 @@ class GreekSubsProvider(Provider):
                              timeout=30, allow_redirects=False)
 
         if r.status_code == 302:
-            logger.critical("Greeksubs allow only one download per search. Search again to generate a new single use "
-                            "download token.")
-            return None
+            if not self._refresh_download_link(subtitle):
+                logger.error("Unable to refresh Greeksubs single use download token")
+                return False
+
+            r = self.session.get(subtitle.page_link,
+                                 headers={'Referer': subtitle.referer},
+                                 timeout=30, allow_redirects=False)
+
+            if r.status_code == 302:
+                logger.error("Greeksubs single use download token is still invalid after refresh")
+                return False
 
         r.raise_for_status()
+
+        content_type = r.headers.get('Content-Type', '').lower()
+        content_disposition = r.headers.get('Content-Disposition', '').lower()
+        if r.content and ('attachment' in content_disposition or
+                          content_type and not content_type.startswith('text/html')):
+            subtitle.content = fix_line_ending(r.content)
+            return
 
         download_req = None
         soup_dll = ParserBeautifulSoup(r.content.decode('utf-8', 'ignore'), ['html.parser'])
@@ -206,8 +211,22 @@ class GreekSubsProvider(Provider):
                                                                            'dll': dll},
                                              headers={'Referer': subtitle.page_link}, timeout=10)
 
-        if download_req and not download_req.content:
+        if download_req is None or not download_req.content:
             logger.error('Unable to download subtitle. No data returned from provider')
             return False
 
         subtitle.content = fix_line_ending(download_req.content)
+
+    def _refresh_download_link(self, subtitle):
+        r = self.session.get(subtitle.referer, timeout=30)
+        r.raise_for_status()
+
+        soup_page = ParserBeautifulSoup(r.content.decode('utf-8', 'ignore'), ['html.parser'])
+        sec_code_input = soup_page.find('input', {'id': 'secCode'})
+        if sec_code_input is None or not sec_code_input.get('value'):
+            return False
+
+        download_link = self.server_url + 'dll/' + subtitle.subtitle_id + '/0/' + sec_code_input.get('value')
+        subtitle.page_link = download_link
+        subtitle.download_link = download_link
+        return True

--- a/tests/subliminal_patch/test_greeksubs.py
+++ b/tests/subliminal_patch/test_greeksubs.py
@@ -1,0 +1,104 @@
+from subzero.language import Language
+from requests import Session
+from subliminal.video import Movie
+
+from subliminal_patch.providers.greeksubs import GreekSubsProvider
+from subliminal_patch.providers.greeksubs import GreekSubsSubtitle
+
+
+REFERER = "https://greeksubs.net/en/view/tt0479997"
+STALE_DOWNLOAD_LINK = "https://greeksubs.net/dll/subtitle-id/0/stale-token"
+FRESH_DOWNLOAD_LINK = "https://greeksubs.net/dll/subtitle-id/0/fresh-token"
+
+
+def test_list_subtitles_parses_current_table_markup(requests_mock):
+    requests_mock.get(
+        REFERER,
+        text=(
+            '<input type="hidden" value="fresh-token" id="secCode">'
+            '<table id="elSub"><tbody><tr>'
+            '<td>1</td><td><img src="/resources/lang/greek.jpg" alt="el"></td><span>'
+            '<td></td><td></td><td><button onclick="downloadMe(\'subtitle-id\')">Download</button></td>'
+            '<td>64</td><td>Season-of-the-Witch-2011-1080p-bluray-x264-blow</td>'
+            '<td><img class="userProfileImgN"><div class="userNameBox">WhiteAngel</div></td>'
+            '</span></tr></tbody></table>'
+        ),
+    )
+    movie = Movie(
+        "Season.of.the.Witch.2011.1080p.BluRay.x264.mkv",
+        "Season of the Witch",
+        year=2011,
+        imdb_id="tt0479997",
+    )
+    provider = GreekSubsProvider()
+    provider.session = Session()
+
+    subtitles = provider.list_subtitles(movie, {Language("ell")})
+
+    assert len(subtitles) == 1
+    assert subtitles[0].subtitle_id == "subtitle-id"
+    assert subtitles[0].page_link == FRESH_DOWNLOAD_LINK
+    assert subtitles[0].version == "Season.of.the.Witch.2011.1080p.bluray.x264.blow"
+    assert subtitles[0].uploader == "WhiteAngel"
+
+
+def test_download_subtitle_refreshes_expired_token(requests_mock):
+    requests_mock.get(STALE_DOWNLOAD_LINK, status_code=302)
+    requests_mock.get(REFERER, text='<input id="secCode" value="fresh-token">')
+    requests_mock.get(
+        FRESH_DOWNLOAD_LINK,
+        content=b"1\r\n00:00:01,000 --> 00:00:02,000\r\nHello\r\n",
+        headers={
+            "Content-Type": "application/octet-stream",
+            "Content-Disposition": 'attachment; filename="subtitle.srt"',
+        },
+    )
+
+    subtitle = GreekSubsSubtitle(
+        language=Language("ell"),
+        page_link=STALE_DOWNLOAD_LINK,
+        version="Season-of-the-Witch-2011-1080p-bluray-x264-blow",
+        uploader="uploader",
+        referer=REFERER,
+        subtitle_id="subtitle-id",
+    )
+    provider = GreekSubsProvider()
+    provider.session = Session()
+
+    provider.download_subtitle(subtitle)
+
+    assert subtitle.page_link == FRESH_DOWNLOAD_LINK
+    assert subtitle.download_link == FRESH_DOWNLOAD_LINK
+    assert subtitle.is_valid()
+    assert b"\r\n" not in subtitle.content
+
+
+def test_download_subtitle_submits_legacy_download_form(requests_mock):
+    requests_mock.get(
+        FRESH_DOWNLOAD_LINK,
+        text=(
+            '<input name="langcode" value="el">'
+            '<input name="uid" value="user-id">'
+            '<input name="output" value="subtitle.srt">'
+            '<input name="dll" value="download-id">'
+        ),
+    )
+    requests_mock.post(
+        FRESH_DOWNLOAD_LINK,
+        content=b"1\r\n00:00:01,000 --> 00:00:02,000\r\nHello\r\n",
+    )
+    subtitle = GreekSubsSubtitle(
+        language=Language("ell"),
+        page_link=FRESH_DOWNLOAD_LINK,
+        version="Season-of-the-Witch-2011-1080p-bluray-x264-blow",
+        uploader="uploader",
+        referer=REFERER,
+        subtitle_id="subtitle-id",
+    )
+    provider = GreekSubsProvider()
+    provider.session = Session()
+
+    provider.download_subtitle(subtitle)
+
+    assert subtitle.is_valid()
+    assert b"\r\n" not in subtitle.content


### PR DESCRIPTION
## Summary

- parse GreekSubs current subtitle table markup while retaining the subtitle ID and source-page referer
- when a cached single-use download token returns 302, refresh the source page, rebuild the link for the same subtitle, and retry once
- support the provider’s current direct-file response while preserving its legacy download-form flow
- add regression tests for listing, token refresh, direct downloads, and the legacy form

Fixes #3219

## Validation

- `NO_CLI=true python -m pytest tests/subliminal_patch/test_greeksubs.py -vv` — 3 passed
- `NO_CLI=true python -m pytest --flakes custom_libs/subliminal_patch/providers/greeksubs.py tests/subliminal_patch/test_greeksubs.py -q` — 5 passed
- live GreekSubs validation after rebasing: 4 results listed; selected token consumed; link refreshed; downloaded subtitle valid (42,223 bytes)
- backend suite: 172 passed; 2 unrelated video-analyzer tests require local `mediainfo`/`mkvmerge` binaries
- broader provider collection is currently blocked upstream by the missing `subliminal_patch.providers.argenteamdump` module

## AI disclosure

OpenAI Codex assisted with investigation, implementation, rebasing, and test execution. The change was traced through the complete manual-download path: cached result metadata, one-time token invalidation, source-page token refresh, direct-file detection, and the legacy form fallback. The implementation is limited to the GreekSubs provider and its focused regression tests.