### PR TITLE
Fixed SuperSubtitles year matching

### DIFF
--- a/custom_libs/subliminal_patch/providers/supersubtitles.py
+++ b/custom_libs/subliminal_patch/providers/supersubtitles.py
@@ -90,8 +90,8 @@ class SuperSubtitlesSubtitle(Subtitle):
 
     def __get_name(self):
         ep_addon = f"S{self.season:02}E{self.episode:02}" if self.episode else ""
-        year_str = f" ({self.year})"
-        return f"{self.series}{year_str or ''} {ep_addon}".strip()
+        year_str = f" ({self.year})" if self.year else ""
+        return f"{self.series}{year_str} {ep_addon}".strip()
 
     def get_matches(self, video):
         matches = set()
@@ -469,15 +469,16 @@ class SuperSubtitlesProvider(Provider, ProviderSubtitleArchiveMixin):
                 asked_for_episode = None
                 sub_season = None
                 sub_episode = None
-                sub_english = table.findAll("div", {"class": "eredeti"})
-                sub_english_name = re.search(r'(?<=<div class="eredeti">).*?(?=</div>)', str(sub_english))
-                sub_english_name = sub_english_name.group() if sub_english_name else ''
+                sub_english = table.find("div", {"class": "eredeti"})
+                sub_english_name = sub_english.get_text(strip=True) if sub_english else ''
+                sub_year_match = re.search(r'\(((?:19|20)\d{2})\)', sub_english_name)
+                sub_year = int(sub_year_match.group(1)) if sub_year_match else None
                 sub_english_name = sub_english_name.split(' (')[0]
 
                 sub_english_name = sub_english_name.replace('&amp;', '&')
                 sub_version = 'n/a'
-                if len(str(sub_english).split('(')) > 1:
-                    sub_version = (str(sub_english).split('(')[len(str(sub_english).split('(')) - 1]).split(')')[0]
+                if sub_english and len(sub_english.get_text().split('(')) > 1:
+                    sub_version = sub_english.get_text().rsplit('(', 1)[1].split(')', 1)[0]
                 # <small>Angol</small>
                 lang = table.find("small")
                 sub_language = re.search(r"(?<=<small>).*(?=</small>)", str(lang))
@@ -501,7 +502,6 @@ class SuperSubtitlesProvider(Provider, ProviderSubtitleArchiveMixin):
 
                 sub_id = re.search(r"(?<=felirat=).*(?=\">)", link)
                 sub_id = sub_id.group() if sub_id else ''
-                sub_year = video.year
                 sub_releases = [s.strip() for s in sub_version.split(',')]
 
                 uploader = ''

--- a/tests/subliminal_patch/test_supersubtitles.py
+++ b/tests/subliminal_patch/test_supersubtitles.py
@@ -4,6 +4,7 @@ import pytest
 from subliminal_patch.providers.supersubtitles import SuperSubtitlesProvider
 from subliminal_patch.providers.supersubtitles import SuperSubtitlesSubtitle
 from subliminal_patch.core import Episode
+from subliminal_patch.core import Movie
 from subzero.language import Language
 
 
@@ -154,6 +155,62 @@ def test_subtitle_reprs(movies):
     )
     assert isinstance(subtitle.__repr__(), str)
     assert isinstance(subtitle.__str__(), str)
+
+
+@pytest.mark.parametrize(
+    ("provider_title", "expected_year"),
+    [
+        ("Obey (2018) (WEBRip.720p-YIFY)", 2018),
+        ("Obey (WEBRip.720p-YIFY)", None),
+    ],
+)
+def test_movie_result_uses_provider_year(
+    requests_mock, mocker, provider_title, expected_year
+):
+    movie = Movie(
+        "Obey (2013) - [720p][AAC 2.0][AVC].mp4",
+        "Obey",
+        year=2013,
+    )
+    language = Language.fromalpha2("en")
+    url = (
+        "https://www.feliratok.eu/"
+        "index.php?search=Obey&soriSorszam=&nyelv=&tab=film"
+    )
+    requests_mock.get(
+        url,
+        text=f"""
+            <table>
+                <tr><td>header</td></tr>
+                <tr><td>header</td></tr>
+                <tr id="vilagit">
+                    <td></td>
+                    <td><small>Angol</small></td>
+                    <td>
+                        <div class="eredeti">
+                            {provider_title}
+                        </div>
+                    </td>
+                    <td>Anonymus</td>
+                    <td>2019-03-02</td>
+                    <td>
+                        <a href="/index.php?action=letolt&amp;fnev=Obey.2018.srt&amp;felirat=1551531078">
+                            Download
+                        </a>
+                    </td>
+                </tr>
+            </table>
+        """,
+    )
+
+    with SuperSubtitlesProvider() as provider:
+        mocker.patch.object(provider, "find_imdb_id", return_value="tt6145764")
+        subtitles = provider.process_subs({language}, movie, url)
+
+    assert len(subtitles) == 1
+    assert subtitles[0].year == expected_year
+    assert "(None)" not in subtitles[0].release_info
+    assert "year" not in subtitles[0].get_matches(movie)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- parse a movie year from the provider’s original-title metadata instead of copying the requested video year into every result
- leave the result year unknown when SuperSubtitles does not provide one
- avoid rendering `(None)` in release information for unknown years
- add regression coverage for both an explicit wrong year and missing year metadata

Fixes #2956

## Validation

- reproduced the bug before the fix: live `Obey (2013)` search returned links for `Obey.2018` but assigned them year 2013 and a false `year` match
- `NO_CLI=true python -m pytest tests/subliminal_patch/test_supersubtitles.py -q` — 9 passed
- post-fix live search: 2 results, both parsed as 2018, both links identify 2018, and neither receives a `year` match against the 2013 movie
- changed files compile successfully
- static scan reports only two pre-existing provider findings: unused `APIThrottled` and duplicate `sanitize` imports

## AI disclosure

OpenAI Codex assisted with investigation, implementation, and test execution. Codex reproduced the exact live mismatch, traced it to `process_subs()` assigning `video.year` to every movie result, added provider-markup regressions, and verified the corrected scoring against the current live provider.