### PR TITLE
Update API key logging code to hide more varieties of API KEY

### DIFF
--- a/bazarr/app/logger.py
+++ b/bazarr/app/logger.py
@@ -23,7 +23,10 @@ class FileHandlerFormatter(logging.Formatter):
     # and value chars [a-zA-Z0-9], so a provider using `api_key=` — or a key
     # like `subdl_Cq…-5IU…` — was written to the log verbatim. These logs are
     # routinely pasted into public issue reports.
-    APIKEY_RE = re.compile(r'api[-_]?key(?:=|%3D)([\w.\-]+)', re.IGNORECASE)
+    SECRET_NAME_RE = (r'(?:x[-_])?(?:api[-_]?key|access[-_]?token|auth[-_]?token|'
+                      r'plex[-_]?token|token)')
+    APIKEY_RE = re.compile(rf'\b{SECRET_NAME_RE}["\']?\s*(?:=|%3D|:)\s*(["\']?)'
+                           r'(?!\(removed\))([^&\s,;"\'}\])]*)', re.IGNORECASE)
     IPv4_RE = re.compile(r'\b(?<!Failed\sauthentication\sfrom\s)(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.)'
                          r'{3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\b')
     PLEX_URL_RE = re.compile(r'(?:https?://)?[0-9\-]+\.[a-f0-9]+\.plex\.direct(?::\d+)?')
@@ -38,7 +41,7 @@ class FileHandlerFormatter(logging.Formatter):
     def formatApikey(self, s):
         # Keep the parameter name the caller used so the log still reads
         # naturally; only the value is removed.
-        return re.sub(self.APIKEY_RE, lambda m: f'{m.group(0)[:m.start(1) - m.start(0)]}(removed)', s)
+        return re.sub(self.APIKEY_RE, lambda m: f'{m.group(0)[:m.start(2) - m.start(0)]}(removed)', s)
 
     def formatIPv4(self, s):
         return re.sub(self.IPv4_RE, '***.***.***.***', s)

--- a/bazarr/app/logger.py
+++ b/bazarr/app/logger.py
@@ -17,7 +17,7 @@ logger = logging.getLogger()
 
 
 class FileHandlerFormatter(logging.Formatter):
-    """Formatter that removes apikey from logs."""
+    """Formatter that masks the tail of any apikey in logs."""
     # Matches `apikey=`, `api_key=` and `apiKey=`, url-encoded or not, and keys
     # containing '-', '_' or '.'. The old pattern required the literal `apikey`
     # and value chars [a-zA-Z0-9], so a provider using `api_key=` — or a key
@@ -26,7 +26,8 @@ class FileHandlerFormatter(logging.Formatter):
     SECRET_NAME_RE = (r'(?:x[-_])?(?:api[-_]?key|access[-_]?token|auth[-_]?token|'
                       r'plex[-_]?token|token)')
     APIKEY_RE = re.compile(rf'\b{SECRET_NAME_RE}["\']?\s*(?:=|%3D|:)\s*(["\']?)'
-                           r'(?!\(removed\))([^&\s,;"\'}\])]*)', re.IGNORECASE)
+                           r'([^&\s,;"\'}\])]*)', re.IGNORECASE)
+    APIKEY_MASK = 'xxxxxxxx'
     IPv4_RE = re.compile(r'\b(?<!Failed\sauthentication\sfrom\s)(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.)'
                          r'{3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\b')
     PLEX_URL_RE = re.compile(r'(?:https?://)?[0-9\-]+\.[a-f0-9]+\.plex\.direct(?::\d+)?')
@@ -39,9 +40,16 @@ class FileHandlerFormatter(logging.Formatter):
         return repr(result)  # or format into one line however you want to
 
     def formatApikey(self, s):
-        # Keep the parameter name the caller used so the log still reads
-        # naturally; only the value is removed.
-        return re.sub(self.APIKEY_RE, lambda m: f'{m.group(0)[:m.start(2) - m.start(0)]}(removed)', s)
+        # Keep the parameter name and the leading part of the key so a log still
+        # says which key was in play; only the last characters are masked.
+        def mask(match):
+            value = match.group(2)
+            if not value:
+                return match.group(0)
+            prefix = match.group(0)[:match.start(2) - match.start(0)]
+            return f'{prefix}{value[:-len(self.APIKEY_MASK)]}{self.APIKEY_MASK}'
+
+        return re.sub(self.APIKEY_RE, mask, s)
 
     def formatIPv4(self, s):
         return re.sub(self.IPv4_RE, '***.***.***.***', s)

--- a/tests/bazarr/test_logging_filters.py
+++ b/tests/bazarr/test_logging_filters.py
@@ -1,6 +1,6 @@
 import logging
 
-from bazarr.app.logger import UnwantedWaitressMessageFilter
+from bazarr.app.logger import FileHandlerFormatter, UnwantedWaitressMessageFilter
 
 def test_true_for_bazarr():
   record = logging.LogRecord("", logging.INFO, "", 0, "a message from BAZARR for logging", (), None)
@@ -13,3 +13,53 @@ def test_false_below_error():
 def test_true_above_error():
   record = logging.LogRecord("", logging.CRITICAL, "", 0, "", (), None)
   assert UnwantedWaitressMessageFilter().filter(record)
+
+
+SECRET = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
+
+
+def _redact(message):
+  record = logging.LogRecord("", logging.INFO, "", 0, message, (), None)
+  return FileHandlerFormatter("%(message)s").format(record)
+
+
+def test_redacts_signalr_access_token():
+  out = _redact(f"http://sonarr:8989/signalr/messages?access_token={SECRET}")
+  assert SECRET not in out
+  assert out == "http://sonarr:8989/signalr/messages?access_token=(removed)"
+
+
+def test_redacts_jellyfin_authorization_token():
+  out = _redact(f'Device="Bazarr", Token="{SECRET}"')
+  assert SECRET not in out
+  assert out == 'Device="Bazarr", Token="(removed)"'
+
+
+def test_redacts_header_mapping_forms():
+  for header in ("X-API-KEY", "X-Plex-Token"):
+    out = _redact(f"{{'{header}': '{SECRET}', 'Accept': 'application/json'}}")
+    assert SECRET not in out, header
+    assert out == f"{{'{header}': '(removed)', 'Accept': 'application/json'}}"
+
+
+def test_redacts_query_string_spellings():
+  for param in ("apikey", "api_key", "apiKey", "apikey%3D"):
+    sep = "" if param.endswith("%3D") else "="
+    out = _redact(f"http://radarr/api/v3/movie?{param}{sep}{SECRET}&pageSize=1")
+    assert SECRET not in out, param
+
+
+def test_redacts_keys_containing_punctuation():
+  assert _redact("apikey=subdl_Cq7-5IU_x.9") == "apikey=(removed)"
+
+
+def test_redaction_is_idempotent():
+  once = _redact(f"?access_token={SECRET}")
+  assert _redact(once) == once
+
+
+def test_leaves_non_secrets_alone():
+  for message in ("Bad AntiCaptcha API key",
+                  "settings.plex.apikey_encrypted = True",
+                  "Invalid SubX API key"):
+    assert _redact(message) == message

--- a/tests/bazarr/test_logging_filters.py
+++ b/tests/bazarr/test_logging_filters.py
@@ -16,6 +16,7 @@ def test_true_above_error():
 
 
 SECRET = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
+MASKED = "a1b2c3d4e5f6a7b8c9d0e1f2xxxxxxxx"
 
 
 def _redact(message):
@@ -23,37 +24,59 @@ def _redact(message):
   return FileHandlerFormatter("%(message)s").format(record)
 
 
-def test_redacts_signalr_access_token():
+def test_masks_signalr_access_token():
   out = _redact(f"http://sonarr:8989/signalr/messages?access_token={SECRET}")
   assert SECRET not in out
-  assert out == "http://sonarr:8989/signalr/messages?access_token=(removed)"
+  assert out == f"http://sonarr:8989/signalr/messages?access_token={MASKED}"
 
 
-def test_redacts_jellyfin_authorization_token():
+def test_masks_jellyfin_authorization_token():
   out = _redact(f'Device="Bazarr", Token="{SECRET}"')
   assert SECRET not in out
-  assert out == 'Device="Bazarr", Token="(removed)"'
+  assert out == f'Device="Bazarr", Token="{MASKED}"'
 
 
-def test_redacts_header_mapping_forms():
+def test_masks_header_mapping_forms():
   for header in ("X-API-KEY", "X-Plex-Token"):
     out = _redact(f"{{'{header}': '{SECRET}', 'Accept': 'application/json'}}")
     assert SECRET not in out, header
-    assert out == f"{{'{header}': '(removed)', 'Accept': 'application/json'}}"
+    assert out == f"{{'{header}': '{MASKED}', 'Accept': 'application/json'}}"
 
 
-def test_redacts_query_string_spellings():
+def test_masks_query_string_spellings():
   for param in ("apikey", "api_key", "apiKey", "apikey%3D"):
     sep = "" if param.endswith("%3D") else "="
     out = _redact(f"http://radarr/api/v3/movie?{param}{sep}{SECRET}&pageSize=1")
     assert SECRET not in out, param
+    assert out == f"http://radarr/api/v3/movie?{param}{sep}{MASKED}&pageSize=1", param
 
 
-def test_redacts_keys_containing_punctuation():
-  assert _redact("apikey=subdl_Cq7-5IU_x.9") == "apikey=(removed)"
+def test_masks_exactly_the_last_eight_characters():
+  # The point of masking rather than removing: enough of the key survives to
+  # tell which one was in play, without publishing the whole thing.
+  out = _redact(f"apikey={SECRET}")
+  masked = out.split("=", 1)[1]
+  assert len(masked) == len(SECRET)
+  assert masked.endswith("xxxxxxxx")
+  assert masked[:-8] == SECRET[:-8]
+  assert SECRET[-8:] not in out
 
 
-def test_redaction_is_idempotent():
+def test_masks_keys_containing_punctuation():
+  assert _redact("apikey=subdl_Cq7-5IU_x.9") == "apikey=subdl_Cq7xxxxxxxx"
+
+
+def test_short_key_is_masked_entirely():
+  # Nothing of a key shorter than the mask should survive.
+  assert _redact("apikey=abc") == "apikey=xxxxxxxx"
+
+
+def test_empty_value_is_left_alone():
+  # There is no key here to mask, so do not invent one.
+  assert _redact("apikey=") == "apikey="
+
+
+def test_masking_is_idempotent():
   once = _redact(f"?access_token={SECRET}")
   assert _redact(once) == once
 

--- a/tests/bazarr/test_logging_filters.py
+++ b/tests/bazarr/test_logging_filters.py
@@ -66,9 +66,17 @@ def test_masks_keys_containing_punctuation():
   assert _redact("apikey=subdl_Cq7-5IU_x.9") == "apikey=subdl_Cq7xxxxxxxx"
 
 
-def test_short_key_is_masked_entirely():
-  # Nothing of a key shorter than the mask should survive.
-  assert _redact("apikey=abc") == "apikey=xxxxxxxx"
+def test_key_no_longer_than_the_mask_is_masked_entirely():
+  # A key at or under the mask length has nothing to spare, so none of it may
+  # survive - and every one masks to the same width, so its length is hidden too.
+  for length in range(1, 9):
+    key = "s3cr3tk3y"[:length]
+    assert _redact(f"apikey={key}") == "apikey=xxxxxxxx", key
+
+
+def test_key_one_longer_than_the_mask_keeps_one_character():
+  # The boundary the other way: the first length at which anything survives.
+  assert _redact("apikey=s3cr3tk3y") == "apikey=sxxxxxxxx"
 
 
 def test_empty_value_is_left_alone():


### PR DESCRIPTION
API keys of the form apiKey / API_KEY were being hidden in the logs, but there's plenty of other API keys that were not, and were appearing in plain text. 

This patch just updates the logging filter code to obfuscate the final 8 characters of any matching API key.
Note: This does mean that if you have an especially short API key (8 or less characters) then it will become an 8 character, completely obfuscated key, and you won't be able to tell the original length. 

I'd hope we have no <8 character keys in existence!

Regexp was written by Claude.

Newly blocked keys:

Sonarr / Radarr SignalR key (?access_token=)
X-API-KEY header (Bazarr itself)
X-Plex-Token header and query form
Jellyfin API key (Token="…")
Lingarr translator token (X-Api-Key header)
assrt / betaseries (?token=)