### PR TITLE
Stop logging entire subtitle files when there's a UnicodeDecodeError on download

### DIFF
--- a/bazarr/subtitles/download.py
+++ b/bazarr/subtitles/download.py
@@ -92,7 +92,7 @@ def generate_subtitles(path, languages, audio_language, sceneName, title, media_
                                                                        use_original_format=original_format in (1, "1", "True", True),
                                                                        fallback_allowed=fallback_allowed)
                     except Exception as e:
-                        logging.exception(f'BAZARR Error downloading Subtitles for this file {path}: {repr(e)}')
+                        logging.exception(f'BAZARR Error downloading Subtitles for this file {path}: {str(e)}')
                         return None
 
                 if downloaded_subtitles:
@@ -126,7 +126,7 @@ def generate_subtitles(path, languages, audio_language, sceneName, title, media_
                                                              )
                         except Exception as e:
                             logging.exception(
-                                f'BAZARR Error saving Subtitles file to disk for this file {path}: {repr(e)}')
+                                f'BAZARR Error saving Subtitles file to disk for this file {path}: {str(e)}')
                             pass
                         else:
                             saved_any = True

--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -154,7 +154,7 @@ def store_subtitles_movie(radarr_id, use_cache=True):
             subtitles = guess_external_subtitles(full_dest_folder_path, subtitles,
                                                  previously_indexed_subtitles_to_exclude)
         except Exception as e:
-            logging.exception(f"BAZARR unable to index external subtitles for this file {mapped_path}: {repr(e)}")
+            logging.exception(f"BAZARR unable to index external subtitles for this file {mapped_path}: {str(e)}")
         else:
             # For each external subtitle, store it in the database
             for subtitle, language in subtitles.items():

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -156,7 +156,7 @@ def store_subtitles(sonarr_episode_id, use_cache=True):
             subtitles = guess_external_subtitles(full_dest_folder_path, subtitles,
                                                  previously_indexed_subtitles_to_exclude)
         except Exception as e:
-            logging.exception(f"BAZARR unable to index external subtitles for this file {mapped_path}: {repr(e)}")
+            logging.exception(f"BAZARR unable to index external subtitles for this file {mapped_path}: {str(e)}")
         else:
             # For each external subtitle, store it in the database
             for subtitle, language in subtitles.items():

--- a/bazarr/subtitles/manual.py
+++ b/bazarr/subtitles/manual.py
@@ -73,7 +73,7 @@ def manual_search(path, profile_id, providers, sceneName, title, media_type):
                 logging.info("BAZARR All providers are throttled")
                 return 'All providers are throttled'
         except Exception as e:
-            logging.exception(f"BAZARR Error trying to get Subtitle list from provider for this file {path}: {repr(e)}")
+            logging.exception(f"BAZARR Error trying to get Subtitle list from provider for this file {path}: {str(e)}")
         else:
             subtitles_list = []
             minimum_score = settings.general.minimum_score
@@ -226,7 +226,7 @@ def manual_download_subtitle(path, audio_language, hi, forced, subtitle, provide
                                                  formats=(subtitle.format,),
                                                  path_decoder=force_unicode)
             except Exception as e:
-                logging.exception(f'BAZARR Error saving Subtitles file to disk for this file {path}: {repr(e)}')
+                logging.exception(f'BAZARR Error saving Subtitles file to disk for this file {path}: {str(e)}')
                 return 'Error saving Subtitles file to disk'
             else:
                 if saved_subtitles:

--- a/bazarr/subtitles/post_processing.py
+++ b/bazarr/subtitles/post_processing.py
@@ -29,7 +29,7 @@ def postprocessing(command, path):
         out = out.replace('\n', ' ').replace('\r', ' ')
 
     except Exception as e:
-        logging.error(f'BAZARR Post-processing failed for file {path}: {str(e)}')
+        logging.error(f'BAZARR Post-processing failed for file {path}: {str(e)}', exc_info=True)
     else:
         if err:
             parsed_err = err.replace('\n', ' ').replace('\r', ' ')

--- a/bazarr/subtitles/post_processing.py
+++ b/bazarr/subtitles/post_processing.py
@@ -29,7 +29,7 @@ def postprocessing(command, path):
         out = out.replace('\n', ' ').replace('\r', ' ')
 
     except Exception as e:
-        logging.error(f'BAZARR Post-processing failed for file {path}: {repr(e)}')
+        logging.error(f'BAZARR Post-processing failed for file {path}: {str(e)}')
     else:
         if err:
             parsed_err = err.replace('\n', ' ').replace('\r', ' ')

--- a/bazarr/subtitles/upload.py
+++ b/bazarr/subtitles/upload.py
@@ -134,7 +134,7 @@ def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, fil
                                          formats=sub_format if use_original_format else ("srt",),
                                          path_decoder=force_unicode)
     except Exception as e:
-        logging.exception(f'BAZARR Error saving Subtitles file to disk for this file {path}: {repr(e)}')
+        logging.exception(f'BAZARR Error saving Subtitles file to disk for this file {path}: {str(e)}')
         return
 
     if len(saved_subtitles) < 1:

--- a/tests/bazarr/test_post_processing.py
+++ b/tests/bazarr/test_post_processing.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 
+import logging
 import os
 from unittest import mock
 
@@ -291,3 +292,65 @@ def test_release_info_windows_metacharacters_stay_single_token(payload):
     args, kwargs = mock_popen.call_args
     assert kwargs['shell'] is False
     assert args[0] == ['cmd', f'"{payload}"']
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Exception logging – the whole subtitle file shouldn't be logged
+# ──────────────────────────────────────────────────────────────────────────────
+#
+# repr() of a UnicodeDecodeError includes its `object` attribute, which for a
+# failed subtitle decode is the entire file. 
+# str(e) keeps the diagnosis (codec, byte, position) and
+# drops the payload; exc_info=True puts the exception type back, since this call
+# site uses logging.error and so has no traceback of its own.
+
+_PAYLOAD_MARKER = 'SUBTITLE-FILE-CONTENTS'
+_FAKE_SUBTITLE = (_PAYLOAD_MARKER + ' ').encode() * 2000
+
+
+def _run_postprocessing_raising(exc, caplog):
+    with mock.patch('os.name', 'posix'), \
+         mock.patch('subprocess.Popen', side_effect=exc), \
+         caplog.at_level(logging.ERROR):
+        postprocessing('python3 /usr/local/bin/process.py', '/srv/media/show.mkv')
+    assert caplog.records, 'expected postprocessing to log the failure'
+    return caplog.records[-1]
+
+
+def test_postprocessing_failure_does_not_log_subtitle_contents(caplog):
+    decode_error = UnicodeDecodeError(
+        'utf-8', _FAKE_SUBTITLE, 15348, 15349, 'invalid start byte')
+    record = _run_postprocessing_raising(decode_error, caplog)
+
+    message = record.getMessage()
+    assert _PAYLOAD_MARKER not in message
+    assert len(message) < 500
+
+
+def test_postprocessing_failure_still_logs_the_diagnosis(caplog):
+    decode_error = UnicodeDecodeError(
+        'utf-8', _FAKE_SUBTITLE, 15348, 15349, 'invalid start byte')
+    record = _run_postprocessing_raising(decode_error, caplog)
+
+    message = record.getMessage()
+    # Everything needed to identify the offending file and byte survives.
+    assert '/srv/media/show.mkv' in message
+    assert 'invalid start byte' in message
+    assert 'position 15348' in message
+
+
+def test_postprocessing_failure_records_the_exception_type(caplog):
+    record = _run_postprocessing_raising(ValueError(), caplog)
+
+    assert record.exc_info is not None
+    assert record.exc_info[0] is ValueError
+
+
+def test_postprocessing_failure_does_not_log_contents_via_traceback(caplog):
+    decode_error = UnicodeDecodeError(
+        'utf-8', _FAKE_SUBTITLE, 15348, 15349, 'invalid start byte')
+    record = _run_postprocessing_raising(decode_error, caplog)
+
+    formatted = logging.Formatter('%(message)s').format(record)
+    assert _PAYLOAD_MARKER not in formatted
+    assert 'UnicodeDecodeError' in formatted


### PR DESCRIPTION
When downloading a subtitle file, the line
logging.exception(f'BAZARR Error saving Subtitles file to disk for this file {path}: {repr(e)}')
if thrown by a UnicodeDecodeError has the entire subtitle file attached to the exception, causing the whole thing to be logged. 

This PR updates the logging of repr(e) to str(e) in all places where it seems to be safe to do so (i.e. without losing useful info). The only lost data I have seen is a missing the exception type name. The one place where we need it, I've explicitly added exc_info=True to capture that data still. Other code in the repo uses this approach so I'm confident it's safe.

If commenters/reviewers prefer, I can limit this change to just download.py, as it's hopefully unlikely that you'd be able to download the subtitles file without a parse error and then subsequently get one. I could also just catch UnicodeDecodeError explicitly and make the same change if that's preferred, but it adds a little more complexity for very little value IMO.

So let me know if you want the scope of this change reduced. Or if I've accidentally removed something useful from the logging! In testing I can't see any issues.

Tests written by Claude, code changes implemented by me.