### PR TITLE
Episode was misspelt in the ID check for blacklists. 

### DIFF
--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -382,8 +382,13 @@ def _handle_mgb(name, exception, ids, language):
         if exception.media_type == "series":
             if ids.get('sonarrSeriesId') and ids.get('sonarrEpisodeId'):
                 blacklist_log(ids['sonarrSeriesId'], ids['sonarrEpisodeId'], name, exception.id, language_str)
-        else:
+            else:
+                logging.debug(f'BAZARR cannot blacklist subtitle {exception.id} from {name}: unknown series or '
+                              f'episode id')
+        elif ids.get('radarrId'):
             blacklist_log_movie(ids['radarrId'], name, exception.id, language_str)
+        else:
+            logging.debug(f'BAZARR cannot blacklist subtitle {exception.id} from {name}: unknown movie id')
 
 
 def provider_throttle(name, exception, ids=None, language=None):

--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -380,7 +380,7 @@ def _handle_mgb(name, exception, ids, language):
 
     if ids:
         if exception.media_type == "series":
-            if 'sonarrSeriesId' in ids and 'sonarrEpsiodeId' in ids:
+            if ids.get('sonarrSeriesId') and ids.get('sonarrEpisodeId'):
                 blacklist_log(ids['sonarrSeriesId'], ids['sonarrEpisodeId'], name, exception.id, language_str)
         else:
             blacklist_log_movie(ids['radarrId'], name, exception.id, language_str)

--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -388,7 +388,7 @@ def _handle_mgb(name, exception, ids, language):
         elif ids.get('radarrId'):
             blacklist_log_movie(ids['radarrId'], name, exception.id, language_str)
         else:
-            logging.debug(f'BAZARR cannot blacklist subtitle {exception.id} from {name}: unknown movie id')
+            logging.debug(f'BAZARR cannot blacklist subtitle {exception.id} from {name}: unknown id')
 
 
 def provider_throttle(name, exception, ids=None, language=None):

--- a/tests/bazarr/test_get_providers_blacklist.py
+++ b/tests/bazarr/test_get_providers_blacklist.py
@@ -143,7 +143,7 @@ def test_skipped_movie_blacklisting_is_logged(caplog):
     text = _call_capturing_log('movie', _ids(radarr_id=None), caplog)
     assert _SUBS_ID in text
     assert _PROVIDER in text
-    assert 'unknown movie id' in text
+    assert 'unknown id' in text
 
 
 def test_successful_blacklisting_logs_no_skip(caplog):

--- a/tests/bazarr/test_get_providers_blacklist.py
+++ b/tests/bazarr/test_get_providers_blacklist.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 
+import logging
 from unittest import mock
 
 import pytest
@@ -35,6 +36,15 @@ def _call(media_type, ids, language=None):
          mock.patch('app.get_providers.blacklist_log_movie') as log_movie:
         _handle_mgb(_PROVIDER, exception, ids, language)
     return log, log_movie
+
+
+def _call_capturing_log(media_type, ids, caplog):
+    exception = MustGetBlacklisted(_SUBS_ID, media_type)
+    with mock.patch('app.get_providers.blacklist_log'), \
+         mock.patch('app.get_providers.blacklist_log_movie'), \
+         caplog.at_level(logging.DEBUG, logger='root'):
+        _handle_mgb(_PROVIDER, exception, ids, Language('eng'))
+    return caplog.text
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -81,6 +91,13 @@ def test_series_without_known_ids_is_not_blacklisted(series_id, episode_id):
     assert not log.called
 
 
+def test_movie_without_known_id_is_not_blacklisted():
+    # radarr_id is a ForeignKey too, and the movie branch used to index
+    # ids['radarrId'] with no guard at all.
+    _, log_movie = _call('movie', _ids(radarr_id=None))
+    assert not log_movie.called
+
+
 def test_no_ids_at_all_is_not_blacklisted():
     log, log_movie = _call('series', None)
     assert not log.called
@@ -106,3 +123,29 @@ def test_hi_language_is_suffixed():
     hi = Language.rebuild(Language('eng'), hi=True)
     log, _ = _call('series', _ids(), hi)
     assert log.call_args[0][4] == 'en:hi'
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# A skipped blacklisting must not be silent
+# ──────────────────────────────────────────────────────────────────────────────
+#
+# Not blacklisting is itself a decision - it means the subtitle stays eligible
+# and will be offered again. Say so, rather than returning quietly.
+
+def test_skipped_series_blacklisting_is_logged(caplog):
+    text = _call_capturing_log('series', _ids(episode_id=None), caplog)
+    assert _SUBS_ID in text
+    assert _PROVIDER in text
+    assert 'unknown series or episode id' in text
+
+
+def test_skipped_movie_blacklisting_is_logged(caplog):
+    text = _call_capturing_log('movie', _ids(radarr_id=None), caplog)
+    assert _SUBS_ID in text
+    assert _PROVIDER in text
+    assert 'unknown movie id' in text
+
+
+def test_successful_blacklisting_logs_no_skip(caplog):
+    assert 'cannot blacklist' not in _call_capturing_log('series', _ids(), caplog)
+    assert 'cannot blacklist' not in _call_capturing_log('movie', _ids(), caplog)

--- a/tests/bazarr/test_get_providers_blacklist.py
+++ b/tests/bazarr/test_get_providers_blacklist.py
@@ -1,0 +1,108 @@
+# coding=utf-8
+
+from unittest import mock
+
+import pytest
+
+from subzero.language import Language
+from subliminal_patch.exceptions import MustGetBlacklisted
+
+from app.get_providers import _handle_mgb
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+_PROVIDER = 'someprovider'
+_SUBS_ID = 'subtitle-1234'
+
+
+def _ids(series_id=42, episode_id=99, radarr_id=7):
+    # Built the way core.py does it: every key always present, None when the
+    # video object had no such attribute.
+    return {
+        'radarrId': radarr_id,
+        'sonarrSeriesId': series_id,
+        'sonarrEpisodeId': episode_id,
+    }
+
+
+def _call(media_type, ids, language=None):
+    exception = MustGetBlacklisted(_SUBS_ID, media_type)
+    language = language or Language('eng')
+    with mock.patch('app.get_providers.blacklist_log') as log, \
+         mock.patch('app.get_providers.blacklist_log_movie') as log_movie:
+        _handle_mgb(_PROVIDER, exception, ids, language)
+    return log, log_movie
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Series blacklisting – the guard used to test a misspelled key
+# ──────────────────────────────────────────────────────────────────────────────
+#
+# _handle_mgb is how a provider says "this subtitle is broken, never offer it
+# again" (MustGetBlacklisted). The series guard checked 'sonarrEpsiodeId', which
+# is never a key in the ids dict, so blacklist_log was never called and the bad
+# subtitle was re-selected on every subsequent search. Movies were unaffected.
+
+def test_series_is_blacklisted():
+    log, _ = _call('series', _ids())
+    log.assert_called_once_with(42, 99, _PROVIDER, _SUBS_ID, 'en')
+
+
+def test_movie_is_blacklisted():
+    _, log_movie = _call('movie', _ids())
+    log_movie.assert_called_once_with(7, _PROVIDER, _SUBS_ID, 'en')
+
+
+def test_series_does_not_touch_the_movie_blacklist():
+    log, log_movie = _call('series', _ids())
+    assert log.called
+    assert not log_movie.called
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# The ids must be known before a row is written
+# ──────────────────────────────────────────────────────────────────────────────
+#
+# sonarr_series_id and sonarr_episode_id are ForeignKey columns on
+# TableBlacklist, and the ids dict carries None rather than omitting a key. So
+# the guard has to test the values: a key-presence check would always pass and
+# write NULL foreign keys.
+
+@pytest.mark.parametrize('series_id,episode_id', [
+    (42, None),
+    (None, 99),
+    (None, None),
+])
+def test_series_without_known_ids_is_not_blacklisted(series_id, episode_id):
+    log, _ = _call('series', _ids(series_id=series_id, episode_id=episode_id))
+    assert not log.called
+
+
+def test_no_ids_at_all_is_not_blacklisted():
+    log, log_movie = _call('series', None)
+    assert not log.called
+    assert not log_movie.called
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# The language string recorded against the blacklist entry
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_plain_language_is_recorded_bare():
+    log, _ = _call('series', _ids(), Language('eng'))
+    assert log.call_args[0][4] == 'en'
+
+
+def test_forced_language_is_suffixed():
+    forced = Language.rebuild(Language('eng'), forced=True)
+    log, _ = _call('series', _ids(), forced)
+    assert log.call_args[0][4] == 'en:forced'
+
+
+def test_hi_language_is_suffixed():
+    hi = Language.rebuild(Language('eng'), hi=True)
+    log, _ = _call('series', _ids(), hi)
+    assert log.call_args[0][4] == 'en:hi'


### PR DESCRIPTION
"EpisodeId" was misspelled in the blacklisting code so it was never matched. I don't think series blacklisting worked at all prior to this point.

Fixing that made me notice that there's a weird (and probably never encountered) edge case where we would be inserting null rows if sonarrSeriesId, sonarrEpisodeId or radarrId was empty. 

I don't if anything could cause a failure like that, but a simple check is enough to resolve it.

I added debug logging for each of the null cases described, so it'll at least not fail silently if it somehow happens.

Spelling mistake is fixed, value checking is implemented.

Tests written by Claude, code changes by me.