### PR TITLE
Fixed bidirectional language equals matching

### DIFF
--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -199,6 +199,9 @@ class _LanguageEquals(list):
             if from_ in items:
                 logger.debug("Adding %r to %s item(s) set", to_, len(items))
                 to_add.append(to_)
+            if to_ in items:
+                logger.debug("Adding %r to %s item(s) set", from_, len(items))
+                to_add.append(from_)
 
         new_items = items.copy()
         new_items.update(to_add)

--- a/tests/subliminal_patch/test_core.py
+++ b/tests/subliminal_patch/test_core.py
@@ -99,10 +99,10 @@ def test_language_equals_check_set(langs):
     assert equals.check_set(lang_set) == set(langs)
 
 
-def test_language_equals_check_set_do_nothing():
+def test_language_equals_check_set_reversed():
     equals = core._LanguageEquals([(core.Language("eng"), core.Language("spa"))])
     lang_set = {core.Language("spa")}
-    assert equals.check_set(lang_set) == {core.Language("spa")}
+    assert equals.check_set(lang_set) == {core.Language("eng"), core.Language("spa")}
 
 
 def test_language_equals_check_set_do_nothing_w_forced():


### PR DESCRIPTION
## Summary

Fixes #3544.

`_LanguageEquals.check_set()` currently expands configured language equality only from the first language to the second.

For example, with:

    nor:nob

an existing `nor` subtitle also satisfies `nob`, but an existing `nob` subtitle does not satisfy `nor`.

This change makes the equality comparison bidirectional by also adding the first language when the second language is present.

This is a follow-up to the language equivalence indexing work from #2820.

## Changes

- Make `_LanguageEquals.check_set()` expand equality pairs in both directions.
- Update the existing reverse-direction unit test to verify the expected behavior.

## Testing

Focused unit tests on Python 3.12.3:

    tests/subliminal_patch/test_core.py -k language_equals_check_set

Result:

    5 passed, 13 deselected

Live validation was also performed using a real Bazarr instance and library data on Ubuntu 24.04.

Reproduction configuration:

    Language Equals:
    Norwegian -> Norwegian Bokmål
    nor:nob

Test media contained an embedded Norwegian Bokmål subtitle but no generic Norwegian subtitle.

Before the fix, Bazarr reported Norwegian as missing.

After applying the change and running Scan Disk, the Norwegian missing-subtitle entry disappeared while the Norwegian Bokmål subtitle remained correctly indexed.

## AI assistance disclosure

ChatGPT was used as an assistant during investigation, implementation, and test planning. I reviewed and understand the resulting change and its purpose. The issue and fix were validated manually on a live Bazarr instance with real library data, as well as with the existing focused unit tests.
