### PR TITLE
Blacklist files that fail to decode due to parsing errors

### DIFF
--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -370,7 +370,9 @@ def get_providers_auth():
     }
 
 
-def _handle_mgb(name, exception, ids, language):
+# download.py doesn't have an exception with the id and media type on it, so can't take an exception 
+# as _handle_mgb() does. 
+def blacklist_subtitle(name, subs_id, media_type, ids, language):
     if language.forced:
         language_str = f'{language.basename}:forced'
     elif language.hi:
@@ -379,16 +381,20 @@ def _handle_mgb(name, exception, ids, language):
         language_str = language.basename
 
     if ids:
-        if exception.media_type == "series":
+        if media_type == "series":
             if ids.get('sonarrSeriesId') and ids.get('sonarrEpisodeId'):
-                blacklist_log(ids['sonarrSeriesId'], ids['sonarrEpisodeId'], name, exception.id, language_str)
+                blacklist_log(ids['sonarrSeriesId'], ids['sonarrEpisodeId'], name, subs_id, language_str)
             else:
-                logging.debug(f'BAZARR cannot blacklist subtitle {exception.id} from {name}: unknown series or '
+                logging.debug(f'BAZARR cannot blacklist subtitle {subs_id} from {name}: unknown series or '
                               f'episode id')
         elif ids.get('radarrId'):
-            blacklist_log_movie(ids['radarrId'], name, exception.id, language_str)
+            blacklist_log_movie(ids['radarrId'], name, subs_id, language_str)
         else:
-            logging.debug(f'BAZARR cannot blacklist subtitle {exception.id} from {name}: unknown id')
+            logging.debug(f'BAZARR cannot blacklist subtitle {subs_id} from {name}: unknown id')
+
+
+def _handle_mgb(name, exception, ids, language):
+    blacklist_subtitle(name, exception.id, exception.media_type, ids, language)
 
 
 def provider_throttle(name, exception, ids=None, language=None):

--- a/bazarr/subtitles/download.py
+++ b/bazarr/subtitles/download.py
@@ -18,6 +18,8 @@ from utilities.path_mappings import path_mappings
 from utilities.helper import get_target_folder, force_unicode
 from languages.get_languages import alpha3_from_alpha2, alpha2_from_alpha3
 
+from app.get_providers import blacklist_subtitle
+
 from .pool import update_pools, _get_pool
 from .utils import get_video, _get_lang_obj, _get_scores, _set_forced_providers
 from .processing import process_subtitle
@@ -124,10 +126,16 @@ def generate_subtitles(path, languages, audio_language, sceneName, title, media_
                                                              formats=subtitle_formats,
                                                              path_decoder=force_unicode
                                                              )
+                        # for decode/reencode errors ONLY, add the subtitles file to the blacklist so they're not re-tried endlessly.
+                        # Purposely only catches UnicodeError as an IO error etc should not blacklist a file. UnicodeError handles
+                        # UnicodeEncodeError, UnicodeDecodeError and UnicodeTranslateError cases.
+                        except UnicodeError as e:
+                            logging.exception(
+                                f'BAZARR Cannot decode Subtitles file for this file {path}: {str(e)}')
+                            _blacklist_unusable_subtitles(video, subtitles, media_type, language)
                         except Exception as e:
                             logging.exception(
                                 f'BAZARR Error saving Subtitles file to disk for this file {path}: {str(e)}')
-                            pass
                         else:
                             saved_any = True
                             for subtitle in saved_subtitles:
@@ -154,6 +162,20 @@ def generate_subtitles(path, languages, audio_language, sceneName, title, media_
     subliminal.region.backend.sync()
 
     logging.debug(f'BAZARR Ended searching Subtitles for file: {path}')
+
+
+def _blacklist_unusable_subtitles(video, subtitles, media_type, language):
+    # A subtitle we cannot decode will be downloaded and fail to save again, 
+    # so record it as bad rather than retrying it forever.
+    ids = {
+        'radarrId': getattr(video, 'radarrId', None),
+        'sonarrSeriesId': getattr(video, 'sonarrSeriesId', None),
+        'sonarrEpisodeId': getattr(video, 'sonarrEpisodeId', None),
+    }
+
+    for subtitle in subtitles:
+        logging.info(f'BAZARR blacklisting undecodable subtitle {subtitle.id} from {subtitle.provider_name}')
+        blacklist_subtitle(subtitle.provider_name, subtitle.id, media_type, ids, language)
 
 
 def _get_language_obj(languages):

--- a/tests/bazarr/test_download_blacklist_on_failure.py
+++ b/tests/bazarr/test_download_blacklist_on_failure.py
@@ -1,0 +1,145 @@
+# coding=utf-8
+
+import logging
+from unittest import mock
+
+import pytest
+
+from subzero.language import Language
+
+from subtitles.download import _blacklist_unusable_subtitles
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helper functions/classes
+# ──────────────────────────────────────────────────────────────────────────────
+_PROVIDER = 'someprovider'
+_SUBS_ID = 'subtitle-1234'
+
+
+class _Video:
+    def __init__(self, **ids):
+        for name, value in ids.items():
+            setattr(self, name, value)
+
+
+class _Subtitle:
+    def __init__(self, provider_name=_PROVIDER, subs_id=_SUBS_ID):
+        self.provider_name = provider_name
+        self.id = subs_id
+        self.format = 'srt'
+        self.mods = None
+
+
+def _episode_video():
+    return _Video(sonarrSeriesId=42, sonarrEpisodeId=99)
+
+def _movie_video():
+    return _Video(radarrId=7)
+
+def _no_id_video():
+    return _Video()
+
+def _blacklist(video, media_type, subtitles=None, language=None):
+    subtitles = [_Subtitle()] if subtitles is None else subtitles
+    language = language or Language('eng')
+    with mock.patch('app.get_providers.blacklist_log') as log, \
+         mock.patch('app.get_providers.blacklist_log_movie') as log_movie:
+        _blacklist_unusable_subtitles(video, subtitles, media_type, language)
+    return log, log_movie
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# An undecodable subtitle is recorded so it is not downloaded again
+# ──────────────────────────────────────────────────────────────────────────────
+def test_episode_subtitle_is_blacklisted():
+    log, _ = _blacklist(_episode_video(), 'series')
+    log.assert_called_once_with(42, 99, _PROVIDER, _SUBS_ID, 'en')
+
+
+def test_movie_subtitle_is_blacklisted():
+    _, log_movie = _blacklist(_movie_video(), 'movie')
+    log_movie.assert_called_once_with(7, _PROVIDER, _SUBS_ID, 'en')
+
+
+def test_forced_language_is_recorded():
+    forced = Language.rebuild(Language('eng'), forced=True)
+    log, _ = _blacklist(_episode_video(), 'series', language=forced)
+    assert log.call_args[0][4] == 'en:forced'
+
+
+def test_every_subtitle_in_the_batch_is_blacklisted():
+    subtitles = [_Subtitle(subs_id='a'), _Subtitle(subs_id='b')]
+    log, _ = _blacklist(_episode_video(), 'series', subtitles=subtitles)
+    assert [call[0][3] for call in log.call_args_list] == ['a', 'b']
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# A video with no known ids writes nothing - don't blacklist nulls!
+# ──────────────────────────────────────────────────────────────────────────────
+def test_no_id_video_is_not_blacklisted():
+    log, log_movie = _blacklist(_no_id_video(), 'series')
+    assert not log.called
+    assert not log_movie.called
+
+
+def test_no_id_video_is_logged(caplog):
+    with caplog.at_level(logging.DEBUG):
+        _blacklist(_Video(), 'movie')
+    assert 'cannot blacklist' in caplog.text
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Only UnicodeError should blacklist files
+# ──────────────────────────────────────────────────────────────────────────────
+def _run_generate_subtitles(save_error):
+    video = _episode_video()
+    video.original_path = '/media/tv/Show/S01E01.mkv'
+    subtitle = _Subtitle()
+
+    settings = mock.MagicMock()
+    settings.general.utf8_encode = False
+    settings.general.chmod_enabled = False
+    settings.general.single_language = False
+
+    with mock.patch('subtitles.download.settings', settings), \
+         mock.patch('subtitles.download.get_array_from', return_value=[]), \
+         mock.patch('subtitles.download.get_profiles_list',
+                    return_value={'originalFormat': False, 'items': []}), \
+         mock.patch('subtitles.download._get_pool') as pool, \
+         mock.patch('subtitles.download._get_language_obj', return_value=[Language('eng')]), \
+         mock.patch('subtitles.download._set_forced_providers'), \
+         mock.patch('subtitles.download._get_scores', return_value=(0, 100, {})), \
+         mock.patch('subtitles.download.get_video', return_value=video), \
+         mock.patch('subtitles.download.get_target_folder', return_value='/media/tv/Show'), \
+         mock.patch('subtitles.download.download_best_subtitles',
+                    return_value={video: [subtitle]}), \
+         mock.patch('subtitles.download.save_subtitles', side_effect=save_error), \
+         mock.patch('app.get_providers.blacklist_log') as log, \
+         mock.patch('app.get_providers.blacklist_log_movie') as log_movie:
+        pool.return_value.providers = ['someprovider']
+        from subtitles.download import generate_subtitles
+        list(generate_subtitles('/media/tv/Show/S01E01.mkv', ['en'], 'English', None,
+                                'Show', 'series', 1))
+    return log, log_movie
+
+
+@pytest.mark.parametrize('error', [
+    UnicodeDecodeError('utf-8', b'x', 0, 1, 'invalid start byte'),
+    UnicodeEncodeError('ascii', 'x', 0, 1, 'ordinal not in range'),
+])
+def test_undecodable_subtitle_is_blacklisted(error):
+    # Both directions matter: get_modified_content decodes and re-encodes.
+    log, _ = _run_generate_subtitles(error)
+    log.assert_called_once_with(42, 99, _PROVIDER, _SUBS_ID, 'en')
+
+
+@pytest.mark.parametrize('error', [
+    OSError(28, 'No space left on device'),
+    PermissionError(13, 'Permission denied'),
+    FileNotFoundError(2, 'No such file or directory'),
+])
+def test_environmental_failure_is_not_blacklisted(error):
+    log, log_movie = _run_generate_subtitles(error)
+    assert not log.called
+    assert not log_movie.called


### PR DESCRIPTION
Bit of an optional one here, if this feature is unwanted close this out, but I think it could be helpful.

If we get a UnicodeError when calling save_subtitles it's exclusively because the actual file is broken. (I am pretty sure this is true anyhow). UnicodeError is the parent class for UnicodeDecodeError, UnicodeEncodeError, and UnicodeTranslateError. I don't believe any of those errors are actually recoverable from, but with the current handling a file that throws a UnicodeDecodeError will be downloaded again the next time round and throw the same exception each time.

This change is to blacklist files that cannot be decoded.

Functionally it:

1. Updates and renames the blacklisting function so it doesn't necessarily need to take an exception with an id and media type (because I didn't want to just fake an exception with the correct fields on it just to reuse the existing function)

2. Updates the original blacklisting function to just call the new one with the correct (existing) parameters (so no functional changes to the existing blacklisting flow)

3. Upon getting a UnicodeError in generate_subtitles()  (via subliminal's save_subtitles(), which calls get_modified_content() which actually throws this Error), it will add that subtitle file to the blacklist DB.

Note that this relies on only processing a single subtitle file at a time, which is currently true as download_best_subtitles is called with only one language at a time. If that were to change we'd be unable to tell which subtitle failed, and would need to modify the subliminal function to add a little more data to the exception. It's currently safe though.

Tests by Claude, code by me.

Comments/suggestions are welcome.

Edit: Also, I'm happy to make the (very small) subliminal patch which would simply attach the specific subtitle details to the UnicodeError. This would have no functional benefit right now, but if we started passing in multiple languages etc into the subliminal methods that take them, it would allow us to identify which specific subtitle failed. 

This isn't currently an issue as the code never runs those functions with multiple languages at once. But it'd future proof this fix.