### PR TITLE
fix(plex): report missing Plex Pass when listing webhooks

### DIFF
--- a/bazarr/api/plex/oauth.py
+++ b/bazarr/api/plex/oauth.py
@@ -1061,7 +1061,15 @@ class PlexWebhookList(Resource):
             
             from plexapi.myplex import MyPlexAccount
             account = MyPlexAccount(token=decrypted_token)
-            
+
+            # Webhooks are a Plex Pass feature. Without it plex.tv answers the webhooks endpoint
+            # with 403 (error 1043, "This action is not available for this user"), which would
+            # otherwise surface as a generic 502 and read to the user as a lost connection.
+            # webhook/create already reports this properly; do the same here.
+            has_webhooks, error_msg = check_plex_pass_feature(account, 'webhooks')
+            if not has_webhooks:
+                return {'error': error_msg}, 403
+
             webhooks = account.webhooks()
             webhook_list = []
             


### PR DESCRIPTION
### Problem

On an account without Plex Pass, the Plex settings **Automation** section shows:

> Failed to load webhooks: You have disconnected from the server

The connection is fine. Webhooks are a Plex Pass feature, so plex.tv answers `GET /api/v2/user/webhooks` with a 403:

```xml
<errors>
  <error code="1043" message="This action is not available for this user" status="403"/>
</errors>
```

`PlexWebhookList.get` funnels every exception into a generic 502:

```python
except Exception as e:
    logger.error(f"Failed to list Plex webhooks: {e}")
    return {'error': f'Failed to list webhooks: {str(e)}'}, 502
```

and the frontend's fallback message for a response it can't parse an error out of is *"You have disconnected from the server"* (`frontend/src/apis/raw/client.ts`). So a subscription limitation is reported as a lost connection, which sends people debugging their server URL and network instead.

### Fix

Use the check that already exists for exactly this, matching what `PlexWebhookCreate` does a few lines above:

```python
has_webhooks, error_msg = check_plex_pass_feature(account, 'webhooks')
if not has_webhooks:
    return {'error': error_msg}, 403
```

`check_plex_pass_feature` produces the accurate message ("Plex Pass subscription required…" / "…not available for your Plex account"), and a 403 body the frontend can render, so the user is told the real reason.

### Notes

- One file, +9/−1. No behaviour change for accounts that do have Plex Pass — `check_plex_pass_feature` passes and the listing proceeds exactly as before.
- Reproduced against a Plex account without Plex Pass; the 403/1043 above is the actual logged response.