### PR TITLE
Fix translating an embedded track from the manual Translate action

### DIFF
--- a/bazarr/api/subtitles/subtitles.py
+++ b/bazarr/api/subtitles/subtitles.py
@@ -9,7 +9,7 @@ from flask_restx import Resource, Namespace, reqparse, fields, marshal
 from app.database import TableShows, TableEpisodes, TableMovies, database, select, get_subtitles
 from utilities.path_mappings import path_mappings
 from utilities.video_analyzer import subtitles_sync_references
-from subtitles.tools.translate.main import translate_subtitles_file
+from subtitles.tools.translate.main import translate_subtitles_file, extract_and_translate_embedded
 from subtitles.tools.translate.core.translator_utils import resolve_translation_source
 from subtitles.tools.mods import subtitles_apply_mods
 from subtitles.indexer.series import store_subtitles
@@ -197,29 +197,37 @@ class Subtitles(Resource):
             except ValueError as e:
                 return str(e), 400
 
-            # Translating an embedded track requires extracting it to an external file first.
-            # extract_embedded_subtitle returns the path of the newly created external file.
+            # Translating an embedded track requires extracting it to an external file first. Both steps must run
+            # inside the same job: called outside a job context, extract_embedded_subtitle self-enqueues and
+            # returns False, so handling them separately would enqueue the translation with an invalid source
+            # path before the extraction job has even started.
             if embedded_subtitle_id is not None:
                 try:
-                    subtitles_path = extract_embedded_subtitle(
-                        subtitles_id=embedded_subtitle_id, media_type=media_type)
+                    extract_and_translate_embedded(
+                        subtitles_id=embedded_subtitle_id, media_type=media_type, video_path=video_path,
+                        from_lang=from_language, to_lang=dest_language, forced=forced, hi=hi,
+                        sonarr_series_id=metadata.sonarrSeriesId if media_type == "episode" else None,
+                        sonarr_episode_id=id if media_type == "episode" else None,
+                        radarr_id=id if media_type == "movie" else None,
+                        metadata=metadata,
+                        original_format=args.get('original_format') == 'True')
                 except BitmapSubtitlesNotSupportedError:
                     return 'Image based embedded subtitles cannot be extracted', 415
                 except (EmbeddedSubtitlesExtractionError, OSError):
                     return 'Unable to take action on subtitles file. Check logs.', 409
+            else:
+                try:
+                    translate_subtitles_file(video_path=video_path, source_srt_file=subtitles_path,
+                                             from_lang=from_language, to_lang=dest_language, forced=forced, hi=hi,
+                                             media_type=media_type,
+                                             original_format=args.get('original_format') == 'True',
+                                             sonarr_series_id=metadata.sonarrSeriesId if media_type == "episode" else None,
+                                             sonarr_episode_id=id,
+                                             radarr_id=id,
+                                             metadata=metadata)
 
-            try:
-                translate_subtitles_file(video_path=video_path, source_srt_file=subtitles_path,
-                                         from_lang=from_language, to_lang=dest_language, forced=forced, hi=hi,
-                                         media_type=media_type,
-                                         original_format=args.get('original_format') == 'True',
-                                         sonarr_series_id=metadata.sonarrSeriesId if media_type == "episode" else None,
-                                         sonarr_episode_id=id,
-                                         radarr_id=id,
-                                         metadata=metadata)
-
-            except OSError:
-                return 'Unable to edit subtitles file. Check logs.', 409
+                except OSError:
+                    return 'Unable to edit subtitles file. Check logs.', 409
         elif action == 'extract':
             if not subtitles_id:
                 return 'Subtitles ID is required for extraction', 400

--- a/bazarr/subtitles/tools/translate/main.py
+++ b/bazarr/subtitles/tools/translate/main.py
@@ -15,6 +15,31 @@ from app.jobs_queue import jobs_queue
 from utilities.helper import get_target_folder
 
 
+def extract_and_translate_embedded(subtitles_id, media_type, video_path, from_lang, to_lang, forced, hi,
+                                   sonarr_series_id, sonarr_episode_id, radarr_id, metadata,
+                                   original_format=False, job_id=None):
+    # Extract an embedded subtitles track then translate the resulting external file, both inside a single job.
+    # add_job_from_function must remain the first statement: it binds the caller's locals to this signature, so
+    # no other local variable can exist yet.
+    if not job_id:
+        jobs_queue.add_job_from_function(f'Extracting and translating from {from_lang.upper()} to '
+                                         f'{to_lang.upper()}', is_progress=True)
+        return
+
+    from subtitles.embedded import extract_embedded_subtitle
+    subtitles_path = extract_embedded_subtitle(subtitles_id=subtitles_id, media_type=media_type, job_id=job_id)
+    if not subtitles_path:
+        logging.error(f'BAZARR was unable to extract embedded subtitles track id {subtitles_id}, '
+                      f'aborting translation')
+        return
+
+    translate_subtitles_file(video_path=video_path, source_srt_file=subtitles_path, from_lang=from_lang,
+                             to_lang=to_lang, forced=forced, hi=hi, media_type=media_type,
+                             sonarr_series_id=sonarr_series_id, sonarr_episode_id=sonarr_episode_id,
+                             radarr_id=radarr_id, metadata=metadata, original_format=original_format,
+                             job_id=job_id)
+
+
 def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, forced, hi,
                              media_type, sonarr_series_id, sonarr_episode_id, radarr_id, metadata,
                              original_format=False, job_id=None):

--- a/tests/bazarr/test_api_subtitles_translate.py
+++ b/tests/bazarr/test_api_subtitles_translate.py
@@ -65,3 +65,52 @@ def test_resolve_invalid_language_raises():
 def test_resolve_neither_path_nor_id_raises():
     with pytest.raises(ValueError, match="Invalid source language code"):
         _resolve([_external()], None, None)
+
+
+def _run_combined(mocker, job_id=None, extracted_path="/tmp/extracted.en.srt"):
+    from bazarr.subtitles.tools.translate.main import extract_and_translate_embedded
+
+    # extract_embedded_subtitle is imported inside the job body from its top-level module path,
+    # so patch it there rather than under the bazarr.* package path used by these tests.
+    extract = mocker.patch("subtitles.embedded.extract_embedded_subtitle",
+                           return_value=extracted_path)
+    translate = mocker.patch("bazarr.subtitles.tools.translate.main.translate_subtitles_file")
+
+    extract_and_translate_embedded(
+        subtitles_id=4, media_type="movie", video_path="/movies/Foo (2020)/Foo.mkv",
+        from_lang="eng", to_lang="fra", forced=False, hi=True,
+        sonarr_series_id=None, sonarr_episode_id=None, radarr_id=12,
+        metadata={"imdbId": "tt0000001"}, original_format=True, job_id=job_id)
+
+    return extract, translate
+
+
+def test_combined_job_self_enqueues_without_job_id(mocker):
+    enqueue = mocker.patch("bazarr.subtitles.tools.translate.main.jobs_queue.add_job_from_function",
+                           return_value=1)
+
+    extract, translate = _run_combined(mocker, job_id=None)
+
+    # A single job is enqueued and neither step runs synchronously.
+    enqueue.assert_called_once()
+    assert "ENG" in enqueue.call_args[0][0] and "FRA" in enqueue.call_args[0][0]
+    extract.assert_not_called()
+    translate.assert_not_called()
+
+
+def test_combined_job_extracts_then_translates_with_same_job_id(mocker):
+    extract, translate = _run_combined(mocker, job_id=99)
+
+    extract.assert_called_once_with(subtitles_id=4, media_type="movie", job_id=99)
+    translate.assert_called_once_with(
+        video_path="/movies/Foo (2020)/Foo.mkv", source_srt_file="/tmp/extracted.en.srt",
+        from_lang="eng", to_lang="fra", forced=False, hi=True, media_type="movie",
+        sonarr_series_id=None, sonarr_episode_id=None, radarr_id=12,
+        metadata={"imdbId": "tt0000001"}, original_format=True, job_id=99)
+
+
+def test_combined_job_skips_translation_when_extraction_fails(mocker):
+    extract, translate = _run_combined(mocker, job_id=99, extracted_path=None)
+
+    extract.assert_called_once()
+    translate.assert_not_called()


### PR DESCRIPTION
## Describe the bug

Manually translating an embedded subtitles track (Series or Movies page, Translate action on a track with no external file) extracts the track successfully but never translates it: the extraction job completes, and a notification reports a translation error. Extracting the track manually first and then running Translate works, because the second attempt resolves the newly created external file.

## Root cause

In `api/subtitles/subtitles.py`, the translate action for an embedded track does this outside any job context:

1. `extract_embedded_subtitle(subtitles_id, media_type)` is called without a `job_id`. Following the jobs queue self-enqueueing convention, it enqueues an extraction job and immediately returns `False`.
2. That `False` is assigned to `subtitles_path` and passed as `source_srt_file` to `translate_subtitles_file`, which also self-enqueues and returns.
3. When the queue later runs the translation job, `validate_translation_params` fails on the missing source file. The extraction job runs independently and succeeds, which is why the file is there afterwards and a second manual Translate works.

## Fix

Both steps now run inside a single job. New `extract_and_translate_embedded` in `bazarr/subtitles/tools/translate/main.py` follows the same self-enqueueing convention as its neighbours: without a `job_id` it enqueues one job and returns; inside the job it calls `extract_embedded_subtitle` with the job id, then `translate_subtitles_file` with the extracted path and the same job id. The API translate action calls it for embedded tracks, and the external-file path is unchanged.

## How to reproduce

1. Open a movie or episode that has an embedded subtitles track and no external subtitle for the target language.
2. From the subtitles menu, run Translate directly on the embedded track.
3. Before this PR: the track is extracted and a translation error notification appears; no translated file. After this PR: the track is extracted and translated in one job.

## Checklist

- [x] Translate on an embedded track extracts and translates in a single job
- [x] Translate on an external file is unchanged
- [x] Manual Extract then Translate still works
- [x] Unit tests cover the enqueue path, the in-job extract-then-translate order, and the extraction-failure abort