### PR TITLE
Fix LegendasNet search returning no results when name is incorrect despite a valid IMDb ID, and add RAR support

### DIFF
--- a/custom_libs/subliminal_patch/providers/legendasnet.py
+++ b/custom_libs/subliminal_patch/providers/legendasnet.py
@@ -7,6 +7,7 @@ import json
 from typing import Callable
 
 from zipfile import ZipFile, is_zipfile
+from rarfile import RarFile, is_rarfile
 from urllib.parse import urljoin
 from requests import Session, Response
 
@@ -137,32 +138,38 @@ class LegendasNetProvider(ProviderRetryMixin, Provider):
 
         # query the server
         if isinstance(self.video, Episode):
+            search_params = {
+                'page': 1,
+                'per_page': 25,
+                'tv_episode': video.episode,
+                'tv_season': video.season,
+                'imdb_id': video.series_imdb_id
+            }
+            if not video.series_imdb_id:
+                search_params['name'] = video.series
+
             res = self.retry(
                 lambda: self.checked(
                     lambda: self.session.get(self.server_url() + 'search/tv',
-                                             json={
-                                                 'name': video.series,
-                                                 'page': 1,
-                                                 'per_page': 25,
-                                                 'tv_episode': video.episode,
-                                                 'tv_season': video.season,
-                                                 'imdb_id': video.series_imdb_id
-                                             },
+                                             json=search_params,
                                              headers={'Content-Type': 'application/json'},
                                              timeout=30)),
                 amount=retry_amount,
                 retry_timeout=retry_timeout
             )
         else:
+            search_params = {
+                'page': 1,
+                'per_page': 25,
+                'imdb_id': video.imdb_id
+            }
+            if not video.imdb_id:
+                search_params['name'] = video.title
+
             res = self.retry(
                 lambda: self.checked(
                     lambda: self.session.get(self.server_url() + 'search/movie',
-                                             json={
-                                                 'name': video.title,
-                                                 'page': 1,
-                                                 'per_page': 25,
-                                                 'imdb_id': video.imdb_id
-                                             },
+                                             json=search_params,
                                              headers={'Content-Type': 'application/json'},
                                              timeout=30)),
                 amount=retry_amount,
@@ -250,6 +257,12 @@ class LegendasNetProvider(ProviderRetryMixin, Provider):
             archive_stream = io.BytesIO(r.content)
             if is_zipfile(archive_stream):
                 archive = ZipFile(archive_stream)
+                for name in archive.namelist():
+                    subtitle_content = archive.read(name)
+                    subtitle.content = fix_line_ending(subtitle_content)
+                    return
+            elif is_rarfile(archive_stream):
+                archive = RarFile(archive_stream)
                 for name in archive.namelist():
                     subtitle_content = archive.read(name)
                     subtitle.content = fix_line_ending(subtitle_content)


### PR DESCRIPTION
## Summary

Fixes two issues with the Legendas.net provider:

- Avoids sending the series and movie title when an IMDb ID is available.
- Adds support for subtitles distributed as `.rar` archives.

## Problem

Legendas.net may return no results when both `name` and `imdb_id` are sent and the title used by Sonarr/Bazarr differs from the title stored by Legendas.net.

For example:

```text
Ghosts (US)
```

returns no results, while:

```text
Ghosts
```

or searching only by IMDb ID returns the expected subtitles.

The provider was also only handling ZIP archives. Legendas.net can return RAR archives, causing the raw archive content to be treated as subtitle text and resulting in:

```text
FormatAutodetectionError: No suitable formats
```

## Changes

- Use `imdb_id` for TV searches without sending `name` when an IMDb ID is available.
- Fall back to the series/movie name when no IMDb ID is available.
- Detect and extract subtitles from RAR archives.
- Preserve existing ZIP and plain subtitle support.

## Tested

Tested with Legendas.net TV subtitles, including:

- Searches where the Sonarr/Bazarr series title differs from Legendas.net.
- Direct IMDb-based searches.
- `.rar` subtitle downloads.
- Existing `.zip` / direct subtitle handling.