### PR TITLE
Blacklist individual subtitles in a list of subtitles

### DIFF
--- a/bazarr/subtitles/download.py
+++ b/bazarr/subtitles/download.py
@@ -132,7 +132,8 @@ def generate_subtitles(path, languages, audio_language, sceneName, title, media_
                         except UnicodeError as e:
                             logging.exception(
                                 f'BAZARR Cannot decode Subtitles file for this file {path}: {str(e)}')
-                            _blacklist_unusable_subtitles(video, subtitles, media_type, language)
+                            _blacklist_unusable_subtitles(video, subtitles, media_type, language,
+                                                          getattr(e, 'bazarr_failed_subtitle', None))
                         except Exception as e:
                             logging.exception(
                                 f'BAZARR Error saving Subtitles file to disk for this file {path}: {str(e)}')
@@ -164,8 +165,8 @@ def generate_subtitles(path, languages, audio_language, sceneName, title, media_
     logging.debug(f'BAZARR Ended searching Subtitles for file: {path}')
 
 
-def _blacklist_unusable_subtitles(video, subtitles, media_type, language):
-    # A subtitle we cannot decode will be downloaded and fail to save again, 
+def _blacklist_unusable_subtitles(video, subtitles, media_type, language, failed_subtitle=None):
+    # A subtitle we cannot decode will be downloaded and fail to save again,
     # so record it as bad rather than retrying it forever.
     ids = {
         'radarrId': getattr(video, 'radarrId', None),
@@ -173,7 +174,9 @@ def _blacklist_unusable_subtitles(video, subtitles, media_type, language):
         'sonarrEpisodeId': getattr(video, 'sonarrEpisodeId', None),
     }
 
-    for subtitle in subtitles:
+    # save_subtitles tags the exception with the subtitle it choked on. Without
+    # that tag we cannot tell which one failed, so fall back to the whole batch.
+    for subtitle in [failed_subtitle] if failed_subtitle is not None else subtitles:
         logging.info(f'BAZARR blacklisting undecodable subtitle {subtitle.id} from {subtitle.provider_name}')
         blacklist_subtitle(subtitle.provider_name, subtitle.id, media_type, ids, language)
 

--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -1261,7 +1261,13 @@ def save_subtitles(file_path, subtitles, single=False, directory=None, chmod=Non
                 subtitle_path = os.path.splitext(subtitle_path)[0] + (u".%s" % format)
 
             logger.debug(u"Saving %r to %r", subtitle, subtitle_path)
-            content = subtitle.get_modified_content(format=format, debug=debug_mods)
+            try:
+                content = subtitle.get_modified_content(format=format, debug=debug_mods)
+            except UnicodeError as e:
+                # The caller only sees the list it passed in, so tag which member of it could not be decoded. 
+                # We can then blacklist an individual subtitle rather than every subtitle in the batch.
+                e.bazarr_failed_subtitle = subtitle  # type: ignore[attr-defined]
+                raise
             if content:
                 if os.path.exists(subtitle_path):
                     os.remove(subtitle_path)

--- a/tests/bazarr/test_download_blacklist_on_failure.py
+++ b/tests/bazarr/test_download_blacklist_on_failure.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import logging
+import os
 from unittest import mock
 
 import pytest
@@ -143,3 +144,64 @@ def test_environmental_failure_is_not_blacklisted(error):
     log, log_movie = _run_generate_subtitles(error)
     assert not log.called
     assert not log_movie.called
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Only the subtitle that actually failed gets blacklisted
+# ──────────────────────────────────────────────────────────────────────────────
+#
+# save_subtitles aborts mid-loop, so the caller only has the list it passed in
+# and cannot tell which member failed. It therefore tags the exception with that
+# subtitle. Without the tag the whole batch would be blacklisted, banning good
+# subtitles alongside the bad one.
+
+def _blacklist_with_tag(failed_subtitle, subtitles):
+    with mock.patch('app.get_providers.blacklist_log') as log, \
+         mock.patch('app.get_providers.blacklist_log_movie'):
+        _blacklist_unusable_subtitles(_episode_video(), subtitles, 'series',
+                                      Language('eng'), failed_subtitle)
+    return [call[0][3] for call in log.call_args_list]
+
+
+def test_only_the_tagged_subtitle_is_blacklisted():
+    good_a, bad, good_b = _Subtitle(subs_id='a'), _Subtitle(subs_id='bad'), _Subtitle(subs_id='b')
+    assert _blacklist_with_tag(bad, [good_a, bad, good_b]) == ['bad']
+
+
+def test_untagged_falls_back_to_the_whole_batch():
+    # Nothing should reach this today, but blacklisting nothing would let the
+    # download loop resume, which is what the feature exists to stop.
+    subtitles = [_Subtitle(subs_id='a'), _Subtitle(subs_id='b')]
+    assert _blacklist_with_tag(None, subtitles) == ['a', 'b']
+
+
+def test_save_subtitles_tags_the_failing_subtitle():
+    # The other half of the contract, against the real save_subtitles.
+    import tempfile
+    from subliminal_patch.core import save_subtitles
+
+    class _Savable:
+        def __init__(self, subs_id, language, decodable):
+            self.id = subs_id
+            self.provider_name = _PROVIDER
+            self.content = b'1\n00:00:01,000 --> 00:00:02,000\nhi\n\n'
+            self.text = '1\n00:00:01,000 --> 00:00:02,000\nhi\n\n'
+            self.language = language
+            self.format = 'srt'
+            self.mods = None
+            self.storage_path = None
+            self._decodable = decodable
+
+        def get_modified_content(self, format='srt', debug=False):
+            if not self._decodable:
+                raise UnicodeDecodeError('utf-8', b'\xbf', 0, 1, 'invalid start byte')
+            return self.content
+
+    good = _Savable('good', Language('eng'), True)
+    bad = _Savable('bad', Language('fra'), False)
+
+    with tempfile.TemporaryDirectory() as directory:
+        with pytest.raises(UnicodeDecodeError) as raised:
+            save_subtitles(os.path.join(directory, 'video.mkv'), [good, bad], directory=directory)
+
+    assert raised.value.bazarr_failed_subtitle is bad


### PR DESCRIPTION
Follow on PR from https://github.com/morpheus65535/bazarr/pull/3548

Currently we don't ever call save_subtitles with a list of languages (or any other lists) but the function does accept them, and could potentially return multiple subtitles.

However if one of those subtitles throws a UnicodeError, we are unable to tell which subtitle it is, so our choices would be "ignore the whole error and keep retrying" or "blacklist the entire set of subtitles"

This patch first updates the subliminal save_subtitles method to add an attribute to the UnicodeError detailing precisely which subtitle failed.

Then if a unicode error is actually thrown during this process, we can access the "failed_subtitles" attribute from the exception to blacklist only the file that threw the error. 

Note: This UnicodeError will prevent that batch of subtitles from downloading any subtitles remaining in the batch. Subtitles before the error will be correctly returned. But remaining subtitles will be re-downloaded on the next scheduled sync.

Also note that this patch currently has NO functional effect, due to the one-by-one processing of subtitles that currently exists. It just patches a potential future functionality issue, were we to call save_subtitles with a list.

Code by me, tests by Claude. 