### PR TITLE
Fix Titrari subtitle descriptions

### DIFF
--- a/custom_libs/subliminal_patch/providers/titrari.py
+++ b/custom_libs/subliminal_patch/providers/titrari.py
@@ -252,7 +252,7 @@ class TitrariProvider(Provider, ProviderSubtitleArchiveMixin):
 
             comments = ''
             try:
-                comments = row.parent.parent.select('.comment')[1].text
+                comments = row.parent.parent.select('.comment')[index * 2 + 1].text
             except:
                 logger.error("Error parsing comments")
 


### PR DESCRIPTION
Fixed an issue where the comment for the first subtitle result would just repeat for every entry.