### PR TITLE
Fix/lingarr skip blank lines

### DIFF
--- a/bazarr/subtitles/tools/translate/services/lingarr_translator.py
+++ b/bazarr/subtitles/tools/translate/services/lingarr_translator.py
@@ -116,6 +116,8 @@ class LingarrTranslatorService:
 
             lines_payload = []
             for i, line in enumerate(lines_list):
+                if not line.strip():
+                    continue
                 lines_payload.append({
                     "position": i,
                     "line": line

--- a/tests/bazarr/test_lingarr_translator.py
+++ b/tests/bazarr/test_lingarr_translator.py
@@ -1,0 +1,62 @@
+from bazarr.subtitles.tools.translate.services import lingarr_translator
+
+
+def _build_service(tmp_path):
+    return lingarr_translator.LingarrTranslatorService(
+        source_srt_file=str(tmp_path / "input.srt"),
+        dest_srt_file=str(tmp_path / "output.srt"),
+        lang_obj=type("L", (), {"alpha2": "fr"})(),
+        to_lang="fra",
+        from_lang="en",
+        media_type="movie",
+        video_path="/tmp/video.mkv",
+        orig_to_lang="fr",
+        forced=False,
+        hi=False,
+        sonarr_series_id=1,
+        sonarr_episode_id=1,
+        radarr_id=1,
+    )
+
+
+def test_lingarr_request_skips_blank_lines_and_preserves_positions(mocker, tmp_path):
+    """Blank lines are skipped while original positions are preserved."""
+    service = _build_service(tmp_path)
+
+    mocker.patch.object(lingarr_translator, "get_title", return_value="Synthetic movie")
+    mocker.patch.object(
+        lingarr_translator.settings.translator,
+        "lingarr_url",
+        "http://lingarr:9876",
+        create=True,
+    )
+    mocker.patch.object(
+        lingarr_translator.settings.translator,
+        "lingarr_token",
+        "",
+        create=True,
+    )
+
+    response = mocker.Mock()
+    response.status_code = 200
+    response.json.return_value = [
+        {"position": 0, "line": "Bonjour"},
+        {"position": 3, "line": "Au revoir"},
+    ]
+
+    post = mocker.patch.object(
+        lingarr_translator.requests,
+        "post",
+        return_value=response,
+    )
+
+    result = service._translate_content(
+        ["Hello", "", "   ", "Goodbye"],
+        job_id="job-1",
+    )
+
+    assert result == response.json.return_value
+    assert post.call_args.kwargs["json"]["lines"] == [
+        {"position": 0, "line": "Hello"},
+        {"position": 3, "line": "Goodbye"},
+    ]


### PR DESCRIPTION
### **Summary**

Lingarr's /api/translate/content endpoint rejects subtitle entries where Line is empty.
Bazarr currently includes every subtitle line in the Lingarr request, including empty and whitespace lines. This results to the translation request failing.
This change skips the unsupported lines in the Lingarr request payload and preserves original positions, so translations are mapped correctly. 

### **Reproduction of the bug**

Using an isolated Bazarr dev environment with a Lingarr instance, a request such as:

> position 0: "Hello"
> position 1: ""
> position 2: "   "
> position 3: "Goodbye"
> 

was rejected by Lingarr with HTTP 400:

> Lines[1].Line: The Line field is required. 


### **Fix**

Empty and whispace lines are skipped from being added to the Lingarr request payload:

```
for i, line in enumerate(lines_list):
                if not line.strip():
                    continue

```

The loop skips over the incorrect lines and the entries are not renumbered, in this example positions 0 and 3 are sent by Bazarr, and translated lines map back to the original subtitles.

### **Testing**

A regression test is also added to verify that blank lines are ommited and original positions are preserved.

Before patch: 

> FAILED tests/bazarr/test_lingarr_translator.py::test_lingarr_request_skips_blank_lines_and_preserves_positions
> 1 failed, 1 warning in 3.44s

After patch the test passed and gave correct positions: 

> RESULT: PASS
> returned positions: [0, 3]
> 

I ran into this bug whilst creating a script that would automate translating subtitles it can't find via existing subtitle providers and it seemed like an easy fix.
I used AI to generate the test but reviewed the code before submitting.
