### PR TITLE
Add SubsDump subtitle provider

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,7 @@
+# Bazarr authorship
+
+Author: D3lphi3r - Bazarr@d3lphi3r.com
+
+This identity applies to the SubsDump provider integration and its first-party
+tests and documentation in this fork. Bazarr remains an upstream project by
+morpheus65535 and its contributors; their existing notices remain authoritative.

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,7 +1,0 @@
-# Bazarr authorship
-
-Author: D3lphi3r - Bazarr@d3lphi3r.com
-
-This identity applies to the SubsDump provider integration and its first-party
-tests and documentation in this fork. Bazarr remains an upstream project by
-morpheus65535 and its contributors; their existing notices remain authoritative.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ At the request of some users, here is a way to show appreciation for the efforts
 - Subsarr (self-hosted, requires [slimcdk/subsarr](https://github.com/slimcdk/subsarr))
 - Subscene
 - Subscenter
+- SubsDump (self-hosted, requires [D3lphi3r/SubsDump](https://github.com/D3lphi3r/SubsDump))
 - SubsRo
 - Subsunacs.net
 - SubSynchro

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -473,6 +473,10 @@ validators = [
     # subsarr section
     Validator('subsarr.base_url', must_exist=True, default='', is_type_of=str),
 
+    # subsdump section
+    Validator('subsdump.base_url', must_exist=True, default='', is_type_of=str),
+    Validator('subsdump.api_key', must_exist=True, default='', is_type_of=str, cast=str),
+
     # subx section
     Validator('subx.api_key', must_exist=True, default='', is_type_of=str),
     

--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -359,6 +359,10 @@ def get_providers_auth():
         'subsarr': {
             'base_url': settings.subsarr.base_url,
         },
+        'subsdump': {
+            'base_url': settings.subsdump.base_url,
+            'api_key': settings.subsdump.api_key,
+        },
         'animesubinfo': {},
         'subx':
             {

--- a/custom_libs/subliminal_patch/providers/subsdump.py
+++ b/custom_libs/subliminal_patch/providers/subsdump.py
@@ -1,0 +1,351 @@
+import logging
+from typing import ClassVar
+from urllib.parse import urlsplit
+
+from requests import Session
+from requests.exceptions import ConnectionError, JSONDecodeError, SSLError, Timeout
+from subliminal import Episode, Movie
+from subliminal.exceptions import (
+    AuthenticationError,
+    ConfigurationError,
+    ProviderError,
+    ServiceUnavailable,
+)
+from subliminal.subtitle import fix_line_ending
+from subliminal_patch.providers import Provider, utils
+from subliminal_patch.subtitle import Subtitle
+from subzero.language import Language
+
+logger = logging.getLogger(__name__)
+
+_LANGUAGE_CODES = {
+    "ara",
+    "aze",
+    "bel",
+    "ben",
+    "bos",
+    "bul",
+    "cat",
+    "ces",
+    "dan",
+    "deu",
+    "ell",
+    "eng",
+    "epo",
+    "est",
+    "eus",
+    "fas",
+    "fin",
+    "fra",
+    "heb",
+    "hin",
+    "hrv",
+    "hun",
+    "hye",
+    "ind",
+    "isl",
+    "ita",
+    "jpn",
+    "kal",
+    "kan",
+    "kat",
+    "khm",
+    "kin",
+    "kor",
+    "kur",
+    "lav",
+    "lit",
+    "mal",
+    "mkd",
+    "mni",
+    "mon",
+    "msa",
+    "mya",
+    "nep",
+    "nld",
+    "nor",
+    "pan",
+    "pol",
+    "por",
+    "pus",
+    "ron",
+    "rus",
+    "sin",
+    "slk",
+    "slv",
+    "som",
+    "spa",
+    "sqi",
+    "srp",
+    "sun",
+    "swa",
+    "swe",
+    "tam",
+    "tel",
+    "tgl",
+    "tha",
+    "tur",
+    "ukr",
+    "urd",
+    "vie",
+    "yor",
+    "zho",
+}
+
+
+class SubsDumpSubtitle(Subtitle):
+    provider_name = "subsdump"
+    hash_verifiable = False
+    hearing_impaired_verifiable = True
+
+    def __init__(self, language, record, content_path, page_link):
+        super().__init__(
+            language,
+            hearing_impaired=bool(record.get("hearing_impaired")),
+            page_link=page_link,
+        )
+        self.record_id = record["id"]
+        self.content_path = content_path
+        self.title = record["media"]["title"]
+        self.imdb_id = record["media"].get("imdb_id")
+        self.year = record["media"].get("year")
+        self.season = record["media"].get("season")
+        self.episode = record["media"].get("episode")
+        self.releases = record.get("releases") or []
+        release_info = ", ".join(self.releases)
+        self.release_info = f"SubsDump: {release_info}" if release_info else "SubsDump"
+        self.uploader = record.get("uploader")
+        self.matches = set()
+
+    @property
+    def id(self):
+        return self.record_id
+
+    def get_matches(self, video):
+        matches = set()
+        if isinstance(video, Episode):
+            if self.title and video.series and self.title.casefold() == video.series.casefold():
+                matches.add("series")
+            if self.season == video.season:
+                matches.add("season")
+            if self.episode == video.episode:
+                matches.add("episode")
+        else:
+            if self.title and video.title and self.title.casefold() == video.title.casefold():
+                matches.add("title")
+            if self.year and self.year == video.year:
+                matches.add("year")
+
+        utils.update_matches(matches, video, self.releases)
+        self.matches = matches
+        return matches
+
+
+class SubsDumpProvider(Provider):
+    provider_name = "subsdump"
+    subtitle_class = SubsDumpSubtitle
+    video_types = (Episode, Movie)
+    languages: ClassVar[set] = {Language(code) for code in _LANGUAGE_CODES}
+    languages.add(Language("por", "BR"))
+    languages.update(Language.rebuild(language, hi=True) for language in list(languages))
+
+    def __init__(self, base_url=None, api_key=None):
+        if not base_url:
+            raise ConfigurationError("SubsDump Base URL is required")
+
+        parsed = urlsplit(base_url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ConfigurationError("SubsDump Base URL must begin with http:// or https://")
+        if parsed.username or parsed.password or parsed.query or parsed.fragment:
+            raise ConfigurationError(
+                "SubsDump Base URL cannot contain credentials, a query, or a fragment"
+            )
+
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key or ""
+        self.session = None
+
+    def initialize(self):
+        self.session = Session()
+        self.session.headers.update(
+            {"Accept": "application/json", "User-Agent": "Bazarr SubsDump"}
+        )
+        if self.api_key:
+            self.session.headers["X-API-Key"] = self.api_key
+
+        try:
+            info = self._json("/api/v1/info", timeout=10)
+            if info.get("name") != "SubsDump" or info.get("api_version") != "v1":
+                raise ConfigurationError("The server does not provide the SubsDump v1 API")
+        except Exception:
+            self.terminate()
+            raise
+
+    def terminate(self):
+        if self.session is not None:
+            self.session.close()
+            self.session = None
+
+    def ping(self):
+        try:
+            info = self._json("/api/v1/info", timeout=10)
+            return info.get("name") == "SubsDump" and info.get("api_version") == "v1"
+        except ProviderError:
+            return False
+
+    def _json(self, path, params=None, timeout=30):
+        if self.session is None:
+            raise ProviderError("SubsDump provider is not initialized")
+
+        try:
+            response = self.session.get(
+                f"{self.base_url}{path}",
+                params=params,
+                timeout=timeout,
+                allow_redirects=False,
+            )
+        except SSLError as error:
+            raise ConfigurationError("SubsDump TLS verification failed") from error
+        except Timeout as error:
+            raise ProviderError("SubsDump request timed out") from error
+        except ConnectionError as error:
+            raise ProviderError("SubsDump is unreachable") from error
+
+        if response.status_code in {401, 403}:
+            raise AuthenticationError("SubsDump rejected the API key")
+        if response.status_code == 503:
+            raise ServiceUnavailable("SubsDump is not ready")
+        if response.status_code != 200:
+            raise ProviderError(f"SubsDump returned HTTP {response.status_code}")
+        if len(response.content) > 2 * 1024 * 1024:
+            raise ProviderError("SubsDump response exceeded the size limit")
+
+        try:
+            payload = response.json()
+        except (JSONDecodeError, ValueError) as error:
+            raise ProviderError("SubsDump returned malformed JSON") from error
+        if not isinstance(payload, dict):
+            raise ProviderError("SubsDump returned an unexpected response")
+        return payload
+
+    @staticmethod
+    def _language_code(language):
+        if language.alpha3 == "por" and language.country == "BR":
+            return "por-BR"
+        return language.alpha3
+
+    @staticmethod
+    def _valid_record(record, requested_language):
+        if not isinstance(record, dict):
+            return False
+
+        record_id = record.get("id")
+        media = record.get("media")
+        language = record.get("language")
+        links = record.get("links")
+        releases = record.get("releases")
+        if not isinstance(record_id, int) or isinstance(record_id, bool) or record_id < 1:
+            return False
+        if not isinstance(media, dict) or not isinstance(media.get("title"), str):
+            return False
+        if not isinstance(language, dict) or language.get("code") != requested_language:
+            return False
+        if not isinstance(releases, list) or not all(isinstance(item, str) for item in releases):
+            return False
+        if not isinstance(links, dict):
+            return False
+        return (
+            links.get("page") == f"/subtitles/{record_id}"
+            and links.get("content") == f"/api/v1/subtitles/{record_id}/content"
+        )
+
+    def _query_language(self, video, language):
+        language_code = self._language_code(language)
+        params = {"language": language_code, "per_page": 100}
+        original_name = getattr(video, "original_name", None)
+        if original_name:
+            params["release"] = original_name[:512]
+
+        if isinstance(video, Episode):
+            imdb_id = getattr(video, "series_imdb_id", None)
+            if imdb_id:
+                path = (
+                    f"/api/v1/series/{imdb_id}/seasons/{video.season}"
+                    f"/episodes/{video.episode}/subtitles"
+                )
+            else:
+                path = "/api/v1/subtitles"
+                params.update(
+                    {
+                        "title": video.series,
+                        "media_type": "episode",
+                        "season": video.season,
+                        "episode": video.episode,
+                    }
+                )
+        else:
+            imdb_id = getattr(video, "imdb_id", None)
+            if imdb_id:
+                path = f"/api/v1/movies/{imdb_id}/subtitles"
+                if video.year:
+                    params["year"] = video.year
+            else:
+                path = "/api/v1/subtitles"
+                params.update({"title": video.title, "media_type": "movie"})
+                if video.year:
+                    params["year"] = video.year
+
+        payload = self._json(path, params=params)
+        records = payload.get("subtitles")
+        if not isinstance(records, list):
+            raise ProviderError("SubsDump response is missing subtitles")
+
+        subtitles = []
+        for record in records:
+            if not self._valid_record(record, language_code):
+                logger.debug("Skipping malformed SubsDump subtitle record")
+                continue
+            page_path = record["links"]["page"]
+            subtitle = SubsDumpSubtitle(
+                language,
+                record,
+                record["links"]["content"],
+                f"{self.base_url}{page_path}",
+            )
+            subtitle.get_matches(video)
+            subtitles.append(subtitle)
+        return subtitles
+
+    def list_subtitles(self, video, languages):
+        subtitles = []
+        for language in languages:
+            base_language = Language.rebuild(language, hi=False, forced=False)
+            if base_language not in self.languages:
+                continue
+            subtitles.extend(self._query_language(video, language))
+        return subtitles
+
+    def download_subtitle(self, subtitle):
+        if self.session is None:
+            raise ProviderError("SubsDump provider is not initialized")
+
+        try:
+            response = self.session.get(
+                f"{self.base_url}{subtitle.content_path}",
+                timeout=30,
+                allow_redirects=False,
+            )
+        except SSLError as error:
+            raise ConfigurationError("SubsDump TLS verification failed") from error
+        except Timeout as error:
+            raise ProviderError("SubsDump download timed out") from error
+        except ConnectionError as error:
+            raise ProviderError("SubsDump is unreachable") from error
+
+        if response.status_code in {401, 403}:
+            raise AuthenticationError("SubsDump rejected the API key")
+        if response.status_code != 200:
+            raise ProviderError(f"SubsDump download returned HTTP {response.status_code}")
+        if not response.content or len(response.content) > 10 * 1024 * 1024:
+            raise ProviderError("SubsDump returned an invalid subtitle file")
+        subtitle.content = fix_line_ending(response.content)

--- a/custom_libs/subliminal_patch/providers/subsdump.py
+++ b/custom_libs/subliminal_patch/providers/subsdump.py
@@ -112,8 +112,7 @@ class SubsDumpSubtitle(Subtitle):
         self.season = record["media"].get("season")
         self.episode = record["media"].get("episode")
         self.releases = record.get("releases") or []
-        release_info = ", ".join(self.releases)
-        self.release_info = f"SubsDump: {release_info}" if release_info else "SubsDump"
+        self.release_info = ", ".join(self.releases)
         self.uploader = record.get("uploader")
         self.matches = set()
 

--- a/frontend/src/pages/Settings/Providers/list.tsx
+++ b/frontend/src/pages/Settings/Providers/list.tsx
@@ -540,6 +540,33 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
     ],
   },
   {
+    key: "subsdump",
+    name: "SubsDump",
+    description:
+      "Connect Bazarr to a self-hosted SubsDump instance for fast subtitle search and downloads from your local Subscene archive.",
+    message: (
+      <Anchor
+        href="https://github.com/D3lphi3r/SubsDump"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        SubsDump project
+      </Anchor>
+    ),
+    inputs: [
+      {
+        type: "text",
+        key: "base_url",
+        name: "Base URL",
+      },
+      {
+        type: "password",
+        key: "api_key",
+        name: "API Key (optional)",
+      },
+    ],
+  },
+  {
     key: "subssabbz",
     name: "Subs.sab.bz",
     description: "Bulgarian Subtitles Provider",

--- a/tests/subliminal_patch/test_subsdump.py
+++ b/tests/subliminal_patch/test_subsdump.py
@@ -1,0 +1,300 @@
+from unittest.mock import Mock
+
+import pytest
+from requests import Session
+from requests.exceptions import ConnectionError, SSLError, Timeout
+from subliminal.exceptions import AuthenticationError, ConfigurationError, ProviderError
+from subliminal_patch.providers import subsdump
+from subliminal_patch.providers.subsdump import SubsDumpProvider
+from subzero.language import Language
+
+BASE_URL = "https://subsdump.example.com"
+
+
+def _record(
+    *,
+    subtitle_id=42,
+    title="Dune",
+    language="ara",
+    media_type="movie",
+    year=2021,
+    season=None,
+    episode=None,
+    hearing_impaired=False,
+):
+    return {
+        "id": subtitle_id,
+        "media": {
+            "type": media_type,
+            "title": title,
+            "imdb_id": "tt1160419",
+            "year": year,
+            "season": season,
+            "episode": episode,
+        },
+        "language": {"code": language, "name": "Arabic"},
+        "releases": ["Dune.2021.1080p.WEBRip.DD5.1.x264-SHITBOX"],
+        "hearing_impaired": hearing_impaired,
+        "uploader": "contributor",
+        "links": {
+            "page": f"/subtitles/{subtitle_id}",
+            "archive": f"/api/v1/subtitles/{subtitle_id}/archive",
+            "content": f"/api/v1/subtitles/{subtitle_id}/content",
+        },
+    }
+
+
+def _provider(api_key=""):
+    provider = SubsDumpProvider(BASE_URL, api_key)
+    provider.session = Session()
+    if api_key:
+        provider.session.headers["X-API-Key"] = api_key
+    return provider
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        None,
+        "",
+        "subsdump.example.com",
+        "ftp://subsdump.example.com",
+        "https://user:secret@subsdump.example.com",
+        "https://subsdump.example.com?key=value",
+        "https://subsdump.example.com#fragment",
+    ],
+)
+def test_base_url_validation(url):
+    with pytest.raises(ConfigurationError):
+        SubsDumpProvider(url)
+
+
+def test_initialize_uses_optional_api_key_and_cleanup(requests_mock):
+    requests_mock.get(
+        f"{BASE_URL}/api/v1/info",
+        json={"name": "SubsDump", "version": "2.1.0", "api_version": "v1"},
+    )
+    provider = SubsDumpProvider(f"{BASE_URL}/", "api-secret")
+
+    provider.initialize()
+
+    assert provider.base_url == BASE_URL
+    assert requests_mock.last_request.headers["X-API-Key"] == "api-secret"
+    assert provider.session is not None
+    provider.terminate()
+    assert provider.session is None
+
+
+def test_initialize_without_api_key(requests_mock):
+    requests_mock.get(
+        f"{BASE_URL}/api/v1/info",
+        json={"name": "SubsDump", "version": "2.1.0", "api_version": "v1"},
+    )
+    provider = SubsDumpProvider(BASE_URL)
+
+    provider.initialize()
+
+    assert "X-API-Key" not in requests_mock.last_request.headers
+    provider.terminate()
+
+
+def test_initialize_rejects_an_incompatible_service_and_closes_session(monkeypatch):
+    response = Mock(status_code=200, content=b"{}")
+    response.json.return_value = {"name": "Another service", "api_version": "v1"}
+    session = Mock(headers={})
+    session.get.return_value = response
+    monkeypatch.setattr(subsdump, "Session", lambda: session)
+    provider = SubsDumpProvider(BASE_URL)
+
+    with pytest.raises(ConfigurationError, match="SubsDump v1 API"):
+        provider.initialize()
+
+    session.close.assert_called_once_with()
+    assert provider.session is None
+
+
+def test_movie_lookup_returns_matches_and_page_link(movies, requests_mock):
+    requests_mock.get(
+        f"{BASE_URL}/api/v1/movies/tt1160419/subtitles",
+        json={"subtitles": [_record()]},
+    )
+    provider = _provider()
+
+    results = provider.list_subtitles(movies["dune"], {Language("ara")})
+
+    assert len(results) == 1
+    subtitle = results[0]
+    assert subtitle.provider_name == "subsdump"
+    assert subtitle.page_link == f"{BASE_URL}/subtitles/42"
+    assert subtitle.content_path == "/api/v1/subtitles/42/content"
+    assert subtitle.release_info == "SubsDump: Dune.2021.1080p.WEBRip.DD5.1.x264-SHITBOX"
+    assert subtitle.uploader == "contributor"
+    assert {"title", "year", "release_group"}.issubset(
+        subtitle.get_matches(movies["dune"])
+    )
+    assert requests_mock.last_request.qs["language"] == ["ara"]
+
+
+def test_episode_lookup_maps_season_episode_and_release(episodes, requests_mock):
+    record = _record(
+        title="Game of Thrones",
+        media_type="episode",
+        year=None,
+        season=3,
+        episode=10,
+    )
+    requests_mock.get(
+        f"{BASE_URL}/api/v1/series/tt0944947/seasons/3/episodes/10/subtitles",
+        json={"subtitles": [record]},
+    )
+    provider = _provider()
+
+    results = provider.list_subtitles(episodes["got_s03e10"], {Language("ara")})
+
+    assert len(results) == 1
+    assert {"series", "season", "episode"}.issubset(
+        results[0].get_matches(episodes["got_s03e10"])
+    )
+    assert requests_mock.last_request.qs["release"] == [
+        "game.of.thrones.s03e10.mhysa.720p.web-dl.dd5.1.h.264-ntb.mkv"
+    ]
+
+
+def test_title_fallback_for_episode_without_imdb_id(episodes, requests_mock):
+    requests_mock.get(f"{BASE_URL}/api/v1/subtitles", json={"subtitles": []})
+    provider = _provider()
+
+    assert provider.list_subtitles(
+        episodes["better_call_saul_s06e04"], {Language("ara")}
+    ) == []
+    assert requests_mock.last_request.qs["title"] == ["better call saul"]
+    assert requests_mock.last_request.qs["media_type"] == ["episode"]
+    assert requests_mock.last_request.qs["season"] == ["6"]
+    assert requests_mock.last_request.qs["episode"] == ["4"]
+
+
+def test_language_mapping_and_hearing_impaired_metadata(movies, requests_mock):
+    requests_mock.get(
+        f"{BASE_URL}/api/v1/movies/tt1160419/subtitles",
+        json={"subtitles": [_record(language="por-BR", hearing_impaired=True)]},
+    )
+    provider = _provider()
+
+    results = provider.list_subtitles(movies["dune"], {Language("por", "BR", hi=True)})
+
+    assert len(results) == 1
+    assert results[0].language == Language("por", "BR", hi=True)
+    assert results[0].hearing_impaired is True
+    assert requests_mock.last_request.qs["language"] == ["por-br"]
+
+
+def test_no_results(movies, requests_mock):
+    requests_mock.get(
+        f"{BASE_URL}/api/v1/movies/tt1160419/subtitles",
+        json={"subtitles": []},
+    )
+    assert _provider().list_subtitles(movies["dune"], {Language("ara")}) == []
+
+
+def test_malformed_json(movies, requests_mock):
+    requests_mock.get(
+        f"{BASE_URL}/api/v1/movies/tt1160419/subtitles", text="not JSON"
+    )
+    with pytest.raises(ProviderError, match="malformed JSON"):
+        _provider().list_subtitles(movies["dune"], {Language("ara")})
+
+
+@pytest.mark.parametrize("status_code", [404, 500])
+def test_search_http_error(movies, requests_mock, status_code):
+    requests_mock.get(
+        f"{BASE_URL}/api/v1/movies/tt1160419/subtitles", status_code=status_code
+    )
+    with pytest.raises(ProviderError, match=f"HTTP {status_code}"):
+        _provider().list_subtitles(movies["dune"], {Language("ara")})
+
+
+def test_malformed_subtitle_record_is_ignored(movies, requests_mock):
+    record = _record()
+    record["links"]["page"] = "/subtitles/different"
+    requests_mock.get(
+        f"{BASE_URL}/api/v1/movies/tt1160419/subtitles",
+        json={"subtitles": [record]},
+    )
+    assert _provider().list_subtitles(movies["dune"], {Language("ara")}) == []
+
+
+def test_invalid_authentication(movies, requests_mock):
+    requests_mock.get(
+        f"{BASE_URL}/api/v1/movies/tt1160419/subtitles", status_code=401
+    )
+    with pytest.raises(AuthenticationError, match="API key"):
+        _provider("wrong-key").list_subtitles(movies["dune"], {Language("ara")})
+
+
+@pytest.mark.parametrize(
+    ("error", "message"),
+    [
+        (Timeout(), "timed out"),
+        (ConnectionError(), "unreachable"),
+        (SSLError(), "TLS verification"),
+    ],
+)
+def test_remote_request_errors(movies, requests_mock, error, message):
+    requests_mock.get(
+        f"{BASE_URL}/api/v1/movies/tt1160419/subtitles", exc=error
+    )
+    with pytest.raises(ProviderError, match=message):
+        _provider().list_subtitles(movies["dune"], {Language("ara")})
+
+
+def test_download_uses_native_content_endpoint(requests_mock):
+    requests_mock.get(
+        f"{BASE_URL}/api/v1/subtitles/42/content",
+        content=b"1\r\n00:00:01,000 --> 00:00:02,000\r\nHello\r\n",
+    )
+    provider = _provider("api-secret")
+    subtitle = Mock(content_path="/api/v1/subtitles/42/content", content=None)
+
+    provider.download_subtitle(subtitle)
+
+    assert subtitle.content == b"1\n00:00:01,000 --> 00:00:02,000\nHello\n"
+    assert requests_mock.last_request.headers["X-API-Key"] == "api-secret"
+
+
+@pytest.mark.parametrize(
+    ("status_code", "exception", "message"),
+    [
+        (401, AuthenticationError, "API key"),
+        (404, ProviderError, "HTTP 404"),
+        (500, ProviderError, "HTTP 500"),
+    ],
+)
+def test_download_http_errors(requests_mock, status_code, exception, message):
+    requests_mock.get(
+        f"{BASE_URL}/api/v1/subtitles/42/content", status_code=status_code
+    )
+    provider = _provider("api-secret")
+    subtitle = Mock(content_path="/api/v1/subtitles/42/content", content=None)
+
+    with pytest.raises(exception, match=message):
+        provider.download_subtitle(subtitle)
+
+
+def test_download_rejects_empty_content(requests_mock):
+    requests_mock.get(f"{BASE_URL}/api/v1/subtitles/42/content", content=b"")
+    provider = _provider()
+    subtitle = Mock(content_path="/api/v1/subtitles/42/content", content=None)
+
+    with pytest.raises(ProviderError, match="invalid subtitle file"):
+        provider.download_subtitle(subtitle)
+
+
+def test_download_timeout(requests_mock):
+    requests_mock.get(
+        f"{BASE_URL}/api/v1/subtitles/42/content", exc=Timeout()
+    )
+    provider = _provider()
+    subtitle = Mock(content_path="/api/v1/subtitles/42/content", content=None)
+
+    with pytest.raises(ProviderError, match="download timed out"):
+        provider.download_subtitle(subtitle)

--- a/tests/subliminal_patch/test_subsdump.py
+++ b/tests/subliminal_patch/test_subsdump.py
@@ -127,7 +127,7 @@ def test_movie_lookup_returns_matches_and_page_link(movies, requests_mock):
     assert subtitle.provider_name == "subsdump"
     assert subtitle.page_link == f"{BASE_URL}/subtitles/42"
     assert subtitle.content_path == "/api/v1/subtitles/42/content"
-    assert subtitle.release_info == "SubsDump: Dune.2021.1080p.WEBRip.DD5.1.x264-SHITBOX"
+    assert subtitle.release_info == "Dune.2021.1080p.WEBRip.DD5.1.x264-SHITBOX"
     assert subtitle.uploader == "contributor"
     assert {"title", "year", "release_group"}.issubset(
         subtitle.get_matches(movies["dune"])


### PR DESCRIPTION
## Summary

Adds SubsDump, a provider for the self-hosted [SubsDump](https://github.com/D3lphi3r/SubsDump) Subscene archive search and download service.

- Uses SubsDump's native HTTP API for movie and episode searches.
- Supports language and release matching, hearing-impaired metadata, and an optional API key.
- Requires only a reachable Base URL; Bazarr and SubsDump need no shared filesystem or co-location.
- Provides human-readable subtitle page links separately from subtitle content downloads.

The implementation follows Bazarr's provider conventions and is limited to the provider, its provider-specific configuration wiring, its Settings entry, and focused provider tests. Generic manual-search behavior is unchanged, and release information contains only the source release strings.

Project: https://github.com/D3lphi3r/SubsDump  
Current release: https://github.com/D3lphi3r/SubsDump/releases/tag/v2.1.0

## Testing

- 29 provider tests passed on Python 3.13; provider pyflakes checks passed.
- 29 provider tests passed on Python 3.12 in Bazarr's official backend development image.
- 221 Bazarr backend tests passed in the official backend development image.
- 10 affected frontend Settings tests passed.
- Frontend Prettier, TypeScript, Oxlint, and development build passed.
- Live SubsDump v2.1.0 validation covered Arabic movie and episode searches, page links, and subtitle downloads.

## Generative-tool disclosure

Generative tools assisted implementation and test development from the contributor-defined native API design; the complete diff was reviewed and validated end to end.
