### PR TITLE
Fixed animetosho forced subtitles

### DIFF
--- a/custom_libs/subliminal_patch/providers/animetosho.py
+++ b/custom_libs/subliminal_patch/providers/animetosho.py
@@ -50,11 +50,16 @@ class AnimeToshoSubtitle(Subtitle):
     """AnimeTosho.org Subtitle."""
     provider_name = 'animetosho'
 
-    def __init__(self, language, download_link, meta, release_info):
+    def __init__(self, language, download_link, meta, release_info, forced=False):
+        # AnimeTosho reports the forced disposition flag of the subtitle track. Keep it on the
+        # language so a forced (signs only) track is never offered as a normal subtitle.
+        language = Language.rebuild(language, forced=forced)
+
         super(AnimeToshoSubtitle, self).__init__(language, page_link=download_link)
         self.meta = meta
         self.download_link = download_link
         self.release_info = release_info
+        self.forced = forced
         self.matches = set()
 
     @property
@@ -75,6 +80,10 @@ class AnimeToshoProvider(Provider, ProviderSubtitleArchiveMixin):
     """AnimeTosho.org Provider."""
     subtitle_class = AnimeToshoSubtitle
     languages = {Language('por', 'BR')} | {Language(sl) for sl in supported_languages}
+    # The provider pool intersects the requested languages with the languages declared here before
+    # calling list_subtitles, so the forced variants have to be declared as well or a profile
+    # asking for forced subtitles would never reach this provider.
+    languages.update(set(Language.rebuild(lang, forced=True) for lang in languages))
     video_types = Episode
 
     def __init__(self, search_threshold=None):
@@ -145,13 +154,15 @@ class AnimeToshoProvider(Provider, ProviderSubtitleArchiveMixin):
                 for subtitle_file in subtitle_files:
                     hex_id = format(subtitle_file['id'], '08x')
 
+                    info = subtitle_file['info']
+
                     # Animetosho assumes missing languages as english as fallback when not specified.
-                    lang = Language.fromalpha3b(subtitle_file['info'].get('lang', 'eng'))
+                    lang = Language.fromalpha3b(info.get('lang', 'eng'))
 
                     # For Portuguese and Portuguese Brazilian they both share the same code, the name is the only
                     # identifier AnimeTosho provides. Also, some subtitles does not have name, in this case it could
                     # be a false negative but there is nothing we can use to guarantee it is PT-BR, we rather skip it.
-                    if lang.alpha3 == 'por' and 'brazil' in subtitle_file['info'].get('name', '').lower():
+                    if lang.alpha3 == 'por' and 'brazil' in info.get('name', '').lower():
                         lang = Language('por', 'BR')
 
                     subtitle = self.subtitle_class(
@@ -159,6 +170,8 @@ class AnimeToshoProvider(Provider, ProviderSubtitleArchiveMixin):
                         storage_download_url + '{}/{}.xz'.format(hex_id, subtitle_file['id']),
                         meta=file,
                         release_info=entry.get('title'),
+                        # AnimeTosho exposes the forced disposition flag of the track as 0/1.
+                        forced=bool(info.get('forced', False)),
                     )
 
                     logger.debug('Found subtitle %r', subtitle)

--- a/custom_libs/subliminal_patch/providers/animetosho_xyz.py
+++ b/custom_libs/subliminal_patch/providers/animetosho_xyz.py
@@ -43,7 +43,11 @@ _BRAZILIAN_PORTUGUESE_RE = re.compile(r'brazil|\bbr\b', re.IGNORECASE)
 class AnimeToshoXYZSubtitle(Subtitle):
     provider_name = 'animetosho_xyz'
 
-    def __init__(self, language, download_link, meta, release_info):
+    def __init__(self, language, download_link, meta, release_info, forced=False):
+        # AnimeTosho reports the forced disposition flag of the subtitle track. Keep it on the
+        # language so a forced (signs only) track is never offered as a normal subtitle.
+        language = Language.rebuild(language, forced=forced)
+
         super(AnimeToshoXYZSubtitle, self).__init__(
             language,
             page_link=download_link,
@@ -51,6 +55,7 @@ class AnimeToshoXYZSubtitle(Subtitle):
         self.meta = meta
         self.download_link = download_link
         self.release_info = release_info
+        self.forced = forced
         self.matches = set()
 
     @property
@@ -71,6 +76,10 @@ class AnimeToshoXYZProvider(Provider, ProviderSubtitleArchiveMixin):
     provider_name = 'animetosho_xyz'
     subtitle_class = AnimeToshoXYZSubtitle
     languages = {Language('por', 'BR')} | {Language(sl) for sl in supported_languages}
+    # The provider pool intersects the requested languages with the languages declared here before
+    # calling list_subtitles, so the forced variants have to be declared as well or a profile
+    # asking for forced subtitles would never reach this provider.
+    languages.update(set(Language.rebuild(lang, forced=True) for lang in languages))
     video_types = Episode
 
     def __init__(self):
@@ -158,11 +167,8 @@ class AnimeToshoXYZProvider(Provider, ProviderSubtitleArchiveMixin):
             )
 
             torrent_data = r.json()
-            attachments = torrent_data.get('attachments', [])
 
-            subtitle_files = list(filter(lambda a: a.get('type') == 'subtitle', attachments))
-
-            for subtitle_file in subtitle_files:
+            for subtitle_file in self._iter_subtitle_attachments(torrent_data):
                 info = subtitle_file.get('info', {})
                 lang_code = info.get('language_code', 'eng')
                 lang = Language.fromalpha3b(lang_code)
@@ -178,12 +184,42 @@ class AnimeToshoXYZProvider(Provider, ProviderSubtitleArchiveMixin):
                     subtitle_file['url'],
                     meta=torrent_data,
                     release_info=entry.get('title'),
+                    # AnimeTosho exposes the forced disposition flag of the track as a boolean.
+                    forced=bool(info.get('forced', False)),
                 )
 
                 logger.debug('Found subtitle %r', subtitle)
                 subtitles.append(subtitle)
 
         return subtitles
+
+    @staticmethod
+    def _iter_subtitle_attachments(torrent_data):
+        """Yield the subtitle attachments of a release.
+
+        AnimeTosho.xyz lists them either at the top level of the release ("attachments") or nested
+        under each of its files ("files[].attachments"), depending on the release, so both shapes
+        have to be collected. A release only ever uses one of them but the same attachment is
+        still guarded against being yielded twice.
+        """
+        seen = set()
+
+        def collect(attachments):
+            for attachment in attachments or []:
+                if attachment.get('type') != 'subtitle':
+                    continue
+
+                key = (attachment.get('id'), attachment.get('url'))
+                if key in seen:
+                    continue
+
+                seen.add(key)
+                yield attachment
+
+        yield from collect(torrent_data.get('attachments'))
+
+        for file in torrent_data.get('files') or []:
+            yield from collect(file.get('attachments'))
 
     def _get_series_entries(self, episode_id):
         api_url = 'https://feed.animetosho.xyz/feed/json'

--- a/tests/subliminal_patch/data/animetosho_xyz_series_nested_attachments_response.json
+++ b/tests/subliminal_patch/data/animetosho_xyz_series_nested_attachments_response.json
@@ -1,0 +1,71 @@
+{
+  "id": 592301,
+  "title": "Frieren Beyond Journeys End S02E01 Shall We Go Then 1080p CR WEB-DL MULTi AAC2.0 H 264-VARYG (Sousou no Frieren, Multi-Audio, Multi-Subs)",
+  "torrent_name": "Frieren Beyond Journeys End S02E01 Shall We Go Then 1080p CR WEB-DL MULTi AAC2.0 H 264-VARYG (Sousou no Frieren, Multi-Audio, Multi-Subs)",
+  "link": "https://animetosho.xyz/view/592301",
+  "timestamp": 1770422161,
+  "status": "complete",
+  "anidb_aid": 18886,
+  "anidb_eid": 306529,
+  "num_files": 1,
+  "primary_file_id": 1359162,
+  "attachments": null,
+  "files": [
+    {
+      "id": 1359162,
+      "filename": "Frieren.Beyond.Journeys.End.S02E01.Shall.We.Go.Then.1080p.CR.WEB-DL.MULTi.AAC2.0.H.264-VARYG.mkv",
+      "name": "Frieren.Beyond.Journeys.End.S02E01.Shall.We.Go.Then.1080p.CR.WEB-DL.MULTi.AAC2.0.H.264-VARYG.mkv",
+      "size": 1762960405,
+      "attachments": [
+        {
+          "id": 3146378,
+          "info": {
+            "default": true,
+            "forced": false,
+            "format": "ASS",
+            "language_code": "eng"
+          },
+          "size": null,
+          "type": "subtitle",
+          "url": "https://storage.animetosho.xyz/attachments/0029a/811.xz"
+        },
+        {
+          "id": 3548588,
+          "info": {
+            "default": false,
+            "forced": true,
+            "format": "ASS",
+            "language_code": "eng"
+          },
+          "size": null,
+          "type": "subtitle",
+          "url": "https://storage.animetosho.xyz/attachments/002a1/6fb.xz"
+        },
+        {
+          "id": 3235500,
+          "info": {
+            "default": false,
+            "forced": false,
+            "format": "ASS",
+            "language_code": "por"
+          },
+          "size": null,
+          "type": "subtitle",
+          "url": "https://storage.animetosho.xyz/attachments/0029a/81a.xz"
+        },
+        {
+          "id": 3385037,
+          "info": {
+            "default": false,
+            "forced": true,
+            "format": "ASS",
+            "language_code": "por"
+          },
+          "size": null,
+          "type": "subtitle",
+          "url": "https://storage.animetosho.xyz/attachments/002a1/975.xz"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/subliminal_patch/test_animetosho.py
+++ b/tests/subliminal_patch/test_animetosho.py
@@ -59,17 +59,73 @@ def test_list_subtitles(anime_episodes, requests_mock, data):
         assert len(subtitles) == 2
 
 
-def _torrent_response(sub_info):
+def _torrent_response(*sub_infos):
+    """Build an animetosho.org torrent payload carrying one subtitle attachment per info dict."""
     return {
         "files": [
             {
                 "filename": "[EMBER] Ore dake Level Up na Ken S01E12 [1080p] [HEVC WEBRip].mkv",
                 "attachments": [
-                    {"id": 1, "filename": "subs.ass", "type": "subtitle", "info": sub_info},
+                    {"id": idx, "filename": f"track{idx}.ass", "type": "subtitle", "info": info}
+                    for idx, info in enumerate(sub_infos, start=1)
                 ],
             }
         ]
     }
+
+
+def _varyg_torrent_response():
+    """The Brazilian Portuguese attachments of the VARYG release reported in #3579. AnimeTosho
+    flags 2759029 as forced (a signs only track) and 2730010 as the normal full subtitle."""
+    return {
+        "files": [
+            {
+                "filename": "Frieren.Beyond.Journeys.End.S02E01.Shall.We.Go.Then.1080p.CR.WEB-DL."
+                            "MULTi.AAC2.0.H.264-VARYG.mkv",
+                "attachments": [
+                    {
+                        "id": 2759029,
+                        "filename": "track24.ass",
+                        "type": "subtitle",
+                        "size": 3282,
+                        "info": {"codec": "ASS", "lang": "por", "name": "Brazilian (Forced)",
+                                 "default": 0, "enabled": 1, "forced": 1, "trackid": 24,
+                                 "tracknum": 25},
+                    },
+                    {
+                        "id": 2730010,
+                        "filename": "track25.ass",
+                        "type": "subtitle",
+                        "size": 26993,
+                        "info": {"codec": "ASS", "lang": "por", "name": "Brazilian",
+                                 "default": 0, "enabled": 1, "forced": 0, "trackid": 25,
+                                 "tracknum": 26},
+                    },
+                ],
+            }
+        ]
+    }
+
+
+def _mock_feed(requests_mock, torrent_response, entry_id=608526):
+    requests_mock.get(
+        'https://feed.animetosho.org/json?eid=277518',
+        json=[{"id": entry_id, "timestamp": 1711853493, "status": "complete",
+               "title": "Solo Leveling - 12"}],
+    )
+    requests_mock.get(
+        f'https://feed.animetosho.org/json?show=torrent&id={entry_id}',
+        json=torrent_response,
+    )
+
+
+# Every variant has to be requested when the test asserts on the resolved language, otherwise
+# list_subtitles filters the subtitle out before it can be inspected.
+_ALL_VARIANTS = {
+    Language("eng"), Language("eng", forced=True),
+    Language("por"), Language("por", forced=True),
+    Language("por", "BR"), Language("por", "BR", forced=True),
+}
 
 
 @pytest.mark.parametrize(
@@ -89,14 +145,7 @@ def _torrent_response(sub_info):
 def test_portuguese_brazilian_detection(anime_episodes, requests_mock, info, expected):
     item = anime_episodes["solo_leveling_s01e10"]
 
-    requests_mock.get(
-        'https://feed.animetosho.org/json?eid=277518',
-        json=[{"id": 608526, "timestamp": 1711853493, "status": "complete", "title": "Solo Leveling - 12"}],
-    )
-    requests_mock.get(
-        'https://feed.animetosho.org/json?show=torrent&id=608526',
-        json=_torrent_response(info),
-    )
+    _mock_feed(requests_mock, _torrent_response(info))
 
     with AnimeToshoProvider(1) as provider:
         # Ask for both variants so nothing is filtered out and the resolved language is asserted.
@@ -104,3 +153,57 @@ def test_portuguese_brazilian_detection(anime_episodes, requests_mock, info, exp
 
         assert len(subtitles) == 1
         assert subtitles[0].language == expected
+
+
+@pytest.mark.parametrize(
+    "info,expected",
+    [
+        # AnimeTosho reports the forced disposition flag of the track as 0/1. It has to reach the
+        # language, otherwise a signs only track is offered as a normal subtitle. #3579
+        ({"lang": "eng", "forced": 1}, Language("eng", forced=True)),
+        ({"lang": "eng", "forced": 0}, Language("eng")),
+        ({"lang": "por", "name": "Brazilian (Forced)", "forced": 1}, Language("por", "BR", forced=True)),
+        ({"lang": "por", "name": "Brazilian", "forced": 0}, Language("por", "BR")),
+        # Payloads that predate the flag, or tracks that simply do not carry it.
+        ({"lang": "eng"}, Language("eng")),
+        ({"lang": "por", "name": "Brazilian"}, Language("por", "BR")),
+    ],
+)
+def test_forced_flag_is_propagated(anime_episodes, requests_mock, info, expected):
+    item = anime_episodes["solo_leveling_s01e10"]
+
+    _mock_feed(requests_mock, _torrent_response(info))
+
+    with AnimeToshoProvider(1) as provider:
+        subtitles = provider.list_subtitles(item, languages=_ALL_VARIANTS)
+
+        assert len(subtitles) == 1
+        assert subtitles[0].language == expected
+        assert subtitles[0].forced is bool(expected.forced)
+
+
+def test_forced_track_is_not_offered_as_a_normal_subtitle(anime_episodes, requests_mock):
+    """#3579: a profile asking for normal Brazilian Portuguese was served the forced track."""
+    item = anime_episodes["solo_leveling_s01e10"]
+
+    _mock_feed(requests_mock, _varyg_torrent_response())
+
+    with AnimeToshoProvider(1) as provider:
+        normal = provider.list_subtitles(item, languages={Language("por", "BR")})
+        forced = provider.list_subtitles(item, languages={Language("por", "BR", forced=True)})
+
+    # The normal request only gets the full subtitle, the forced one only the signs only track.
+    assert [(s.language, s.forced) for s in normal] == [(Language("por", "BR"), False)]
+    assert normal[0].download_link == "https://animetosho.org/storage/attach/0029a81a/2730010.xz"
+
+    assert [(s.language, s.forced) for s in forced] == [(Language("por", "BR", forced=True), True)]
+    assert forced[0].download_link == "https://animetosho.org/storage/attach/002a1975/2759029.xz"
+
+
+def test_forced_languages_are_declared():
+    # The provider pool intersects the requested languages with the ones declared by the provider
+    # before calling list_subtitles, so without the forced variants a profile asking for forced
+    # subtitles would never reach AnimeTosho at all.
+    assert Language("eng", forced=True) in AnimeToshoProvider.languages
+    assert Language("por", "BR", forced=True) in AnimeToshoProvider.languages
+

--- a/tests/subliminal_patch/test_animetosho_xyz.py
+++ b/tests/subliminal_patch/test_animetosho_xyz.py
@@ -25,7 +25,98 @@ def anime_episodes():
             resolution="1080p",
             video_codec="H.264",
         ),
+        # The VARYG release reported in #3579. AnimeTosho.xyz nests its attachments under the file
+        # for this one instead of exposing them at the top level of the release.
+        "frieren_s02e01": Episode(
+            "Frieren.Beyond.Journeys.End.S02E01.Shall.We.Go.Then.1080p.CR.WEB-DL.MULTi.AAC2.0.H.264-VARYG.mkv",
+            "Frieren: Beyond Journey's End",
+            2,
+            1,
+            source="Web",
+            series_anidb_id=18886,
+            series_anidb_episode_id=306529,
+            series_tvdb_id=424536,
+            series_imdb_id="tt22248376",
+            release_group="VARYG",
+            resolution="1080p",
+            video_codec="H.264",
+        ),
     }
+
+
+_RELEASE_NAME = "[Erai-raws] Crowned in a Hundred Days - 08 (CA) [1080p CR WEB-DL AVC AAC][MultiSub][81FBD56D]"
+
+
+def _top_level_response(*sub_infos):
+    """Release payload exposing its subtitle attachments at the top level."""
+    return {
+        "id": 622245,
+        "torrent_name": _RELEASE_NAME,
+        "attachments": [
+            {
+                "id": idx,
+                "type": "subtitle",
+                "url": f"https://storage.animetosho.xyz/releases/622245/subtitles/track{idx}.ass.xz",
+                "info": info,
+            }
+            for idx, info in enumerate(sub_infos, start=1)
+        ],
+        "files": [{"id": 1, "filename": f"{_RELEASE_NAME}.mkv"}],
+    }
+
+
+def _nested_response(*sub_infos):
+    """Release payload nesting its subtitle attachments under its file, which is what
+    AnimeTosho.xyz does for most releases."""
+    return {
+        "id": 592301,
+        "torrent_name": "Frieren Beyond Journeys End S02E01 Shall We Go Then 1080p CR WEB-DL MULTi "
+                        "AAC2.0 H 264-VARYG (Sousou no Frieren, Multi-Audio, Multi-Subs)",
+        "attachments": None,
+        "files": [
+            {
+                "id": 1,
+                "filename": "Frieren.Beyond.Journeys.End.S02E01.Shall.We.Go.Then.1080p.CR.WEB-DL."
+                            "MULTi.AAC2.0.H.264-VARYG.mkv",
+                "attachments": [
+                    {
+                        "id": idx,
+                        "type": "subtitle",
+                        "url": f"https://storage.animetosho.xyz/attachments/0029a/{idx}.xz",
+                        "info": info,
+                    }
+                    for idx, info in enumerate(sub_infos, start=1)
+                ],
+            }
+        ],
+    }
+
+
+def _mock_feed(requests_mock, torrent_response, eid=313249, entry_id=622245, title=_RELEASE_NAME):
+    """Mock the feed endpoint and, when a payload is given, the release detail endpoint. Leave
+    torrent_response as None to register the detail endpoint from a recorded file instead."""
+    requests_mock.get(
+        f'https://feed.animetosho.xyz/feed/json?eid={eid}',
+        json=[{"id": entry_id, "timestamp": 1784290258, "status": "complete", "title": title}],
+    )
+
+    if torrent_response is not None:
+        requests_mock.get(
+            f'https://feed.animetosho.xyz/json?show=torrent&id={entry_id}',
+            json=torrent_response,
+        )
+
+
+# Every variant has to be requested when the test asserts on the resolved language, otherwise
+# list_subtitles filters the subtitle out before it can be inspected.
+_ALL_VARIANTS = {
+    Language("eng"), Language("eng", forced=True),
+    Language("por"), Language("por", forced=True),
+    Language("por", "BR"), Language("por", "BR", forced=True),
+}
+
+_VARYG_TITLE = ("Frieren Beyond Journeys End S02E01 Shall We Go Then 1080p CR WEB-DL MULTi AAC2.0 "
+                "H 264-VARYG (Sousou no Frieren, Multi-Audio, Multi-Subs)")
 
 
 def test_list_subtitles(anime_episodes, requests_mock, data):
@@ -132,3 +223,111 @@ def test_list_subtitles_with_episode_id_tuple(anime_episodes, requests_mock, dat
     with AnimeToshoXYZProvider() as provider:
         subtitles = provider.list_subtitles(item, languages={language})
         assert len(subtitles) == 2
+
+
+@pytest.mark.parametrize(
+    "info,expected",
+    [
+        # AnimeTosho reports the forced disposition flag of the track as a boolean. It has to
+        # reach the language, otherwise a signs only track is offered as a normal subtitle. #3579
+        ({"language": "English", "language_code": "eng", "forced": True}, Language("eng", forced=True)),
+        ({"language": "English", "language_code": "eng", "forced": False}, Language("eng")),
+        ({"language": "Portuguese[BR]", "language_code": "por", "forced": True},
+         Language("por", "BR", forced=True)),
+        ({"language": "Portuguese[BR]", "language_code": "por", "forced": False}, Language("por", "BR")),
+        # Payloads that predate the flag, or tracks that simply do not carry it.
+        ({"language": "English", "language_code": "eng"}, Language("eng")),
+        ({"language": "Portuguese[BR]", "language_code": "por"}, Language("por", "BR")),
+    ],
+)
+def test_forced_flag_is_propagated(anime_episodes, requests_mock, info, expected):
+    item = anime_episodes["crowned_s01e08"]
+
+    _mock_feed(requests_mock, _top_level_response(info))
+
+    with AnimeToshoXYZProvider() as provider:
+        subtitles = provider.list_subtitles(item, languages=_ALL_VARIANTS)
+
+        assert len(subtitles) == 1
+        assert subtitles[0].language == expected
+        assert subtitles[0].forced is bool(expected.forced)
+
+
+def test_nested_attachments_are_found(anime_episodes, requests_mock, data):
+    """Most releases nest their attachments under "files[].attachments" and carry no top level
+    "attachments" at all. Those used to be missed entirely, so nothing was ever listed for them."""
+    item = anime_episodes["frieren_s02e01"]
+
+    _mock_feed(requests_mock, None, eid=306529, entry_id=592301, title=_VARYG_TITLE)
+    with open(os.path.join(data, 'animetosho_xyz_series_nested_attachments_response.json'), "rb") as f:
+        requests_mock.get('https://feed.animetosho.xyz/json?show=torrent&id=592301', content=f.read())
+
+    with AnimeToshoXYZProvider() as provider:
+        subtitles = provider.list_subtitles(item, languages=_ALL_VARIANTS)
+
+    assert {(s.language, s.forced) for s in subtitles} == {
+        (Language("eng"), False),
+        (Language("eng", forced=True), True),
+        # Nested attachments only carry "language_code" and no "language" name, so there is nothing
+        # telling Brazilian Portuguese apart from Portuguese and it stays plain Portuguese.
+        (Language("por"), False),
+        (Language("por", forced=True), True),
+    }
+
+    by_language = {(s.language, s.forced): s for s in subtitles}
+    assert by_language[(Language("por"), False)].download_link \
+        == "https://storage.animetosho.xyz/attachments/0029a/81a.xz"
+    assert by_language[(Language("por", forced=True), True)].download_link \
+        == "https://storage.animetosho.xyz/attachments/002a1/975.xz"
+
+
+def test_forced_track_is_not_offered_as_a_normal_subtitle(anime_episodes, requests_mock, data):
+    """#3579 on animetosho.xyz: the forced Portuguese attachment of the VARYG release must not be
+    served to a profile asking for normal Portuguese, and vice versa."""
+    item = anime_episodes["frieren_s02e01"]
+
+    _mock_feed(requests_mock, None, eid=306529, entry_id=592301, title=_VARYG_TITLE)
+    with open(os.path.join(data, 'animetosho_xyz_series_nested_attachments_response.json'), "rb") as f:
+        requests_mock.get('https://feed.animetosho.xyz/json?show=torrent&id=592301', content=f.read())
+
+    with AnimeToshoXYZProvider() as provider:
+        normal = provider.list_subtitles(item, languages={Language("por")})
+        forced = provider.list_subtitles(item, languages={Language("por", forced=True)})
+
+    assert [(s.language, s.forced) for s in normal] == [(Language("por"), False)]
+    assert [(s.language, s.forced) for s in forced] == [(Language("por", forced=True), True)]
+
+
+def test_attachments_are_not_listed_twice(anime_episodes, requests_mock):
+    # A release only ever uses one of the two shapes, but a release carrying both must still not
+    # produce a duplicate subtitle for the same attachment.
+    item = anime_episodes["crowned_s01e08"]
+
+    info = {"language": "English", "language_code": "eng", "forced": False}
+    url = "https://storage.animetosho.xyz/releases/622245/subtitles/track1.eng.ass.xz"
+    attachment = {"id": 127399, "type": "subtitle", "url": url, "info": info}
+
+    response = {
+        "id": 622245,
+        "torrent_name": _RELEASE_NAME,
+        "attachments": [dict(attachment)],
+        "files": [
+            {"id": 1, "filename": f"{_RELEASE_NAME}.mkv", "attachments": [dict(attachment)]},
+        ],
+    }
+
+    _mock_feed(requests_mock, response)
+
+    with AnimeToshoXYZProvider() as provider:
+        subtitles = provider.list_subtitles(item, languages={Language("eng")})
+
+        assert len(subtitles) == 1
+        assert subtitles[0].download_link == url
+
+
+def test_forced_languages_are_declared():
+    # The provider pool intersects the requested languages with the ones declared by the provider
+    # before calling list_subtitles, so without the forced variants a profile asking for forced
+    # subtitles would never reach AnimeTosho at all.
+    assert Language("eng", forced=True) in AnimeToshoXYZProvider.languages
+    assert Language("por", "BR", forced=True) in AnimeToshoXYZProvider.languages


### PR DESCRIPTION
# Description

Closes #3579.

AnimeTosho exposes the container's **forced disposition flag** for every subtitle attachment, but both AnimeTosho providers dropped it.

While verifying this on `animetosho_xyz`, I found a second, unrelated bug that masked the first one there: that provider only read attachments from the top level of the release response, while `animetosho.xyz` nests them under `files[].attachments` for most releases. For the episode in the linked issue it returned **no subtitles at all**

<img width="1586" height="289" alt="image" src="https://github.com/user-attachments/assets/d704bae3-e1bf-4edd-9552-977c606515bf" />