### PR TITLE
Fixed AnimeTosho discarding distinct release associations that share the same attachment URL

### DIFF
--- a/custom_libs/subliminal_patch/providers/animetosho.py
+++ b/custom_libs/subliminal_patch/providers/animetosho.py
@@ -50,7 +50,7 @@ class AnimeToshoSubtitle(Subtitle):
     """AnimeTosho.org Subtitle."""
     provider_name = 'animetosho'
 
-    def __init__(self, language, download_link, meta, release_info, forced=False):
+    def __init__(self, language, download_link, meta, release_info, release_id, forced=False):
         # AnimeTosho reports the forced disposition flag of the subtitle track. Keep it on the
         # language so a forced (signs only) track is never offered as a normal subtitle.
         language = Language.rebuild(language, forced=forced)
@@ -59,12 +59,15 @@ class AnimeToshoSubtitle(Subtitle):
         self.meta = meta
         self.download_link = download_link
         self.release_info = release_info
+        self.release_id = release_id
         self.forced = forced
         self.matches = set()
 
     @property
     def id(self):
-        return self.download_link
+        # AnimeTosho may reuse the same attachment URL across releases; keep each
+        # release association distinct so scoring can use release-specific metadata.
+        return f'{self.release_id}:{self.download_link}'
 
     def get_matches(self, video):
         self.matches |= guess_matches(video, guessit(self.meta['filename']))
@@ -170,6 +173,7 @@ class AnimeToshoProvider(Provider, ProviderSubtitleArchiveMixin):
                         storage_download_url + '{}/{}.xz'.format(hex_id, subtitle_file['id']),
                         meta=file,
                         release_info=entry.get('title'),
+                        release_id=entry['id'],
                         # AnimeTosho exposes the forced disposition flag of the track as 0/1.
                         forced=bool(info.get('forced', False)),
                     )

--- a/custom_libs/subliminal_patch/providers/animetosho_xyz.py
+++ b/custom_libs/subliminal_patch/providers/animetosho_xyz.py
@@ -43,7 +43,7 @@ _BRAZILIAN_PORTUGUESE_RE = re.compile(r'brazil|\bbr\b', re.IGNORECASE)
 class AnimeToshoXYZSubtitle(Subtitle):
     provider_name = 'animetosho_xyz'
 
-    def __init__(self, language, download_link, meta, release_info, forced=False):
+    def __init__(self, language, download_link, meta, release_info, release_id, forced=False):
         # AnimeTosho reports the forced disposition flag of the subtitle track. Keep it on the
         # language so a forced (signs only) track is never offered as a normal subtitle.
         language = Language.rebuild(language, forced=forced)
@@ -55,12 +55,15 @@ class AnimeToshoXYZSubtitle(Subtitle):
         self.meta = meta
         self.download_link = download_link
         self.release_info = release_info
+        self.release_id = release_id
         self.forced = forced
         self.matches = set()
 
     @property
     def id(self):
-        return self.download_link
+        # AnimeTosho may reuse the same attachment URL across releases; keep each
+        # release association distinct so scoring can use release-specific metadata.
+        return f'{self.release_id}:{self.download_link}'
 
     def get_matches(self, video):
         self.matches |= guess_matches(video, guessit(self.meta.get('torrent_name', '')))
@@ -184,6 +187,7 @@ class AnimeToshoXYZProvider(Provider, ProviderSubtitleArchiveMixin):
                     subtitle_file['url'],
                     meta=torrent_data,
                     release_info=entry.get('title'),
+                    release_id=torrent_data['id'],
                     # AnimeTosho exposes the forced disposition flag of the track as a boolean.
                     forced=bool(info.get('forced', False)),
                 )

--- a/tests/subliminal_patch/test_animetosho.py
+++ b/tests/subliminal_patch/test_animetosho.py
@@ -24,6 +24,22 @@ def anime_episodes():
             resolution="1080p",
             video_codec="H.264",
         ),
+        # VARYG / Earendur releases of S02E01 share PT-BR attachment 2730010 on AnimeTosho.org;
+        # used to assert release associations stay distinct until scoring.
+        "frieren_s02e01": Episode(
+            "Frieren.Beyond.Journeys.End.S02E01.Shall.We.Go.Then.1080p.CR.WEB-DL.MULTi.AAC2.0.H.264-VARYG.mkv",
+            "Frieren: Beyond Journey's End",
+            2,
+            1,
+            source="Web",
+            series_anidb_id=18886,
+            series_anidb_episode_id=306529,
+            series_tvdb_id=424536,
+            series_imdb_id="tt22248376",
+            release_group="VARYG",
+            resolution="1080p",
+            video_codec="H.264",
+        ),
         "solo_leveling_s01e10": Episode(
             "[New-raws] Ore Dake Level Up na Ken - 12 END [1080p] [AMZN].mkv",
             "Solo Leveling",
@@ -107,11 +123,10 @@ def _varyg_torrent_response():
     }
 
 
-def _mock_feed(requests_mock, torrent_response, entry_id=608526):
+def _mock_feed(requests_mock, torrent_response, entry_id, eid, title):
     requests_mock.get(
-        'https://feed.animetosho.org/json?eid=277518',
-        json=[{"id": entry_id, "timestamp": 1711853493, "status": "complete",
-               "title": "Solo Leveling - 12"}],
+        f'https://feed.animetosho.org/json?eid={eid}',
+        json=[{"id": entry_id, "timestamp": 1711853493, "status": "complete", "title": title}],
     )
     requests_mock.get(
         f'https://feed.animetosho.org/json?show=torrent&id={entry_id}',
@@ -145,7 +160,13 @@ _ALL_VARIANTS = {
 def test_portuguese_brazilian_detection(anime_episodes, requests_mock, info, expected):
     item = anime_episodes["solo_leveling_s01e10"]
 
-    _mock_feed(requests_mock, _torrent_response(info))
+    _mock_feed(
+        requests_mock,
+        _torrent_response(info),
+        entry_id=608526,
+        eid=277518,
+        title="Solo Leveling - 12",
+    )
 
     with AnimeToshoProvider(1) as provider:
         # Ask for both variants so nothing is filtered out and the resolved language is asserted.
@@ -172,7 +193,13 @@ def test_portuguese_brazilian_detection(anime_episodes, requests_mock, info, exp
 def test_forced_flag_is_propagated(anime_episodes, requests_mock, info, expected):
     item = anime_episodes["solo_leveling_s01e10"]
 
-    _mock_feed(requests_mock, _torrent_response(info))
+    _mock_feed(
+        requests_mock,
+        _torrent_response(info),
+        entry_id=608526,
+        eid=277518,
+        title="Solo Leveling - 12",
+    )
 
     with AnimeToshoProvider(1) as provider:
         subtitles = provider.list_subtitles(item, languages=_ALL_VARIANTS)
@@ -186,7 +213,13 @@ def test_forced_track_is_not_offered_as_a_normal_subtitle(anime_episodes, reques
     """#3579: a profile asking for normal Brazilian Portuguese was served the forced track."""
     item = anime_episodes["solo_leveling_s01e10"]
 
-    _mock_feed(requests_mock, _varyg_torrent_response())
+    _mock_feed(
+        requests_mock,
+        _varyg_torrent_response(),
+        entry_id=608526,
+        eid=277518,
+        title="Solo Leveling - 12",
+    )
 
     with AnimeToshoProvider(1) as provider:
         normal = provider.list_subtitles(item, languages={Language("por", "BR")})
@@ -198,6 +231,46 @@ def test_forced_track_is_not_offered_as_a_normal_subtitle(anime_episodes, reques
 
     assert [(s.language, s.forced) for s in forced] == [(Language("por", "BR", forced=True), True)]
     assert forced[0].download_link == "https://animetosho.org/storage/attach/002a1975/2759029.xz"
+
+
+def test_reused_attachment_across_releases_keeps_distinct_candidates(anime_episodes, requests_mock):
+    # AnimeTosho.org may associate the same attachment with multiple releases. Each release
+    # association must stay distinct until scoring, otherwise the pool drops later ones by id
+    # (Frieren S02E01 / attachment 2730010 on both VARYG and Earendur).
+    item = anime_episodes["frieren_s02e01"]
+    shared_url = "https://animetosho.org/storage/attach/0029a81a/2730010.xz"
+
+    # Reuse the VARYG payload, keeping only the complete (non-forced) PT-BR attachment that is
+    # shared across releases.
+    torrent = _varyg_torrent_response()
+    torrent["files"][0]["attachments"] = [
+        a for a in torrent["files"][0]["attachments"] if not a["info"].get("forced")
+    ]
+
+    varyg_title = ("Frieren Beyond Journeys End S02E01 Shall We Go Then 1080p CR WEB-DL MULTi "
+                   "AAC2.0 H 264-VARYG")
+    earendur_title = "Earendur Frieren S02E01"
+
+    requests_mock.get(
+        'https://feed.animetosho.org/json?eid=306529',
+        json=[
+            {"id": 592301, "timestamp": 200, "status": "complete", "title": varyg_title},
+            {"id": 592300, "timestamp": 100, "status": "complete", "title": earendur_title},
+        ],
+    )
+    requests_mock.get('https://feed.animetosho.org/json?show=torrent&id=592301', json=torrent)
+    requests_mock.get('https://feed.animetosho.org/json?show=torrent&id=592300', json=torrent)
+
+    with AnimeToshoProvider(2) as provider:
+        subtitles = provider.list_subtitles(item, languages={Language("por", "BR")})
+
+    assert len(subtitles) == 2
+    assert {s.download_link for s in subtitles} == {shared_url}
+    assert {s.release_id for s in subtitles} == {592301, 592300}
+    assert {s.id for s in subtitles} == {
+        f"592301:{shared_url}",
+        f"592300:{shared_url}",
+    }
 
 
 def test_forced_languages_are_declared():

--- a/tests/subliminal_patch/test_animetosho_xyz.py
+++ b/tests/subliminal_patch/test_animetosho_xyz.py
@@ -41,6 +41,20 @@ def anime_episodes():
             resolution="1080p",
             video_codec="H.264",
         ),
+        # Exact Erai-raws release whose PT-BR attachment URL is reused across other releases on
+        # AnimeTosho.xyz; used to assert release associations stay distinct until scoring.
+        "black_torch_s01e10": Episode(
+            "[Erai-raws] Black Torch - 10 [1080p CR WEB-DL AVC AAC][MultiSub][1595FA67].mkv",
+            "BLACK TORCH",
+            1,
+            10,
+            source="Web",
+            series_anidb_id=19001,
+            series_anidb_episode_id=315278,
+            release_group="Erai-raws",
+            resolution="1080p",
+            video_codec="H.264",
+        ),
     }
 
 
@@ -92,7 +106,7 @@ def _nested_response(*sub_infos):
     }
 
 
-def _mock_feed(requests_mock, torrent_response, eid=313249, entry_id=622245, title=_RELEASE_NAME):
+def _mock_feed(requests_mock, torrent_response, eid, entry_id, title):
     """Mock the feed endpoint and, when a payload is given, the release detail endpoint. Leave
     torrent_response as None to register the detail endpoint from a recorded file instead."""
     requests_mock.get(
@@ -243,7 +257,13 @@ def test_list_subtitles_with_episode_id_tuple(anime_episodes, requests_mock, dat
 def test_forced_flag_is_propagated(anime_episodes, requests_mock, info, expected):
     item = anime_episodes["crowned_s01e08"]
 
-    _mock_feed(requests_mock, _top_level_response(info))
+    _mock_feed(
+        requests_mock,
+        _top_level_response(info),
+        eid=313249,
+        entry_id=622245,
+        title=_RELEASE_NAME,
+    )
 
     with AnimeToshoXYZProvider() as provider:
         subtitles = provider.list_subtitles(item, languages=_ALL_VARIANTS)
@@ -316,13 +336,73 @@ def test_attachments_are_not_listed_twice(anime_episodes, requests_mock):
         ],
     }
 
-    _mock_feed(requests_mock, response)
+    _mock_feed(
+        requests_mock,
+        response,
+        eid=313249,
+        entry_id=622245,
+        title=_RELEASE_NAME,
+    )
 
     with AnimeToshoXYZProvider() as provider:
         subtitles = provider.list_subtitles(item, languages={Language("eng")})
 
         assert len(subtitles) == 1
         assert subtitles[0].download_link == url
+
+
+def test_reused_attachment_across_releases_keeps_distinct_candidates(anime_episodes, requests_mock):
+    # AnimeTosho.xyz may point multiple releases at the same attachment URL. Each release
+    # association must stay distinct until scoring, otherwise the pool drops later ones by id
+    # and the exact local release can be lost (BLACK TORCH S01E10 / Erai-raws 1080p).
+    item = anime_episodes["black_torch_s01e10"]
+
+    shared_url = "https://storage.animetosho.xyz/attachments/10002/3f70.xz"
+    pt_br_info = {"language": "Portuguese[BR]", "language_code": "por", "forced": False}
+
+    onalrie_title = "[Onalrie] Black Torch - S01E10 [1080p WEBRip AV1]"
+    erai_title = "[Erai-raws] Black Torch - 10 [1080p CR WEB-DL AVC AAC][MultiSub][1595FA67]"
+
+    requests_mock.get(
+        'https://feed.animetosho.xyz/feed/json?eid=315278',
+        json=[
+            {"id": 685592, "timestamp": 200, "status": "complete", "title": onalrie_title},
+            {"id": 685550, "timestamp": 100, "status": "complete", "title": erai_title},
+        ],
+    )
+    requests_mock.get(
+        'https://feed.animetosho.xyz/json?show=torrent&id=685592',
+        json={
+            "id": 685592,
+            "torrent_name": onalrie_title,
+            "attachments": [
+                {"id": 3, "type": "subtitle", "url": shared_url, "info": pt_br_info},
+            ],
+            "files": [],
+        },
+    )
+    requests_mock.get(
+        'https://feed.animetosho.xyz/json?show=torrent&id=685550',
+        json={
+            "id": 685550,
+            "torrent_name": erai_title,
+            "attachments": [
+                {"id": 3, "type": "subtitle", "url": shared_url, "info": pt_br_info},
+            ],
+            "files": [],
+        },
+    )
+
+    with AnimeToshoXYZProvider() as provider:
+        subtitles = provider.list_subtitles(item, languages={Language("por", "BR")})
+
+    assert len(subtitles) == 2
+    assert {s.download_link for s in subtitles} == {shared_url}
+    assert {s.release_id for s in subtitles} == {685592, 685550}
+    assert {s.id for s in subtitles} == {
+        f"685592:{shared_url}",
+        f"685550:{shared_url}",
+    }
 
 
 def test_forced_languages_are_declared():


### PR DESCRIPTION
## Summary

AnimeTosho can reuse the same subtitle attachment URL across multiple releases. Because `AnimeToshoXYZSubtitle.id` (and the legacy `AnimeToshoSubtitle.id`) was only the `download_link`, the provider pool deduplicated those associations before scoring and could drop the candidate for the exact local release.

This change makes subtitle identity release-specific:

```python
return f'{self.release_id}:{self.download_link}'
```

- `release_id` comes from the API release/torrent `id`
- download URL / preview behavior is unchanged
- intra-release deduplication (same attachment listed twice in one release response) stays as-is

Also applies the same fix to the deprecated legacy `animetosho` provider, which has the same root cause.

Fixes #3582

## Reproduction (BLACK TORCH S01E10)

Local/Sonarr scene name:

```text
[Erai-raws] Black Torch - 10 [1080p CR WEB-DL AVC AAC][MultiSub][1595FA67].mkv
```

The shared PT-BR attachment:

```text
https://storage.animetosho.xyz/attachments/10002/3f70.xz
```

was associated with multiple releases, including Onalrie and the exact Erai-raws 1080p release (`685550`). Newest-first feed ordering kept Onalrie and discarded the Erai-raws associations before scoring.

### Before

Manual search returned 10 candidates; exact Erai-raws 1080p was absent (best visible AnimeTosho.xyz results around 94%):

<img width="1789" height="1109" alt="Before: manual search without exact Erai-raws 1080p candidate" src="https://github.com/user-attachments/assets/53b4ed3e-b345-45b1-bd10-42798996a30c" />

### After

Manual search returned 16 candidates; exact Erai-raws 1080p reached scoring at 100% (`Computed score 360`):

<img width="1790" height="1434" alt="After: exact Erai-raws 1080p candidate at 100%" src="https://github.com/user-attachments/assets/8b8a3cf8-d812-4e50-bc52-3755f7ff5b80" />

Related Erai-raws 480p/720p associations also survived and scored `359`. Download, preview and forced-subtitle handling were verified manually after the change.

## Changes

- Add `release_id` to `AnimeToshoXYZSubtitle` / `AnimeToshoSubtitle` and compose `id` as `{release_id}:{download_link}`
- Populate `release_id` from `torrent_data['id']` (xyz) / `entry['id']` (legacy)
- Regression tests:
  - xyz: BLACK TORCH S01E10 shared attachment across Onalrie + Erai-raws
  - legacy: Frieren S02E01 shared attachment `2730010` across VARYG + Earendur
- Keep existing `test_attachments_are_not_listed_twice` coverage for same-release duplicates

## Test plan

- [x] `pytest tests/subliminal_patch/test_animetosho.py tests/subliminal_patch/test_animetosho_xyz.py` (29 passed)
- [x] Manual search for BLACK TORCH S01E10 with Erai-raws 1080p scene name and PT-BR profile: exact release reaches scoring (~100%)
- [x] Confirm download/preview still work for the selected AnimeTosho.xyz subtitle
- [x] Confirm same-release duplicate attachments are still listed once