### PR TITLE
Fix embedded subtitles pt-BR detection and same-language track extraction

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -420,6 +420,7 @@ validators = [
     Validator('embeddedsubtitles.timeout', must_exist=True, default=600, is_type_of=int, gte=1),
     Validator('embeddedsubtitles.unknown_as_fallback', must_exist=True, default=False, is_type_of=bool),
     Validator('embeddedsubtitles.fallback_lang', must_exist=True, default='en', is_type_of=str, cast=str),
+    Validator('embeddedsubtitles.use_mediainfo', must_exist=True, default=False, is_type_of=bool),
 
     # karagarga section
     Validator('karagarga.username', must_exist=True, default='', is_type_of=str, cast=str),

--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -236,6 +236,15 @@ _FFPROBE_BINARY = get_binary("ffprobe")
 _FFMPEG_BINARY = get_binary("ffmpeg")
 
 
+def _get_mediainfo_binary():
+    try:
+        return get_binary("mediainfo")
+    except Exception:
+        logging.warning("BAZARR could not find the mediainfo binary; embedded subtitles "
+                        "language detection will fall back to ffprobe.")
+        return None
+
+
 def get_providers_auth():
     return {
         'addic7ed': {
@@ -316,6 +325,7 @@ def get_providers_auth():
             'timeout': settings.embeddedsubtitles.timeout,
             'unknown_as_fallback': settings.embeddedsubtitles.unknown_as_fallback,
             'fallback_lang': settings.embeddedsubtitles.fallback_lang,
+            'mediainfo_path': _get_mediainfo_binary() if settings.embeddedsubtitles.use_mediainfo else None,
         },
         'karagarga': {
             'username': settings.karagarga.username,

--- a/custom_libs/subliminal_patch/providers/embeddedsubtitles.py
+++ b/custom_libs/subliminal_patch/providers/embeddedsubtitles.py
@@ -2,10 +2,12 @@
 
 import functools
 import hashlib
+import json
 import logging
 import os
 import re
 import shutil
+import subprocess
 import tempfile
 from typing import List
 
@@ -110,6 +112,7 @@ class EmbeddedSubtitlesProvider(Provider):
         timeout=600,
         unknown_as_fallback=False,
         fallback_lang="en",
+        mediainfo_path=None,
     ):
         self._included_codecs = set(included_codecs or _ALLOWED_CODECS)
 
@@ -125,6 +128,7 @@ class EmbeddedSubtitlesProvider(Provider):
         self._fallback_lang = fallback_lang
         self._cached_paths = {}
         self._timeout = int(timeout)
+        self._mediainfo_path = mediainfo_path
 
         container.FFPROBE_PATH = ffprobe_path or container.FFPROBE_PATH
         container.FFMPEG_PATH = ffmpeg_path or container.FFMPEG_PATH
@@ -159,6 +163,9 @@ class EmbeddedSubtitlesProvider(Provider):
 
             self._blacklist.add(path)
             streams = []
+
+        if self._mediainfo_path:
+            _enrich_languages_with_mediainfo(streams, path, self._mediainfo_path)
 
         _rebuild_langs(streams)
 
@@ -246,7 +253,7 @@ class EmbeddedSubtitlesProvider(Provider):
                 self._cache_dir,
                 timeout=self._timeout,
                 fallback_to_convert=True,
-                basename_callback=_basename_callback,
+                basename_callback=_make_unique_basename_callback(),
                 progress_callback=lambda d: logger.debug("Progress: %s", d),
             )
             # Add the extracted paths to the containter path key
@@ -337,6 +344,83 @@ def _rebuild_langs(streams):
         stream.language = Language.rebuild(language, **kwargs)
 
         logger.debug("Rebuild language: %r", stream.language)
+
+
+def _mediainfo_languages_by_stream_order(path, mediainfo_path):
+    """Map stream order (== ffmpeg absolute index) to the BCP-47 language
+    mediainfo reports for each text track, including region/script sub-tags
+    (e.g. pt-BR) that ffprobe frequently omits."""
+    try:
+        output = subprocess.run(
+            [mediainfo_path, "--Output=JSON", path],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        ).stdout
+    except (subprocess.CalledProcessError, OSError) as error:
+        logger.warning("mediainfo failed to analyze %s: %s", path, error)
+        return {}
+
+    try:
+        data = json.loads(output or b"{}")
+        tracks = data["media"]["track"]
+    except (ValueError, KeyError, TypeError) as error:
+        logger.warning("Could not parse mediainfo output for %s: %s", path, error)
+        return {}
+
+    languages = {}
+    for track in tracks:
+        if track.get("@type") != "Text":
+            continue
+        stream_order = track.get("StreamOrder")
+        language = track.get("Language")
+        if stream_order is None or not language:
+            continue
+        try:
+            languages[int(stream_order)] = language
+        except (TypeError, ValueError):
+            continue
+
+    return languages
+
+
+def _enrich_languages_with_mediainfo(streams, path, mediainfo_path):
+    """Refine each stream language with mediainfo, only when it adds
+    region/script detail to the same base language ffprobe already found, so a
+    mismatch never downgrades or replaces the ffprobe-detected language."""
+    if not streams:
+        return
+
+    languages = _mediainfo_languages_by_stream_order(path, mediainfo_path)
+    if not languages:
+        return
+
+    for stream in streams:
+        mediainfo_lang = languages.get(stream.index)
+        if not mediainfo_lang:
+            continue
+
+        try:
+            refined = Language.fromietf(mediainfo_lang)
+        except Exception:
+            logger.debug("mediainfo language %r not recognized", mediainfo_lang)
+            continue
+
+        current = stream.language
+        if refined.alpha3 != current.alpha3:
+            continue
+        if refined.country == current.country and refined.script == current.script:
+            continue
+        if current.country is not None and refined.country is None:
+            continue
+
+        logger.debug(
+            "mediainfo refined stream %s language: %r -> %r",
+            stream.index,
+            current,
+            refined,
+        )
+        stream.language = refined
 
 
 def _get_chinese_language_from_tags(stream):
@@ -430,3 +514,30 @@ def _format_duration(duration):
 def _basename_callback(path: str):
     path, ext = os.path.splitext(path)
     return hashlib.md5(path.encode()).hexdigest() + ext
+
+
+def _make_unique_basename_callback():
+    """Build a stateful basename callback that guarantees a unique output file
+    per subtitle stream.
+
+    fese derives the extraction filename from the container path plus the
+    stream's language/disposition suffix. When a container has more than one
+    track sharing the same language *and* disposition (e.g. two Portuguese
+    tracks, one pt-BR and one pt), those tracks collapse to the same filename
+    and ffmpeg overwrites one with the other -- so every colliding index ends
+    up mapped to a single extracted file. Since the callback is invoked once
+    per stream, in stream order, we disambiguate repeated basenames by
+    appending a counter, keeping each stream's extraction distinct.
+    """
+    seen = {}
+
+    def callback(path: str):
+        base = _basename_callback(path)
+        count = seen.get(base, 0)
+        seen[base] = count + 1
+        if count == 0:
+            return base
+        root, ext = os.path.splitext(base)
+        return f"{root}.{count:02}{ext}"
+
+    return callback

--- a/frontend/src/pages/Settings/Providers/list.tsx
+++ b/frontend/src/pages/Settings/Providers/list.tsx
@@ -210,6 +210,11 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
         name: "Fallback language",
         defaultValue: "en",
       },
+      {
+        type: "switch",
+        key: "use_mediainfo",
+        name: "Use mediainfo for language detection (detects region variants such as pt-BR that ffprobe may miss; requires the mediainfo binary)",
+      },
     ],
     message:
       "Warning for cloud users: this provider needs to read the entire file in order to extract subtitles.",


### PR DESCRIPTION
## What
Two related fixes to the Embedded Subtitles provider:

1. **Region-aware language detection (pt-BR).** Added an optional
    "Use mediainfo for language detection" toggle to the Embedded Subtitles
    provider. ffprobe often reports region variants (e.g. Brazilian
    Portuguese) as plain Portuguese because it does not expose the Matroska
    `LanguageIETF` element, while mediainfo does. When enabled, stream
    languages are refined with mediainfo before matching — but only when it
    adds region/script detail to the same base language, so it never
    downgrades or replaces ffprobe's detection.

2. **Same-language track extraction collision.** fese names each extracted
    file from the container path + language/disposition suffix. When a file
    has two tracks sharing the same language *and* disposition (e.g. a pt-BR
    and a pt track both tagged `por`), they collapsed to the same output
    filename and ffmpeg overwrote one with the other — so both stream indices
    resolved to a single extracted file. The provider now uses a
    collision-safe basename callback that keeps each stream distinct.

## Why
On a real file with two Portuguese embedded tracks, requesting Brazilian
Portuguese either failed to match (bug 1) or downloaded a file correctly
named `.pt-BR.srt` but containing European Portuguese content (bug 2).

## How tested
- Live validation in a running Bazarr instance against real media with two
  Portuguese embedded tracks (one pt-BR, one pt):
  - Before: pt-BR either unmatched or saved with European content.
  - After: pt-BR matched correctly and the saved `.pt-BR.srt` contains the
    Brazilian track.
- Verified no regression on a file with distinct-language tracks: extracted
  content unchanged.

## Notes
- The mediainfo option is **opt-in** (default off); when the binary is
  missing it logs a warning and falls back to ffprobe.
- The extraction fix is a no-op for files whose tracks have distinct
  languages/dispositions.