### PR TITLE
Add option to prefer embedded subtitles over external providers

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -420,6 +420,7 @@ validators = [
     Validator('embeddedsubtitles.timeout', must_exist=True, default=600, is_type_of=int, gte=1),
     Validator('embeddedsubtitles.unknown_as_fallback', must_exist=True, default=False, is_type_of=bool),
     Validator('embeddedsubtitles.fallback_lang', must_exist=True, default='en', is_type_of=str, cast=str),
+    Validator('embeddedsubtitles.prefer_embedded', must_exist=True, default=False, is_type_of=bool),
 
     # karagarga section
     Validator('karagarga.username', must_exist=True, default='', is_type_of=str, cast=str),

--- a/bazarr/subtitles/download.py
+++ b/bazarr/subtitles/download.py
@@ -20,7 +20,7 @@ from languages.get_languages import alpha3_from_alpha2, alpha2_from_alpha3
 
 from app.get_providers import blacklist_subtitle
 
-from .pool import update_pools, _get_pool
+from .pool import update_pools, _get_pool, _get_embedded_pool
 from .utils import get_video, _get_lang_obj, _get_scores, _set_forced_providers
 from .processing import process_subtitle
 
@@ -86,13 +86,35 @@ def generate_subtitles(path, languages, audio_language, sceneName, title, media_
                             break
 
                     try:
-                        downloaded_subtitles = download_best_subtitles(videos={video},
-                                                                       languages={language},
-                                                                       pool_instance=pool,
-                                                                       min_score=int(min_score),
-                                                                       hearing_impaired=hi_mode,
-                                                                       use_original_format=original_format in (1, "1", "True", True),
-                                                                       fallback_allowed=fallback_allowed)
+                        downloaded_subtitles = None
+
+                        # When "prefer embedded" is enabled, search the embedded
+                        # provider first: an embedded track comes from the media
+                        # file itself, so it always matches the release. If it
+                        # satisfies this language, skip the external providers.
+                        if settings.embeddedsubtitles.prefer_embedded:
+                            embedded_pool = _get_embedded_pool(media_type, profile_id)
+                            if embedded_pool is not None:
+                                downloaded_subtitles = download_best_subtitles(
+                                    videos={video},
+                                    languages={language},
+                                    pool_instance=embedded_pool,
+                                    min_score=int(min_score),
+                                    hearing_impaired=hi_mode,
+                                    use_original_format=original_format in (1, "1", "True", True),
+                                    fallback_allowed=fallback_allowed)
+                                if downloaded_subtitles and any(downloaded_subtitles.values()):
+                                    logging.debug(f"BAZARR found an embedded subtitle for "
+                                                  f"{parse_language_object(language)}; skipping external providers.")
+
+                        if not (downloaded_subtitles and any(downloaded_subtitles.values())):
+                            downloaded_subtitles = download_best_subtitles(videos={video},
+                                                                           languages={language},
+                                                                           pool_instance=pool,
+                                                                           min_score=int(min_score),
+                                                                           hearing_impaired=hi_mode,
+                                                                           use_original_format=original_format in (1, "1", "True", True),
+                                                                           fallback_allowed=fallback_allowed)
                     except Exception as e:
                         logging.exception(f'BAZARR Error downloading Subtitles for this file {path}: {str(e)}')
                         return None

--- a/bazarr/subtitles/pool.py
+++ b/bazarr/subtitles/pool.py
@@ -39,6 +39,36 @@ def _get_pool(media_type, profile_id=None):
         return _pools[f'{media_type}_{profile_id or ""}']
 
 
+_EMBEDDED_PROVIDER = "embeddedsubtitles"
+_embedded_pools = {}
+
+
+def _get_embedded_pool(media_type, profile_id=None):
+    """Return a pool restricted to the embedded subtitles provider.
+
+    Used by the "prefer embedded" behavior to search embedded tracks before
+    querying external providers. Returns None when the embedded provider is not
+    enabled.
+    """
+    if _EMBEDDED_PROVIDER not in (get_providers() or []):
+        return None
+
+    pool_key = f'{media_type}_{profile_id or ""}'
+    pool = _embedded_pools.get(pool_key)
+    if pool is None:
+        pool = _init_pool(media_type, profile_id, providers=[_EMBEDDED_PROVIDER])
+        _embedded_pools[pool_key] = pool
+    else:
+        pool.update(
+            [_EMBEDDED_PROVIDER],
+            get_providers_auth(),
+            get_blacklist() if media_type == "series" else get_blacklist_movie(),
+            get_ban_list(profile_id),
+            get_language_equals(),
+        )
+    return pool
+
+
 def _update_pool(media_type, profile_id=None):
     pool_key = f'{media_type}_{profile_id or ""}'
     logging.debug("BAZARR updating pool: %s", pool_key)

--- a/frontend/src/pages/Settings/Providers/list.tsx
+++ b/frontend/src/pages/Settings/Providers/list.tsx
@@ -210,6 +210,11 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
         name: "Fallback language",
         defaultValue: "en",
       },
+      {
+        type: "switch",
+        key: "prefer_embedded",
+        name: "Prefer embedded subtitles (search embedded tracks first and skip other providers for any language they satisfy)",
+      },
     ],
     message:
       "Warning for cloud users: this provider needs to read the entire file in order to extract subtitles.",


### PR DESCRIPTION
## What
Adds an opt-in "Prefer embedded subtitles" toggle to the Embedded Subtitles
provider. When enabled, each subtitle search queries the embedded provider
first; if it satisfies the requested language, external providers are skipped
for that language. Languages the file doesn't contain still fall through to
external providers as usual.

## Why
An embedded subtitle is extracted from the media file itself, so it always
matches the exact release (correct timing, correct version). When the user
has embedded tracks for a language, there's usually no need to query external
providers for it.

## How tested
Live validation in a running Bazarr with Embedded Subtitles + OpenSubtitles
enabled and the toggle on:
- Episode whose embedded tracks include the wanted language → embedded
  subtitle used, external providers skipped
  (`found an embedded subtitle for <lang>; skipping external providers`).
- Episode whose embedded tracks do NOT include the wanted language → search
  falls through to external providers.

## Notes
- Off by default; no behavior change unless enabled.
- Uses a dedicated, cached embedded-only provider pool rather than mutating
  the shared pool state, to avoid threading side effects.
- Respects the existing per-language HI/forced profile handling and min score.